### PR TITLE
Make property grid column resizer more movable

### DIFF
--- a/common/changes/@itwin/components-react/Make_property_grid_column_resizer_more-movable_2023-04-14-12-43.json
+++ b/common/changes/@itwin/components-react/Make_property_grid_column_resizer_more-movable_2023-04-14-12-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Make column resizer more movable in property grid",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/Make_property_grid_column_resizer_more-movable_2023-04-14-12-43.json
+++ b/common/changes/@itwin/core-react/Make_property_grid_column_resizer_more-movable_2023-04-14-12-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "change core-element-separator z-index from 1 to 2",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/ui/components-react/src/components-react/properties/renderers/ActionButtonList.scss
+++ b/ui/components-react/src/components-react/properties/renderers/ActionButtonList.scss
@@ -22,4 +22,5 @@
 
 .components-action-button-container {
   margin: 0 5px 0 5px;
+  z-index: 1;
 }

--- a/ui/components-react/src/components-react/propertygrid/component/ColumnResizingPropertyListPropsSupplier.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/ColumnResizingPropertyListPropsSupplier.tsx
@@ -38,8 +38,8 @@ export interface ColumnResizingPropertyListPropsSupplierState {
  */
 export class ColumnResizingPropertyListPropsSupplier extends React.Component<ColumnResizingPropertyListPropsSupplierProps, ColumnResizingPropertyListPropsSupplierState> {
   private readonly _initialRatio = 0.25;
-  private readonly _defaultMinRatio = 0.15;
-  private readonly _defaultMaxRatio = 0.6;
+  private readonly _defaultMinRatio = 0.01;
+  private readonly _defaultMaxRatio = 0.99;
   private _minRatio = this._defaultMinRatio;
   private _maxRatio = this._defaultMaxRatio;
 
@@ -50,9 +50,9 @@ export class ColumnResizingPropertyListPropsSupplier extends React.Component<Col
   };
 
   public static defaultProps: Partial<ColumnResizingPropertyListPropsSupplierProps> = {
-    minLabelWidth: 100,
-    minValueWidth: 100,
-    actionButtonWidth: 90,
+    minLabelWidth: 10,
+    minValueWidth: 10,
+    actionButtonWidth: 0,
   };
 
   private _onColumnRatioChanged = (ratio: number): RatioChangeResult => {

--- a/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
+++ b/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
@@ -55,7 +55,7 @@
   border-style: none;
   padding: 0px;
   opacity: 0;
-  z-index: 1;
+  z-index: 2;
 
   &--vertical {
     width: 100%;


### PR DESCRIPTION
fixes iTwin/presentation#116