### PR TITLE
SimplePropertyDataProvider return objects on getData

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -2460,6 +2460,7 @@ export class ShortDateTypeConverter extends DateTimeTypeConverterBase {
 
 // @public
 export class SimplePropertyDataProvider implements IPropertyDataProvider, PropertyData {
+    constructor();
     // (undocumented)
     addCategory(category: PropertyCategory): number;
     // (undocumented)

--- a/common/changes/@itwin/components-react/raplemie-simpleDataProviderStaleData_2023-04-27-17-43.json
+++ b/common/changes/@itwin/components-react/raplemie-simpleDataProviderStaleData_2023-04-27-17-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "`SimplePropertyDataProvider` correctly updates when used in `VirtualizedPropertyGridWithDataProvider`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/propertygrid/SimplePropertyDataProvider.ts
+++ b/ui/components-react/src/components-react/propertygrid/SimplePropertyDataProvider.ts
@@ -20,11 +20,30 @@ export class SimplePropertyDataProvider implements IPropertyDataProvider, Proper
   public categories: PropertyCategory[] = [];
   public records: { [categoryName: string]: PropertyRecord[] } = {};
   public onDataChanged = new PropertyDataChangeEvent();
+  private _propertyData: PropertyData;
+
+  constructor() {
+    this._propertyData = this.createPropertyData();
+  }
+
+  private createPropertyData(): PropertyData {
+    return {
+      label: this.label,
+      description: this.description,
+      categories: this.categories,
+      records: this.records,
+    };
+  }
+
+  private updatePropertyData() {
+    this._propertyData = this.createPropertyData();
+    this.onDataChanged.raiseEvent();
+  }
 
   public addCategory(category: PropertyCategory): number {
     const categoryIdx = this.categories.push(category) - 1;
     this.records[this.categories[categoryIdx].name] = [];
-    this.onDataChanged.raiseEvent();
+    this.updatePropertyData();
     return categoryIdx;
   }
 
@@ -37,7 +56,7 @@ export class SimplePropertyDataProvider implements IPropertyDataProvider, Proper
 
   public addProperty(propertyRecord: PropertyRecord, categoryIdx: number): void {
     this.records[this.categories[categoryIdx].name].push(propertyRecord);
-    this.onDataChanged.raiseEvent();
+    this.updatePropertyData();
   }
 
   public removeProperty(propertyRecord: PropertyRecord, categoryIdx: number): boolean {
@@ -50,7 +69,7 @@ export class SimplePropertyDataProvider implements IPropertyDataProvider, Proper
     // istanbul ignore else
     if (index >= 0) {
       this.records[this.categories[categoryIdx].name].splice(index, 1);
-      this.onDataChanged.raiseEvent();
+      this.updatePropertyData();
       result = true;
     }
     return result;
@@ -72,6 +91,6 @@ export class SimplePropertyDataProvider implements IPropertyDataProvider, Proper
   }
 
   public async getData(): Promise<PropertyData> {
-    return this;
+    return this._propertyData;
   }
 }

--- a/ui/components-react/src/test/propertygrid/SimplePropertyDataProvider.test.ts
+++ b/ui/components-react/src/test/propertygrid/SimplePropertyDataProvider.test.ts
@@ -6,7 +6,7 @@
 import { expect } from "chai";
 import type { PrimitiveValue, PropertyRecord} from "@itwin/appui-abstract";
 import { PropertyValueFormat } from "@itwin/appui-abstract";
-import type { PropertyCategory} from "../../components-react";
+import type { PropertyCategory, PropertyData } from "../../components-react";
 import { SimplePropertyDataProvider } from "../../components-react";
 import TestUtils from "../TestUtils";
 
@@ -94,5 +94,46 @@ describe("SimplePropertyDataProvider", () => {
     const record2 = records[1];
     const propertyDescription = record2.property;
     expect(propertyDescription.displayLabel).to.equal("Test-New");
+  });
+
+  it("getData should return same object when no data changes", async () => {
+    const tested = new SimplePropertyDataProvider();
+    const first = await tested.getData();
+    const second = await tested.getData();
+    expect(first).to.equal(second);
+  });
+
+  it("getData should return different object when data changes", async () => {
+    const tested = new SimplePropertyDataProvider();
+    const initial = await tested.getData();
+    tested.addCategory({name: "Name1", label: "Label1", expand: false});
+    const categoryAdded = await tested.getData();
+    expect(initial).to.not.equal(categoryAdded);
+
+    const property = TestUtils.createPrimitiveStringProperty("String1", "string1");
+    tested.addProperty(property, 0);
+    const propertyAdded = await tested.getData();
+    expect(categoryAdded).to.not.equal(propertyAdded);
+
+    tested.removeProperty(property, 0);
+    const propertyRemoved = await tested.getData();
+    expect(propertyAdded).to.not.equal(propertyRemoved);
+  });
+
+  it("getData should return different object when onDataChanged is called", (done) => {
+    const tested = new SimplePropertyDataProvider();
+    let initial: PropertyData | undefined;
+    tested.getData().then((data) => {
+      initial = data;
+    }).catch(() => expect.fail("getData threw"));
+
+    tested.onDataChanged.addListener(() => {
+      tested.getData().then((data) => {
+        expect(initial).to.not.equal(data);
+        done();
+      }).catch(() => { expect.fail("onDataChanged getData threw"); });
+    });
+
+    tested.addCategory({name: "Name1", label: "Label1", expand: false});
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

`SimplePropertyDataProvider` now return a different object if the data is modified with the provided methods and `getData` is called. I did not use the `onDataChange` event because it can be cleared.

## Testing

POC was validated with measure-tools widget, tests were added to validate that we dont loose this behavior in the future.

Resolves #299 