### PR TITLE
Fix selection scope field

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3951,7 +3951,7 @@ export enum SelectionScope {
 }
 
 // @public
-export const SelectionScopeField: ConnectedComponent<typeof SelectionScopeFieldComponent, Omit_3<SelectionScopeFieldProps, "activeSelectionScope" | "availableSelectionScopes">>;
+export const SelectionScopeField: ConnectedComponent<typeof SelectionScopeFieldComponent, Omit_3<SelectionScopeFieldProps, "availableSelectionScopes" | "activeSelectionScope">>;
 
 // @public
 export interface SessionState {

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3951,7 +3951,7 @@ export enum SelectionScope {
 }
 
 // @public
-export const SelectionScopeField: ConnectedComponent<typeof SelectionScopeFieldComponent, Omit_3<React_2.ClassAttributes<SelectionScopeFieldComponent> & SelectionScopeFieldProps, "availableSelectionScopes" | "activeSelectionScope">>;
+export const SelectionScopeField: ConnectedComponent<typeof SelectionScopeFieldComponent, Omit_3<SelectionScopeFieldProps, "activeSelectionScope" | "availableSelectionScopes">>;
 
 // @public
 export interface SessionState {

--- a/common/changes/@itwin/appui-react/fix-selection-scope-field_2023-04-11-07-43.json
+++ b/common/changes/@itwin/appui-react/fix-selection-scope-field_2023-04-11-07-43.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix stale options of SelectionScopeField.",
+      "type": "none"
+    },
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Remove selection scope fallback labels.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -12,6 +12,7 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Component changes](#component-changes)
   - [Static manager classes](#static-manager-classes)
+  - [SelectionScopeField](#selectionscopefield)
 - [@itwin/core-react](#itwincore-react)
   - [SCSS variables](#scss-variables)
 - [@itwin/components-react](#itwincomponents-react)
@@ -321,6 +322,11 @@ Below is a list of the changes from this move, some of these new access point ma
 | UiFramework.childWindowManager.closeAllChildWindows | UiFramework.childWindows.closeAll                   |
 | UiFramework.childWindowManager.closeChildWindow     | UiFramework.childWindows.close                      |
 | UiFramework.backstageManager                        | UiFramework.backstage                               |
+
+### SelectionScopeField
+
+`SelectionScopeField` is fixed to correctly update options of a `Select` component after store changes.
+Fallback selection scope labels are removed and no longer applied.
 
 ## @itwin/core-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -12,7 +12,6 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Component changes](#component-changes)
   - [Static manager classes](#static-manager-classes)
-  - [SelectionScopeField](#selectionscopefield)
 - [@itwin/core-react](#itwincore-react)
   - [SCSS variables](#scss-variables)
 - [@itwin/components-react](#itwincomponents-react)
@@ -257,6 +256,11 @@ UI item provider types no longer extend from `ProviderItem`.
 - `show` method will now open the widget if it is hidden as the documentation mention.
 - `expand` method will also now open the widget, and will correctly expand the widget section to take most of the space in the panel.
 
+`SelectionScopeField`:
+
+- Fixed to correctly update options of a `Select` component after store changes.
+- Fallback selection scope labels are removed and no longer applied.
+
 ### Static manager classes
 
 In an effort to reduce usage complexity and discoverability of this package, many `*Manager` classes are now exposed through the `UiFramework` entry point. The direct classes access is being deprecated.
@@ -322,11 +326,6 @@ Below is a list of the changes from this move, some of these new access point ma
 | UiFramework.childWindowManager.closeAllChildWindows | UiFramework.childWindows.closeAll                   |
 | UiFramework.childWindowManager.closeChildWindow     | UiFramework.childWindows.close                      |
 | UiFramework.backstageManager                        | UiFramework.backstage                               |
-
-### SelectionScopeField
-
-`SelectionScopeField` is fixed to correctly update options of a `Select` component after store changes.
-Fallback selection scope labels are removed and no longer applied.
 
 ## @itwin/core-react
 

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -13,7 +13,7 @@ import { getClassName } from "@itwin/appui-abstract";
 import {
   ActionsUnion, AppNotificationManager, AppUiSettings, BackstageComposer, ConfigurableUiContent, createAction, DeepReadonly, FrameworkAccuDraw, FrameworkReducer,
   FrameworkRootState, FrameworkToolAdmin, FrameworkUiAdmin, FrontstageDeactivatedEventArgs, IModelViewportControl, InitialAppUiSettings,
-  ModalFrontstageClosedEventArgs, SafeAreaContext, SafeAreaInsets, StateManager, SyncUiEventDispatcher, SYSTEM_PREFERRED_COLOR_THEME, ThemeManager,
+  ModalFrontstageClosedEventArgs, PresentationSelectionScope, SafeAreaContext, SafeAreaInsets, SessionStateActionId, StateManager, SyncUiEventDispatcher, SYSTEM_PREFERRED_COLOR_THEME, ThemeManager,
   ToolbarDragInteractionContext, UiFramework, UiItemsManager, UiStateStorageHandler,
 } from "@itwin/appui-react";
 import { assert, Id64String, Logger, LogLevel, ProcessDetector, UnexpectedErrors } from "@itwin/core-bentley";
@@ -193,6 +193,13 @@ export class SampleAppIModelApp {
     // default to showing imperial formatted units
     await IModelApp.quantityFormatter.setActiveUnitSystem("imperial");
     await IModelApp.quantityFormatter.setUnitFormattingSettingsProvider(new LocalUnitFormatProvider(IModelApp.quantityFormatter, true)); // pass true to save per imodel
+
+    const availableScopes: PresentationSelectionScope[] = [
+      { id: "element", label: "Element" },
+      { id: "assembly", label: "Assembly" },
+      { id: "top-assembly", label: "Top Assembly" },
+    ];
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetAvailableSelectionScopes, availableScopes);
 
     await FrontendDevTools.initialize();
     await HyperModeling.initialize();

--- a/tools/internal/scripts/rush/audit.js
+++ b/tools/internal/scripts/rush/audit.js
@@ -45,6 +45,7 @@ const rushCommonDir = path.join(__dirname, "../../../../common/");
     "GHSA-hhq3-ff78-jv3g", // https://github.com/advisories/GHSA-hhq3-ff78-jv3g appui-test-app>@bentley/react-scripts>react-dev-utils>loader-utils
     "GHSA-9c47-m6qq-7p4h", // https://github.com/advisories/GHSA-9c47-m6qq-7p4h appui-test-app>@bentley/react-scripts>@babel/core>json5 appui-test-providers>@itwin/eslint-plugin>eslint-import-resolver-typescript>tsconfig-paths>json5
     "GHSA-rc47-6667-2j5j", // https://github.com/advisories/GHSA-rc47-6667-2j5j appui-test-app>electron>@electron/get>got>cacheable-request>http-cache-semantics
+    "GHSA-776f-qx25-q3cc", // https://github.com/advisories/GHSA-776f-qx25-q3cc appui-test-app>@itwin/core-frontend>@itwin/object-storage-azure>@azure/storage-blob>@azure/core-http>xml2js
   ];
 
   let shouldFailBuild = false;

--- a/ui/appui-react/public/locales/en/UiFramework.json
+++ b/ui/appui-react/public/locales/en/UiFramework.json
@@ -62,11 +62,6 @@
     "label": "Scope",
     "toolTip": "Selection Scope"
   },
-  "selectionScopeLabels": {
-    "element": "Element",
-    "assembly": "Assembly",
-    "top-assembly": "Top Assembly"
-  },
   "tests": {
     "singleContent": "Single Content",
     "label": "Test Label",

--- a/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
@@ -11,7 +11,7 @@ import classnames from "classnames";
 import * as React from "react";
 import { connect } from "react-redux";
 import { FooterIndicator } from "@itwin/appui-layout-react";
-import { Select, SelectOption } from "@itwin/itwinui-react";
+import { Select } from "@itwin/itwinui-react";
 import { PresentationSelectionScope } from "../redux/SessionState";
 import { UiFramework } from "../UiFramework";
 import { CommonProps } from "@itwin/core-react";
@@ -20,7 +20,6 @@ import { CommonProps } from "@itwin/core-react";
  * @public
  */
 interface SelectionScopeFieldProps extends CommonProps {
-
   activeSelectionScope: string;
   availableSelectionScopes: PresentationSelectionScope[];
 }
@@ -33,47 +32,39 @@ interface SelectionScopeFieldProps extends CommonProps {
  * in the Redux state.
  * @public
  */
-class SelectionScopeFieldComponent extends React.Component<SelectionScopeFieldProps> {
-  private _label = UiFramework.translate("selectionScopeField.label");
-  private _toolTip = UiFramework.translate("selectionScopeField.toolTip");
-  private _scopeOptions: SelectOption<string>[] = [];
+function SelectionScopeFieldComponent(props: SelectionScopeFieldProps) {
+  const [label] = React.useState(UiFramework.translate("selectionScopeField.label"));
+  const [toolTip] = React.useState(UiFramework.translate("selectionScopeField.toolTip"));
 
-  constructor(props: SelectionScopeFieldProps) {
-    super(props);
-    this._scopeOptions = this.props.availableSelectionScopes.map((scope: PresentationSelectionScope) => {
-      const label = !!scope.label ? scope.label : UiFramework.translate(`selectionScopeLabels.${scope.id}`);
-      return { value: scope.id, label };
-    });
-  }
+  const options = React.useMemo(() => props.availableSelectionScopes.map((scope) => {
+    return { value: scope.id, label: scope.label };
+  }), [props.availableSelectionScopes]);
 
-  private _updateSelectValue = (newValue: string) => {
+  const updateSelectValue = (newValue: string) => {
     // istanbul ignore else
     if (newValue) {
       UiFramework.setActiveSelectionScope(newValue);
     }
   };
 
-  public override render(): React.ReactNode {
-
-    return (
-      <FooterIndicator
-        className={classnames("uifw-statusFields-selectionScope", this.props.className)}
-        style={this.props.style}
-      >
-        <label className="uifw-statusFields-selectionScope-label">
-          {this._label}:
-        </label>
-        <Select
-          className="uifw-statusFields-selectionScope-selector"
-          value={this.props.activeSelectionScope}
-          options={this._scopeOptions}
-          onChange={this._updateSelectValue}
-          data-testid="components-selectionScope-selector"
-          title={this._toolTip}
-          size="small" />
-      </FooterIndicator >
-    );
-  }
+  return (
+    <FooterIndicator
+      className={classnames("uifw-statusFields-selectionScope", props.className)}
+      style={props.style}
+    >
+      <label className="uifw-statusFields-selectionScope-label">
+        {label}:
+      </label>
+      <Select
+        className="uifw-statusFields-selectionScope-selector"
+        value={props.activeSelectionScope}
+        options={options}
+        onChange={updateSelectValue}
+        data-testid="components-selectionScope-selector"
+        title={toolTip}
+        size="small" />
+    </FooterIndicator >
+  );
 }
 
 /** Function used by Redux to map state data in Redux store to props that are used to render this component. */

--- a/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
@@ -33,8 +33,8 @@ interface SelectionScopeFieldProps extends CommonProps {
  * @public
  */
 function SelectionScopeFieldComponent(props: SelectionScopeFieldProps) {
-  const [label] = React.useState(UiFramework.translate("selectionScopeField.label"));
-  const [toolTip] = React.useState(UiFramework.translate("selectionScopeField.toolTip"));
+  const label = React.useRef(UiFramework.translate("selectionScopeField.label"));
+  const toolTip = React.useRef(UiFramework.translate("selectionScopeField.toolTip"));
 
   const options = React.useMemo(() => props.availableSelectionScopes.map((scope) => {
     return { value: scope.id, label: scope.label };
@@ -53,7 +53,7 @@ function SelectionScopeFieldComponent(props: SelectionScopeFieldProps) {
       style={props.style}
     >
       <label className="uifw-statusFields-selectionScope-label">
-        {label}:
+        {label.current}:
       </label>
       <Select
         className="uifw-statusFields-selectionScope-selector"
@@ -61,7 +61,7 @@ function SelectionScopeFieldComponent(props: SelectionScopeFieldProps) {
         options={options}
         onChange={updateSelectValue}
         data-testid="components-selectionScope-selector"
-        title={toolTip}
+        title={toolTip.current}
         size="small" />
     </FooterIndicator >
   );

--- a/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
@@ -33,8 +33,8 @@ interface SelectionScopeFieldProps extends CommonProps {
  * @public
  */
 function SelectionScopeFieldComponent(props: SelectionScopeFieldProps) {
-  const label = React.useRef(UiFramework.translate("selectionScopeField.label"));
-  const toolTip = React.useRef(UiFramework.translate("selectionScopeField.toolTip"));
+  const label = UiFramework.translate("selectionScopeField.label");
+  const toolTip = UiFramework.translate("selectionScopeField.toolTip");
 
   const options = React.useMemo(() => props.availableSelectionScopes.map((scope) => {
     return { value: scope.id, label: scope.label };
@@ -53,7 +53,7 @@ function SelectionScopeFieldComponent(props: SelectionScopeFieldProps) {
       style={props.style}
     >
       <label className="uifw-statusFields-selectionScope-label">
-        {label.current}:
+        {label}:
       </label>
       <Select
         className="uifw-statusFields-selectionScope-selector"
@@ -61,7 +61,7 @@ function SelectionScopeFieldComponent(props: SelectionScopeFieldProps) {
         options={options}
         onChange={updateSelectValue}
         data-testid="components-selectionScope-selector"
-        title={toolTip.current}
+        title={toolTip}
         size="small" />
     </FooterIndicator >
   );

--- a/ui/appui-react/src/test/statusfields/SelectionScope.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SelectionScope.test.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { Provider } from "react-redux";
 import { IModelApp, MockRender } from "@itwin/core-frontend";
 import { render } from "@testing-library/react";
-import { PresentationSelectionScope, SelectionScopeField, SessionStateActionId, StatusBar, UiFramework } from "../../appui-react";
+import { SelectionScopeField, SessionStateActionId, StatusBar, UiFramework } from "../../appui-react";
 import TestUtils, { handleError, selectChangeValueByIndex, stubScrollIntoView } from "../TestUtils";
 
 describe(`SelectionScopeField`, () => {
@@ -34,9 +34,9 @@ describe(`SelectionScopeField`, () => {
 
     it("SelectionScopeField with multiple scopes", async () => {
       UiFramework.dispatchActionToStore(SessionStateActionId.SetAvailableSelectionScopes, [
-        { id: "element", label: "Element" } as PresentationSelectionScope,
-        { id: "assembly", label: "Assembly" } as PresentationSelectionScope,
-        { id: "top-assembly", label: "Top Assembly" } as PresentationSelectionScope,
+        { id: "element", label: "Element" },
+        { id: "assembly", label: "Assembly" },
+        { id: "top-assembly", label: "Top Assembly" },
       ]);
 
       UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "top-assembly");
@@ -75,9 +75,9 @@ describe(`SelectionScopeField`, () => {
 
     it("SelectionScopeField with specific scopes", async () => {
       UiFramework.dispatchActionToStore(SessionStateActionId.SetAvailableSelectionScopes, [
-        { id: "element", label: "Element" } as PresentationSelectionScope,
-        { id: "assembly", label: "Assembly" } as PresentationSelectionScope,
-        { id: "top-assembly", label: "Top Assembly" } as PresentationSelectionScope,
+        { id: "element", label: "Element" },
+        { id: "assembly", label: "Assembly" },
+        { id: "top-assembly", label: "Top Assembly" },
       ]);
 
       UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "top-assembly");
@@ -95,34 +95,11 @@ describe(`SelectionScopeField`, () => {
       // expect(selectElement.selectedIndex).to.be.equal(1);
     });
 
-    it("SelectionScopeField should properly handle empty override scope labels", async () => {
-      UiFramework.dispatchActionToStore(SessionStateActionId.SetAvailableSelectionScopes, [
-        { id: "element", label: "" } as PresentationSelectionScope,
-        { id: "assembly", label: "" } as PresentationSelectionScope,
-        { id: "top-assembly", label: "" } as PresentationSelectionScope,
-      ]);
-
-      UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "top-assembly");
-
-      const component = render(<Provider store={TestUtils.store}>
-        <StatusBar><SelectionScopeField /></StatusBar>
-      </Provider>);
-      expect(component).not.to.be.undefined;
-      const selectElement = component.getByTestId("components-selectionScope-selector") as HTMLSelectElement;
-      expect(selectElement).not.to.be.null;
-      expect(UiFramework.getActiveSelectionScope()).to.be.equal("top-assembly");
-      component.getByText("selectionScopeLabels.top-assembly");
-      UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "assembly");
-      await component.findByText("selectionScopeLabels.assembly");
-      UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "element");
-      await component.findByText("selectionScopeLabels.element");
-    });
-
     it("SelectionScopeField should properly handle override scope labels", async () => {
       UiFramework.dispatchActionToStore(SessionStateActionId.SetAvailableSelectionScopes, [
-        { id: "element", label: "Functional Element" } as PresentationSelectionScope,
-        { id: "assembly", label: "Functional Assembly" } as PresentationSelectionScope,
-        { id: "top-assembly", label: "Functional TopAssembly" } as PresentationSelectionScope,
+        { id: "element", label: "Functional Element" },
+        { id: "assembly", label: "Functional Assembly" },
+        { id: "top-assembly", label: "Functional TopAssembly" },
       ]);
 
       UiFramework.dispatchActionToStore(SessionStateActionId.SetSelectionScope, "top-assembly");


### PR DESCRIPTION
This PR converts `SelectionScopeField` to a function component and fixes an issue with stale options of a `Select`.
Fallback labels defined in `selectionScopeLabels` are removed, since labels are provided by `presentation` layer.