### PR TITLE
Allow ReactNode icon argument in item utilities.

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -525,8 +525,8 @@ export type BackstageItem = BackstageActionItem | BackstageStageLauncher;
 
 // @beta
 export namespace BackstageItemUtilities {
-    export function createActionItem(itemId: string, groupPriority: number, itemPriority: number, execute: () => void, label: string, subtitle?: string, iconSpec?: string, overrides?: Partial<BackstageActionItem>): BackstageActionItem;
-    export function createStageLauncher(frontstageId: string, groupPriority: number, itemPriority: number, label: string, subtitle?: string, iconSpec?: string, overrides?: Partial<BackstageStageLauncher>): BackstageStageLauncher;
+    export function createActionItem(itemId: string, groupPriority: number, itemPriority: number, execute: () => void, label: string, subtitle?: string, icon?: IconSpec, overrides?: Partial<BackstageActionItem>): BackstageActionItem;
+    export function createStageLauncher(frontstageId: string, groupPriority: number, itemPriority: number, label: string, subtitle?: string, icon?: IconSpec, overrides?: Partial<BackstageStageLauncher>): BackstageStageLauncher;
 }
 
 // @public
@@ -4317,11 +4317,11 @@ export interface StatusBarItemProps extends CommonProps {
 // @public
 export namespace StatusBarItemUtilities {
     // @beta
-    export function createActionItem(id: string, section: StatusBarSection, itemPriority: number, icon: string | ConditionalStringValue, tooltip: string | ConditionalStringValue, execute: () => void, overrides?: Partial<StatusBarActionItem>): StatusBarActionItem;
+    export function createActionItem(id: string, section: StatusBarSection, itemPriority: number, icon: IconSpec, tooltip: string | ConditionalStringValue, execute: () => void, overrides?: Partial<StatusBarActionItem>): StatusBarActionItem;
     // @beta
     export function createCustomItem(id: string, section: StatusBarSection, itemPriority: number, content: React_2.ReactNode, overrides?: Partial<StatusBarCustomItem>): StatusBarCustomItem;
     // @beta
-    export function createLabelItem(id: string, section: StatusBarSection, itemPriority: number, icon: string | ConditionalStringValue, label: string | ConditionalStringValue, labelSide?: StatusBarLabelSide, overrides?: Partial<StatusBarLabelItem>): StatusBarLabelItem;
+    export function createLabelItem(id: string, section: StatusBarSection, itemPriority: number, icon: IconSpec, label: string | ConditionalStringValue, labelSide?: StatusBarLabelSide, overrides?: Partial<StatusBarLabelItem>): StatusBarLabelItem;
 }
 
 // @beta

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -451,9 +451,9 @@ beta;StatusBarIndicatorProps
 public;StatusBarItem = StatusBarActionItem | StatusBarLabelItem | StatusBarCustomItem
 internal;StatusBarItemProps 
 public;StatusBarItemUtilities
-beta;createActionItem(id: string, section: StatusBarSection, itemPriority: number, icon: string | ConditionalStringValue, tooltip: string | ConditionalStringValue, execute: () => void, overrides?: Partial
+beta;createActionItem(id: string, section: StatusBarSection, itemPriority: number, icon: IconSpec, tooltip: string | ConditionalStringValue, execute: () => void, overrides?: Partial
 beta;createCustomItem(id: string, section: StatusBarSection, itemPriority: number, content: React_2.ReactNode, overrides?: Partial
-beta;createLabelItem(id: string, section: StatusBarSection, itemPriority: number, icon: string | ConditionalStringValue, label: string | ConditionalStringValue, labelSide?: StatusBarLabelSide, overrides?: Partial
+beta;createLabelItem(id: string, section: StatusBarSection, itemPriority: number, icon: IconSpec, label: string | ConditionalStringValue, labelSide?: StatusBarLabelSide, overrides?: Partial
 beta;StatusBarLabelIndicator(props: StatusBarLabelIndicatorProps): JSX.Element
 beta;StatusBarLabelIndicatorProps 
 public;StatusBarLabelItem 

--- a/common/changes/@itwin/appui-react/fix-utilities-icon-type_2023-04-24-07-43.json
+++ b/common/changes/@itwin/appui-react/fix-utilities-icon-type_2023-04-24-07-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Allow ReactNode icon argument in item utilities.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/backstage/BackstageItemUtilities.ts
+++ b/ui/appui-react/src/appui-react/backstage/BackstageItemUtilities.ts
@@ -6,6 +6,7 @@
  * @module Backstage
  */
 
+import { IconSpec } from "@itwin/core-react";
 import { BackstageActionItem, BackstageStageLauncher } from "./BackstageItem";
 
 /** Utilities for creating and maintaining backstage items
@@ -13,10 +14,10 @@ import { BackstageActionItem, BackstageStageLauncher } from "./BackstageItem";
  */
 export namespace BackstageItemUtilities {
   /** Creates a stage launcher backstage item. */
-  export function createStageLauncher(frontstageId: string, groupPriority: number, itemPriority: number, label: string, subtitle?: string, iconSpec?: string, overrides?: Partial<BackstageStageLauncher>): BackstageStageLauncher {
+  export function createStageLauncher(frontstageId: string, groupPriority: number, itemPriority: number, label: string, subtitle?: string, icon?: IconSpec, overrides?: Partial<BackstageStageLauncher>): BackstageStageLauncher {
     return {
       groupPriority,
-      icon: iconSpec,
+      icon,
       id: frontstageId,
       itemPriority,
       label,
@@ -27,11 +28,11 @@ export namespace BackstageItemUtilities {
   }
 
   /** Creates an action backstage item. */
-  export function createActionItem(itemId: string, groupPriority: number, itemPriority: number, execute: () => void, label: string, subtitle?: string, iconSpec?: string, overrides?: Partial<BackstageActionItem>): BackstageActionItem {
+  export function createActionItem(itemId: string, groupPriority: number, itemPriority: number, execute: () => void, label: string, subtitle?: string, icon?: IconSpec, overrides?: Partial<BackstageActionItem>): BackstageActionItem {
     return {
       execute,
       groupPriority,
-      icon: iconSpec,
+      icon,
       id: itemId,
       itemPriority,
       label,

--- a/ui/appui-react/src/appui-react/statusbar/StatusBarItemUtilities.ts
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBarItemUtilities.ts
@@ -8,6 +8,7 @@
 
 import * as React from "react";
 import { ConditionalStringValue } from "@itwin/appui-abstract";
+import { IconSpec } from "@itwin/core-react";
 import { StatusBarActionItem, StatusBarCustomItem, StatusBarLabelItem, StatusBarLabelSide, StatusBarSection } from "./StatusBarItem";
 
 /** Utility functions for creating and maintaining StatusBar items.
@@ -17,7 +18,7 @@ export namespace StatusBarItemUtilities {
   /** Creates a StatusBar item to perform an action.
    * @beta
    */
-  export function createActionItem(id: string, section: StatusBarSection, itemPriority: number, icon: string | ConditionalStringValue, tooltip: string | ConditionalStringValue, execute: () => void, overrides?: Partial<StatusBarActionItem>): StatusBarActionItem {
+  export function createActionItem(id: string, section: StatusBarSection, itemPriority: number, icon: IconSpec, tooltip: string | ConditionalStringValue, execute: () => void, overrides?: Partial<StatusBarActionItem>): StatusBarActionItem {
     return {
       id,
       section,
@@ -32,7 +33,7 @@ export namespace StatusBarItemUtilities {
   /** Creates a StatusBar item to display a label.
    * @beta
    */
-  export function createLabelItem(id: string, section: StatusBarSection, itemPriority: number, icon: string | ConditionalStringValue, label: string | ConditionalStringValue, labelSide = StatusBarLabelSide.Right, overrides?: Partial<StatusBarLabelItem>): StatusBarLabelItem {
+  export function createLabelItem(id: string, section: StatusBarSection, itemPriority: number, icon: IconSpec, label: string | ConditionalStringValue, labelSide = StatusBarLabelSide.Right, overrides?: Partial<StatusBarLabelItem>): StatusBarLabelItem {
     return {
       id,
       section,


### PR DESCRIPTION
## Changes

Allow `ReactNode` as an icon argument in `BackstageItemUtilities` and `StatusBarItemUtilities`.

## Testing

N/A
