### PR TITLE
Prepare `components-react` tests for React18

### DIFF
--- a/common/changes/@itwin/components-react/raplemie-react18-components-react_2022-12-14-19-09.json
+++ b/common/changes/@itwin/components-react/raplemie-react18-components-react_2022-12-14-19-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Prepare tests for React18",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/datepicker/DatePicker.tsx
+++ b/ui/components-react/src/components-react/datepicker/DatePicker.tsx
@@ -82,6 +82,13 @@ export function DatePicker(props: DatePickerProps) {
   const [displayedMonthIndex, setDisplayedMonthIndex] = React.useState(selectedDay.getMonth());
   const [displayedYear, setDisplayedYear] = React.useState(selectedDay.getFullYear());
   const [focusedDay, setFocusedDay] = React.useState(selectedDay);
+  React.useEffect(() => {
+    const newSelectedDay = new Date(props.selected);
+    setSelectedDay(new Date(props.selected));
+    setDisplayedMonthIndex(newSelectedDay.getMonth());
+    setDisplayedYear(newSelectedDay.getFullYear());
+    setFocusedDay(newSelectedDay);
+  }, [props.selected]);
   const days = React.useMemo(() => {
     const msFirstDayOfMonth = new Date(displayedYear, displayedMonthIndex, 1).getTime();
     let offsetToFirst = new Date(msFirstDayOfMonth).getDay();

--- a/ui/components-react/src/test/common/DelayedSpinner.test.tsx
+++ b/ui/components-react/src/test/common/DelayedSpinner.test.tsx
@@ -6,7 +6,7 @@
 import * as React from "react";
 import { expect } from "chai";
 import sinon from "sinon";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { DelayedSpinner } from "../../components-react/common/DelayedSpinner";
 
 describe("<DelayedSpinner />", () => {
@@ -17,7 +17,7 @@ describe("<DelayedSpinner />", () => {
     expect(spinnerNode).to.not.be.null;
   });
 
-  it("renders spinner with delay", () => {
+  it("renders spinner with delay", async () => {
     const clock = sinon.useFakeTimers({ now: Date.now() });
     const delay = 100;
     const { container } = render(<DelayedSpinner delay={delay} />);
@@ -26,7 +26,7 @@ describe("<DelayedSpinner />", () => {
 
     clock.tick(delay);
 
-    expect(container.children.length).to.be.eq(1);
+    await waitFor(() => expect(container.children.length).to.be.eq(1));
     expect(container.querySelector(".iui-large")).to.not.be.null;
     clock.restore();
   });

--- a/ui/components-react/src/test/common/UseAsyncValue.test.tsx
+++ b/ui/components-react/src/test/common/UseAsyncValue.test.tsx
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
+import { waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { useAsyncValue } from "../../components-react/common/UseAsyncValue";
 import { ResolvablePromise } from "../test-helpers/misc";
@@ -21,7 +22,7 @@ describe("useAsyncValue", () => {
     const { result } = renderHook((props: { value: Promise<string> }) => useAsyncValue(props.value), { initialProps: { value: valuePromise } });
     expect(result.current).to.be.undefined;
     await valuePromise;
-    expect(result.current).to.be.eq(value);
+    await waitFor(() => expect(result.current).to.be.eq(value));
   });
 
   it("returns correct value from multiple promises", async () => {
@@ -32,7 +33,7 @@ describe("useAsyncValue", () => {
     rerender({ value: updatePromise });
     expect(result.current).to.be.undefined;
     await updatePromise.resolve("updated value");
-    expect(result.current).to.be.eq("updated value");
+    await waitFor(() => expect(result.current).to.be.eq("updated value"));
     await initialPromise.resolve("initial value");
     expect(result.current).to.be.eq("updated value");
   });

--- a/ui/components-react/src/test/common/UseDebouncedAsyncValue.test.tsx
+++ b/ui/components-react/src/test/common/UseDebouncedAsyncValue.test.tsx
@@ -3,6 +3,7 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
+import { waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { useDebouncedAsyncValue } from "../../components-react/common/UseDebouncedAsyncValue";
 import { ResolvablePromise } from "../test-helpers/misc";
@@ -29,7 +30,7 @@ describe("useDebouncedAsyncValue", () => {
     expect(result.current.value).to.be.undefined;
 
     await valuePromise.resolve(value);
-    expect(result.current.inProgress).to.be.false;
+    await waitFor(() => expect(result.current.inProgress).to.be.false);
     expect(result.current.value).to.eq(value);
   });
 
@@ -46,7 +47,7 @@ describe("useDebouncedAsyncValue", () => {
     rerender({ value: async () => 2 });
     await initialPromise.resolve(0);
 
-    expect(result.current.inProgress).to.be.false;
+    await waitFor(() => expect(result.current.inProgress).to.be.false);
     expect(result.current.value).to.eq(2);
   });
 

--- a/ui/components-react/src/test/datepicker/TimeField.test.tsx
+++ b/ui/components-react/src/test/datepicker/TimeField.test.tsx
@@ -6,7 +6,7 @@
 import { expect } from "chai";
 import React from "react";
 import sinon from "sinon";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { TimeField, TimeSpec } from "../../components-react/datepicker/TimeField";
 import TestUtils from "../TestUtils";
 import { SpecialKey, TimeDisplay } from "@itwin/appui-abstract";
@@ -105,7 +105,7 @@ describe("<TimeField />", () => {
     expect(inputs[2].value).to.eq("13");
   });
 
-  it("should trigger time hour change", () => {
+  it("should trigger time hour change", async () => {
     const renderedComponent = render(<TimeField time={amTime} timeDisplay={TimeDisplay.H12MC} onTimeChange={renderSpy} readOnly={false} />);
     // renderedComponent.debug();
     expect(renderedComponent).not.to.be.undefined;
@@ -140,17 +140,17 @@ describe("<TimeField />", () => {
     fireEvent.change(hour, { target: { value: "26" } });
     // fireEvent.keyDown(hour, { key: SpecialKey.Enter });
     hour.blur();
-    expect(hour.value).to.eq("12");
+    await waitFor(() => expect(hour.value).to.eq("12"));
 
     hour.focus();
     fireEvent.change(hour, { target: { value: "08" } });
     hour.blur();
     expect(hour.value).to.eq("08");
-    expect(cycle.value).to.eq("timepicker.day-period-am");
+    await waitFor(() => expect(cycle.value).to.eq("timepicker.day-period-am"));
 
   });
 
-  it("should trigger time minute change", () => {
+  it("should trigger time minute change", async () => {
     const renderedComponent = render(<TimeField time={amTime} timeDisplay={TimeDisplay.H12MC} onTimeChange={renderSpy} readOnly={false} />);
     // renderedComponent.debug();
     expect(renderedComponent).not.to.be.undefined;
@@ -171,7 +171,7 @@ describe("<TimeField />", () => {
     minute.focus();
     fireEvent.change(minute, { target: { value: "66" } });
     minute.blur();
-    expect(minute.value).to.eq("30");
+    await waitFor(() => expect(minute.value).to.eq("30"));
     fireEvent.keyDown(minute, { key: SpecialKey.Home });
     expect(minute.value).to.eq("00");
     fireEvent.keyDown(minute, { key: SpecialKey.ArrowDown });
@@ -182,7 +182,7 @@ describe("<TimeField />", () => {
     expect(minute.value).to.eq("00");
   });
 
-  it("should trigger time seconds change", () => {
+  it("should trigger time seconds change", async () => {
     const renderedComponent = render(<TimeField time={amTime} timeDisplay={TimeDisplay.H12MSC} onTimeChange={renderSpy} readOnly={false} />);
     // renderedComponent.debug();
     expect(renderedComponent).not.to.be.undefined;
@@ -207,7 +207,7 @@ describe("<TimeField />", () => {
     seconds.focus();
     fireEvent.change(seconds, { target: { value: "66" } });
     seconds.blur();
-    expect(seconds.value).to.eq("30");
+    await waitFor(() => expect(seconds.value).to.eq("30"));
     fireEvent.keyDown(seconds, { key: SpecialKey.Home });
     expect(seconds.value).to.eq("00");
     fireEvent.keyDown(seconds, { key: SpecialKey.ArrowDown });
@@ -216,7 +216,7 @@ describe("<TimeField />", () => {
     expect(seconds.value).to.eq("59");
   });
 
-  it("should trigger time period change", () => {
+  it("should trigger time period change", async () => {
     const renderedComponent = render(<TimeField time={amTime} timeDisplay={TimeDisplay.H12MSC} onTimeChange={renderSpy} readOnly={false} />);
     // renderedComponent.debug();
     expect(renderedComponent).not.to.be.undefined;
@@ -262,7 +262,7 @@ describe("<TimeField />", () => {
     cycle.focus();
     fireEvent.change(cycle, { target: { value: "pm" } });
     cycle.blur();
-    expect(cycle.value).to.eq("timepicker.day-period-pm");
+    await waitFor(() => expect(cycle.value).to.eq("timepicker.day-period-pm"));
 
     cycle.focus();
     fireEvent.change(hour, { target: { value: "22" } });
@@ -276,31 +276,31 @@ describe("<TimeField />", () => {
     fireEvent.keyDown(hour, { key: SpecialKey.Enter });
     fireEvent.change(cycle, { target: { value: "PM" } });
     cycle.blur();
-    expect(cycle.value).to.eq("timepicker.day-period-pm");
+    await waitFor(() => expect(cycle.value).to.eq("timepicker.day-period-pm"));
 
     cycle.focus();
     fireEvent.change(hour, { target: { value: "22" } });
     fireEvent.keyDown(hour, { key: SpecialKey.Enter });
     fireEvent.change(cycle, { target: { value: "am" } });
     cycle.blur();
-    expect(cycle.value).to.eq("timepicker.day-period-am");
+    await waitFor(() => expect(cycle.value).to.eq("timepicker.day-period-am"));
 
     cycle.focus();
     fireEvent.change(hour, { target: { value: "08" } });
     fireEvent.keyDown(hour, { key: SpecialKey.Enter });
     fireEvent.change(cycle, { target: { value: "timepicker.day-period-pm" } });
     cycle.blur();
-    expect(cycle.value).to.eq("timepicker.day-period-pm");
+    await waitFor(() => expect(cycle.value).to.eq("timepicker.day-period-pm"));
 
     cycle.focus();
     fireEvent.change(cycle, { target: { value: "AM" } });
     cycle.blur();
-    expect(cycle.value).to.eq("timepicker.day-period-am");
+    await waitFor(() => expect(cycle.value).to.eq("timepicker.day-period-am"));
 
     cycle.focus();
     fireEvent.change(cycle, { target: { value: "AM" } });
     cycle.blur();
-    expect(cycle.value).to.eq("timepicker.day-period-am");
+    await waitFor(() => expect(cycle.value).to.eq("timepicker.day-period-am"));
 
     renderedComponent.rerender(<TimeField time={pmTime} timeDisplay={TimeDisplay.H12MSC} onTimeChange={renderSpy} readOnly={false} />);
   });

--- a/ui/components-react/src/test/editors/PopupButton.test.tsx
+++ b/ui/components-react/src/test/editors/PopupButton.test.tsx
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { expect } from "chai";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import sinon from "sinon";
 import * as React from "react";
 import { SpecialKey } from "@itwin/appui-abstract";
@@ -138,7 +138,7 @@ describe("<PopupButton />", () => {
 
     popupButtonRef.current?.closePopup();
 
-    spyOnClose.calledOnce.should.true;
+    await waitFor(() => spyOnClose.calledOnce.should.true);
   });
 
 });

--- a/ui/components-react/src/test/filter-builder/FilterBuilderRuleGroup.test.tsx
+++ b/ui/components-react/src/test/filter-builder/FilterBuilderRuleGroup.test.tsx
@@ -137,9 +137,9 @@ describe("PropertyFilterBuilderRuleGroupRenderer", () => {
     expect(removeItemSpy).to.be.calledOnceWith(defaultProps.path);
   });
 
-  it("dispatches operator change event when operator is selected", () => {
+  it("dispatches operator change event when operator is selected", async () => {
     const actions = new PropertyFilterBuilderActions(sinon.spy());
-    const {container, getByText} = renderWithContext(<PropertyFilterBuilderRuleGroupRenderer
+    const {container, findByText} = renderWithContext(<PropertyFilterBuilderRuleGroupRenderer
       {...defaultProps}
     />, {actions});
     const setRuleGroupOperatorSpy = sinon.stub(actions, "setRuleGroupOperator");
@@ -149,7 +149,7 @@ describe("PropertyFilterBuilderRuleGroupRenderer", () => {
 
     selector?.click();
 
-    getByText(TestUtils.i18n.getLocalizedString("Components:filterBuilder.operators.or")).click();
+    (await findByText(TestUtils.i18n.getLocalizedString("Components:filterBuilder.operators.or"))).click();
 
     expect(setRuleGroupOperatorSpy).to.be.calledOnceWith(defaultProps.path, PropertyFilterRuleGroupOperator.Or);
   });

--- a/ui/components-react/src/test/filter-builder/FilterBuilderRuleValue.test.tsx
+++ b/ui/components-react/src/test/filter-builder/FilterBuilderRuleValue.test.tsx
@@ -6,11 +6,16 @@ import { expect } from "chai";
 import * as React from "react";
 import sinon from "sinon";
 import { PropertyDescription, PropertyValueFormat } from "@itwin/appui-abstract";
-import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { PropertyFilterBuilderRuleValue } from "../../components-react/filter-builder/FilterBuilderRuleValue";
-import TestUtils from "../TestUtils";
+import TestUtils, { userEvent } from "../TestUtils";
 
 describe("PropertyFilterBuilderRuleValue", () => {
+  let theUserTo: ReturnType<typeof userEvent.setup>;
+  beforeEach(()=>{
+    theUserTo = userEvent.setup();
+  });
+
   const defaultProperty: PropertyDescription = {
     name: "prop",
     displayLabel: "Prop",
@@ -48,19 +53,14 @@ describe("PropertyFilterBuilderRuleValue", () => {
 
   it("calls onChange when value is changed", async () => {
     const spy = sinon.spy();
-    const {container, getByDisplayValue} = render(<PropertyFilterBuilderRuleValue
+    render(<PropertyFilterBuilderRuleValue
       property={defaultProperty}
       onChange={spy}
     />);
 
-    const input = container.querySelector<HTMLInputElement>(".iui-input");
-    expect(input).to.not.be.null;
+    await theUserTo.type(screen.getByRole("textbox"), "test text");
+    screen.getByRole("textbox").blur();
 
-    act(() => { fireEvent.change(input!, {target: {value: "test text"}}); });
-    act(() => { fireEvent.focusOut(input!); });
-
-    await waitFor(() => getByDisplayValue("test text"));
-
-    expect(spy).to.be.calledOnceWith({valueFormat: PropertyValueFormat.Primitive, value: "test text", displayValue: ""});
+    await waitFor(() => expect(spy).to.be.calledOnceWith({valueFormat: PropertyValueFormat.Primitive, value: "test text", displayValue: "test text"}));
   });
 });

--- a/ui/components-react/src/test/propertygrid/component/ColumnResizingPropertyListPropsSupplier.test.tsx
+++ b/ui/components-react/src/test/propertygrid/component/ColumnResizingPropertyListPropsSupplier.test.tsx
@@ -10,7 +10,7 @@ import { Orientation } from "@itwin/core-react";
 import { ColumnResizingPropertyListPropsSupplier } from "../../../components-react/propertygrid/component/ColumnResizingPropertyListPropsSupplier";
 import { PropertyList } from "../../../components-react/propertygrid/component/PropertyList";
 import TestUtils, { styleMatch, userEvent } from "../../TestUtils";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 
 describe("ColumnResizingPropertyListPropsSupplier", () => {
 
@@ -53,8 +53,10 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
         { coords: {x: 40 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: /^55(?:\.\d*|)% 1px auto/}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: /^55(?:\.\d*|)% 1px auto/}));
+      });
     });
 
     it("changes label-value ratio to 0.15 when it's modified lower than allowed", async () => {
@@ -71,8 +73,10 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
         { coords: {x: 0 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "15% 1px auto"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "15% 1px auto"}));
+      });
     });
 
     it("changes label-value ratio to 0.6 when it's modified higher than allowed", async () => {
@@ -89,8 +93,10 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
         { coords: {x: 90 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "60% 1px auto"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "60% 1px auto"}));
+      });
     });
   });
 
@@ -116,8 +122,10 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
         { coords: {x: 490 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 50%) 1px minmax(100px, 1fr)"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 50%) 1px minmax(100px, 1fr)"}));
+      });
     });
 
     it("changes label-value ratio to minimum label width when it's modified lower than allowed", async () => {
@@ -140,8 +148,10 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
         { coords: {x: 0 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 10%) 1px minmax(100px, 1fr)"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 10%) 1px minmax(100px, 1fr)"}));
+      });
     });
 
     it("changes label-value ratio to maximum label width when it's modified higher than allowed", async () => {
@@ -163,8 +173,10 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
         { coords: {x: 950 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)"}));
+      });
     });
 
     it("stops changing label-value ratio after reaching max when element not hovered", async () => {
@@ -187,16 +199,20 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
         { coords: {x: 950 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)"}));
+      });
 
       await theUserTo.pointer([
         { coords: {x: 980 }},
         { coords: {x: 500 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)"}));
+      });
     });
 
     it("stops changing label-value ratio after reaching min when element not hovered", async () => {
@@ -219,16 +235,20 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
         { coords: {x: 10 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 10%) 1px minmax(100px, 1fr)"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 10%) 1px minmax(100px, 1fr)"}));
+      });
 
       await theUserTo.pointer([
         { coords: {x: 0 }},
         { coords: {x: 500 }},
       ]);
 
-      expect(screen.getByRole("presentation"))
-        .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 10%) 1px minmax(100px, 1fr)"}));
+      await waitFor(() => {
+        expect(screen.getByRole("presentation"))
+          .satisfy(styleMatch({gridTemplateColumns: "minmax(100px, 10%) 1px minmax(100px, 1fr)"}));
+      });
     });
   });
 });

--- a/ui/components-react/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
+++ b/ui/components-react/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
@@ -80,9 +80,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
-
-      expect(container.querySelector(".components-property-record--horizontal")).to.be.not.null;
+      await waitFor(() => expect(container.querySelector(".components-property-record--horizontal")).to.be.not.null);
     });
 
     it("renders correctly vertically", async () => {
@@ -94,9 +92,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
-
-      expect(container.querySelector(".components-property-record--vertical")).to.be.not.null;
+      await waitFor(() => expect(container.querySelector(".components-property-record--vertical")).to.be.not.null);
     });
 
     it("renders horizontally by default", async () => {
@@ -115,13 +111,13 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
     it("renders PropertyCategoryBlocks correctly", async () => {
       const { container } = render(<VirtualizedPropertyGridWithDataProvider {...defaultProps} />);
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => {
+        const categoryBlocks = container.querySelectorAll(".virtualized-grid-node-category");
+        expect(categoryBlocks.length, "Wrong amount of categories").to.be.equal(2);
 
-      const categoryBlocks = container.querySelectorAll(".virtualized-grid-node-category");
-      expect(categoryBlocks.length, "Wrong amount of categories").to.be.equal(2);
-
-      expect(categoryBlocks[0].textContent).to.be.equal("Group 1");
-      expect(categoryBlocks[1].textContent).to.be.equal("Group 2");
+        expect(categoryBlocks[0].textContent).to.be.equal("Group 1");
+        expect(categoryBlocks[1].textContent).to.be.equal("Group 2");
+      });
     });
 
     it("renders nested property categories", async () => {
@@ -151,19 +147,19 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
       const { container } = render(
         <VirtualizedPropertyGridWithDataProvider  {...defaultProps} dataProvider={dataProvider} />,
       );
-      await waitForPropertyGridLoad(container);
-
-      const categoryBlocks = container.querySelectorAll(".virtualized-grid-node-category");
-      expect(categoryBlocks.length, "Wrong amount of categories").to.be.equal(2);
+      await waitFor(() => {
+        const categoryBlocks = container.querySelectorAll(".virtualized-grid-node-category");
+        expect(categoryBlocks.length, "Wrong amount of categories").to.be.equal(2);
+      });
     });
 
     it("renders PropertyCategoryBlock as collapsed when it gets clicked", async () => {
       const { container } = render(<VirtualizedPropertyGridWithDataProvider  {...defaultProps} />);
 
-      await waitForPropertyGridLoad(container);
-
-      let categoryChild = container.querySelector(".virtualized-grid-node span[title=\"CADID1\"]");
-      expect(categoryChild, "Category child is not rendered").to.not.be.null;
+      await waitFor(() => {
+        const categoryChild = container.querySelector(".virtualized-grid-node span[title=\"CADID1\"]");
+        expect(categoryChild, "Category child is not rendered").to.not.be.null;
+      });
 
       const categoryBlocks = container.querySelectorAll(".virtualized-grid-node-category .iui-header");
       expect(categoryBlocks.length, "Wrong amount of categories").to.be.equal(2);
@@ -171,8 +167,10 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
 
       fireEvent.click(categoryBlock);
 
-      categoryChild = container.querySelector(".virtualized-grid-node span[title=\"CADID1\"]");
-      expect(categoryChild, "Category child rendered").to.be.null;
+      await waitFor(() => {
+        const categoryChild = container.querySelector(".virtualized-grid-node span[title=\"CADID1\"]");
+        expect(categoryChild, "Category child rendered").to.be.null;
+      });
     });
 
     it("keeps the collapsed state of PropertyCategoryBlock when non-nested data is refreshed", async () => {
@@ -320,10 +318,10 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
       });
       dataProvider.onDataChanged.raiseEvent();
 
-      await waitForPropertyGridLoad(container);
-
-      const categoryBlocks = container.querySelectorAll(".virtualized-grid-node-category");
-      expect(categoryBlocks.length).to.be.eq(3);
+      await waitFor(() => {
+        const categoryBlocks = container.querySelectorAll(".virtualized-grid-node-category");
+        expect(categoryBlocks.length).to.be.eq(3);
+      });
     });
 
     it("doesn't rerender on intermediate data changes", async () => {
@@ -349,8 +347,10 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
       expect(dataFake).to.be.calledOnce;
 
       // simulate multiple onDataChanged calls
-      for (let i = 1; i <= 10; ++i)
+      for (let i = 1; i <= 10; ++i) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
         dataProvider.onDataChanged.raiseEvent();
+      }
 
       // resolve the data promise
       await dataPromise.resolve(data);
@@ -370,9 +370,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
-
-      expect(container.querySelector(".components-property-record--horizontal")).to.be.not.null;
+      await waitFor(() => expect(container.querySelector(".components-property-record--horizontal")).to.be.not.null);
 
       rerender(
         <VirtualizedPropertyGridWithDataProvider
@@ -441,8 +439,8 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
           isOrientationFixed={true}
         />,
       );
-      await waitForPropertyGridLoad(container);
-      expect(container.querySelector(".components-property-record--horizontal")).to.be.not.null;
+
+      await waitFor(() => expect(container.querySelector(".components-property-record--horizontal")).to.be.not.null);
 
       rerender(
         <VirtualizedPropertyGridWithDataProvider
@@ -606,7 +604,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       expect(onPropertySelectionChanged.called).to.be.false;
 
@@ -624,7 +622,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         <VirtualizedPropertyGridWithDataProvider {...defaultProps} isPropertySelectionEnabled={true} />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       expect(container.querySelectorAll(".components--selected").length).to.be.equal(0);
 
@@ -651,7 +649,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components-property-record--horizontal").length).to.be.greaterThan(0));
 
       const renderedRecords = container.querySelectorAll(".components-property-record--horizontal");
       expect(renderedRecords.length).to.be.greaterThan(0);
@@ -672,7 +670,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       const clickableComponents = container.querySelectorAll(".components--clickable");
       expect(clickableComponents.length).to.be.greaterThan(0);
@@ -693,7 +691,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       const clickableComponents = container.querySelectorAll(".components--clickable");
       expect(clickableComponents.length).to.be.greaterThan(0);
@@ -715,7 +713,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       const clickableComponents = container.querySelectorAll(".components--clickable");
       expect(clickableComponents.length).to.be.greaterThan(0);
@@ -737,7 +735,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       const clickableComponents = container.querySelectorAll(".components--clickable");
       expect(clickableComponents.length).to.be.greaterThan(0);
@@ -762,7 +760,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       const clickableComponents = container.querySelectorAll(".components--clickable");
       expect(clickableComponents.length).to.be.greaterThan(0);
@@ -795,7 +793,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor( () => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       const clickableComponents = container.querySelectorAll(".components--clickable");
       expect(clickableComponents.length).to.be.greaterThan(0);
@@ -809,7 +807,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
 
       await waitForPropertyGridLoad(container);
 
-      expect(spyMethod).to.be.calledOnce;
+      await waitFor(() => expect(spyMethod).to.be.calledOnce);
     });
 
     it("does not start editor on click if not selected yet", async () => {
@@ -821,7 +819,7 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0));
 
       const clickableComponents = container.querySelectorAll(".components--clickable");
       expect(clickableComponents.length).to.be.greaterThan(0);
@@ -840,7 +838,9 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         />,
       );
 
-      await waitForPropertyGridLoad(container);
+      await waitFor(() => {
+        expect(container.querySelectorAll(".components--clickable").length).to.be.greaterThan(0);
+      });
 
       const clickableComponents = container.querySelectorAll(".components--clickable");
       expect(clickableComponents.length).to.be.greaterThan(0);
@@ -872,11 +872,12 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
           isOrientationFixed={true}
         />,
       );
-      await waitForPropertyGridLoad(container);
 
-      const clickableComponents = container.querySelectorAll(".components-property-record--horizontal");
-      expect(clickableComponents.length).to.be.greaterThan(0);
-      fireEvent.contextMenu(clickableComponents[0]);
+      await waitFor(() => {
+        const clickableComponents = container.querySelectorAll(".components-property-record--horizontal");
+        expect(clickableComponents.length).to.be.greaterThan(0);
+        fireEvent.contextMenu(clickableComponents[0]);
+      });
 
       expect(callback).to.be.calledOnce;
       expect(callback.firstCall.args[0].propertyRecord).to.deep.eq(records[0]);
@@ -888,14 +889,15 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
       const { container } = render(
         <VirtualizedPropertyGridWithDataProvider {...defaultProps} isOrientationFixed={true} />,
       );
-      await waitForPropertyGridLoad(container);
 
-      const clickableComponents = container.querySelectorAll(".virtualized-grid-node");
-      expect(clickableComponents.length).to.be.equal(3);
+      await waitFor(() => {
+        const clickableComponents = container.querySelectorAll(".virtualized-grid-node");
+        expect(clickableComponents.length).to.be.equal(3);
 
-      expect(clickableComponents[0].querySelector(".virtualized-grid-node > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[1].querySelector(".virtualized-grid-node > .nested-border-middle.nested-border-bottom > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[2].querySelector(".virtualized-grid-node > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[0].querySelector(".virtualized-grid-node > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[1].querySelector(".virtualized-grid-node > .nested-border-middle.nested-border-bottom > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[2].querySelector(".virtualized-grid-node > .virtualized-grid-node-content")).to.be.not.null;
+      });
     });
 
     it("Wraps nested content in nested borders correctly", async () => {
@@ -949,25 +951,26 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
           isOrientationFixed={true}
         />,
       );
-      await waitForPropertyGridLoad(container);
 
-      const clickableComponents = container.querySelectorAll(".virtualized-grid-node");
-      expect(clickableComponents.length).to.be.equal(12);
+      await waitFor(() => {
+        const clickableComponents = container.querySelectorAll(".virtualized-grid-node");
+        expect(clickableComponents.length).to.be.equal(12);
 
-      expect(clickableComponents[0].querySelector(".virtualized-grid-node > .virtualized-grid-node-category")).to.be.not.null;
-      expect(clickableComponents[1].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[2].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[3].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[4].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[0].querySelector(".virtualized-grid-node > .virtualized-grid-node-category")).to.be.not.null;
+        expect(clickableComponents[1].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[2].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[3].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[4].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
 
-      expect(clickableComponents[5].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-category")).to.be.not.null;
-      expect(clickableComponents[6].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[7].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[8].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[9].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
-      expect(clickableComponents[10].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle.nested-border-bottom > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[5].querySelector(".virtualized-grid-node > .nested-border-middle > .virtualized-grid-node-category")).to.be.not.null;
+        expect(clickableComponents[6].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[7].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[8].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[9].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle > .virtualized-grid-node-content")).to.be.not.null;
+        expect(clickableComponents[10].querySelector(".virtualized-grid-node > .nested-border-middle > .nested-border-middle.nested-border-bottom > .virtualized-grid-node-content")).to.be.not.null;
 
-      expect(clickableComponents[11].querySelector(".virtualized-grid-node > .nested-border-middle.nested-border-bottom > .virtualized-grid-node-category")).to.be.not.null;
+        expect(clickableComponents[11].querySelector(".virtualized-grid-node > .nested-border-middle.nested-border-bottom > .virtualized-grid-node-category")).to.be.not.null;
+      });
     });
   });
 
@@ -997,11 +1000,12 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
           isOrientationFixed={true}
         />,
       );
-      await waitForPropertyGridLoad(container);
 
-      const gridNodes = container.querySelectorAll(".virtualized-grid-node");
-      expect(gridNodes.length).to.be.greaterThan(0);
-      expect(gridNodes.length).to.be.lessThan(1000);
+      await waitFor(() =>
+        expect(container.querySelectorAll(".virtualized-grid-node").length)
+          .to.be.greaterThan(0)
+          .to.be.lessThan(1000)
+      );
     });
   });
 

--- a/ui/components-react/src/test/toolbar/ToolbarWithOverflow.test.tsx
+++ b/ui/components-react/src/test/toolbar/ToolbarWithOverflow.test.tsx
@@ -7,7 +7,7 @@ import { expect } from "chai";
 import React from "react";
 import * as sinon from "sinon";
 import { ActionButton, BadgeType, CommonToolbarItem, GroupButton, SpecialKey, ToolbarItemUtilities } from "@itwin/appui-abstract";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { CustomToolbarItem, ToolbarOpacitySetting, ToolbarPanelAlignment, ToolbarPanelAlignmentHelpers, ToolbarPopupAutoHideContext, ToolbarWithOverflow } from "../../components-react/toolbar/ToolbarWithOverflow";
 import { Direction } from "../../components-react/toolbar/utilities/Direction";
 import TestUtils from "../TestUtils";
@@ -999,7 +999,7 @@ describe("<ToolbarWithOverflow />", () => {
       // renderedComponent.debug();
     });
 
-    it("should open on drag", () => {
+    it("should open on drag", async () => {
       const childItems: ReadonlyArray<ActionButton | GroupButton> = [
         ToolbarItemUtilities.createActionButton("Entry1", 10, "icon-developer", "Entry1", (): void => { }),
         ToolbarItemUtilities.createActionButton("Entry2", 20, "icon-developer", "Entry2", (): void => { }),
@@ -1038,7 +1038,7 @@ describe("<ToolbarWithOverflow />", () => {
       button!.dispatchEvent(createBubbledEvent("pointermove", { clientX: 30, clientY: 60 }));
 
       // renderedComponent.debug();
-      expect(renderedComponent.queryByText("Group1-Tools")).not.to.be.null;
+      await waitFor(() => expect(renderedComponent.queryByText("Group1-Tools")).not.to.be.null);
       expect(renderedComponent.queryByText("Entry1")).not.to.be.null;
       expect(renderedComponent.queryByText("Entry2")).not.to.be.null;
       expect(renderedComponent.queryByText("Entry3")).not.to.be.null;
@@ -1134,7 +1134,7 @@ describe("<ToolbarWithOverflow />", () => {
       button!.dispatchEvent(createBubbledEvent("pointerdown", { clientX: 30, clientY: 30 }));
       fakeTimers.tick(500);
 
-      expect(renderedComponent.queryByText("Group1-Tools")).not.to.be.null;
+      await waitFor(() => expect(renderedComponent.queryByText("Group1-Tools")).not.to.be.null);
       expect(renderedComponent.queryByText("Entry1")).not.to.be.null;
       const groupEntry2 = renderedComponent.queryByText("Entry2");
       expect(groupEntry2).not.to.be.null;

--- a/ui/components-react/src/test/tree/controlled/TreeHooks.test.tsx
+++ b/ui/components-react/src/test/tree/controlled/TreeHooks.test.tsx
@@ -83,7 +83,7 @@ describe("useTreeNodeLoader", () => {
       { initialProps: { dataProvider: dataProviderMock, modelSource: modelSourceMock.object } },
     );
     const nodeLoader = result.current;
-    rerender();
+    rerender({ dataProvider: dataProviderMock, modelSource: modelSourceMock.object });
 
     expect(result.current).to.be.eq(nodeLoader);
   });
@@ -122,7 +122,7 @@ describe("usePagedTreeNodeLoader", () => {
       { initialProps: { dataProvider: dataProviderMock, pageSize: 10, modelSource: modelSourceMock.object } },
     );
     const nodeLoader = result.current;
-    rerender();
+    rerender({ dataProvider: dataProviderMock, pageSize: 10, modelSource: modelSourceMock.object });
 
     expect(result.current).to.be.eq(nodeLoader);
   });


### PR DESCRIPTION
With react testing library for react 18, there is some timing changes in the components that sometime requires awaiting for the result to show up, rather than expecting an immediate effect (Mostly in behavior resulting from event listener)

This adds these waits ahead of time so we should be able to "switch" to the next version when we are ready to do so.

At the moment, most of these "waitFor" are not needed, so there might be some places where we'll review/rework tests in the mean time and we end up removing these, its Ok. The goal is that whatever is not in active development will be ready to go.

part of https://github.com/iTwin/appui/issues/97