### PR TITLE
Cleanup changelog entries for 4.0 release

### DIFF
--- a/common/changes/@itwin/appui-layout-react/auto-hide-fixes_2022-10-05-10-29.json
+++ b/common/changes/@itwin/appui-layout-react/auto-hide-fixes_2022-10-05-10-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Expose onMouseEnter and onMouseLeave events for a FloatingWidget.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/close-widget-overflow_2022-10-14-10-17.json
+++ b/common/changes/@itwin/appui-layout-react/close-widget-overflow_2022-10-14-10-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Close widget overflow popup when panel is collapsed.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/fix-widget-resize_2022-12-20-10-06.json
+++ b/common/changes/@itwin/appui-layout-react/fix-widget-resize_2022-12-20-10-06.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Fix a floating widget resize issue.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/greta-jon-variable-replace_2023-01-10-14-27.json
+++ b/common/changes/@itwin/appui-layout-react/greta-jon-variable-replace_2023-01-10-14-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Using iTwinUI-variables",
+      "comment": "Using iTwinUI-variables.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-3.4.0_2022-10-18-18-32.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-3.4.0_2022-10-18-18-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Move to iTwinJs 3.4.0 packages",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-4-removeStatusBarHOC_2022-09-15-16-48.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-4-removeStatusBarHOC_2022-09-15-16-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Remove isInFooterMode prop from some components",
+      "comment": "Remove isInFooterMode prop from some components.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-React18Typings_2022-10-05-21-03.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-React18Typings_2022-10-05-21-03.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Update typings for React18",
+      "comment": "Update typings for React18.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-cleanDependencies_2023-03-01-16-39.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-cleanDependencies_2023-03-01-16-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Clean dependencies",
+      "comment": "Clean dependencies.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-enzyme-appui-layout_2022-11-14-21-37.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-enzyme-appui-layout_2022-11-14-21-37.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Remove enzyme tests",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-gripOverflowScrollbars_2023-03-23-20-27.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-gripOverflowScrollbars_2023-03-23-20-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Clear scrollbars with panel grips",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-min362_2023-03-17-19-34.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-min362_2023-03-17-19-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Bump minimum of core to 3.6.2",
+      "comment": "Bump minimum of core packages to 3.7.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-panelHandlePriority_2022-10-06-16-15.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-panelHandlePriority_2022-10-06-16-15.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Bring panel handle on top of panel splitter",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-prepareCoreReactTestTo18_2022-10-12-20-10.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-prepareCoreReactTestTo18_2022-10-12-20-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Prepare tests for react18",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-react18-package.json_2023-02-27-22-29.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-react18-package.json_2023-02-27-22-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "peerDependency allow react: ^18.0.0",
+      "comment": "peerDependency allow react: ^18.0.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "iTwin.js 3.5.1",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/remove-stage-panels_2022-10-06-09-34.json
+++ b/common/changes/@itwin/appui-layout-react/remove-stage-panels_2022-10-06-09-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Remove StagePanel components.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/remove-widgets_2022-10-10-10-11.json
+++ b/common/changes/@itwin/appui-layout-react/remove-widgets_2022-10-10-10-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Remove UI1.0 Widget components.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/remove-zones_2022-10-05-16-35.json
+++ b/common/changes/@itwin/appui-layout-react/remove-zones_2022-10-05-16-35.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Remove Zone components.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/sendback-outline_2023-02-23-08-12.json
+++ b/common/changes/@itwin/appui-layout-react/sendback-outline_2023-02-23-08-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Added functionality to floating widget send back button to display an outline of it's home send back",
+      "comment": "Added functionality to floating widget send back button to display an outline of it's home send back.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/ui-toolbar-opacity_2022-11-18-19-29.json
+++ b/common/changes/@itwin/appui-layout-react/ui-toolbar-opacity_2022-11-18-19-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Use --buic-toolbar-opacity to set the opacity of toolbar items.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/ui-widget-docking-restrictions_2022-09-20-22-24.json
+++ b/common/changes/@itwin/appui-layout-react/ui-widget-docking-restrictions_2022-09-20-22-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Update TabState to honor allowedPanelTargets when creating new widgets.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/update-package-files_2023-03-30-16-17.json
+++ b/common/changes/@itwin/appui-layout-react/update-package-files_2023-03-30-16-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Update package.json dependecies and repo documentation.",
+      "comment": "Update package.json dependencies and repo documentation.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-layout-react/widget-offset-portal_2022-12-01-17-10.json
+++ b/common/changes/@itwin/appui-layout-react/widget-offset-portal_2022-12-01-17-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-layout-react",
-      "comment": "Fix floating widget offset issue.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/abstract-refactor_2023-01-13-08-53.json
+++ b/common/changes/@itwin/appui-react/abstract-refactor_2023-01-13-08-53.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Expose AppUI specific types previously defined in @itwin/appui-abstract.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/api-promotions_2023-04-03-22-28.json
+++ b/common/changes/@itwin/appui-react/api-promotions_2023-04-03-22-28.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Promote APIs in use by apps",
+      "comment": "Promote APIs in use by apps.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/auto-hide-fixes_2022-10-05-10-29.json
+++ b/common/changes/@itwin/appui-react/auto-hide-fixes_2022-10-05-10-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Do not auto-hide the UI when floating widget is hovered.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/cleanup_localized_strings_2023-04-20-15-54.json
+++ b/common/changes/@itwin/appui-react/cleanup_localized_strings_2023-04-20-15-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Removed unused localization strings",
+      "comment": "Removed unused localization strings.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/feat-feature-overrides-uievent_2023-04-04-15-00.json
+++ b/common/changes/@itwin/appui-react/feat-feature-overrides-uievent_2023-04-04-15-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "add FeatureOverridesChanged SyncUIEvent to SyncUIEventDispatcher",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/floating-view-fix_2023-03-02-16-59.json
+++ b/common/changes/@itwin/appui-react/floating-view-fix_2023-03-02-16-59.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "ADd ContentViewManager tracking info back into FloatingViewportContent.",
+      "comment": "Add ContentViewManager tracking info back into FloatingViewportContent.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/greta-jon-variable-replace_2023-01-10-14-27.json
+++ b/common/changes/@itwin/appui-react/greta-jon-variable-replace_2023-01-10-14-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Using iTwinUI-variables",
+      "comment": "Using iTwinUI-variables.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/greta-use-itwinv2_2023-02-28-11-49.json
+++ b/common/changes/@itwin/appui-react/greta-use-itwinv2_2023-02-28-11-49.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Update iTwinUI-react to v2.x",
+      "comment": "Update iTwinUI-react to v2.x.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/kayla-viewSelectorSearch_2023-03-29-14-13.json
+++ b/common/changes/@itwin/appui-react/kayla-viewSelectorSearch_2023-03-29-14-13.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Fixed ViewSelector rendering bug",
+      "comment": "Fixed ViewSelector rendering bug.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/list-sizing_2022-10-19-16-04.json
+++ b/common/changes/@itwin/appui-react/list-sizing_2022-10-19-16-04.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Add automatic horizonal scrolling to the ListPicker's expandable blocks for small form factors or long strings.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-3.4.0_2022-10-18-18-32.json
+++ b/common/changes/@itwin/appui-react/raplemie-3.4.0_2022-10-18-18-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Move to iTwinJs 3.4.0 packages",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-4-removeStatusBarHOC_2022-09-15-16-48.json
+++ b/common/changes/@itwin/appui-react/raplemie-4-removeStatusBarHOC_2022-09-15-16-48.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Remove StatusBarContext related code",
+      "comment": "Remove StatusBarContext related code.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-React18-AppuiReact_2023-02-17-20-36.json
+++ b/common/changes/@itwin/appui-react/raplemie-React18-AppuiReact_2023-02-17-20-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Update tests to be ready for React18",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-React18Typings_2022-10-05-21-03.json
+++ b/common/changes/@itwin/appui-react/raplemie-React18Typings_2022-10-05-21-03.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Update typings for React18",
+      "comment": "Update typings for React18.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-UiFrameworkRefactor_2023-01-20-23-03.json
+++ b/common/changes/@itwin/appui-react/raplemie-UiFrameworkRefactor_2023-01-20-23-03.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Move `Manager` classes under `UiFramework`",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-appui-react-noenzyme_2022-09-13-21-05.json
+++ b/common/changes/@itwin/appui-react/raplemie-appui-react-noenzyme_2022-09-13-21-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Refactored many tests to remove enzyme and snaphot testing",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-cleanDependencies_2023-03-01-16-39.json
+++ b/common/changes/@itwin/appui-react/raplemie-cleanDependencies_2023-03-01-16-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Clean dependencies",
+      "comment": "Clean dependencies.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-core-react-batch_2022-12-19-19-54.json
+++ b/common/changes/@itwin/appui-react/raplemie-core-react-batch_2022-12-19-19-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Refactor to use iTwinUI instead of deprecated core-react",
+      "comment": "Refactor to use iTwinUI instead of deprecated core-react.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-deprecated-Table_2022-10-31-18-42.json
+++ b/common/changes/@itwin/appui-react/raplemie-deprecated-Table_2022-10-31-18-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Removed react-dnd dependency",
+      "comment": "Removed react-dnd dependency.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-deprecated-componentsFinal_2022-11-04-14-07.json
+++ b/common/changes/@itwin/appui-react/raplemie-deprecated-componentsFinal_2022-11-04-14-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "React to toolbar changes",
+      "comment": "React to toolbar changes.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-enzyme-appui-react_2022-11-24-21-55.json
+++ b/common/changes/@itwin/appui-react/raplemie-enzyme-appui-react_2022-11-24-21-55.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Removed Enzyme tests and related dependencies",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-min362_2023-03-17-19-34.json
+++ b/common/changes/@itwin/appui-react/raplemie-min362_2023-03-17-19-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Bump minimum of core to 3.6.2",
+      "comment": "Bump minimum of core packages to 3.7.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-prepareCoreReactTestTo18_2022-10-12-20-10.json
+++ b/common/changes/@itwin/appui-react/raplemie-prepareCoreReactTestTo18_2022-10-12-20-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Prepare tests for react18",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-react18-package.json_2023-02-27-22-29.json
+++ b/common/changes/@itwin/appui-react/raplemie-react18-package.json_2023-02-27-22-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "peerDependency allow react: ^18.0.0",
+      "comment": "peerDependency allow react: ^18.0.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-scssCleanup_2023-03-14-17-26.json
+++ b/common/changes/@itwin/appui-react/raplemie-scssCleanup_2023-03-14-17-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Clean SCSS",
+      "comment": "Clean SCSS.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-snapModeDispatchSyncEvent_2023-04-11-19-42.json
+++ b/common/changes/@itwin/appui-react/raplemie-snapModeDispatchSyncEvent_2023-04-11-19-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "SnapModeField now emit syncEvent",
+      "comment": "SnapModeField now emit syncEvent.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-supportCreateRoot_2023-02-15-20-36.json
+++ b/common/changes/@itwin/appui-react/raplemie-supportCreateRoot_2023-02-15-20-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Support React18 in child windows",
+      "comment": "Support React18 in child windows.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
+++ b/common/changes/@itwin/appui-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "iTwin.js 3.5.1",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/remove-3-7-deprecations_2023-04-19-22-44.json
+++ b/common/changes/@itwin/appui-react/remove-3-7-deprecations_2023-04-19-22-44.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Remove remaining 3.x deprecations.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/remove-core-deprecations_2022-10-26-19-20.json
+++ b/common/changes/@itwin/appui-react/remove-core-deprecations_2022-10-26-19-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Remove deprecated components with dependencies on deprecations in core-react",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/remove-widgets_2022-10-10-10-11.json
+++ b/common/changes/@itwin/appui-react/remove-widgets_2022-10-10-10-11.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Remove UI1.0 Widget components.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/restore-frontstages_2022-10-10-13-17.json
+++ b/common/changes/@itwin/appui-react/restore-frontstages_2022-10-10-13-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Add RestoreAllFrontstages tool.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/safe-area_2022-10-18-09-13.json
+++ b/common/changes/@itwin/appui-react/safe-area_2022-10-18-09-13.json
@@ -7,7 +7,7 @@
     },
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Remove deprecated Backstage components.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/ui-persist-toolbar-opacity_2022-11-23-16-25.json
+++ b/common/changes/@itwin/appui-react/ui-persist-toolbar-opacity_2022-11-23-16-25.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Persist the toolbar-opacity to state.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/ui-toolbar-opacity_2022-11-18-19-29.json
+++ b/common/changes/@itwin/appui-react/ui-toolbar-opacity_2022-11-18-19-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Add a toolbar opacity to the state and the UiFramework API to allow users or apps to configure it. Add a slider to the UiSettingsPage to control the toolbar opacity. ",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/ui-widget-docking-restrictions_2022-09-20-22-24.json
+++ b/common/changes/@itwin/appui-react/ui-widget-docking-restrictions_2022-09-20-22-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Update WidgetDef to pass the optional prop allowedPanelTargets to createTab wh",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/update-package-files_2023-03-30-16-16.json
+++ b/common/changes/@itwin/appui-react/update-package-files_2023-03-30-16-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Update package.json dependecies and repo documentation.",
+      "comment": "Update package.json dependencies and repo documentation.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/widget-offset-portal_2022-12-05-15-38.json
+++ b/common/changes/@itwin/appui-react/widget-offset-portal_2022-12-05-15-38.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Fix floating widget offset issue.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/Fix_property_record_value_overflow_2023-04-12-13-29.json
+++ b/common/changes/@itwin/components-react/Fix_property_record_value_overflow_2023-04-12-13-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Fix property value overflow",
+      "comment": "Fix property value overflow.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/fix_property_grid_expanders_2023-04-05-11-06.json
+++ b/common/changes/@itwin/components-react/fix_property_grid_expanders_2023-04-05-11-06.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "VirtualizedPropertyGrid: Fixed non-primitive property expander style",
+      "comment": "VirtualizedPropertyGrid: Fixed non-primitive property expander style.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/greta-jon-variable-replace_2023-01-10-14-27.json
+++ b/common/changes/@itwin/components-react/greta-jon-variable-replace_2023-01-10-14-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Using iTwinUI-variables",
+      "comment": "Using iTwinUI-variables.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/greta-use-itwinv2_2023-02-28-11-49.json
+++ b/common/changes/@itwin/components-react/greta-use-itwinv2_2023-02-28-11-49.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Update iTwinUI-react to v2.x",
+      "comment": "Update iTwinUI-react to v2.x.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/master_2022-11-10-17-49.json
+++ b/common/changes/@itwin/components-react/master_2022-11-10-17-49.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Remove Enzyme tests and packages",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/presentation-api_promotion_2023-01-24-15-18.json
+++ b/common/changes/@itwin/components-react/presentation-api_promotion_2023-01-24-15-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "API promotion",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/presentation-create_complex_instance_filters_2022-10-17-06-50.json
+++ b/common/changes/@itwin/components-react/presentation-create_complex_instance_filters_2022-10-17-06-50.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Enabled virtualization in FilterBuilder property selector",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/presentation-filtering_docs_2023-01-24-08-43.json
+++ b/common/changes/@itwin/components-react/presentation-filtering_docs_2023-01-24-08-43.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "API promotion",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/presentation-fix_operator_rendering_2023-01-25-13-56.json
+++ b/common/changes/@itwin/components-react/presentation-fix_operator_rendering_2023-01-25-13-56.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Fixed rule rendering in 'PropertyFilterBuilder' component to not render symbol '0' with 'IS TRUE' operator.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/presentation-refactor_class_info_loading_2022-11-18-13-39.json
+++ b/common/changes/@itwin/components-react/presentation-refactor_class_info_loading_2022-11-18-13-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Add ability to disable property selection in `PropertyFilterBuilder` component",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/presentation-tree_branches_filtering_2023-01-12-13-01.json
+++ b/common/changes/@itwin/components-react/presentation-tree_branches_filtering_2023-01-12-13-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "`PropertyFilterBuilder`: Do not show rule group operator if there are less than 2 rules",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/promote_tree_related_apis_2023-02-10-15-31.json
+++ b/common/changes/@itwin/components-react/promote_tree_related_apis_2023-02-10-15-31.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Promote 'ControlledTree' related APIs from 'internal' to 'public'",
+      "comment": "Promote 'ControlledTree' related APIs from 'internal' to 'public'.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-3.4.0_2022-10-18-18-32.json
+++ b/common/changes/@itwin/components-react/raplemie-3.4.0_2022-10-18-18-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Move to iTwinJs 3.4.0 packages",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-React18Typings_2022-10-05-21-03.json
+++ b/common/changes/@itwin/components-react/raplemie-React18Typings_2022-10-05-21-03.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Update typings for React18",
+      "comment": "Update typings for React18.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-cleanDependencies_2023-03-01-16-39.json
+++ b/common/changes/@itwin/components-react/raplemie-cleanDependencies_2023-03-01-16-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Clean dependencies",
+      "comment": "Clean dependencies.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-core-react-batch_2022-12-19-19-54.json
+++ b/common/changes/@itwin/components-react/raplemie-core-react-batch_2022-12-19-19-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Refactor to use iTwinUI instead of deprecated core-react",
+      "comment": "Refactor to use iTwinUI instead of deprecated core-react.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-deprecated-Breadcrumbs_2022-10-25-16-13.json
+++ b/common/changes/@itwin/components-react/raplemie-deprecated-Breadcrumbs_2022-10-25-16-13.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Remove Breadcrumbs deprecated component (and related)",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-deprecated-Table_2022-10-31-18-42.json
+++ b/common/changes/@itwin/components-react/raplemie-deprecated-Table_2022-10-31-18-42.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Removed Table component",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-deprecated-componentsFinal_2022-11-04-14-07.json
+++ b/common/changes/@itwin/components-react/raplemie-deprecated-componentsFinal_2022-11-04-14-07.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Remove deprecated components",
+      "comment": "Remove deprecated components.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-min362_2023-03-17-19-34.json
+++ b/common/changes/@itwin/components-react/raplemie-min362_2023-03-17-19-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Bump minimum of core to 3.6.2",
+      "comment": "Bump minimum of core packages to 3.7.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-prepareCoreReactTestTo18_2022-10-12-20-10.json
+++ b/common/changes/@itwin/components-react/raplemie-prepareCoreReactTestTo18_2022-10-12-20-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Prepare tests for react18",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-react18-components-react_2022-12-14-19-09.json
+++ b/common/changes/@itwin/components-react/raplemie-react18-components-react_2022-12-14-19-09.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Prepare tests for React18",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-react18-package.json_2023-02-27-22-29.json
+++ b/common/changes/@itwin/components-react/raplemie-react18-package.json_2023-02-27-22-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "peerDependency allow react: ^18.0.0",
+      "comment": "peerDependency allow react: ^18.0.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-scssCleanup_2023-03-14-17-26.json
+++ b/common/changes/@itwin/components-react/raplemie-scssCleanup_2023-03-14-17-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Clean SCSS",
+      "comment": "Clean SCSS.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-supportCreateRoot_2023-02-15-20-36.json
+++ b/common/changes/@itwin/components-react/raplemie-supportCreateRoot_2023-02-15-20-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Support React18 in FavoritePropertiesRenderer",
+      "comment": "Support React18 in FavoritePropertiesRenderer.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
+++ b/common/changes/@itwin/components-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "iTwin.js 3.5.1",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/remove-3-7-deprecations_2023-04-19-22-44.json
+++ b/common/changes/@itwin/components-react/remove-3-7-deprecations_2023-04-19-22-44.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Remove remaining 3.x deprecations.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/remove-core-deprecations_2022-10-26-19-20.json
+++ b/common/changes/@itwin/components-react/remove-core-deprecations_2022-10-26-19-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Remove deprecated components with dependencies on deprecations in core-react",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/ui-disabled-tree-node_2022-10-11-10-23.json
+++ b/common/changes/@itwin/components-react/ui-disabled-tree-node_2022-10-11-10-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "`ControlledTree`: Add ability to mark nodes as not selectable",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/ui-fix_filtering_input_placeholder_2022-12-13-15-00.json
+++ b/common/changes/@itwin/components-react/ui-fix_filtering_input_placeholder_2022-12-13-15-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Fixed 'FilteringInput' placeholder text localization",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/ui-toolbar-opacity_2022-11-18-19-29.json
+++ b/common/changes/@itwin/components-react/ui-toolbar-opacity_2022-11-18-19-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Use --buic-toolbar-opacity to set the opacity of toolbar items.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/update-package-files_2023-03-30-16-16.json
+++ b/common/changes/@itwin/components-react/update-package-files_2023-03-30-16-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Update package.json dependecies and repo documentation.",
+      "comment": "Update package.json dependencies and repo documentation.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/greta-jon-variable-replace_2023-01-10-14-27.json
+++ b/common/changes/@itwin/core-react/greta-jon-variable-replace_2023-01-10-14-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Using iTwinUI-variables",
+      "comment": "Using iTwinUI-variables.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/greta-use-itwinv2_2023-02-28-11-49.json
+++ b/common/changes/@itwin/core-react/greta-use-itwinv2_2023-02-28-11-49.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Update iTwinUI-react to v2.x",
+      "comment": "Update iTwinUI-react to v2.x.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/master_2023-01-26-17-35.json
+++ b/common/changes/@itwin/core-react/master_2023-01-26-17-35.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Fixed css variable typo.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/presentation-component-fixes_2023-03-31-08-06.json
+++ b/common/changes/@itwin/core-react/presentation-component-fixes_2023-03-31-08-06.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Fix tree node chevron alignment",
+      "comment": "Fix tree node chevron alignment.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-3.4.0_2022-10-18-18-32.json
+++ b/common/changes/@itwin/core-react/raplemie-3.4.0_2022-10-18-18-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Move to iTwinJs 3.4.0 packages",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-React18Typings_2022-10-05-21-03.json
+++ b/common/changes/@itwin/core-react/raplemie-React18Typings_2022-10-05-21-03.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Update typings for React18",
+      "comment": "Update typings for React18.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-cleanDependencies_2023-03-01-16-39.json
+++ b/common/changes/@itwin/core-react/raplemie-cleanDependencies_2023-03-01-16-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Clean dependencies",
+      "comment": "Clean dependencies.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-core-react-batch_2022-12-19-19-54.json
+++ b/common/changes/@itwin/core-react/raplemie-core-react-batch_2022-12-19-19-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Remove deprecated components and API",
+      "comment": "Remove deprecated components and API.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-min362_2023-03-17-19-34.json
+++ b/common/changes/@itwin/core-react/raplemie-min362_2023-03-17-19-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Bump minimum of core to 3.6.2",
+      "comment": "Bump minimum of core packages to 3.7.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-prepareCoreReactTestTo18_2022-10-12-20-10.json
+++ b/common/changes/@itwin/core-react/raplemie-prepareCoreReactTestTo18_2022-10-12-20-10.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Prepare tests for react18",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-react18-package.json_2023-02-27-22-29.json
+++ b/common/changes/@itwin/core-react/raplemie-react18-package.json_2023-02-27-22-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "peerDependency allow react: ^18.0.0",
+      "comment": "peerDependency allow react: ^18.0.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-scssCleanup_2023-03-14-17-26.json
+++ b/common/changes/@itwin/core-react/raplemie-scssCleanup_2023-03-14-17-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Remove deprecated SCSS files",
+      "comment": "Remove deprecated SCSS files.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-svgSprite_2022-12-22-17-59.json
+++ b/common/changes/@itwin/core-react/raplemie-svgSprite_2022-12-22-17-59.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Remove SvgSprite component and support",
+      "comment": "Remove SvgSprite component and support.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
+++ b/common/changes/@itwin/core-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "iTwin.js 3.5.1",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/ui-dialog-backstop_2022-11-23-16-33.json
+++ b/common/changes/@itwin/core-react/ui-dialog-backstop_2022-11-23-16-33.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Change core-dialog-hidden class so that modeless dialogs will be compatible with iTwinUI components.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/ui-toolbar-opacity_2022-11-18-19-29.json
+++ b/common/changes/@itwin/core-react/ui-toolbar-opacity_2022-11-18-19-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Use --buic-toolbar-opacity to set the opacity of toolbar items.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/update-package-files_2023-03-30-16-16.json
+++ b/common/changes/@itwin/core-react/update-package-files_2023-03-30-16-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Update package.json dependecies and repo documentation.",
+      "comment": "Update package.json dependencies and repo documentation.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/variables_import_2023-02-03-13-00.json
+++ b/common/changes/@itwin/core-react/variables_import_2023-02-03-13-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Fix '@itwin/itwinui-variables' css import.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/greta-jon-variable-replace_2023-01-10-14-27.json
+++ b/common/changes/@itwin/imodel-components-react/greta-jon-variable-replace_2023-01-10-14-27.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Using iTwinUI-variables",
+      "comment": "Using iTwinUI-variables.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/greta-use-itwinv2_2023-02-28-11-49.json
+++ b/common/changes/@itwin/imodel-components-react/greta-use-itwinv2_2023-02-28-11-49.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Update iTwinUI-react to v2.x",
+      "comment": "Update iTwinUI-react to v2.x.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/navigation-experiments_2023-03-20-22-19.json
+++ b/common/changes/@itwin/imodel-components-react/navigation-experiments_2023-03-20-22-19.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Update CubeNavigationAid in line with current design goals.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-3.4.0_2022-10-18-18-32.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-3.4.0_2022-10-18-18-32.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Move to iTwinJs 3.4.0 packages",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-TimelineMenu_2023-03-22-18-51.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-TimelineMenu_2023-03-22-18-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "TimelineComponent menu display fix.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-cleanDependencies_2023-03-01-16-39.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-cleanDependencies_2023-03-01-16-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Clean dependencies",
+      "comment": "Clean dependencies.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-core-react-batch_2022-12-19-19-54.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-core-react-batch_2022-12-19-19-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Refactor to use iTwinUI instead of deprecated core-react",
+      "comment": "Refactor to use iTwinUI instead of deprecated core-react.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-enzyme-imodel-cpt_2022-10-21-19-39.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-enzyme-imodel-cpt_2022-10-21-19-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Remove Enzyme related tests and packages",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-min362_2023-03-17-19-34.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-min362_2023-03-17-19-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Bump minimum of core to 3.6.2",
+      "comment": "Bump minimum of core packages to 3.7.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-react18-imodel-components-react_2022-12-14-21-17.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-react18-imodel-components-react_2022-12-14-21-17.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Prepare tests for React18",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-react18-package.json_2023-02-27-22-29.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-react18-package.json_2023-02-27-22-29.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "peerDependency allow react: ^18.0.0",
+      "comment": "peerDependency allow react: ^18.0.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-scssCleanup_2023-03-14-17-26.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-scssCleanup_2023-03-14-17-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Clean SCSS",
+      "comment": "Clean SCSS.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-upgrade_3_5_1_2022-12-20-21-18.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "iTwin.js 3.5.1",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/remove-deprecations_2023-04-05-14-36.json
+++ b/common/changes/@itwin/imodel-components-react/remove-deprecations_2023-04-05-14-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Remove components and interfaces that were deprecated in 2.x and 3.0",
+      "comment": "Remove components and interfaces that were deprecated in 2.x and 3.0.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/update-package-files_2023-03-30-16-16.json
+++ b/common/changes/@itwin/imodel-components-react/update-package-files_2023-03-30-16-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Update package.json dependecies and repo documentation.",
+      "comment": "Update package.json dependencies and repo documentation.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
Many elements were updated multiple time, or were backported in a prior release. The elements that were already included in prior release were removed, or that are not relevant (Test related, or multiples changes to the same thing)