### PR TITLE
PropertyGrid: Fix non primitive property expander

### DIFF
--- a/common/changes/@itwin/components-react/fix_property_grid_expanders_2023-04-05-11-06.json
+++ b/common/changes/@itwin/components-react/fix_property_grid_expanders_2023-04-05-11-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "VirtualizedPropertyGrid: Fixed non-primitive property expander style",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/properties/renderers/label/NonPrimitivePropertyLabelRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/label/NonPrimitivePropertyLabelRenderer.tsx
@@ -8,10 +8,9 @@
 
 import "./PropertyLabelRenderer.scss";
 import * as React from "react";
+import { SvgChevronRight } from "@itwin/itwinui-icons-react";
 import { PrimitivePropertyLabelRendererProps } from "./PrimitivePropertyLabelRenderer";
 import { PropertyLabelRenderer } from "./PropertyLabelRenderer";
-import { SvgChevronRight } from "@itwin/itwinui-icons-react";
-import { Icon } from "@itwin/core-react";
 
 /** Properties for the [[NonPrimitivePropertyLabelRenderer]] React component
  * @public
@@ -43,8 +42,8 @@ export class NonPrimitivePropertyLabelRenderer extends React.PureComponent<NonPr
         onClick={this._onClick}
         role="presentation"
       >
-        <div className={(this.props.isExpanded ? " components-expanded" : "")}>
-          <Icon iconSpec={<SvgChevronRight />}/>
+        <div className={(this.props.isExpanded ? "components-expanded" : "")}>
+          <SvgChevronRight />
         </div>
         <PropertyLabelRenderer renderColon={this.props.renderColon}>{this.props.children}</PropertyLabelRenderer>
       </div>

--- a/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
+++ b/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
@@ -64,18 +64,18 @@
 
   > .components-property-label-renderer {
     flex: 1;
+    padding-left: var(--iui-size-2xs);
   }
 
   > div {
-    width: 22px;
-    height: 22px;
-    margin-left: -7px;
-    margin-right: 2px;
-    font-size: 10px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     @include transition(var(--iui-duration-1), ease-in-out);
+
+    svg {
+      width: var(--iui-size-s);
+      height: var(--iui-size-s);
+      fill: var(--iui-color-icon);
+      display: block;
+    }
 
     &.components-expanded {
       @include rotate(90deg);

--- a/ui/components-react/src/test/properties/renderers/label/PropertyLabelRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/label/PropertyLabelRenderer.test.tsx
@@ -13,7 +13,7 @@ describe("PrimitivePropertyLabelRenderer ", () => {
   it("renders correctly when offset is not provided", () => {
     const { container } = render(<PrimitivePropertyLabelRenderer>Title</PrimitivePropertyLabelRenderer>);
 
-    expect(container.firstElementChild).that.satisfy(styleMatch({paddingLeft: "0px"}));
+    expect(container.firstElementChild).that.satisfy(styleMatch({ paddingLeft: "0px" }));
     expect(screen.getByText("Title")).to.exist;
   });
 
@@ -21,7 +21,7 @@ describe("PrimitivePropertyLabelRenderer ", () => {
     const { container } = render(<PrimitivePropertyLabelRenderer className="test-class" offset={50}>Title</PrimitivePropertyLabelRenderer>);
 
     expect(container.firstElementChild).that
-      .satisfy(styleMatch({paddingLeft: "50px"}))
+      .satisfy(styleMatch({ paddingLeft: "50px" }))
       .satisfy(selectorMatches(".test-class"));
   });
 
@@ -29,7 +29,7 @@ describe("PrimitivePropertyLabelRenderer ", () => {
 
 describe("NonPrimitivePropertyLabelRenderer  ", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
-  beforeEach(()=>{
+  beforeEach(() => {
     theUserTo = userEvent.setup();
   });
   it("renders correctly", () => {
@@ -44,7 +44,7 @@ describe("NonPrimitivePropertyLabelRenderer  ", () => {
       </NonPrimitivePropertyLabelRenderer>);
 
     expect(screen.getByRole("presentation")).to
-      .satisfy(childStructure("i.icon"))
+      .satisfy(childStructure("svg"))
       .satisfy(selectorMatches(".test-class-name"))
       .not.satisfy(childStructure(".components-expanded"));
     expect(screen.getByText("Title")).to.exist;


### PR DESCRIPTION
Fixed style of non primitive property expander.

Before:
![image](https://user-images.githubusercontent.com/24278440/230063463-27ae9675-15b1-4416-bb0b-2663121624c1.png)

After:
![image](https://user-images.githubusercontent.com/24278440/230063496-140a8251-8aab-4138-8a42-e83ed636ecae.png)

