### PR TITLE
Add FeatureOverridesChanged SyncUIEvent to SyncUIEventDispatcher

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4857,6 +4857,8 @@ export enum SyncUiEventId {
     BackstageEvent = "backstageevent",
     ContentControlActivated = "contentcontrolactivated",
     ContentLayoutActivated = "contentlayoutactivated",
+    // @alpha
+    FeatureOverridesChanged = "featureoverrideschanged",
     FrontstageActivating = "frontstageactivating",
     FrontstageReady = "frontstageready",
     ModalDialogChanged = "modaldialogchanged",
@@ -4890,7 +4892,7 @@ export interface TabLocation {
 }
 
 // @public
-export const ThemeManager: ConnectedComponent<typeof ThemeManagerComponent, Omit_3<React_2.ClassAttributes<ThemeManagerComponent> & ThemeManagerProps, "theme" | "widgetOpacity" | "toolbarOpacity">>;
+export const ThemeManager: ConnectedComponent<typeof ThemeManagerComponent, Omit_3<React_2.ClassAttributes<ThemeManagerComponent> & ThemeManagerProps, "widgetOpacity" | "toolbarOpacity" | "theme">>;
 
 // @public
 export class TileLoadingIndicator extends React_2.PureComponent<CommonProps, TileLoadingIndicatorState> {

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4892,7 +4892,7 @@ export interface TabLocation {
 }
 
 // @public
-export const ThemeManager: ConnectedComponent<typeof ThemeManagerComponent, Omit_3<React_2.ClassAttributes<ThemeManagerComponent> & ThemeManagerProps, "widgetOpacity" | "toolbarOpacity" | "theme">>;
+export const ThemeManager: ConnectedComponent<typeof ThemeManagerComponent, Omit_3<React_2.ClassAttributes<ThemeManagerComponent> & ThemeManagerProps, "theme" | "widgetOpacity" | "toolbarOpacity">>;
 
 // @public
 export class TileLoadingIndicator extends React_2.PureComponent<CommonProps, TileLoadingIndicatorState> {

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4857,7 +4857,6 @@ export enum SyncUiEventId {
     BackstageEvent = "backstageevent",
     ContentControlActivated = "contentcontrolactivated",
     ContentLayoutActivated = "contentlayoutactivated",
-    // @alpha
     FeatureOverridesChanged = "featureoverrideschanged",
     FrontstageActivating = "frontstageactivating",
     FrontstageReady = "frontstageready",

--- a/common/changes/@itwin/appui-react/feat-feature-overrides-uievent_2023-04-04-15-00.json
+++ b/common/changes/@itwin/appui-react/feat-feature-overrides-uievent_2023-04-04-15-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "add FeatureOverridesChanged SyncUIEvent to SyncUIEventDispatcher",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
@@ -59,6 +59,10 @@ export enum SyncUiEventId {
   /** The current object the reads and write UI State has changed. */
   UiStateStorageChanged = "uistatestoragechanged",
   ShowHideManagerSettingChange = "show-hide-setting-change",
+  /** The list of feature overrides applied has been changed
+   * @alpha
+  */
+  FeatureOverridesChanged = "featureoverrideschanged",
 }
 
 /** This class is used to send eventIds to interested UI components so the component can determine if it needs
@@ -119,6 +123,11 @@ export class SyncUiEventDispatcher {
     SyncUiEventDispatcher._uiEventDispatcher.dispatchSyncUiEvent(SyncUiEventId.ViewStateChanged);
   }
 
+  // istanbul ignore next
+  private static _dispatchFeatureOverridesChange() {
+    SyncUiEventDispatcher._uiEventDispatcher.dispatchSyncUiEvent(SyncUiEventId.FeatureOverridesChanged);
+  }
+
   /** Initializes the Monitoring of Events that trigger dispatching sync events */
   public static initialize() {
     // clear any registered listeners - this should only be encountered in unit test scenarios
@@ -176,11 +185,17 @@ export class SyncUiEventDispatcher {
           // istanbul ignore next
           if (args.previous.onViewChanged && typeof args.previous.onViewChanged.removeListener === "function")  // not set during unit test
             args.previous.onViewChanged.removeListener(SyncUiEventDispatcher._dispatchViewChange);
+          // istanbul ignore next
+          if (args.previous.onFeatureOverridesChanged && typeof args.previous.onFeatureOverridesChanged.removeListener === "function")  // not set during unit test
+            args.previous.onFeatureOverridesChanged.removeListener(SyncUiEventDispatcher._dispatchFeatureOverridesChange);
         }
         // istanbul ignore next
         if (args.current) {
           if (args.current.onViewChanged && typeof args.current.onViewChanged.addListener === "function") // not set during unit test
             args.current.onViewChanged.addListener(SyncUiEventDispatcher._dispatchViewChange);
+          // istanbul ignore next
+          if (args.current.onFeatureOverridesChanged && typeof args.current.onFeatureOverridesChanged.addListener === "function") // not set during unit test
+            args.current.onFeatureOverridesChanged.addListener(SyncUiEventDispatcher._dispatchFeatureOverridesChange);
         }
       }));
     }

--- a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
@@ -59,9 +59,7 @@ export enum SyncUiEventId {
   /** The current object the reads and write UI State has changed. */
   UiStateStorageChanged = "uistatestoragechanged",
   ShowHideManagerSettingChange = "show-hide-setting-change",
-  /** The list of feature overrides applied has been changed
-   * @alpha
-  */
+  /** The list of feature overrides applied has been changed */
   FeatureOverridesChanged = "featureoverrideschanged",
 }
 


### PR DESCRIPTION
In SyncUIEventDispatcher, there are currently no SyncUIEvent that listens to when a feature override is applied/removed.
Add FeatureOverridesChanged in SyncUIEventIds and add a listener to the viewport's onFeatureOverridesChanged event.

manually merges changes from [Add FeatureOverridesChanged SyncUIEvent to SyncUIEventDispatcher #4529](https://github.com/iTwin/itwinjs-core/pull/4529)