### PR TITLE
Emit syncEvent on snap mode change

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4340,7 +4340,7 @@ export class SheetsModalFrontstage implements ModalFrontstageInfo {
 export function showWidget(state: NineZoneState, id: TabState["id"]): NineZoneState;
 
 // @public
-export const SnapModeField: ConnectedComponent<typeof SnapModeFieldComponent, Omit_3<React_2.ClassAttributes<SnapModeFieldComponent> & SnapModeFieldProps, "setSnapMode" | "snapMode">>;
+export const SnapModeField: ConnectedComponent<typeof SnapModeFieldComponent, Omit_3<SnapModeFieldProps, "snapMode">>;
 
 // @alpha
 export class SolarTimelineDataProvider extends BaseSolarDataProvider {

--- a/common/changes/@itwin/appui-react/raplemie-snapModeDispatchSyncEvent_2023-04-11-19-42.json
+++ b/common/changes/@itwin/appui-react/raplemie-snapModeDispatchSyncEvent_2023-04-11-19-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "SnapModeField now emit syncEvent",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}


### PR DESCRIPTION
To follow `SelectionScopeField` and allow tracking, `SnapModeField` now emits a `SyncEvent` (which already existed)