### PR TITLE
Fix ToolAssistanceField icon display

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-toolAssistanceImages_2023-05-11-18-56.json
+++ b/common/changes/@itwin/appui-react/raplemie-toolAssistanceImages_2023-05-11-18-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "ToolAssistanceField: Display as class if image is not svg (IE: webfont class image)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -510,7 +510,7 @@ export class ToolAssistanceField extends React.Component<ToolAssistanceFieldProp
       if (instruction.image.length > 0) {
         const svgSource = IconSpecUtilities.getWebComponentSource(instruction.image);
         const className = (svgSource !== undefined) ? "uifw-toolassistance-svg" : "uifw-toolassistance-icon-large";
-        image = <div className={className}><Icon iconSpec={svgSource} /></div>;
+        image = <div className={className}><Icon iconSpec={svgSource ?? instruction.image} /></div>;
       }
     } else if (instruction.image === ToolAssistanceImage.Keyboard) {
       if (instruction.keyboardInfo) {

--- a/ui/appui-react/src/test/statusfields/toolassistance/ToolAssistanceField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/toolassistance/ToolAssistanceField.test.tsx
@@ -319,6 +319,24 @@ describe(`ToolAssistanceField`, () => {
     expect(screen.getByRole("dialog").querySelectorAll("div.uifw-toolassistance-icon-large")).lengthOf(0);
   });
 
+  it("should support webfont icons in string-based instruction.image", async () => {
+    render(<StatusBar>
+      <ToolAssistanceField uiStateStorage={uiSettingsStorage} />
+    </StatusBar>);
+
+    const notifications = new AppNotificationManager();
+    const mainInstruction = ToolAssistance.createInstruction("icon-my-test-icon", "This is the prompt");
+
+    const instructions = ToolAssistance.createInstructions(mainInstruction);
+
+    notifications.setToolAssistance(instructions);
+
+    await theUserTo.click(screen.getByRole("button"));
+
+    expect(screen.getByRole("dialog").querySelectorAll("div.uifw-toolassistance-svg")).lengthOf(0);
+    expect(screen.getByRole("dialog").querySelectorAll("div.uifw-toolassistance-icon-large .icon-my-test-icon")).lengthOf(1);
+  });
+
   it("invalid modifier key info along with image should log error", async () => {
     const spyMethod = sinon.spy(Logger, "logError");
     render(<StatusBar>


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

If the provided instruction.image is not identified as an svg component, use its value as a string, which is likely a webfont class name. (As was prior behavior in 3.x)

## Testing

Added a test that validates that a string not starting with `webSvg:` will be used as a class name on an instruction.
Validated visually that the fix worked in test app.

resolves #303 