### PR TITLE
Do not publish nightly `dev.0` after RC creation.

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -238,7 +238,8 @@ jobs:
           Write-Host The new version is $newVersion
           Write-Host Committing version bump...
 
-          git commit -m "$newVersion" --author="imodeljs-admin <imodeljs-admin@users.noreply.github.com>"
+          # Message is not newVersion because we don't want to publish the dev.0 nightly build.
+          git commit -m "Update master to $newVersion" --author="imodeljs-admin <imodeljs-admin@users.noreply.github.com>"
 
           git status
         displayName: Get version and committing


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

The version bump pipeline, with `releaseCandidate` type, will now create a commit on master that will not trigger a nightly build publishing. (When we created the branch for 4.0.0, packages 4.1.0-dev.0 were published on npm, that was not intended, and caused confusion as the 4.1.0 was not in the work at all and we didnt publish any nightlies after that.)

https://www.npmjs.com/package/@itwin/appui-react/v/4.1.0-dev.0

## Testing

No tests were done, we should see if it works when we create the RC for 4.1.0.