### PR TITLE
Fix tree flickering without keeping horizontal scrollbar

### DIFF
--- a/common/changes/@itwin/components-react/Fix_tree_flickering_without_keeping_scrollbar_2023-05-22-07-42.json
+++ b/common/changes/@itwin/components-react/Fix_tree_flickering_without_keeping_scrollbar_2023-05-22-07-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fix tree flickering without keeping the horizontal scrollbar",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/tree/controlled/component/ControlledTree.scss
+++ b/ui/components-react/src/components-react/tree/controlled/component/ControlledTree.scss
@@ -26,11 +26,11 @@
 
   /**
    * Workaround for horizontal scroll issue.
-   * based on https://github.com/bvaughn/react-virtualized/issues/1248
+   * based on https://github.com/bvaughn/react-window/issues/681
    */
   .ReactVirtualized__Grid,
   .ReactWindow__VariableSizeList {
-    overflow: auto !important;
+    overflow: scroll !important;
     background-color: inherit;
 
     @include uicore-scrollbar;

--- a/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -210,18 +210,6 @@ const TreeRendererInner = React.forwardRef<TreeRendererAttributes, TreeRendererP
     variableSizeListRef.current.scrollToItem(index);
   }, [nodeHighlightingProps]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const innerElementType = React.useCallback(
-    // eslint-disable-next-line react/display-name
-    React.forwardRef((props: ListChildComponentProps, innerRef: React.Ref<HTMLDivElement>) => (
-      <div
-        ref={innerRef}
-        {...props}
-      />
-    )),
-    [],
-  );
-
   const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
     props.treeActions.onTreeKeyDown(e);
   }, [props.treeActions]);
@@ -251,7 +239,6 @@ const TreeRendererInner = React.forwardRef<TreeRendererAttributes, TreeRendererP
           estimatedItemSize={25}
           overscanCount={10}
           itemKey={itemKey}
-          innerElementType={innerElementType}
           onItemsRendered={handleRenderedItemsChange}
         >
           {Node}

--- a/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -109,9 +109,6 @@ interface TreeRendererContext {
   /** Callback used detect when label is rendered. It is used by TreeRenderer for scrolling to active match. */
   onLabelRendered?: (node: TreeModelNode) => void;
 
-  /** A callback that node calls after rendering to report its width */
-  onNodeWidthMeasured?: (width: number) => void;
-
   /** Callback used when an editor closes */
   onNodeEditorClosed?: () => void;
 }
@@ -179,10 +176,6 @@ const TreeRendererInner = React.forwardRef<TreeRendererAttributes, TreeRendererP
     visibleNodes: props.visibleNodes,
     onLabelRendered,
     highlightingEngine,
-    onNodeWidthMeasured: (width: number) => {
-      if (width > minContainerWidth.current)
-        minContainerWidth.current = width;
-    },
     onNodeEditorClosed: () => {
       setFocusToSelected(coreTreeRef);
       props.onNodeEditorClosed && props.onNodeEditorClosed();
@@ -294,7 +287,6 @@ const Node = React.memo<React.FC<ListChildComponentProps>>( // eslint-disable-li
       nodeLoader,
       onLabelRendered,
       highlightingEngine,
-      onNodeWidthMeasured,
       onNodeEditorClosed,
     } = useTreeRendererContext(Node);
     const node = visibleNodes.getAtIndex(index)!;
@@ -303,13 +295,6 @@ const Node = React.memo<React.FC<ListChildComponentProps>>( // eslint-disable-li
 
     // Mark selected node's wrapper to make detecting consecutively selected nodes with css selectors possible
     const className = classnames("node-wrapper", { "is-selected": isTreeModelNode(node) && node.isSelected });
-
-    const ref = React.useRef<HTMLDivElement>(null);
-    React.useEffect(() => {
-      // istanbul ignore else
-      if (onNodeWidthMeasured && ref.current)
-        onNodeWidthMeasured(ref.current.offsetWidth);
-    }, [onNodeWidthMeasured]);
 
     const isEditing = React.useRef(false);
     React.useEffect(() => {
@@ -327,7 +312,7 @@ const Node = React.memo<React.FC<ListChildComponentProps>>( // eslint-disable-li
     }, [node, onNodeEditorClosed]);
 
     return (
-      <div className={className} style={style} ref={ref}>
+      <div className={className} style={style}>
         {React.useMemo(() => {
           if (isTreeModelNode(node)) {
             const nodeHighlightProps = highlightingEngine ? highlightingEngine.createRenderProps(node) : undefined;

--- a/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -162,7 +162,6 @@ const TreeRendererInner = React.forwardRef<TreeRendererAttributes, TreeRendererP
   }
 
   const coreTreeRef = React.useRef<CoreTree>(null);
-  const minContainerWidth = React.useRef<number>(0);
   const onLabelRendered = useScrollToActiveMatch(coreTreeRef, props.nodeHighlightingProps);
   const highlightingEngine = React.useMemo(
     () => props.nodeHighlightingProps && new HighlightingEngine(props.nodeHighlightingProps),
@@ -181,12 +180,6 @@ const TreeRendererInner = React.forwardRef<TreeRendererAttributes, TreeRendererP
       props.onNodeEditorClosed && props.onNodeEditorClosed();
     },
   }), [props, onLabelRendered, highlightingEngine]);
-
-  const prevTreeWidth = React.useRef<number>(0);
-  if (props.width !== prevTreeWidth.current) {
-    minContainerWidth.current = 0;
-    prevTreeWidth.current = props.width;
-  }
 
   const itemKey = React.useCallback(
     (index: number) => getNodeKey(props.visibleNodes.getAtIndex(index)!),
@@ -220,11 +213,10 @@ const TreeRendererInner = React.forwardRef<TreeRendererAttributes, TreeRendererP
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const innerElementType = React.useCallback(
     // eslint-disable-next-line react/display-name
-    React.forwardRef(({ style, ...rest }: ListChildComponentProps, innerRef: React.Ref<HTMLDivElement>) => (
+    React.forwardRef((props: ListChildComponentProps, innerRef: React.Ref<HTMLDivElement>) => (
       <div
         ref={innerRef}
-        style={{ ...style, minWidth: minContainerWidth.current }}
-        {...rest}
+        {...props}
       />
     )),
     [],

--- a/ui/components-react/src/test/tree/controlled/component/TreeRenderer.test.tsx
+++ b/ui/components-react/src/test/tree/controlled/component/TreeRenderer.test.tsx
@@ -293,26 +293,6 @@ describe("TreeRenderer", () => {
     expect(spy).to.be.called;
   });
 
-  it("resizes scrollable content width to be as wide as the widest node after scrolling", () => {
-    const node1 = createRandomMutableTreeModelNode();
-    const node2 = createRandomMutableTreeModelNode();
-    visibleNodesMock.setup((x) => x.getNumNodes()).returns(() => 2);
-    visibleNodesMock.setup((x) => x.getAtIndex(0)).returns(() => node1);
-    visibleNodesMock.setup((x) => x.getAtIndex(1)).returns(() => node2);
-    visibleNodesMock.setup((x) => x.getIndexOfNode(node2.id)).returns(() => 1);
-
-    sinon.stub(HTMLElement.prototype, "offsetWidth").get(() => 123);
-
-    const ref = React.createRef<TreeRenderer>();
-    const { container } = render(<TreeRenderer ref={ref} {...defaultProps} height={50} />);
-
-    const innerContainerInitial = container.querySelector<HTMLDivElement>(".ReactWindow__VariableSizeList > div")!;
-    expect(innerContainerInitial.style.minWidth).to.be.equal("0");
-
-    act(() => ref.current!.scrollToNode(node2.id));
-    expect(innerContainerInitial.style.minWidth).to.be.equal("123px");
-  });
-
   describe("scrollToNode", () => {
     let scrollToItemFake: sinon.SinonSpy;
 

--- a/ui/components-react/src/test/tree/controlled/component/TreeRenderer.test.tsx
+++ b/ui/components-react/src/test/tree/controlled/component/TreeRenderer.test.tsx
@@ -10,7 +10,7 @@ import sinon from "sinon";
 import * as moq from "typemoq";
 import type { PrimitiveValue} from "@itwin/appui-abstract";
 import { SpecialKey } from "@itwin/appui-abstract";
-import { act, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import type { TreeNodeRendererProps } from "../../../../components-react/tree/controlled/component/TreeNodeRenderer";
 import type { TreeRendererProps } from "../../../../components-react/tree/controlled/component/TreeRenderer";
 import { TreeRenderer } from "../../../../components-react/tree/controlled/component/TreeRenderer";


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes
Previously, we were keeping our horizontal scrollbar width to avoid this issue: https://github.com/bvaughn/react-window/issues/681, which can lead to behaviour, where we show horizontal scrollbar, even though there is plenty room for the data

For example: 
![image](https://github.com/iTwin/appui/assets/124659623/a606b47b-750a-46f9-8888-4786e9a13b34)


closes itwin/viewer-components-react#500
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing
N/A
<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
