### PR TITLE
Fix `SelectionInfoField` by displaying selection set size

### DIFF
--- a/common/changes/@itwin/appui-react/fix-selection-info_2023-04-24-08-45.json
+++ b/common/changes/@itwin/appui-react/fix-selection-info_2023-04-24-08-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix SelectionInfoField by displaying selection set size.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
@@ -222,5 +222,10 @@ export class SyncUiEventDispatcher {
     iModelConnection.selectionSet.onChanged.removeListener(SyncUiEventDispatcher.selectionChangedHandler);
     iModelConnection.selectionSet.onChanged.addListener(SyncUiEventDispatcher.selectionChangedHandler);
     iModelConnection.iModelId && UiFramework.setActiveIModelId(iModelConnection.iModelId);
+
+    SyncUiEventDispatcher._unregisterListenerFunc = iModelConnection.selectionSet.onChanged.addListener((ev) => {
+      const numSelected = ev.set.elements.size;
+      UiFramework.dispatchActionToStore(SessionStateActionId.SetNumItemsSelected, numSelected);
+    });
   }
 }


### PR DESCRIPTION
## Changes

Dispatch `SetNumItemsSelected` action when selection set changes.
This fixes `SelectionInfoField` component by displaying selection set size. 

## Testing

Tested via standalone appui-test-app.