### PR TITLE
Backport change from iTwinjs-core to persist the value of toolbar-opacity (#4719)

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -493,6 +493,8 @@ export class AppUiSettings implements UserSettingsProvider {
     // (undocumented)
     showWidgetIcon: UiStateEntry<boolean>;
     // (undocumented)
+    toolbarOpacity: UiStateEntry<number>;
+    // (undocumented)
     useToolAsToolSettingsLabel: UiStateEntry<boolean>;
     // (undocumented)
     widgetOpacity: UiStateEntry<number>;
@@ -929,7 +931,7 @@ export enum ConfigurableUiActionId {
     // (undocumented)
     SetTheme = "configurableui:set_theme",
     // (undocumented)
-    SetToolbarOpacity = "configurableui:set_toolbar_opacity",
+    SetToolbarOpacity = "configurableui:set-toolbar-opacity",
     // (undocumented)
     SetToolPrompt = "configurableui:set_toolprompt",
     // (undocumented)
@@ -2522,6 +2524,8 @@ export interface InitialAppUiSettings {
     dragInteraction: boolean;
     // (undocumented)
     showWidgetIcon?: boolean;
+    // (undocumented)
+    toolbarOpacity: number;
     // (undocumented)
     useToolAsToolSettingsLabel?: boolean;
     // (undocumented)

--- a/common/changes/@itwin/appui-react/ui-persist-toolbar-opacity_2022-11-23-16-25.json
+++ b/common/changes/@itwin/appui-react/ui-persist-toolbar-opacity_2022-11-23-16-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Persist the toolbar-opacity to state.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/test-apps/appui-test-app/connected/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/index.tsx
@@ -261,6 +261,7 @@ export class SampleAppIModelApp {
       widgetOpacity: 0.8,
       showWidgetIcon: true,
       autoCollapseUnpinnedPanels: false,
+      toolbarOpacity: 0.5,
     };
 
     // initialize any settings providers that may need to have defaults set by iModelApp

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -222,6 +222,7 @@ export class SampleAppIModelApp {
       widgetOpacity: 0.8,
       showWidgetIcon: true,
       autoCollapseUnpinnedPanels: false,
+      toolbarOpacity: 0.5,
     };
 
     // initialize any settings providers that may need to have defaults set by iModelApp

--- a/test-apps/ui-test-app/src/frontend/index.tsx
+++ b/test-apps/ui-test-app/src/frontend/index.tsx
@@ -328,6 +328,7 @@ export class SampleAppIModelApp {
       widgetOpacity: 0.8,
       showWidgetIcon: true,
       autoCollapseUnpinnedPanels: false,
+      toolbarOpacity: 0.5,
     };
 
     // initialize any settings providers that may need to have defaults set by iModelApp

--- a/ui/appui-react/src/appui-react/configurableui/state.ts
+++ b/ui/appui-react/src/appui-react/configurableui/state.ts
@@ -27,7 +27,7 @@ export enum ConfigurableUiActionId {
   SetViewOverlayDisplay = "configurableui:set-view-overlay-display",
   AnimateToolSettings = "configurableui:set-animate-tool-settings",
   UseToolAsToolSettingsLabel = "configurableui:set-use-tool-as-tool-settings-label",
-  SetToolbarOpacity = "configurableui:set_toolbar_opacity",
+  SetToolbarOpacity = "configurableui:set-toolbar-opacity",
 }
 
 /** The portion of state managed by the ConfigurableUiReducer.

--- a/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.tsx
+++ b/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.tsx
@@ -76,7 +76,7 @@ export function UiSettingsPage() {
     const syncIdsOfInterest = ["configurableui:set_theme", "configurableui:set_widget_opacity", "configurableui:set-show-widget-icon",
       "configurableui:set-drag-interaction", "configurableui:set-framework-version",
       "configurableui:set-auto-collapse-unpinned-panels", "configurableui:set-animate-tool-settings",
-      "configurableui:set-use-tool-as-tool-settings-label", "configurableui:set_toolbar_opacity", SyncUiEventId.ShowHideManagerSettingChange];
+      "configurableui:set-use-tool-as-tool-settings-label", "configurableui:set-toolbar-opacity", SyncUiEventId.ShowHideManagerSettingChange];
 
     const handleSyncUiEvent = (args: UiSyncEventArgs) => {
       // istanbul ignore else

--- a/ui/appui-react/src/appui-react/uistate/AppUiSettings.ts
+++ b/ui/appui-react/src/appui-react/uistate/AppUiSettings.ts
@@ -25,6 +25,7 @@ export interface InitialAppUiSettings {
   autoCollapseUnpinnedPanels?: boolean;
   animateToolSettings?: boolean;
   useToolAsToolSettingsLabel?: boolean;
+  toolbarOpacity: number;
 }
 
 /** These are the UI settings that are stored in the Redux store. They control the color theme, the UI version,
@@ -52,6 +53,7 @@ export class AppUiSettings implements UserSettingsProvider {
   public autoCollapseUnpinnedPanels: UiStateEntry<boolean>;
   public animateToolSettings: UiStateEntry<boolean>;
   public useToolAsToolSettingsLabel: UiStateEntry<boolean>;
+  public toolbarOpacity: UiStateEntry<number>;
 
   private setColorTheme = (theme: string) => {
     UiFramework.setColorTheme(theme);
@@ -94,6 +96,10 @@ export class AppUiSettings implements UserSettingsProvider {
       (value: boolean) => UiFramework.setUseToolAsToolSettingsLabel(value), defaults.useToolAsToolSettingsLabel);
     this._settings.push(this.useToolAsToolSettingsLabel);
 
+    this.toolbarOpacity = new UiStateEntry<number>(AppUiSettings._settingNamespace, "ToolOpacity",
+      () => UiFramework.getToolbarOpacity(), (value: number) => UiFramework.setToolbarOpacity(value), defaults.toolbarOpacity);
+    this._settings.push(this.toolbarOpacity);
+
     SyncUiEventDispatcher.onSyncUiEvent.addListener(this.handleSyncUiEvent);
   }
 
@@ -124,6 +130,9 @@ export class AppUiSettings implements UserSettingsProvider {
 
     if (args.eventIds.has("configurableui:set-use-tool-as-tool-settings-label"))
       await this.useToolAsToolSettingsLabel.saveSetting(UiFramework.getUiStateStorage());
+
+    if (args.eventIds.has("configurableui:set-toolbar-opacity"))
+      await this.toolbarOpacity.saveSetting(UiFramework.getUiStateStorage());
   };
 
   public async apply(storage: UiStateStorage): Promise<void> {

--- a/ui/appui-react/src/test/redux/StateManager.test.ts
+++ b/ui/appui-react/src/test/redux/StateManager.test.ts
@@ -228,5 +228,8 @@ describe("ConfigurableUiReducer", () => {
 
     outState = ConfigurableUiReducer(initialState, ConfigurableUiActions.setUseToolAsToolSettingsLabel(true));
     expect(outState.useToolAsToolSettingsLabel).to.be.true;
+
+    outState = ConfigurableUiReducer(initialState, ConfigurableUiActions.setToolbarOpacity(.9));
+    expect(outState.toolbarOpacity).to.be.eql(.9);
   });
 });

--- a/ui/appui-react/src/test/uisettings/AppUiSettings.test.ts
+++ b/ui/appui-react/src/test/uisettings/AppUiSettings.test.ts
@@ -30,6 +30,7 @@ describe("AppUiSettings", () => {
     const uiSetting = new AppUiSettings({});
     await uiSetting.loadUserSettings(UiFramework.getUiStateStorage());
     const opacity = 0.5;
+    const toolbarOpacity = 0.8;
     const colorTheme = "dark";
     const useDragInteraction = true;
     const showWidgetIcon = false;
@@ -38,7 +39,7 @@ describe("AppUiSettings", () => {
     const useToolAsToolSettingsLabel = false;
 
     UiFramework.setWidgetOpacity(opacity);
-    UiFramework.setWidgetOpacity(opacity);
+    UiFramework.setToolbarOpacity(toolbarOpacity);
     UiFramework.setUseDragInteraction(true);
     UiFramework.setColorTheme(colorTheme);
     UiFramework.setUseDragInteraction(useDragInteraction);
@@ -49,6 +50,7 @@ describe("AppUiSettings", () => {
     UiFramework.setUseToolAsToolSettingsLabel(useToolAsToolSettingsLabel);
     await TestUtils.flushAsyncOperations();
     expect(UiFramework.getWidgetOpacity()).to.eql(opacity);
+    expect(UiFramework.getToolbarOpacity()).to.eql(toolbarOpacity);
     expect(UiFramework.getColorTheme()).to.eql(colorTheme);
     expect(UiFramework.useDragInteraction).to.eql(useDragInteraction);
     expect(UiFramework.showWidgetIcon).to.eql(showWidgetIcon);
@@ -66,6 +68,7 @@ describe("AppUiSettings", () => {
       autoCollapseUnpinnedPanels: true,
       animateToolSettings: true,
       useToolAsToolSettingsLabel: true,
+      toolbarOpacity: 0.5,
     };
 
     const uiSetting = new AppUiSettings(defaults);


### PR DESCRIPTION
* Persist the toolbar opacity setting in the state

* Rush change and extract-api

* change "_" to "-" in synch Id for consistency