### PR TITLE
Add optional parameter to EditorContainer

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -608,6 +608,8 @@ export interface EditorContainerProps extends CommonProps {
     onCommit: (args: PropertyUpdatedArgs) => void;
     propertyRecord: PropertyRecord;
     setFocus?: boolean;
+    // @internal
+    shouldCommitOnChange?: boolean;
     title?: string;
 }
 
@@ -2003,6 +2005,8 @@ export interface PropertyEditorProps extends CommonProps {
     onCommit?: (args: PropertyUpdatedArgs) => void;
     propertyRecord?: PropertyRecord;
     setFocus?: boolean;
+    // @internal
+    shouldCommitOnChange?: boolean;
 }
 
 // @beta

--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -1089,6 +1089,8 @@ export interface NumberInputProps extends Omit<InputProps_2, "min" | "max" | "st
     containerClassName?: string;
     containerStyle?: React_2.CSSProperties;
     format?: (num: number | null | undefined, formattedValue: string) => string;
+    // @internal
+    isControlled?: boolean;
     max?: number;
     min?: number;
     onChange?: (value: number | undefined, stringValue: string) => void;

--- a/common/changes/@itwin/components-react/add_optional_parameter_to_editors_2023-02-23-09-15.json
+++ b/common/changes/@itwin/components-react/add_optional_parameter_to_editors_2023-02-23-09-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/add_optional_parameter_to_editors_2023-02-23-09-15.json
+++ b/common/changes/@itwin/core-react/add_optional_parameter_to_editors_2023-02-23-09-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/ui/components-react/src/components-react/editors/EditorContainer.tsx
+++ b/ui/components-react/src/components-react/editors/EditorContainer.tsx
@@ -36,6 +36,11 @@ export interface PropertyEditorProps extends CommonProps {
   onBlur?: (event: React.FocusEvent) => void;
   /** Indicates whether the Property Editor should set focus */
   setFocus?: boolean;
+  /**
+   * Indicates whether value change should call onCommit().
+   * @internal
+   */
+  shouldCommitOnChange?: boolean;
 }
 
 /** [[EditorContainer]] React component properties
@@ -55,6 +60,11 @@ export interface EditorContainerProps extends CommonProps {
 
   /** @internal */
   ignoreEditorBlur?: boolean;
+  /**
+  * Indicates whether value change should call onCommit().
+  * @internal
+  */
+  shouldCommitOnChange?: boolean;
 }
 
 /** @internal */
@@ -92,6 +102,7 @@ export class EditorContainer extends React.PureComponent<EditorContainerProps> {
       setFocus: this.props.setFocus !== undefined ? this.props.setFocus : true,
       className: this.props.className,
       style: this.props.style,
+      shouldCommitOnChange: this.props.shouldCommitOnChange,
     };
 
     const propDescription = this.props.propertyRecord.property;

--- a/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
+++ b/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
@@ -174,6 +174,7 @@ export class NumericInputEditor extends React.PureComponent<PropertyEditorProps,
         onBlur={this.props.onBlur}
         onChange={this._updateValue}
         setFocus={this.props.setFocus && !this.state.isDisabled}
+        isControlled={this.props.shouldCommitOnChange}
       />
     );
   }

--- a/ui/components-react/src/components-react/editors/TextEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextEditor.tsx
@@ -68,6 +68,13 @@ export class TextEditor extends React.PureComponent<PropertyEditorProps, TextEdi
     if (this._isMounted)
       this.setState({
         inputValue: e.target.value,
+      }, async () => {
+        if (this.props.shouldCommitOnChange && this.props.onCommit && this.props.propertyRecord) {
+          const newValue = await this.getPropertyValue();
+          // istanbul ignore else
+          if (newValue)
+            this.props.onCommit({ propertyRecord: this.props.propertyRecord, newValue });
+        }
       });
   };
 

--- a/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleValue.tsx
+++ b/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleValue.tsx
@@ -44,6 +44,7 @@ export function PropertyFilterBuilderRuleValue(props: PropertyFilterBuilderRuleV
       onCancel={/* istanbul ignore next */ () => { }}
       onCommit={onValueChange}
       setFocus={false}
+      shouldCommitOnChange={true}
     />
   </div>;
 }

--- a/ui/components-react/src/test/editors/TextEditor.test.tsx
+++ b/ui/components-react/src/test/editors/TextEditor.test.tsx
@@ -133,6 +133,21 @@ describe("<TextEditor />", () => {
     expect(spyOnCommit.calledOnce).to.be.true;
   });
 
+  it("should call onCommit after value change when shouldCommitOnChange is true", async () => {
+    const propertyRecord = TestUtils.createPrimitiveStringProperty("testName", "MyValue");
+    const convertInfo: PropertyConverterInfo = { name: "" };
+    propertyRecord.property.converter = convertInfo;
+
+    const spyOnCommit = sinon.spy();
+
+    const wrapper = render(<EditorContainer propertyRecord={propertyRecord} title="abc" onCommit={spyOnCommit} onCancel={() => { }} shouldCommitOnChange={true}/>);
+    const inputNode = wrapper.container.querySelector("input");
+    expect(inputNode).not.to.be.null;
+
+    await theUserTo.type(inputNode!, "a");
+    expect(spyOnCommit.called).to.be.true;
+  });
+
   describe("Needs IModelApp", () => {
     before(async () => {
       await TestUtils.initializeUiComponents();

--- a/ui/components-react/src/test/filter-builder/FilterBuilderRuleValue.test.tsx
+++ b/ui/components-react/src/test/filter-builder/FilterBuilderRuleValue.test.tsx
@@ -62,6 +62,6 @@ describe("PropertyFilterBuilderRuleValue", () => {
     await theUserTo.type(screen.getByRole("textbox"), "test text");
     screen.getByRole("textbox").blur();
 
-    await waitFor(() => expect(spy).to.be.calledOnceWith({ valueFormat: PropertyValueFormat.Primitive, value: "test text", displayValue: "test text" }));
+    await waitFor(() => expect(spy).to.be.calledWith({ valueFormat: PropertyValueFormat.Primitive, value: "test text", displayValue: "test text" }));
   });
 });

--- a/ui/core-react/src/core-react/inputs/numberinput/NumberInput.tsx
+++ b/ui/core-react/src/core-react/inputs/numberinput/NumberInput.tsx
@@ -48,12 +48,17 @@ export interface NumberInputProps extends Omit<InputProps, "min" | "max" | "step
   showTouchButtons?: boolean;
   /** Provides ability to return reference to HTMLInputElement */
   ref?: React.Ref<HTMLInputElement>;
+  /**
+   * Makes this component behave as controlled component.
+   * @internal
+   */
+  isControlled?: boolean;
 }
 
 const ForwardRefNumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
   function ForwardRefNumberInput(props, ref) {
     const { containerClassName, value, min, max, precision, format, parse,
-      onChange, onBlur, onKeyDown, step, snap, showTouchButtons, containerStyle, ...otherProps } = props;
+      onChange, onBlur, onKeyDown, step, snap, showTouchButtons, containerStyle, isControlled, ...otherProps } = props;
     const currentValueRef = React.useRef(value);
 
     /**
@@ -109,8 +114,10 @@ const ForwardRefNumberInput = React.forwardRef<HTMLInputElement, NumberInputProp
     }, [formatInternal, value]);
 
     const handleChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-      setFormattedValue(event.currentTarget.value);
-    }, []);
+      const newVal = event.currentTarget.value;
+      setFormattedValue(newVal);
+      isControlled && onChange && onChange(parseInternal(newVal), newVal);
+    }, [isControlled, onChange, parseInternal]);
 
     const updateValue = React.useCallback((newVal: number) => {
       const newFormattedVal = formatInternal(newVal);

--- a/ui/core-react/src/test/inputs/numberinput/NumberInput.test.tsx
+++ b/ui/core-react/src/test/inputs/numberinput/NumberInput.test.tsx
@@ -312,6 +312,17 @@ describe("<NumberInput - React Testing Library />", () => {
     expect(value).to.eq(22.3);
   });
 
+  it("should update value when component is controlled", () => {
+    const spyMethod = sinon.spy();
+
+    const wrapper = render(<NumberInput precision={2} value={1.23} step={.25} onChange={spyMethod} isControlled={true}/>);
+    const input = wrapper.container.querySelector("input");
+    expect(input).not.to.be.null;
+    fireEvent.focusIn(input!);
+    fireEvent.change(input!, { target: { value: "22.3" } });
+    expect(spyMethod).calledOnceWith(22.3, "22.3");
+  });
+
   it("should reset value on ESC", () => {
     let value: number | undefined = 1.23;
     const spyMethod = sinon.spy();


### PR DESCRIPTION
Currently, EditorContainer calls onCommit only when Enter is pressed. This parameter allows calling onCommit after every input change.

[Fix "Apply" button being inactive until "Enter" key is pressed in focused value box (even when opening the dialog with pre-filled values) #77](https://github.com/iTwin/presentation/issues/77)