### PR TITLE
Move Toolbar components to @itwin/appui-react

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -39,6 +39,7 @@ import { DialogPropertySyncItem } from '@itwin/appui-abstract';
 import { DialogProps } from '@itwin/core-react';
 import { DialogProps as DialogProps_2 } from '@itwin/appui-abstract';
 import { DialogRow } from '@itwin/appui-abstract';
+import { Direction } from '@itwin/components-react';
 import { DisplayStyle3dState } from '@itwin/core-frontend';
 import { EmphasizeElementsProps } from '@itwin/core-common';
 import { FloatingWidgetState } from '@itwin/appui-layout-react';
@@ -69,6 +70,7 @@ import { NineZoneAction } from '@itwin/appui-layout-react';
 import { NineZoneDispatch } from '@itwin/appui-layout-react';
 import { NineZoneLabels } from '@itwin/appui-layout-react';
 import { NineZoneState } from '@itwin/appui-layout-react';
+import { NoChildrenProps } from '@itwin/core-react';
 import { NotificationManager } from '@itwin/core-frontend';
 import { NotifyMessageDetails } from '@itwin/core-frontend';
 import { Omit as Omit_2 } from '@itwin/core-react';
@@ -116,6 +118,8 @@ import { Tool } from '@itwin/core-frontend';
 import { ToolAdmin } from '@itwin/core-frontend';
 import { ToolAssistanceInstruction } from '@itwin/core-frontend';
 import { ToolAssistanceInstructions } from '@itwin/core-frontend';
+import { ToolbarOpacitySetting } from '@itwin/components-react';
+import { ToolbarPanelAlignment } from '@itwin/components-react';
 import { ToolTipOptions } from '@itwin/core-frontend';
 import { UiAdmin } from '@itwin/appui-abstract';
 import { UiDataProvider } from '@itwin/appui-abstract';
@@ -4954,6 +4958,9 @@ export interface ToolAssistanceFieldProps extends CommonProps {
     uiStateStorage?: UiStateStorage;
 }
 
+// @beta
+export function Toolbar(props: ToolbarProps): JSX.Element;
+
 // @public
 export const TOOLBAR_OPACITY_DEFAULT = 0.5;
 
@@ -5048,10 +5055,36 @@ export interface ToolbarPopupProps extends PopupPropsBase {
     relativePosition: RelativePosition;
 }
 
+// @beta
+export interface ToolbarProps extends CommonProps, NoChildrenProps {
+    expandsTo?: Direction;
+    items: ToolbarItem[];
+    onItemExecuted?: OnItemExecutedFunc;
+    onKeyDown?: (e: React_2.KeyboardEvent) => void;
+    panelAlignment?: ToolbarPanelAlignment;
+    toolbarOpacitySetting?: ToolbarOpacitySetting;
+    useDragInteraction?: boolean;
+}
+
 // @public
 export enum ToolbarUsage {
     ContentManipulation = 0,
     ViewNavigation = 1
+}
+
+// @beta
+export function ToolbarWithOverflow(props: ToolbarWithOverflowProps): JSX.Element;
+
+// @beta
+export interface ToolbarWithOverflowProps extends CommonProps, NoChildrenProps {
+    expandsTo?: Direction;
+    items: ToolbarItem[];
+    onItemExecuted?: OnItemExecutedFunc;
+    onKeyDown?: (e: React_2.KeyboardEvent) => void;
+    overflowExpandsTo?: Direction;
+    panelAlignment?: ToolbarPanelAlignment;
+    toolbarOpacitySetting?: ToolbarOpacitySetting;
+    useDragInteraction?: boolean;
 }
 
 // @public

--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -385,7 +385,7 @@ export class CustomNumberPropertyEditor extends PropertyEditorBase {
     get reactNode(): React_2.ReactNode;
 }
 
-// @public
+// @public @deprecated
 export interface CustomToolbarItem extends CustomButtonDefinition {
     keepContentsLoaded?: boolean;
     panelContentNode?: React_2.ReactNode;
@@ -2820,7 +2820,7 @@ export class TogglePropertyEditor extends PropertyEditorBase {
     get reactNode(): React_2.ReactNode;
 }
 
-// @public
+// @public @deprecated
 export function Toolbar(props: ToolbarProps): JSX.Element;
 
 // @public
@@ -2841,7 +2841,7 @@ export interface ToolbarButtonItemProps extends CommonProps {
     title: string;
 }
 
-// @public
+// @public @deprecated
 export type ToolbarItem = ActionButton | GroupButton | CustomToolbarItem;
 
 // @internal (undocumented)
@@ -2928,7 +2928,7 @@ export interface ToolbarPopupContextProps {
     readonly setSelectedItem?: (buttonItem: ActionButton) => void;
 }
 
-// @public
+// @public @deprecated
 export interface ToolbarProps extends CommonProps, NoChildrenProps {
     expandsTo?: Direction;
     items: CommonToolbarItem[];
@@ -2939,13 +2939,13 @@ export interface ToolbarProps extends CommonProps, NoChildrenProps {
     useDragInteraction?: boolean;
 }
 
-// @public
+// @public @deprecated
 export function ToolbarWithOverflow(props: ToolbarWithOverflowProps): JSX.Element;
 
 // @internal
 export const ToolbarWithOverflowDirectionContext: React_2.Context<ToolbarOverflowContextProps>;
 
-// @public
+// @public @deprecated
 export interface ToolbarWithOverflowProps extends CommonProps, NoChildrenProps {
     expandsTo?: Direction;
     items: CommonToolbarItem[];

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -498,6 +498,7 @@ public;ToolAssistanceChangedEventArgs
 public;ToolAssistanceField 
 internal;ToolAssistanceFieldDefaultProps = Pick
 public;ToolAssistanceFieldProps 
+beta;Toolbar(props: ToolbarProps): JSX.Element
 public;TOOLBAR_OPACITY_DEFAULT = 0.5
 public;ToolbarActionItem 
 public;ToolbarButtonHelper
@@ -511,7 +512,10 @@ beta;ToolbarItemUtilities
 public;ToolbarOrientation
 beta;ToolbarPopup 
 beta;ToolbarPopupProps 
+beta;ToolbarProps 
 public;ToolbarUsage
+beta;ToolbarWithOverflow(props: ToolbarWithOverflowProps): JSX.Element
+beta;ToolbarWithOverflowProps 
 public;ToolIconChangedEvent 
 public;ToolIconChangedEventArgs
 public;ToolInformation

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -38,6 +38,7 @@ internal;convertPrimitiveRecordToString(record: PropertyRecord): string | Promis
 alpha;CustomNumberEditor 
 alpha;CustomNumberPropertyEditor 
 public;CustomToolbarItem 
+deprecated;CustomToolbarItem 
 public;DataController
 public;class DataControllerBase 
 internal;DateField({ initialDate, onDateChange, readOnly, dateFormatter, timeDisplay, style, className }: DateFieldProps): JSX.Element
@@ -306,9 +307,11 @@ public;toDateString: (date: Date, timeZoneOffset?: number, formatOptions?: DateF
 public;ToggleEditor 
 public;TogglePropertyEditor 
 public;Toolbar(props: ToolbarProps): JSX.Element
+deprecated;Toolbar(props: ToolbarProps): JSX.Element
 public;ToolbarButtonItem: React_2.MemoExoticComponent
 public;ToolbarButtonItemProps 
 public;ToolbarItem = ActionButton | GroupButton | CustomToolbarItem
+deprecated;ToolbarItem = ActionButton | GroupButton | CustomToolbarItem
 internal;ToolbarItemComponent({ item, addGroupSeparator }:
 internal;ToolbarItemContext: React_2.Context
 internal;ToolbarItemContextArgs
@@ -320,9 +323,12 @@ public;ToolbarPopupAutoHideContext: React_2.Context
 public;ToolbarPopupContext: React_2.Context
 public;ToolbarPopupContextProps
 public;ToolbarProps 
+deprecated;ToolbarProps 
 public;ToolbarWithOverflow(props: ToolbarWithOverflowProps): JSX.Element
+deprecated;ToolbarWithOverflow(props: ToolbarWithOverflowProps): JSX.Element
 internal;ToolbarWithOverflowDirectionContext: React_2.Context
 public;ToolbarWithOverflowProps 
+deprecated;ToolbarWithOverflowProps 
 internal;toRxjsObservable
 public;toTimeString: (date: Date, timeZoneOffset?: number, formatOptions?: DateFormatOptions) => string
 internal;toToolbarPopupRelativePosition(expandsTo: Direction, alignment: ToolbarPanelAlignment): RelativePosition

--- a/common/changes/@itwin/appui-codemod/move-toolbar_2023-04-07-14-50.json
+++ b/common/changes/@itwin/appui-codemod/move-toolbar_2023-04-07-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-codemod",
+      "comment": "Handle @itwin/components-react Toolbar deprecations.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/appui-codemod"
+}

--- a/common/changes/@itwin/appui-react/move-toolbar_2023-04-07-14-50.json
+++ b/common/changes/@itwin/appui-react/move-toolbar_2023-04-07-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add Toolbar components.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/move-toolbar_2023-04-07-14-50.json
+++ b/common/changes/@itwin/components-react/move-toolbar_2023-04-07-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Deprecate Toolbar components.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -13,6 +13,7 @@ Table of contents:
   - [Component changes](#component-changes)
   - [Static manager classes](#static-manager-classes)
 - [@itwin/core-react](#itwincore-react)
+  - [SCSS variables](#scss-variables)
 - [@itwin/components-react](#itwincomponents-react)
 - [@bentley/icons-generic-webfont](#bentleyicons-generic-webfont)
 
@@ -412,53 +413,53 @@ Along typescript code changes, SCSS code was cleaned of previously deprecated va
 
 Note that these are NOT handled in the codemod.
 
-| Removed | iTwinUI 2.0 replacement |
-|---|---|
-**Spaces**
-| $uicore-xxs | var(--iui-size-3xs) |
-| $uicore-xs | var(--iui-size-2xs) |
-| $uicore-s | var(--iui-size-xs) |
-| $uicore-sm | var(--iui-size-s) |
-| $uicore-m | var(--iui-size-m) |
-| $uicore-l | var(--iui-size-l) |
-| $uicore-xl | var(--iui-size-xl) |
-| $uicore-xxl | var(--iui-size-2xl) |
-| $uicore-3xl | var(--iui-size-3xl) |
-**Speeds**
-| $uicore-speed-fast | var(--iui-duration-1) |
-| $uicore-speed | var(--iui-duration-2) |
-| $uicore-speed-slow | var(--iui-duration-3) |
-**Typograpy**
-| $uicore-sans | var(--iui-font-sans) |
-| $uicore-monospace | var(--iui-font-mono) |
-| $uicore-font-family | var(--iui-font-sans) |
-| $uicore-font-size | var(--iui-font-size-1) |
-| $uicore-font-size-small | var(--iui-font-size-0) |
-| $uicore-font-size-leading | var(--iui-font-size-2) |
-| $uicore-font-size-subheading | var(--iui-font-size-3) |
-| $uicore-font-size-title | var(--iui-font-size-4) |
-| $uicore-font-size-headline | var(--iui-font-size-5) |
-| $uicore-cap-size | var(--iui-font-size-1) |
-| $uicore-cap-size-small | var(--iui-font-size-0) |
-| $uicore-cap-size-leading | var(--iui-font-size-2) |
-| $uicore-cap-size-subheading | var(--iui-font-size-3) |
-| $uicore-cap-size-title | var(--iui-font-size-4) |
-| $uicore-cap-size-headline | var(--iui-font-size-5) |
-| $uicore-font-weight-light | var(--iui-font-weight-light) |
-| $uicore-font-weight-normal | var(--iui-font-weight-normal) |
-| $uicore-font-weight-semibold | var(--iui-font-weight-semibold) |
-| $uicore-font-weight-bold | var(--iui-font-weight-bold) |
-| $uicore-font-loaded-class | var(--iui-font-sans) |
-| `@mixin` uicore-font-family | `{ font-family: var(--iui-font-sans) }` |
-| $uicore-border-radius | var(--iui-border-radius-1) |
+| Removed                      | iTwinUI 2.0 replacement                 |
+| ---------------------------- | --------------------------------------- |
+| **Spaces**                   |
+| $uicore-xxs                  | var(--iui-size-3xs)                     |
+| $uicore-xs                   | var(--iui-size-2xs)                     |
+| $uicore-s                    | var(--iui-size-xs)                      |
+| $uicore-sm                   | var(--iui-size-s)                       |
+| $uicore-m                    | var(--iui-size-m)                       |
+| $uicore-l                    | var(--iui-size-l)                       |
+| $uicore-xl                   | var(--iui-size-xl)                      |
+| $uicore-xxl                  | var(--iui-size-2xl)                     |
+| $uicore-3xl                  | var(--iui-size-3xl)                     |
+| **Speeds**                   |                                         |
+| $uicore-speed-fast           | var(--iui-duration-1)                   |
+| $uicore-speed                | var(--iui-duration-2)                   |
+| $uicore-speed-slow           | var(--iui-duration-3)                   |
+| **Typograpy**                |                                         |
+| $uicore-sans                 | var(--iui-font-sans)                    |
+| $uicore-monospace            | var(--iui-font-mono)                    |
+| $uicore-font-family          | var(--iui-font-sans)                    |
+| $uicore-font-size            | var(--iui-font-size-1)                  |
+| $uicore-font-size-small      | var(--iui-font-size-0)                  |
+| $uicore-font-size-leading    | var(--iui-font-size-2)                  |
+| $uicore-font-size-subheading | var(--iui-font-size-3)                  |
+| $uicore-font-size-title      | var(--iui-font-size-4)                  |
+| $uicore-font-size-headline   | var(--iui-font-size-5)                  |
+| $uicore-cap-size             | var(--iui-font-size-1)                  |
+| $uicore-cap-size-small       | var(--iui-font-size-0)                  |
+| $uicore-cap-size-leading     | var(--iui-font-size-2)                  |
+| $uicore-cap-size-subheading  | var(--iui-font-size-3)                  |
+| $uicore-cap-size-title       | var(--iui-font-size-4)                  |
+| $uicore-cap-size-headline    | var(--iui-font-size-5)                  |
+| $uicore-font-weight-light    | var(--iui-font-weight-light)            |
+| $uicore-font-weight-normal   | var(--iui-font-weight-normal)           |
+| $uicore-font-weight-semibold | var(--iui-font-weight-semibold)         |
+| $uicore-font-weight-bold     | var(--iui-font-weight-bold)             |
+| $uicore-font-loaded-class    | var(--iui-font-sans)                    |
+| `@mixin` uicore-font-family  | `{ font-family: var(--iui-font-sans) }` |
+| $uicore-border-radius        | var(--iui-border-radius-1)              |
 
 Some variables were removed but not replaced:
 
-| Variable | Value |
-| --- | --- |
-| $uicore-component-height-small | 24px |
-| $uicore-component-height-normal | 28px |
-| $uicore-component-height-large | 32px |
+| Variable                        | Value |
+| ------------------------------- | ----- |
+| $uicore-component-height-small  | 24px  |
+| $uicore-component-height-normal | 28px  |
+| $uicore-component-height-large  | 32px  |
 
 Buttons and Checkbox classes and variables were removed and should be replaced by their iTwinUI counterparts. See this [PR](https://github.com/iTwin/appui/pull/204/files) files for more details.
 
@@ -534,9 +535,15 @@ Removed `Table`, `Breadcrumb` and other previously deprecated APIs and component
 | ThemedEnumPropertyEditor                |
 | TreeDataChangesListener                 |
 
-| Deprecated API       |
-| -------------------- |
-| TableDataChangeEvent |
+| Deprecated API             | Replacement                                          |
+| -------------------------- | ---------------------------------------------------- |
+| `TableDataChangeEvent`     |                                                      |
+| `ToolbarProps`             | `ToolbarProps` from *@itwin/appui-react*             |
+| `Toolbar`                  | `Toolbar` from *@itwin/appui-react*                  |
+| `CustomToolbarItem`        | `ToolbarCustomItem` from *@itwin/appui-react*        |
+| `ToolbarItem`              | `ToolbarItem` from *@itwin/appui-react*              |
+| `ToolbarWithOverflowProps` | `ToolbarWithOverflowProps` from *@itwin/appui-react* |
+| `ToolbarWithOverflow`      | `ToolbarWithOverflow` from *@itwin/appui-react*      |
 
 ## @bentley/icons-generic-webfont
 

--- a/tools/codemod/src/v4.0.0/__testfixtures__/full.input.tsx
+++ b/tools/codemod/src/v4.0.0/__testfixtures__/full.input.tsx
@@ -3,11 +3,13 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { Dialog } from "@itwin/appui-layout-react";
+import { ToolbarWithOverflow } from "@itwin/components-react";
 
 function App() {
   return (
     <>
       <Dialog />
+      <ToolbarWithOverflow />
     </>
   );
 }

--- a/tools/codemod/src/v4.0.0/__testfixtures__/full.output.tsx
+++ b/tools/codemod/src/v4.0.0/__testfixtures__/full.output.tsx
@@ -2,11 +2,12 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { StatusBarDialog } from "@itwin/appui-react";
+import { StatusBarDialog, ToolbarWithOverflow } from "@itwin/appui-react";
 
 function App() {
   return (<>
     <StatusBarDialog />
+    <ToolbarWithOverflow />
   </>);
 }
 

--- a/tools/codemod/src/v4.0.0/__tests__/components-react.test.ts
+++ b/tools/codemod/src/v4.0.0/__tests__/components-react.test.ts
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { createDefineInlineTest } from "../../utils/TestUtils";
+import transformer from "../components-react";
+
+const defineInlineTest = createDefineInlineTest(transformer);
+
+describe("components-react", () => {
+  defineInlineTest(
+    `
+    import { Toolbar, ToolbarItem } from "@itwin/components-react";
+    const item: ToolbarItem = {};
+    <Toolbar />
+    `,
+    `
+    import { Toolbar, ToolbarItem } from "@itwin/appui-react";
+    const item: ToolbarItem = {};
+    <Toolbar />
+    `,
+    "should update declaration"
+  );
+
+  defineInlineTest(
+    `
+    import { CustomToolbarItem } from "@itwin/components-react";
+    const item: CustomToolbarItem = {};
+    `,
+    `
+    import { ToolbarCustomItem } from "@itwin/appui-react";
+    const item: ToolbarCustomItem = {};
+    `,
+    "should rename `CustomToolbarItem`"
+  );
+});

--- a/tools/codemod/src/v4.0.0/components-react.ts
+++ b/tools/codemod/src/v4.0.0/components-react.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import type { API, FileInfo, Options } from "jscodeshift";
+import { useExtensions } from "../utils/Extensions";
+
+export default function transformer(file: FileInfo, api: API, options: Options) {
+  const j = api.jscodeshift;
+  useExtensions(j);
+
+  const root = j(file.source);
+
+  root.rename("@itwin/components-react:ToolbarProps", "@itwin/appui-react:ToolbarProps")
+  root.rename("@itwin/components-react:Toolbar", "@itwin/appui-react:Toolbar")
+  root.rename("@itwin/components-react:CustomToolbarItem", "@itwin/appui-react:ToolbarCustomItem")
+  root.rename("@itwin/components-react:ToolbarItem", "@itwin/appui-react:ToolbarItem")
+  root.rename("@itwin/components-react:ToolbarWithOverflowProps", "@itwin/appui-react:ToolbarWithOverflowProps")
+  root.rename("@itwin/components-react:ToolbarWithOverflow", "@itwin/appui-react:ToolbarWithOverflow")
+
+  return root.toSource(options.printOptions);
+}

--- a/tools/codemod/src/v4.0.0/full.ts
+++ b/tools/codemod/src/v4.0.0/full.ts
@@ -5,6 +5,7 @@
 import type { API, FileInfo, Options } from "jscodeshift";
 import abstract from "./abstract";
 import backstageItem from "./backstage-item";
+import componentsReact from "./components-react";
 import frontstageToConfig from "./element-to-config";
 import layoutReact from "./layout-react";
 import react from "./react";
@@ -17,6 +18,7 @@ import widget from "./widget";
 const transforms = [
   layoutReact,
   abstract,
+  componentsReact,
   frontstageToConfig,
   react,
   statusBarItem,

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -191,10 +191,12 @@ export * from "./appui-react/timeline/SolarTimelineDataProvider";
 
 export * from "./appui-react/toolbar/DragInteraction";
 export * from "./appui-react/toolbar/GroupItem";
+export * from "./appui-react/toolbar/Toolbar";
 export * from "./appui-react/toolbar/ToolbarComposer";
 export * from "./appui-react/toolbar/ToolbarHelper";
 export * from "./appui-react/toolbar/ToolbarItem";
 export * from "./appui-react/toolbar/ToolbarItemUtilities";
+export * from "./appui-react/toolbar/ToolbarWithOverflow";
 export * from "./appui-react/toolbar/useDefaultToolbarItems";
 export * from "./appui-react/toolbar/useUiItemsProviderToolbarItems";
 

--- a/ui/appui-react/src/appui-react/popup/CardPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/CardPopup.tsx
@@ -127,7 +127,7 @@ export function Card(props: CardProps) {
       {props.items &&
         <>
           <div className="uifw-card-separator" />
-          <ToolbarWithOverflow
+          <ToolbarWithOverflow // eslint-disable-line deprecation/deprecation
             expandsTo={Direction.Bottom}
             panelAlignment={ToolbarPanelAlignment.Start}
             items={props.items}

--- a/ui/appui-react/src/appui-react/popup/ToolbarPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/ToolbarPopup.tsx
@@ -9,12 +9,12 @@
 import * as React from "react";
 import { OnCancelFunc, OnItemExecutedFunc, RelativePosition, SpecialKey } from "@itwin/appui-abstract";
 import { DivWithOutsideClick, FocusTrap, Orientation, Point, Size, SizeProps } from "@itwin/core-react";
-import { Direction, Toolbar, ToolbarOpacitySetting, ToolbarPanelAlignment } from "@itwin/components-react";
+import { Direction, ToolbarOpacitySetting, ToolbarPanelAlignment } from "@itwin/components-react";
 import { CursorPopup } from "../cursor/cursorpopup/CursorPopup";
 import { PopupManager, PopupPropsBase } from "./PopupManager";
 import { PositionPopup } from "./PositionPopup";
 import { ToolbarItem } from "../toolbar/ToolbarItem";
-import { toUIAToolbarItem } from "../toolbar/toUIAToolbarItem";
+import { Toolbar } from "../toolbar/Toolbar";
 
 /** Props for a popup toolbar
  * @beta */
@@ -65,7 +65,6 @@ export class ToolbarPopup extends React.PureComponent<ToolbarPopupProps, Toolbar
     let point = PopupManager.getPopupPosition(this.props.el, this.props.pt, new Point(), this.state.size);
     const popupRect = CursorPopup.getPopupRect(point, this.props.offset, this.state.size, this.props.relativePosition);
     point = new Point(popupRect.left, popupRect.top);
-    const items = this.props.items.map((item) => toUIAToolbarItem(item));
     return (
       <PositionPopup key={this.props.id}
         className="uifw-no-border"
@@ -77,7 +76,7 @@ export class ToolbarPopup extends React.PureComponent<ToolbarPopupProps, Toolbar
             <Toolbar
               expandsTo={Direction.Bottom}
               panelAlignment={ToolbarPanelAlignment.Start}
-              items={items}
+              items={this.props.items}
               useDragInteraction={true}
               toolbarOpacitySetting={ToolbarOpacitySetting.Defaults}
               onItemExecuted={this.props.onItemExecuted}

--- a/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
@@ -9,7 +9,7 @@
 import * as React from "react";
 import { OnItemExecutedFunc } from "@itwin/appui-abstract";
 import { CommonProps, NoChildrenProps } from "@itwin/core-react";
-import { Direction, Toolbar as CR_Toolbar, ToolbarOpacitySetting, ToolbarPanelAlignment } from "@itwin/components-react";
+import { Toolbar as CR_Toolbar, Direction, ToolbarOpacitySetting, ToolbarPanelAlignment } from "@itwin/components-react";
 import { ToolbarItem } from "./ToolbarItem";
 import { toUIAToolbarItem } from "./toUIAToolbarItem";
 
@@ -42,7 +42,7 @@ export function Toolbar(props: ToolbarProps) {
     return items.map((item) => toUIAToolbarItem(item));
   }, [items]);
   return (
-    <CR_Toolbar
+    <CR_Toolbar // eslint-disable-line deprecation/deprecation
       items={uiaItems}
       {...other}
     />

--- a/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Toolbar
+ */
+
+import * as React from "react";
+import { OnItemExecutedFunc } from "@itwin/appui-abstract";
+import { CommonProps, NoChildrenProps } from "@itwin/core-react";
+import { Direction, Toolbar as CR_Toolbar, ToolbarOpacitySetting, ToolbarPanelAlignment } from "@itwin/components-react";
+import { ToolbarItem } from "./ToolbarItem";
+import { toUIAToolbarItem } from "./toUIAToolbarItem";
+
+/** Properties of [[Toolbar]] component.
+ * @beta
+ */
+export interface ToolbarProps extends CommonProps, NoChildrenProps {
+  /** Describes to which direction the popup panels are expanded. Defaults to: [[Direction.Bottom]] */
+  expandsTo?: Direction;
+  /** Definitions for items of the toolbar. Items are expected to be already sorted by group and item. */
+  items: ToolbarItem[];
+  /** Describes how expanded panels are aligned. Defaults to: [[ToolbarPanelAlignment.Start]] */
+  panelAlignment?: ToolbarPanelAlignment;
+  /** Use Drag Interaction to open popups with nest action buttons */
+  useDragInteraction?: boolean;
+  /** Determines whether to use mouse proximity to alter the opacity of the toolbar */
+  toolbarOpacitySetting?: ToolbarOpacitySetting;
+  /** Optional function to call on any item execution */
+  onItemExecuted?: OnItemExecutedFunc;
+  /** Optional function to call on any KeyDown events processed by toolbar */
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+}
+
+/** Component that displays toolbar items.
+ * @beta
+ */
+export function Toolbar(props: ToolbarProps) {
+  const { items, ...other } = props;
+  const uiaItems = React.useMemo(() => {
+    return items.map((item) => toUIAToolbarItem(item));
+  }, [items]);
+  return (
+    <CR_Toolbar
+      items={uiaItems}
+      {...other}
+    />
+  );
+}

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
@@ -8,7 +8,7 @@
 
 import * as React from "react";
 import { ConditionalBooleanValue } from "@itwin/appui-abstract";
-import { Direction, ToolbarOpacitySetting, ToolbarPanelAlignment, ToolbarWithOverflow } from "@itwin/components-react";
+import { Direction, ToolbarOpacitySetting, ToolbarPanelAlignment } from "@itwin/components-react";
 import { Logger } from "@itwin/core-bentley";
 import { Orientation } from "@itwin/core-react";
 import { SyncUiEventDispatcher } from "../syncui/SyncUiEventDispatcher";
@@ -18,7 +18,7 @@ import { useDefaultToolbarItems } from "./useDefaultToolbarItems";
 import { useUiItemsProviderToolbarItems } from "./useUiItemsProviderToolbarItems";
 import { isToolbarActionItem, isToolbarGroupItem, ToolbarActionItem, ToolbarGroupItem, ToolbarItem, ToolbarOrientation, ToolbarUsage } from "./ToolbarItem";
 import { ToolbarItemsManager } from "./ToolbarItemsManager";
-import { toUIAToolbarItem } from "./toUIAToolbarItem";
+import { ToolbarWithOverflow } from "./ToolbarWithOverflow";
 
 /** Private function to set up sync event monitoring of toolbar items */
 function useToolbarItemSyncEffect(uiDataProvider: ToolbarItemsManager, syncIdsOfInterest: string[]) {
@@ -246,9 +246,8 @@ export function ToolbarComposer(props: ExtensibleToolbarProps) {
   const addonSyncIdsOfInterest = React.useMemo(() => ToolbarItemsManager.getSyncIdsOfInterest(addonItems), [addonItems]);
   useToolbarItemSyncEffect(addonItemsManager, addonSyncIdsOfInterest);
 
-  const toolbarItems = React.useMemo(() => {
-    const items = combineItems(defaultItems, addonItems);
-    return items.map((item) => toUIAToolbarItem(item));
+  const items = React.useMemo(() => {
+    return combineItems(defaultItems, addonItems);
   }, [defaultItems, addonItems]);
 
   const toolbarOrientation = orientation === ToolbarOrientation.Horizontal ? Orientation.Horizontal : Orientation.Vertical;
@@ -260,7 +259,7 @@ export function ToolbarComposer(props: ExtensibleToolbarProps) {
   return <ToolbarWithOverflow
     expandsTo={expandsTo}
     panelAlignment={panelAlignment}
-    items={toolbarItems}
+    items={items}
     useDragInteraction={isDragEnabled}
     toolbarOpacitySetting={useProximityOpacity && !UiFramework.isMobile() ? ToolbarOpacitySetting.Proximity : /* istanbul ignore next */ ToolbarOpacitySetting.Defaults}
   />;

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarWithOverflow.tsx
@@ -10,7 +10,7 @@ import "./Toolbar.scss";
 import * as React from "react";
 import { OnItemExecutedFunc } from "@itwin/appui-abstract";
 import { CommonProps, NoChildrenProps } from "@itwin/core-react";
-import { Direction, ToolbarOpacitySetting, ToolbarPanelAlignment, ToolbarWithOverflow as CR_ToolbarWithOverflow } from "@itwin/components-react";
+import { ToolbarWithOverflow as CR_ToolbarWithOverflow, Direction, ToolbarOpacitySetting, ToolbarPanelAlignment } from "@itwin/components-react";
 import { ToolbarItem } from "./ToolbarItem";
 import { toUIAToolbarItem } from "./toUIAToolbarItem";
 
@@ -45,9 +45,9 @@ export function ToolbarWithOverflow(props: ToolbarWithOverflowProps) {
     return items.map((item) => toUIAToolbarItem(item));
   }, [items]);
   return (
-    <CR_ToolbarWithOverflow
+    <CR_ToolbarWithOverflow // eslint-disable-line deprecation/deprecation
       items={uiaItems}
       {...other}
     />
-  )
+  );
 }

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarWithOverflow.tsx
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Toolbar
+ */
+
+import "./Toolbar.scss";
+import * as React from "react";
+import { OnItemExecutedFunc } from "@itwin/appui-abstract";
+import { CommonProps, NoChildrenProps } from "@itwin/core-react";
+import { Direction, ToolbarOpacitySetting, ToolbarPanelAlignment, ToolbarWithOverflow as CR_ToolbarWithOverflow } from "@itwin/components-react";
+import { ToolbarItem } from "./ToolbarItem";
+import { toUIAToolbarItem } from "./toUIAToolbarItem";
+
+/** Component that displays toolbar items.
+ * @beta
+ */
+export interface ToolbarWithOverflowProps extends CommonProps, NoChildrenProps {
+  /** Describes to which direction the popup panels are expanded. Defaults to: [[Direction.Bottom]] */
+  expandsTo?: Direction;
+  /** Describes to which direction the overflow popup panels are expanded. Defaults to: [[Direction.Right]] */
+  overflowExpandsTo?: Direction;
+  /** Definitions for items of the toolbar. Items are expected to be already sorted by group and item. */
+  items: ToolbarItem[];
+  /** Describes how expanded panels are aligned. Defaults to: [[ToolbarPanelAlignment.Start]] */
+  panelAlignment?: ToolbarPanelAlignment;
+  /** Use Drag Interaction to open popups with nest action buttons */
+  useDragInteraction?: boolean;
+  /** Determines whether to use mouse proximity to alter the opacity of the toolbar */
+  toolbarOpacitySetting?: ToolbarOpacitySetting;
+  /** Optional function to call on any item execution */
+  onItemExecuted?: OnItemExecutedFunc;
+  /** Optional function to call on any KeyDown events processed by toolbar */
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+}
+
+/** Component that displays toolbar items.
+ * @beta
+ */
+export function ToolbarWithOverflow(props: ToolbarWithOverflowProps) {
+  const { items, ...other } = props;
+  const uiaItems = React.useMemo(() => {
+    return items.map((item) => toUIAToolbarItem(item));
+  }, [items]);
+  return (
+    <CR_ToolbarWithOverflow
+      items={uiaItems}
+      {...other}
+    />
+  )
+}

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarWithOverflow.tsx
@@ -6,7 +6,6 @@
  * @module Toolbar
  */
 
-import "./Toolbar.scss";
 import * as React from "react";
 import { OnItemExecutedFunc } from "@itwin/appui-abstract";
 import { CommonProps, NoChildrenProps } from "@itwin/core-react";

--- a/ui/appui-react/src/appui-react/toolbar/toUIAToolbarItem.ts
+++ b/ui/appui-react/src/appui-react/toolbar/toUIAToolbarItem.ts
@@ -13,7 +13,7 @@ import { isToolbarCustomItem, ToolbarItem } from "./ToolbarItem";
 /** @internal */
 export function toUIAToolbarItem(item: ToolbarItem): UIA_CommonToolbarItem {
   if (isToolbarCustomItem(item)) {
-    const customItem: CustomToolbarItem = {
+    const customItem: CustomToolbarItem = { // eslint-disable-line deprecation/deprecation
       ...item,
       isCustom: true,
       icon: item.icon as string,
@@ -21,5 +21,5 @@ export function toUIAToolbarItem(item: ToolbarItem): UIA_CommonToolbarItem {
     };
     return customItem;
   }
-  return item as UIA_CommonToolbarItem; // TODO: 4.0
+  return item as UIA_CommonToolbarItem;
 }

--- a/ui/components-react/src/components-react/toolbar/Toolbar.tsx
+++ b/ui/components-react/src/components-react/toolbar/Toolbar.tsx
@@ -18,8 +18,8 @@ import { Direction, OrthogonalDirection, OrthogonalDirectionHelpers } from "./ut
 import { getToolbarDirection, ToolbarItemComponent, ToolbarItemContext, ToolbarOpacitySetting, ToolbarPanelAlignment, ToolbarWithOverflowDirectionContext } from "./ToolbarWithOverflow";
 
 /** Properties of [[Toolbar]] component.
- * @deprecated in 4.0. Use [ToolbarProps]($appui-react) instead.
  * @public
+ * @deprecated in 4.0. Use [ToolbarProps]($appui-react) instead.
  */
 export interface ToolbarProps extends CommonProps, NoChildrenProps {
   /** Describes to which direction the popup panels are expanded. Defaults to: [[Direction.Bottom]] */
@@ -48,8 +48,8 @@ function getItemWrapperClass(child: React.ReactNode) {
 }
 
 /** Component that displays toolbar items.
- * @deprecated in 4.0. Use [Toolbar]($appui-react) instead.
  * @public
+ * @deprecated in 4.0. Use [Toolbar]($appui-react) instead.
  */
 export function Toolbar(props: ToolbarProps) { // eslint-disable-line deprecation/deprecation
   const expandsTo = props.expandsTo ? props.expandsTo : Direction.Bottom;

--- a/ui/components-react/src/components-react/toolbar/Toolbar.tsx
+++ b/ui/components-react/src/components-react/toolbar/Toolbar.tsx
@@ -51,7 +51,7 @@ function getItemWrapperClass(child: React.ReactNode) {
  * @deprecated in 4.0. Use [Toolbar]($appui-react) instead.
  * @public
  */
-export function Toolbar(props: ToolbarProps) {
+export function Toolbar(props: ToolbarProps) { // eslint-disable-line deprecation/deprecation
   const expandsTo = props.expandsTo ? props.expandsTo : Direction.Bottom;
   const useDragInteraction = !!props.useDragInteraction;
   const panelAlignment = props.panelAlignment ? props.panelAlignment : ToolbarPanelAlignment.Start;

--- a/ui/components-react/src/components-react/toolbar/Toolbar.tsx
+++ b/ui/components-react/src/components-react/toolbar/Toolbar.tsx
@@ -18,6 +18,7 @@ import { Direction, OrthogonalDirection, OrthogonalDirectionHelpers } from "./ut
 import { getToolbarDirection, ToolbarItemComponent, ToolbarItemContext, ToolbarOpacitySetting, ToolbarPanelAlignment, ToolbarWithOverflowDirectionContext } from "./ToolbarWithOverflow";
 
 /** Properties of [[Toolbar]] component.
+ * @deprecated in 4.0. Use [ToolbarProps]($appui-react) instead.
  * @public
  */
 export interface ToolbarProps extends CommonProps, NoChildrenProps {
@@ -46,7 +47,8 @@ function getItemWrapperClass(child: React.ReactNode) {
   return "";
 }
 
-/** Component that displays tool settings as a bar across the top of the content view.
+/** Component that displays toolbar items.
+ * @deprecated in 4.0. Use [Toolbar]($appui-react) instead.
  * @public
  */
 export function Toolbar(props: ToolbarProps) {

--- a/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
@@ -271,6 +271,7 @@ function getItemWrapperClass(child: React.ReactNode) {
 
 /** Properties of [[ToolbarWithOverflow]] component.
  * @public
+ * @deprecated in 4.0. Use [ToolbarWithOverflowProps]($appui-react) instead.
  */
 export interface ToolbarWithOverflowProps extends CommonProps, NoChildrenProps {
   /** Describes to which direction the popup panels are expanded. Defaults to: [[Direction.Bottom]] */
@@ -293,6 +294,7 @@ export interface ToolbarWithOverflowProps extends CommonProps, NoChildrenProps {
 
 /** Component that displays tool settings as a bar across the top of the content view.
  * @public
+ * @deprecated in 4.0. Use [ToolbarWithOverflow]($appui-react) instead.
  */
 export function ToolbarWithOverflow(props: ToolbarWithOverflowProps) {
   const expandsTo = props.expandsTo ? props.expandsTo : Direction.Bottom;

--- a/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
@@ -57,13 +57,13 @@ export function useToolbarPopupAutoHideContext() {
  * @public
  * @deprecated in 4.0. Use [ToolbarItem]($appui-react) instead.
  */
-export type ToolbarItem = ActionButton | GroupButton | CustomToolbarItem;
+export type ToolbarItem = ActionButton | GroupButton | CustomToolbarItem; // eslint-disable-line deprecation/deprecation
 
 /** CustomToolbarItem type guard.
  * @internal
  */
-export function isCustomToolbarItem(item: ToolbarItem): item is CustomToolbarItem {
-  return !!(item as CustomToolbarItem).isCustom && ("panelContentNode" in item);
+export function isCustomToolbarItem(item: ToolbarItem): item is CustomToolbarItem { // eslint-disable-line deprecation/deprecation
+  return !!(item as CustomToolbarItem).isCustom && ("panelContentNode" in item); // eslint-disable-line deprecation/deprecation
 }
 
 /** @internal */
@@ -149,7 +149,7 @@ export const ToolbarWithOverflowDirectionContext = React.createContext<ToolbarOv
 });
 
 /** @internal */
-function CustomItem({ item, addGroupSeparator }: { item: CustomToolbarItem, addGroupSeparator: boolean }) {
+function CustomItem({ item, addGroupSeparator }: { item: CustomToolbarItem, addGroupSeparator: boolean }) { // eslint-disable-line deprecation/deprecation
   const { useDragInteraction } = useToolbarWithOverflowDirectionContext();
   const icon = React.useMemo(() => (item.icon &&
     IconHelper.getIconReactNode(item.icon, item.internalData)) || /* istanbul ignore next */
@@ -236,7 +236,7 @@ function ActionItem({ item, addGroupSeparator }: { item: ActionButton, addGroupS
 }
 
 /** @internal */
-export function ToolbarItemComponent({ item, addGroupSeparator }: { item: ToolbarItem, addGroupSeparator: boolean }) {
+export function ToolbarItemComponent({ item, addGroupSeparator }: { item: ToolbarItem, addGroupSeparator: boolean }) { // eslint-disable-line deprecation/deprecation
   if (ToolbarItemUtilities.isGroupButton(item)) {
     return <GroupPopupItem item={item} addGroupSeparator={addGroupSeparator} />;
   } else if (isCustomToolbarItem(item)) {

--- a/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
@@ -28,6 +28,7 @@ import { SvgPlaceholder } from "@itwin/itwinui-icons-react";
 
 /** Describes the data needed to insert a custom `React` button into an ToolbarWithOverflow.
  * @public
+ * @deprecated in 4.0. Use [ToolbarCustomItem]($appui-react) instead.
  */
 export interface CustomToolbarItem extends CustomButtonDefinition {
   /** defines the content to display in popup panel */
@@ -54,6 +55,7 @@ export function useToolbarPopupAutoHideContext() {
 
 /** Describes toolbar item.
  * @public
+ * @deprecated in 4.0. Use [ToolbarItem]($appui-react) instead.
  */
 export type ToolbarItem = ActionButton | GroupButton | CustomToolbarItem;
 
@@ -70,7 +72,7 @@ export const getToolbarDirection = (expandsTo: Direction): OrthogonalDirection =
   return OrthogonalDirectionHelpers.inverse(orthogonalDirection);
 };
 
-/** Available alignment modes of [[ToolbarWithOverflow]] panels.
+/** Available alignment modes of [[Toolbar]] panels.
  * @public
  */
 export enum ToolbarPanelAlignment {

--- a/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
@@ -296,7 +296,7 @@ export interface ToolbarWithOverflowProps extends CommonProps, NoChildrenProps {
  * @public
  * @deprecated in 4.0. Use [ToolbarWithOverflow]($appui-react) instead.
  */
-export function ToolbarWithOverflow(props: ToolbarWithOverflowProps) {
+export function ToolbarWithOverflow(props: ToolbarWithOverflowProps) { // eslint-disable-line deprecation/deprecation
   const expandsTo = props.expandsTo ? props.expandsTo : Direction.Bottom;
   const useDragInteraction = !!props.useDragInteraction;
   const panelAlignment = props.panelAlignment ? props.panelAlignment : ToolbarPanelAlignment.Start;

--- a/ui/components-react/src/test/toolbar/Toolbar.test.tsx
+++ b/ui/components-react/src/test/toolbar/Toolbar.test.tsx
@@ -15,6 +15,7 @@ import { Direction } from "../../components-react/toolbar/utilities/Direction";
 import { BackArrow } from "../../components-react/toolbar/groupPanel/BackArrow";
 import { GroupTool } from "../../components-react/toolbar/groupPanel/tool/Tool";
 
+/* eslint-disable deprecation/deprecation */
 // cSpell:ignore testid
 
 function createBubbledEvent(type: string, props = {}) {

--- a/ui/components-react/src/test/toolbar/ToolbarWithOverflow.test.tsx
+++ b/ui/components-react/src/test/toolbar/ToolbarWithOverflow.test.tsx
@@ -12,6 +12,7 @@ import { CustomToolbarItem, ToolbarOpacitySetting, ToolbarPanelAlignment, Toolba
 import { Direction } from "../../components-react/toolbar/utilities/Direction";
 import TestUtils from "../TestUtils";
 
+/* eslint-disable deprecation/deprecation */
 // cSpell:ignore testid
 
 function createBubbledEvent(type: string, props = {}) {
@@ -165,8 +166,8 @@ describe("<ToolbarWithOverflow />", () => {
       renderedComponent.rerender(<ToolbarPopupAutoHideContext.Provider value={isHidden}><ToolbarWithOverflow items={toolbarItems} /></ToolbarPopupAutoHideContext.Provider>);
       // renderedComponent.debug();
       const overflowPopup = renderedComponent.getByTestId("core-popup");
-      expect (overflowPopup).not.to.be.null;
-      expect (overflowPopup.className).to.contain("nz-hidden");
+      expect(overflowPopup).not.to.be.null;
+      expect(overflowPopup.className).to.contain("nz-hidden");
     });
 
     it("will render with 3 items + overflow containing group", () => {
@@ -446,8 +447,8 @@ describe("<ToolbarWithOverflow />", () => {
       isHidden = true;
       renderedComponent.rerender(<ToolbarPopupAutoHideContext.Provider value={isHidden}><ToolbarWithOverflow items={toolbarItems} /></ToolbarPopupAutoHideContext.Provider>);
       const corePopup = renderedComponent.getByTestId("core-popup");
-      expect (corePopup).not.to.be.null;
-      expect (corePopup.className).to.contain("nz-hidden");
+      expect(corePopup).not.to.be.null;
+      expect(corePopup.className).to.contain("nz-hidden");
     });
 
     it("should open panel when popup item clicked", () => {


### PR DESCRIPTION
This PR moves `Toolbar` components from **@itwin/components-react** to **@itwin/appui-react**. Moved components are deprecated in the `@itwin/components-react` package. Codemod is also provided to facilitate the change.