### PR TITLE
Cleanup unused localized strings

### DIFF
--- a/common/changes/@itwin/appui-react/cleanup_localized_strings_2023-04-20-15-54.json
+++ b/common/changes/@itwin/appui-react/cleanup_localized_strings_2023-04-20-15-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Removed unused localization strings",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/public/locales/en/UiFramework.json
+++ b/ui/appui-react/public/locales/en/UiFramework.json
@@ -251,51 +251,6 @@
     "shadows": "Shadows",
     "backgroundMap": "Background Map"
   },
-  "visibilityWidget": {
-    "modeltree": "Model Tree",
-    "categories": "Categories",
-    "containment": "Spatial Containment",
-    "options": "Options",
-    "visibilityTree": "Visibility Tree",
-    "noImodelConnection": "No data to display since there is no available iModel Connection."
-  },
-  "modelTree": {
-    "status": {
-      "visible": "Visible",
-      "hidden": "Hidden",
-      "disabled": "Disabled"
-    },
-    "tooltips": {
-      "subject": {
-        "nonSpatialView": "Active view is not spatial",
-        "atLeastOneModelVisible": "At least one model is visible",
-        "allModelsHidden": "All models are hidden"
-      },
-      "model": {
-        "nonSpatialView": "Active view is not spatial"
-      },
-      "category": {
-        "modelNotDisplayed": "Can't control category display if model is not displayed",
-        "displayedThroughPerModelOverride": "Per-model category override set to 'Show'",
-        "hiddenThroughPerModelOverride": "Per-model category override set to 'Hide'",
-        "displayedThroughCategorySelector": "Category display enabled through category selector",
-        "hiddenThroughCategorySelector": "Category display disabled through category selector"
-      },
-      "element": {
-        "modelNotDisplayed": "Can't control element display if model is not displayed",
-        "hiddenThroughNeverDrawnList": "Element(s) in \"never drawn\" list",
-        "displayedThroughAlwaysDrawnList": "Element(s) in \"always drawn\" list",
-        "hiddenDueToOtherElementsExclusivelyAlwaysDrawn": "Other elements in \"exclusively always drawn\" list",
-        "hiddenThroughCategory": "Category not displayed"
-      }
-    },
-    "noModelFound": "No model found.",
-    "noMatchingModelNames": "There are no model names matching your search."
-  },
-  "categoriesTree": {
-    "noCategoryFound": "No category found.",
-    "noMatchingCategoryNames": "There are no category names matching your search."
-  },
   "toolAssistance": {
     "title": "Tool Assistance",
     "promptAtCursor": "Show prompt at cursor",


### PR DESCRIPTION
Remove unused visibility widget localized strings. They were moved to [tree-widget-react](https://github.com/iTwin/viewer-components-react/blob/master/packages/itwin/tree-widget/public/locales/en/TreeWidget.json) package.