### PR TITLE
[core-react]: Fix scss imports (#4716)

### DIFF
--- a/common/changes/@itwin/core-react/core_react_fix_imports_2022-11-23-14-03.json
+++ b/common/changes/@itwin/core-react/core_react_fix_imports_2022-11-23-14-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/ui/core-react/src/core-react/autosuggest/AutoSuggest.scss
+++ b/ui/core-react/src/core-react/autosuggest/AutoSuggest.scss
@@ -3,8 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 @import "../scrollbar";
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/variables";
+@import "../inputs/variables";
+@import "../style/variables";
 @import "~@itwin/itwinui-css/scss/inputs/input";
 @import "~@itwin/itwinui-css/scss/style/typography";
 

--- a/ui/core-react/src/core-react/listbox/Listbox.scss
+++ b/ui/core-react/src/core-react/listbox/Listbox.scss
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/index";
+@import "../index";
 
 $uicore-list-item-height: $uicore-baseline * 2; ///  22px; /// ~1.618;
 


### PR DESCRIPTION
Backport core-react changes from https://github.com/iTwin/itwinjs-core/pull/4716