### PR TITLE
Expose StatusBar.Field and StatusBar.Popup components

### DIFF
--- a/changehistory/NextVersion.md
+++ b/changehistory/NextVersion.md
@@ -15,21 +15,21 @@ Table of contents:
 
 All APIs are marked as internal. `@itwin/appui-layout-react` package is considered as internal implementation detail of the `@itwin/appui-react` package and should not be used directly.
 
-| API from *@itwin/appui-layout-react* | Replacement in *@itwin/appui-react*  |
-| ------------------------------------ | ------------------------------------ |
-| `Dialog`                             | `StatusBarDialog`                    |
-| `DialogProps`                        | `StatusBarDialogProps`               |
-| `FooterIndicator`                    | `StatusBarIndicator`                 |
-| `FooterIndicatorProps`               | `StatusBarIndicatorProps`            |
-| `FooterPopup`                        | `popup` prop of `StatusBarIndicator` |
-| `FooterPopupProps`                   | Removed                              |
-| `FooterPopupContentType`             | Removed                              |
-| `FooterPopupDefaultProps`            | Removed                              |
-| `FooterSeparator`                    | `StatusBarSeparator`                 |
-| `FooterSeparatorProps`               | Removed                              |
-| `SafeAreaInsets`                     | `SafeAreaInsets`                     |
-| `TitleBar`                           | `StatusBarDialog.TitleBar`           |
-| `TitleBarProps`                      | `StatusBarDialogTitleBarProps`       |
+| API from *@itwin/appui-layout-react* | Replacement in *@itwin/appui-react*                       |
+| ------------------------------------ | --------------------------------------------------------- |
+| `Dialog`                             | `StatusBarDialog`                                         |
+| `DialogProps`                        | `StatusBarDialogProps`                                    |
+| `FooterIndicator`                    | `StatusBarIndicator` or `StatusBar.Field`                 |
+| `FooterIndicatorProps`               | `StatusBarIndicatorProps`                                 |
+| `FooterPopup`                        | `popup` prop of `StatusBarIndicator` or `StatusBar.Popup` |
+| `FooterPopupProps`                   | Removed                                                   |
+| `FooterPopupContentType`             | Removed                                                   |
+| `FooterPopupDefaultProps`            | Removed                                                   |
+| `FooterSeparator`                    | `StatusBarSeparator`                                      |
+| `FooterSeparatorProps`               | Removed                                                   |
+| `SafeAreaInsets`                     | `SafeAreaInsets`                                          |
+| `TitleBar`                           | `StatusBarDialog.TitleBar`                                |
+| `TitleBarProps`                      | `StatusBarDialogTitleBarProps`                            |
 
 ## @itwin/appui-abstract
 

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -86,6 +86,7 @@ import { PlaybackSettings } from '@itwin/imodel-components-react';
 import { Point } from '@itwin/core-react';
 import { Point2d } from '@itwin/core-geometry';
 import { PointProps } from '@itwin/appui-abstract';
+import { PopupProps } from '@itwin/core-react';
 import { Primitives } from '@itwin/appui-abstract';
 import { PropertyDescription } from '@itwin/appui-abstract';
 import { PropertyRecord } from '@itwin/appui-abstract';
@@ -4645,6 +4646,14 @@ export class StatusBar extends React_2.Component<StatusBarProps, StatusBarState>
     componentWillUnmount(): void;
     // (undocumented)
     render(): React_2.ReactNode;
+}
+
+// @public
+export namespace StatusBar {
+    const // @beta
+    Field: React_2.ForwardRefExoticComponent<StatusBarFieldProps & React_2.RefAttributes<HTMLDivElement>>;
+    const // @beta
+    Popup: typeof StatusBarPopup;
 }
 
 // @public

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -452,6 +452,7 @@ beta;StandardStatusbarUiItemsProvider
 public;StateManager
 public;StateType
 public;StatusBar 
+public;StatusBar
 public;StatusBarActionItem 
 public;StatusBarCenterSection(props: CommonDivProps): JSX.Element
 public;StatusBarComposer(props: StatusBarComposerProps): JSX.Element

--- a/common/changes/@itwin/appui-react/status-bar-field_2023-03-21-14-53.json
+++ b/common/changes/@itwin/appui-react/status-bar-field_2023-03-21-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Expose StatusBar.Popup and StatusBar.Field components.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/statusbar/Field.scss
+++ b/ui/appui-react/src/appui-react/statusbar/Field.scss
@@ -5,7 +5,7 @@
 @import "~@itwin/appui-layout-react/lib/cjs/appui-layout-react/footer/variables";
 @import "~@itwin/core-react/lib/cjs/core-react/style/colors";
 
-@keyframes uifw-indicator-fadeIn {
+@keyframes uifw-field-fadeIn {
   0% {
     opacity: 0;
     -webkit-transform: scale(0.5);
@@ -24,7 +24,7 @@
   }
 }
 
-@keyframes uifw-indicator-fadeOut {
+@keyframes uifw-field-fadeOut {
   0% {
     opacity: 1;
   }
@@ -34,7 +34,7 @@
   }
 }
 
-.uifw-statusbar-indicator {
+.uifw-statusbar-field {
   visibility: visible;
   gap: var(--iui-size-xs);
 
@@ -46,25 +46,25 @@
     }
   }
 
-  &.uifw-indicator-fade-in {
-    animation: uifw-indicator-fadeIn 1s linear;
+  &.uifw-field-fade-in {
+    animation: uifw-field-fadeIn 1s linear;
     opacity: 1;
     pointer-events: auto;
   }
 
-  &.uifw-indicator-fade-out {
-    animation: uifw-indicator-fadeOut 500ms linear;
+  &.uifw-field-fade-out {
+    animation: uifw-field-fadeOut 500ms linear;
     opacity: 0;
     pointer-events: none;
   }
 
-  > .nz-balloon-container {
+  >.nz-balloon-container {
     height: 100%;
     position: relative;
     display: grid;
     align-content: center;
 
-    > .nz-balloon {
+    >.nz-balloon {
       background-color: var(--iui-color-text);
       text-align: center;
       cursor: pointer;
@@ -76,7 +76,7 @@
       position: relative;
       align-self: center;
 
-      > .nz-arrow {
+      >.nz-arrow {
         position: absolute;
         width: 0;
         bottom: -3px;
@@ -90,7 +90,7 @@
         transform: rotate(25deg);
       }
 
-      > .nz-content {
+      >.nz-content {
         position: relative;
         color: #fff;
         line-height: $min-balloon-height;
@@ -98,7 +98,7 @@
       }
     }
 
-    > .nz-dialog {
+    >.nz-dialog {
       height: 100%;
       width: 100%;
       position: absolute;

--- a/ui/appui-react/src/appui-react/statusbar/Field.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/Field.tsx
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import "./Field.scss";
+import classnames from "classnames";
+import * as React from "react";
+import { CommonProps } from "@itwin/core-react";
+import { FooterIndicator } from "@itwin/appui-layout-react";
+
+/** Properties of [[StatusBarField]] component.
+ * @beta
+ */
+export interface StatusBarFieldProps extends CommonProps {
+  /** Field content. */
+  children?: React.ReactNode;
+  /** Function called when field is clicked. */
+  onClick?: () => void;
+  /** Title of a field. */
+  title?: string;
+}
+
+/** Field component used in [[StatusBar]] component.
+ * @beta
+ */
+export const StatusBarField = React.forwardRef<HTMLDivElement, StatusBarFieldProps>(function StatusBarField(props, ref) {
+  const hasClickAction = !!props.onClick;
+  const classNames = classnames(
+    "uifw-statusbar-field",
+    hasClickAction && "uifw-action",
+    props.className,
+  );
+  return (
+    <FooterIndicator
+      ref={ref}
+      className={classNames}
+      title={props.title}
+      style={props.style}
+      onClick={props.onClick}
+      {...{
+        role: "button",
+        tabIndex: -1,
+      }}
+    >
+      {props.children}
+    </FooterIndicator>
+  );
+});

--- a/ui/appui-react/src/appui-react/statusbar/Indicator.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/Indicator.tsx
@@ -6,11 +6,9 @@
  * @module StatusBar
  */
 
-import "./Indicator.scss";
-import classnames from "classnames";
 import * as React from "react";
 import { CommonProps } from "@itwin/core-react";
-import { FooterIndicator, FooterPopup } from "@itwin/appui-layout-react";
+import { StatusBar } from "./StatusBar";
 
 /** Properties of [[StatusBarIndicator]] component.
  * @beta
@@ -39,33 +37,24 @@ export function StatusBarIndicator(props: StatusBarIndicatorProps) {
     props.onClick?.();
   };
   const target = React.useRef<HTMLDivElement>(null);
-  const classNames = classnames(
-    "uifw-statusbar-indicator",
-    hasClickAction && "uifw-action",
-    props.className,
-  );
   return (
     <>
-      <FooterIndicator
+      <StatusBar.Field
         ref={target}
-        className={classNames}
+        className={props.className}
         title={props.title}
         style={props.style}
-        onClick={handleOnIndicatorClick}
-        {...{
-          role: "button",
-          tabIndex: -1,
-        }}
+        onClick={hasClickAction ? handleOnIndicatorClick : undefined}
       >
         {props.children}
-      </FooterIndicator>
-      {props.popup && <FooterPopup
+      </StatusBar.Field>
+      {props.popup && <StatusBar.Popup
         target={target.current}
         onClose={() => setIsOpen(false)}
         isOpen={isOpen}
       >
         {props.popup}
-      </FooterPopup>}
+      </StatusBar.Popup>}
     </>
   );
 }

--- a/ui/appui-react/src/appui-react/statusbar/Popup.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/Popup.tsx
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import * as React from "react";
+import { PopupProps } from "@itwin/core-react";
+import { FooterPopup } from "@itwin/appui-layout-react";
+
+/** Popup component used in [[StatusBar]] component.
+ * @beta
+ */
+export function StatusBarPopup(props: Partial<PopupProps>) {
+  return (
+    <FooterPopup
+      {...props}
+    />
+  );
+}

--- a/ui/appui-react/src/appui-react/statusbar/StatusBar.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBar.tsx
@@ -16,6 +16,8 @@ import { StatusBarWidgetControl } from "./StatusBarWidgetControl";
 import { toLayoutSafeAreaInsets } from "../safearea/SafeAreaHelpers";
 import { ActivityMessageRenderer } from "../messages/ActivityMessage";
 import { UiFramework } from "../UiFramework";
+import { StatusBarField } from "./Field";
+import { StatusBarPopup } from "./Popup";
 
 // cspell:ignore safearea
 
@@ -174,4 +176,19 @@ export function StatusBarCenterSection(props: CommonDivProps) {
 export function StatusBarRightSection(props: CommonDivProps) {
   const { className, ...divProps } = props;
   return <Div {...divProps} mainClassName={className ? className : "uifw-statusbar-right"} />;
+}
+
+/** Components used in a [[StatusBar]].
+ * @public
+ */
+export namespace StatusBar {
+  /** Field of a [[StatusBar]].
+   * @beta
+   */
+  export const Field = StatusBarField;
+
+  /** Popup of a [[StatusBar]].
+   * @beta
+   */
+  export const Popup = StatusBarPopup;
 }

--- a/ui/appui-react/src/appui-react/statusfields/SectionsField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SectionsField.tsx
@@ -38,7 +38,7 @@ export function SectionsStatusField(props: SectionsStatusFieldProps) {
   const [showIndicator, setShowIndicator] = React.useState(false);
   const [isPopupOpen, setPopupOpen] = React.useState(false);
   const targetDiv = React.useRef<HTMLDivElement>(null);
-  const classes = (showIndicator) ? "uifw-indicator-fade-in" : "uifw-indicator-fade-out";
+  const classes = (showIndicator) ? "uifw-field-fade-in" : "uifw-field-fade-out";
   const [hasManipulatorsShown, setHasManipulatorsShown] = React.useState(false);
 
   React.useEffect(() => {

--- a/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
@@ -26,7 +26,7 @@ describe("SnapModeField", () => {
       <StatusBar><SnapModeField /></StatusBar>
     </Provider>);
 
-    const button = wrapper.container.querySelector(".uifw-statusbar-indicator");
+    const button = wrapper.container.querySelector(".uifw-statusbar-field");
     expect(button).not.to.be.null;
     fireEvent.click(button!);
 


### PR DESCRIPTION
Existing `StatusBarIndicator` container component is easy to use, but not as configurable for advanced use cases, where more control is needed over popup i.e. for nested popups, outside click events or popup state management.
This PR exposes `StatusBar.Field` and `StatusBar.Popup` components to facilitate building such custom status bar indicators.