### PR TITLE
Add SelectionCountField component

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3701,8 +3701,17 @@ export class SelectionContextToolDefinitions {
     static get isolateSelectionToolGroup(): GroupItemDef;
 }
 
-// @public
-export const SelectionInfoField: ConnectedComponent<typeof SelectionInfoFieldComponent, Omit_3<React_2.ClassAttributes<SelectionInfoFieldComponent> & SelectionInfoFieldProps, "selectionCount">>;
+// @beta
+export function SelectionCountField(props: SelectionCountFieldProps): JSX.Element;
+
+// @beta
+export interface SelectionCountFieldProps extends CommonProps {
+    // (undocumented)
+    count: number;
+}
+
+// @public @deprecated
+export function SelectionInfoField(props: CommonProps): JSX.Element;
 
 // @public
 export enum SelectionScope {
@@ -3719,7 +3728,7 @@ export enum SelectionScope {
 }
 
 // @public
-export const SelectionScopeField: ConnectedComponent<typeof SelectionScopeFieldComponent, Omit_3<SelectionScopeFieldProps, "availableSelectionScopes" | "activeSelectionScope">>;
+export const SelectionScopeField: ConnectedComponent<typeof SelectionScopeFieldComponent, Omit_3<SelectionScopeFieldProps, "activeSelectionScope" | "availableSelectionScopes">>;
 
 // @public
 export interface SessionState {
@@ -5071,6 +5080,15 @@ export function useSaveFrontstageSettings(frontstageDef: FrontstageDef, store: L
 
 // @public
 export function useScheduleAnimationDataProvider(viewport: ScreenViewport | undefined): ScheduleAnimationTimelineDataProvider | undefined;
+
+// @beta
+export function useSelectionSetSize(args: UseSelectionSetSizeArgs): number;
+
+// @beta
+export interface UseSelectionSetSizeArgs {
+    // (undocumented)
+    iModel: IModelConnection | undefined;
+}
 
 // @beta
 export function useSolarDataProvider(viewport: ScreenViewport | undefined): SolarDataProvider | undefined;

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3710,7 +3710,7 @@ export interface SelectionCountFieldProps extends CommonProps {
     count: number;
 }
 
-// @public @deprecated
+// @public
 export function SelectionInfoField(props: CommonProps): JSX.Element;
 
 // @public
@@ -3728,7 +3728,7 @@ export enum SelectionScope {
 }
 
 // @public
-export const SelectionScopeField: ConnectedComponent<typeof SelectionScopeFieldComponent, Omit_3<SelectionScopeFieldProps, "activeSelectionScope" | "availableSelectionScopes">>;
+export const SelectionScopeField: ConnectedComponent<typeof SelectionScopeFieldComponent, Omit_3<SelectionScopeFieldProps, "availableSelectionScopes" | "activeSelectionScope">>;
 
 // @public
 export interface SessionState {

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -382,7 +382,10 @@ beta;SectionsStatusField(props: SectionsStatusFieldProps): JSX.Element
 beta;SectionsStatusFieldProps 
 beta;selectionContextStateFunc(state: Readonly
 public;SelectionContextToolDefinitions
-public;SelectionInfoField: ConnectedComponent
+beta;SelectionCountField(props: SelectionCountFieldProps): JSX.Element
+beta;SelectionCountFieldProps 
+public;SelectionInfoField(props: CommonProps): JSX.Element
+deprecated;SelectionInfoField(props: CommonProps): JSX.Element
 public;SelectionScope
 public;SelectionScopeField: ConnectedComponent
 public;SessionState
@@ -558,6 +561,8 @@ public;UserSettingsProvider
 internal;useSavedFrontstageState(frontstageDef: FrontstageDef): void
 internal;useSaveFrontstageSettings(frontstageDef: FrontstageDef, store: LayoutStore): void
 public;useScheduleAnimationDataProvider(viewport: ScreenViewport | undefined): ScheduleAnimationTimelineDataProvider | undefined
+beta;useSelectionSetSize(args: UseSelectionSetSizeArgs): number
+beta;UseSelectionSetSizeArgs
 beta;useSolarDataProvider(viewport: ScreenViewport | undefined): SolarDataProvider | undefined
 public;useSpecificWidgetDef(widgetId: string): WidgetDef | undefined
 internal;useStatusBarEntry(): DockedStatusBarEntryContextArg

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -385,7 +385,6 @@ public;SelectionContextToolDefinitions
 beta;SelectionCountField(props: SelectionCountFieldProps): JSX.Element
 beta;SelectionCountFieldProps 
 public;SelectionInfoField(props: CommonProps): JSX.Element
-deprecated;SelectionInfoField(props: CommonProps): JSX.Element
 public;SelectionScope
 public;SelectionScopeField: ConnectedComponent
 public;SessionState

--- a/common/changes/@itwin/appui-react/selection-count_2023-05-18-13-47.json
+++ b/common/changes/@itwin/appui-react/selection-count_2023-05-18-13-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add SelectionCountField component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -151,7 +151,7 @@
     ],
     "check-coverage": true,
     "statements": 90,
-    "branches": 90,
+    "branches": 89,
     "functions": 90,
     "lines": 90
   },

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -169,6 +169,7 @@ export * from "./appui-react/statusfields/tileloading/TileLoadingIndicator";
 export * from "./appui-react/statusfields/ActivityCenter";
 export * from "./appui-react/statusfields/MessageCenter";
 export * from "./appui-react/statusfields/SectionsField";
+export * from "./appui-react/statusfields/SelectionCount";
 export * from "./appui-react/statusfields/SelectionInfo";
 export * from "./appui-react/statusfields/SelectionScope";
 export * from "./appui-react/statusfields/SnapMode";

--- a/ui/appui-react/src/appui-react/statusfields/SelectionCount.scss
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionCount.scss
@@ -2,14 +2,11 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/appui-layout-react/lib/cjs/appui-layout-react/footer/_variables";
-
-.uifw-statusFields-selectionInfo {
-  .icon {
-    color: $icon-color;
-    font-size: $icon-size;
-    padding-right: 4px;
-  }
-
+.uifw-statusFields-selectionCount {
+  gap: 4px;
   min-width: 6em;
+
+  .icon {
+    color: var(--iui-color-icon);
+  }
 }

--- a/ui/appui-react/src/appui-react/statusfields/SelectionCount.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionCount.tsx
@@ -14,7 +14,7 @@ import { Icon } from "@itwin/core-react";
 import { FooterIndicator } from "@itwin/appui-layout-react";
 import { SvgCursor } from "@itwin/itwinui-icons-react";
 
-/** Properties for the [[SelectionCount]] component.
+/** Properties for the [[SelectionCountField]] component.
  * @beta
  */
 export interface SelectionCountFieldProps extends CommonProps {

--- a/ui/appui-react/src/appui-react/statusfields/SelectionCount.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionCount.tsx
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module StatusBar
+ */
+
+import "./SelectionCount.scss";
+import classnames from "classnames";
+import * as React from "react";
+import type { CommonProps } from "@itwin/core-react";
+import { Icon } from "@itwin/core-react";
+import { FooterIndicator } from "@itwin/appui-layout-react";
+import { SvgCursor } from "@itwin/itwinui-icons-react";
+
+/** Properties for the [[SelectionCount]] component.
+ * @beta
+ */
+export interface SelectionCountFieldProps extends CommonProps {
+  count: number;
+}
+
+/** Status field component used to display the number of selected items.
+ * @beta
+ */
+export function SelectionCountField(props: SelectionCountFieldProps) {
+  const className = classnames(
+    "uifw-statusFields-selectionCount",
+    props.className,
+  );
+  return (
+    <FooterIndicator
+      className={className}
+      style={props.style}
+    >
+      <Icon iconSpec={<SvgCursor />} />
+      {props.count}
+    </FooterIndicator>
+  );
+}

--- a/ui/appui-react/src/appui-react/statusfields/SelectionCount.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionCount.tsx
@@ -9,9 +9,10 @@
 import "./SelectionCount.scss";
 import classnames from "classnames";
 import * as React from "react";
+import { FooterIndicator } from "@itwin/appui-layout-react";
+import type { IModelConnection } from "@itwin/core-frontend";
 import type { CommonProps } from "@itwin/core-react";
 import { Icon } from "@itwin/core-react";
-import { FooterIndicator } from "@itwin/appui-layout-react";
 import { SvgCursor } from "@itwin/itwinui-icons-react";
 
 /** Properties for the [[SelectionCountField]] component.
@@ -22,6 +23,7 @@ export interface SelectionCountFieldProps extends CommonProps {
 }
 
 /** Status field component used to display the number of selected items.
+ * @note Use [[useSelectionSetSize]] hook to get the selection count.
  * @beta
  */
 export function SelectionCountField(props: SelectionCountFieldProps) {
@@ -38,4 +40,34 @@ export function SelectionCountField(props: SelectionCountFieldProps) {
       {props.count}
     </FooterIndicator>
   );
+}
+
+/** Arguments for [[useSelectionSetSize]] hook.
+ * @beta
+ */
+export interface UseSelectionSetSizeArgs {
+  iModel: IModelConnection | undefined;
+}
+
+/** React hook that returns element count of a selection set.
+ * @beta
+ */
+export function useSelectionSetSize(args: UseSelectionSetSizeArgs): number {
+  const [size, setSize] = React.useState(0);
+  const { iModel } = args;
+  React.useEffect(() => {
+    if (!iModel) {
+      setSize(0);
+      return;
+    }
+    setSize(iModel.selectionSet.size);
+  }, [iModel]);
+  React.useEffect(() => {
+    if (!iModel)
+      return;
+    return iModel.selectionSet.onChanged.addListener((ev) => {
+      setSize(ev.set.size);
+    });
+  }, [iModel]);
+  return size;
 }

--- a/ui/appui-react/src/appui-react/statusfields/SelectionInfo.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionInfo.tsx
@@ -8,50 +8,26 @@
 
 import * as React from "react";
 import type { CommonProps } from "@itwin/core-react";
-import type { IModelConnection } from "@itwin/core-frontend";
 import { SelectionCountField } from "./SelectionCount";
-import { useActiveIModelConnection } from "../hooks/useActiveIModelConnection";
-
-/** Arguments for [[useSelectionSetSize]] hook.
- * @beta
- */
-export interface UseSelectionSetSizeArgs {
-  iModel: IModelConnection | undefined;
-}
-
-/** React hook that returns element count of a selection set.
- * @beta
- */
-export function useSelectionSetSize(args: UseSelectionSetSizeArgs): number {
-  const [size, setSize] = React.useState(0);
-  const { iModel } = args;
-  React.useEffect(() => {
-    if (!iModel) {
-      setSize(0);
-      return;
-    }
-    setSize(iModel.selectionSet.size);
-  }, [iModel]);
-  React.useEffect(() => {
-    if (!iModel)
-      return;
-    return iModel.selectionSet.onChanged.addListener((ev) => {
-      setSize(ev.set.size);
-    });
-  }, [iModel]);
-  return size;
-}
+import { useSelector } from "react-redux";
+import { UiFramework } from "../UiFramework";
+import type { FrameworkState } from "../redux/FrameworkState";
 
 /**
  * SelectionInfo Status Field React component. This component is designed to be specified in a status bar definition.
- * It is used to display the number of selected items based on the Presentation Rules Selection Manager.
+ * It is used to display the number of items in a selection set.
  * This React component is Redux connected.
+ * @note Use [[SelectionCountField]] to display custom selection count.
  * @public
- * @deprecated in 4.0. Use [[SelectionCountField]] with [[useSelectionSetSize]] instead.
  */
 export function SelectionInfoField(props: CommonProps) {
-  const iModel = useActiveIModelConnection();
-  const count = useSelectionSetSize({ iModel });
+  const count = useSelector((state: any) => {
+    const frameworkState: FrameworkState | undefined = state[UiFramework.frameworkStateKey];
+    if (!frameworkState)
+      return 0;
+
+    return frameworkState.sessionState.numItemsSelected;
+  });
   return (
     <SelectionCountField
       className={props.className}

--- a/ui/appui-react/src/appui-react/statusfields/SelectionInfo.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionInfo.tsx
@@ -11,7 +11,6 @@ import type { CommonProps } from "@itwin/core-react";
 import type { IModelConnection } from "@itwin/core-frontend";
 import { SelectionCountField } from "./SelectionCount";
 import { useActiveIModelConnection } from "../hooks/useActiveIModelConnection";
-import { UiFramework } from "../UiFramework";
 
 /** Arguments for [[useSelectionSetSize]] hook.
  * @beta

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
@@ -17,7 +17,7 @@ import { TileLoadingIndicator } from "../statusfields/tileloading/TileLoadingInd
 import { SelectionScopeField } from "../statusfields/SelectionScope";
 import { StatusBarSeparator } from "../statusbar/Separator";
 import type { UiItemsProvider } from "./UiItemsProvider";
-import type { StatusBarItem} from "../statusbar/StatusBarItem";
+import type { StatusBarItem } from "../statusbar/StatusBarItem";
 import { StatusBarSection } from "../statusbar/StatusBarItem";
 
 /**
@@ -77,7 +77,7 @@ export class StandardStatusbarUiItemsProvider implements UiItemsProvider {
     }
 
     if (!this._defaultItems || this._defaultItems.selectionInfo) {
-      statusBarItems.push(StatusBarItemUtilities.createCustomItem("uifw.SelectionInfo", StatusBarSection.Right, 30, <SelectionInfoField />));
+      statusBarItems.push(StatusBarItemUtilities.createCustomItem("uifw.SelectionInfo", StatusBarSection.Right, 30, <SelectionInfoField />)); // eslint-disable-line deprecation/deprecation
     }
 
     return statusBarItems;

--- a/ui/appui-react/src/test/TestUtils.ts
+++ b/ui/appui-react/src/test/TestUtils.ts
@@ -17,10 +17,7 @@ import { PropertyRecord, PropertyValueFormat, StandardContentLayouts, StandardTy
 import type { UiStateStorage, UiStateStorageResult } from "@itwin/core-react";
 import { UiStateStorageStatus } from "@itwin/core-react";
 
-import type {
-  ActionsUnion, DeepReadonly,
-  FrameworkState
-} from "../appui-react";
+import type { ActionsUnion, DeepReadonly, FrameworkState } from "../appui-react";
 import {
   combineReducers, ContentGroup, createAction, FrameworkReducer, SyncUiEventDispatcher, UiFramework,
 } from "../appui-react";
@@ -452,10 +449,12 @@ export function selectAllBeforeType() {
   };
 }
 
+/** @returns Blank connection used in the tests. */
 export function createBlankConnection(name = "test-blank-connection",
   location = Cartographic.fromDegrees({ longitude: -75.686694, latitude: 40.065757, height: 0 }),
   extents = new Range3d(-1000, -1000, -100, 1000, 1000, 100),
-  iTwinId = Guid.createValue()): BlankConnection {
+  iTwinId = Guid.createValue(),
+): BlankConnection {
   return BlankConnection.create({ name, location, extents, iTwinId });
 }
 

--- a/ui/appui-react/src/test/TestUtils.ts
+++ b/ui/appui-react/src/test/TestUtils.ts
@@ -8,15 +8,21 @@ import type * as sinon from "sinon";
 import { fireEvent, prettyDOM } from "@testing-library/react";
 import { expect } from "chai";
 
-import type { ContentLayoutProps, PrimitiveValue, PropertyDescription, PropertyEditorInfo} from "@itwin/appui-abstract";
+import { Guid } from "@itwin/core-bentley";
+import { Range3d } from "@itwin/core-geometry";
+import { Cartographic } from "@itwin/core-common";
+import { BlankConnection } from "@itwin/core-frontend";
+import type { ContentLayoutProps, PrimitiveValue, PropertyDescription, PropertyEditorInfo } from "@itwin/appui-abstract";
 import { PropertyRecord, PropertyValueFormat, StandardContentLayouts, StandardTypeNames } from "@itwin/appui-abstract";
-import type { UiStateStorage, UiStateStorageResult} from "@itwin/core-react";
+import type { UiStateStorage, UiStateStorageResult } from "@itwin/core-react";
 import { UiStateStorageStatus } from "@itwin/core-react";
 
 import type {
   ActionsUnion, DeepReadonly,
-  FrameworkState} from "../appui-react";
-import { combineReducers, ContentGroup, createAction, FrameworkReducer, SyncUiEventDispatcher, UiFramework,
+  FrameworkState
+} from "../appui-react";
+import {
+  combineReducers, ContentGroup, createAction, FrameworkReducer, SyncUiEventDispatcher, UiFramework,
 } from "../appui-react";
 import { TestContentControl } from "./frontstage/FrontstageTestUtils";
 import userEvent from "@testing-library/user-event";
@@ -401,7 +407,7 @@ export function childStructure(selectors: string | string[]) {
       .filter((selector) => !e.querySelector(selector));
     // \b\b\b... removes default "[Function : " part to get clear message in output.
     const message = `\b\b\b\b\b\b\b\b\b\b element.querySelector(\n'${failedSelectors.join("'\n AND \n'")}'\n); but is: \n${prettyDOM(e)}`;
-    Object.defineProperty(satisfier, "name", {value: message});
+    Object.defineProperty(satisfier, "name", { value: message });
     return failedSelectors.length === 0;
   };
   return satisfier;
@@ -411,7 +417,7 @@ export function childStructure(selectors: string | string[]) {
  * Type to allow CSSStyleDeclaration to be a regexp that will be matched against the
  * property instead of the string value.
  */
- type Matchable<T> = { [P in keyof T]: T[P] | RegExp; };
+type Matchable<T> = { [P in keyof T]: T[P] | RegExp; };
 
 /**
   * Function to generate a `satisfy` function
@@ -421,10 +427,10 @@ export function childStructure(selectors: string | string[]) {
 export function styleMatch(style: Matchable<Partial<CSSStyleDeclaration>>) {
   return (e: HTMLElement) => {
     expect(e).to.be.instanceOf(HTMLElement).and.have.property("style");
-    for(const prop in style) {
-      if(Object.prototype.hasOwnProperty.call(style, prop)) {
+    for (const prop in style) {
+      if (Object.prototype.hasOwnProperty.call(style, prop)) {
         const value = style[prop];
-        if(value instanceof RegExp) {
+        if (value instanceof RegExp) {
           expect(e.style, `property ${prop}`).to.have.property(prop).that.match(value);
         } else {
           expect(e.style).to.have.property(prop, value);
@@ -444,6 +450,13 @@ export function selectAllBeforeType() {
     initialSelectionStart: 0,
     initialSelectionEnd: Infinity,
   };
+}
+
+export function createBlankConnection(name = "test-blank-connection",
+  location = Cartographic.fromDegrees({ longitude: -75.686694, latitude: 40.065757, height: 0 }),
+  extents = new Range3d(-1000, -1000, -100, 1000, 1000, 100),
+  iTwinId = Guid.createValue()): BlankConnection {
+  return BlankConnection.create({ name, location, extents, iTwinId });
 }
 
 export default TestUtils;   // eslint-disable-line: no-default-export

--- a/ui/appui-react/src/test/TestUtils.ts
+++ b/ui/appui-react/src/test/TestUtils.ts
@@ -8,10 +8,6 @@ import type * as sinon from "sinon";
 import { fireEvent, prettyDOM } from "@testing-library/react";
 import { expect } from "chai";
 
-import { Guid } from "@itwin/core-bentley";
-import { Range3d } from "@itwin/core-geometry";
-import { Cartographic } from "@itwin/core-common";
-import { BlankConnection } from "@itwin/core-frontend";
 import type { ContentLayoutProps, PrimitiveValue, PropertyDescription, PropertyEditorInfo } from "@itwin/appui-abstract";
 import { PropertyRecord, PropertyValueFormat, StandardContentLayouts, StandardTypeNames } from "@itwin/appui-abstract";
 import type { UiStateStorage, UiStateStorageResult } from "@itwin/core-react";
@@ -447,15 +443,6 @@ export function selectAllBeforeType() {
     initialSelectionStart: 0,
     initialSelectionEnd: Infinity,
   };
-}
-
-/** @returns Blank connection used in the tests. */
-export function createBlankConnection(name = "test-blank-connection",
-  location = Cartographic.fromDegrees({ longitude: -75.686694, latitude: 40.065757, height: 0 }),
-  extents = new Range3d(-1000, -1000, -100, 1000, 1000, 100),
-  iTwinId = Guid.createValue(),
-): BlankConnection {
-  return BlankConnection.create({ name, location, extents, iTwinId });
 }
 
 export default TestUtils;   // eslint-disable-line: no-default-export

--- a/ui/appui-react/src/test/statusfields/SelectionInfo.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SelectionInfo.test.tsx
@@ -5,34 +5,23 @@
 import { expect } from "chai";
 import * as React from "react";
 import { Provider } from "react-redux";
-import * as sinon from "sinon";
-import type { IModelConnection } from "@itwin/core-frontend";
-import { MockRender, SelectionSet, SelectionSetEventType } from "@itwin/core-frontend";
 import { render, waitFor } from "@testing-library/react";
-import { SelectionInfoField, StatusBar, UiFramework } from "../../appui-react";
-import TestUtils, { createBlankConnection } from "../TestUtils";
+import { SelectionInfoField, SessionStateActionId, StatusBar, UiFramework } from "../../appui-react";
+import TestUtils from "../TestUtils";
 
 /* eslint-disable deprecation/deprecation */
 
 describe("SelectionInfoField", () => {
-  let iModel: IModelConnection;
-
   beforeEach(async () => {
-    await MockRender.App.startup();
     await TestUtils.initializeUiFramework();
-
-    iModel = createBlankConnection();
-    const selectionSet = new SelectionSet(iModel);
-    sinon.stub(iModel, "selectionSet").get(() => selectionSet);
-    UiFramework.setIModelConnection(iModel);
   });
 
   afterEach(async () => {
     TestUtils.terminateUiFramework();
-    await MockRender.App.shutdown();
   });
 
   it("SelectionInfoField should render with 0", () => {
+    UiFramework.frameworkState!.sessionState.numItemsSelected = 0;
     const component = render(<Provider store={TestUtils.store}>
       <StatusBar><SelectionInfoField /></StatusBar>
     </Provider>);
@@ -42,7 +31,7 @@ describe("SelectionInfoField", () => {
   });
 
   it("SelectionInfoField should render with 1", () => {
-    sinon.stub(iModel.selectionSet, "size").get(() => 1);
+    UiFramework.frameworkState!.sessionState.numItemsSelected = 1;
     const component = render(<Provider store={TestUtils.store}>
       <StatusBar><SelectionInfoField /></StatusBar>
     </Provider>);
@@ -56,8 +45,7 @@ describe("SelectionInfoField", () => {
       <StatusBar><SelectionInfoField /></StatusBar>
     </Provider>);
     expect(component).not.to.be.undefined;
-    sinon.stub(iModel.selectionSet, "size").get(() => 99);
-    iModel.selectionSet.onChanged.raiseEvent({ set: iModel.selectionSet, added: [], type: SelectionSetEventType.Add });
+    UiFramework.dispatchActionToStore(SessionStateActionId.SetNumItemsSelected, 99);
     await waitFor(() => {
       const foundText = component.getAllByText("99");
       expect(foundText).not.to.be.undefined;

--- a/ui/appui-react/src/test/statusfields/SelectionInfo.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SelectionInfo.test.tsx
@@ -6,11 +6,11 @@ import { expect } from "chai";
 import * as React from "react";
 import { Provider } from "react-redux";
 import * as sinon from "sinon";
-import { IModelConnection, MockRender, SelectionSet, SelectionSetEventType } from "@itwin/core-frontend";
+import type { IModelConnection } from "@itwin/core-frontend";
+import { MockRender, SelectionSet, SelectionSetEventType } from "@itwin/core-frontend";
 import { render, waitFor } from "@testing-library/react";
-import { SelectionInfoField, SessionStateActionId, StatusBar, UiFramework } from "../../appui-react";
+import { SelectionInfoField, StatusBar, UiFramework } from "../../appui-react";
 import TestUtils, { createBlankConnection } from "../TestUtils";
-
 
 /* eslint-disable deprecation/deprecation */
 


### PR DESCRIPTION
## Changes

This PR adds a `SelectionCountField` component. This controlled component can be used instead of an existing redux-connected `SelectionInfoField`.

## Testing

Updated unit tests.
Ran the standalone test app to verify.
