### PR TITLE
Change visuals of `Resizer` component for content control

### DIFF
--- a/common/changes/@itwin/appui-react/content-control-handles_2023-05-26-10-10.json
+++ b/common/changes/@itwin/appui-react/content-control-handles_2023-05-26-10-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Make content control resize grip handles visually more like side panel grip handles.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomContent.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomContent.tsx
@@ -9,7 +9,7 @@ import {
   UiFramework,
   UiItemsManager,
 } from "@itwin/appui-react";
-import { ContentLayoutProps, LayoutFragmentProps, StandardContentLayouts } from "@itwin/appui-abstract";
+import { ContentLayoutProps, StandardContentLayouts } from "@itwin/appui-abstract";
 import { CustomContentStageUiProvider } from "../providers/CustomContentStageUiProvider";
 import { SampleContentControl } from "../content/SampleContentControl";
 
@@ -21,18 +21,9 @@ import { SampleContentControl } from "../content/SampleContentControl";
 export class CustomContentGroupProvider extends ContentGroupProvider {
   public override async contentGroup(): Promise<ContentGroup> {
     // copy and then modify standard layout so the content is always shown - note we could have just copied the standard and created a new one in line
-
-    const twoVerticalSplit: LayoutFragmentProps = {
-      verticalSplit: {
-        ...StandardContentLayouts.twoVerticalSplit.verticalSplit!,
-        percentage: 0.5
-      }
-    };
-
     const twoHorizontalSplit: ContentLayoutProps = {
       ...StandardContentLayouts.twoHorizontalSplit, horizontalSplit: {
         ...StandardContentLayouts.twoHorizontalSplit.horizontalSplit!,
-        bottom: twoVerticalSplit,
         minSizeBottom: 100,
         percentage: 0.80,
       },

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomContent.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomContent.tsx
@@ -9,7 +9,7 @@ import {
   UiFramework,
   UiItemsManager,
 } from "@itwin/appui-react";
-import { ContentLayoutProps, StandardContentLayouts } from "@itwin/appui-abstract";
+import { ContentLayoutProps, LayoutFragmentProps, StandardContentLayouts } from "@itwin/appui-abstract";
 import { CustomContentStageUiProvider } from "../providers/CustomContentStageUiProvider";
 import { SampleContentControl } from "../content/SampleContentControl";
 
@@ -21,9 +21,18 @@ import { SampleContentControl } from "../content/SampleContentControl";
 export class CustomContentGroupProvider extends ContentGroupProvider {
   public override async contentGroup(): Promise<ContentGroup> {
     // copy and then modify standard layout so the content is always shown - note we could have just copied the standard and created a new one in line
+
+    const twoVerticalSplit: LayoutFragmentProps = {
+      verticalSplit: {
+        ...StandardContentLayouts.twoVerticalSplit.verticalSplit!,
+        percentage: 0.5
+      }
+    };
+
     const twoHorizontalSplit: ContentLayoutProps = {
       ...StandardContentLayouts.twoHorizontalSplit, horizontalSplit: {
         ...StandardContentLayouts.twoHorizontalSplit.horizontalSplit!,
+        bottom: twoVerticalSplit,
         minSizeBottom: 100,
         percentage: 0.80,
       },

--- a/ui/appui-react/src/appui-react/content/ContentLayout.scss
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.scss
@@ -27,15 +27,33 @@ $resizer-size-large: 14px;
     margin: 0;
     transition: all var(--iui-duration-1) ease;
 
-    &:hover {
-      background-color: var(--iui-color-border-accent);
-    }
-
     &.horizontal {
-      height: $resizer-size;
-      min-height: $resizer-size;
+      height: 1px;
+      min-height: 1px;
       cursor: ns-resize;
       width: 100%;
+
+      >.nz-resizer-grip {
+        background-color: transparent;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        display: flex;
+        height: 10px;
+        top: -5px;
+        transition: background-color 0.2s ease-out;
+
+        &:hover {
+          background-color: var(--iui-color-border-accent);
+        }
+
+        &:before {
+          content: '';
+          position: absolute;
+          width: 100%;
+          height: 20px;
+        }
+      }
 
       @include for-tablet-landscape-down {
         height: $resizer-size-large;
@@ -47,6 +65,13 @@ $resizer-size-large: 14px;
       width: $resizer-size;
       min-width: $resizer-size;
       cursor: ew-resize;
+
+      &:before {
+        content: '';
+        position: absolute;
+        width: 20px;
+        height: 100%;
+      }
 
       @include for-tablet-landscape-down {
         width: $resizer-size-large;

--- a/ui/appui-react/src/appui-react/content/ContentLayout.scss
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.scss
@@ -39,9 +39,9 @@ $resizer-size-large: 14px;
         justify-content: center;
         position: relative;
         display: flex;
-        height: 8px;
+        height: 5px;
         width: 100%;
-        top: -4px;
+        top: -2px;
         z-index: 1;
         transition: background-color 0.2s ease-out;
 
@@ -53,7 +53,7 @@ $resizer-size-large: 14px;
           content: '';
           position: absolute;
           width: 100%;
-          height: 16px;
+          height: 11px;
         }
       }
 
@@ -76,8 +76,8 @@ $resizer-size-large: 14px;
         position: relative;
         display: flex;
         height: 100%;
-        width: 8px;
-        left: -4px;
+        width: 5px;
+        left: -2px;
         z-index: 1;
         transition: background-color 0.2s ease-out;
 
@@ -85,10 +85,10 @@ $resizer-size-large: 14px;
           background-color: var(--iui-color-border-accent);
         }
 
-        &:after {
+        &:before {
           content: '';
           position: absolute;
-          width: 16px;
+          width: 11px;
           height: 100%;
         }
       }

--- a/ui/appui-react/src/appui-react/content/ContentLayout.scss
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.scss
@@ -67,11 +67,27 @@ $resizer-size-large: 14px;
       min-width: $resizer-size;
       cursor: ew-resize;
 
-      &:before {
-        content: '';
-        position: absolute;
-        width: 20px;
-        height: 100%;
+      >.nz-resizer-grip {
+        background-color: transparent;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        display: flex;
+        width: 8px;
+        right: -4px;
+        z-index: 1;
+        transition: background-color 0.2s ease-out;
+
+        &:hover {
+          background-color: var(--iui-color-border-accent);
+        }
+
+        &:before {
+          content: '';
+          position: absolute;
+          width: 16px;
+          height: 100%;
+        }
       }
 
       @include for-tablet-landscape-down {

--- a/ui/appui-react/src/appui-react/content/ContentLayout.scss
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.scss
@@ -40,6 +40,7 @@ $resizer-size-large: 14px;
         position: relative;
         display: flex;
         height: 8px;
+        width: 100%;
         top: -4px;
         z-index: 1;
         transition: background-color 0.2s ease-out;
@@ -63,9 +64,10 @@ $resizer-size-large: 14px;
     }
 
     &.vertical {
-      width: $resizer-size;
-      min-width: $resizer-size;
+      width: 1px;
+      min-width: 1px;
       cursor: ew-resize;
+      height: 100%;
 
       >.nz-resizer-grip {
         background-color: transparent;
@@ -73,8 +75,9 @@ $resizer-size-large: 14px;
         justify-content: center;
         position: relative;
         display: flex;
+        height: 100%;
         width: 8px;
-        right: -4px;
+        left: -4px;
         z-index: 1;
         transition: background-color 0.2s ease-out;
 
@@ -82,7 +85,7 @@ $resizer-size-large: 14px;
           background-color: var(--iui-color-border-accent);
         }
 
-        &:before {
+        &:after {
           content: '';
           position: absolute;
           width: 16px;

--- a/ui/appui-react/src/appui-react/content/ContentLayout.scss
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.scss
@@ -39,8 +39,9 @@ $resizer-size-large: 14px;
         justify-content: center;
         position: relative;
         display: flex;
-        height: 10px;
-        top: -5px;
+        height: 8px;
+        top: -4px;
+        z-index: 1;
         transition: background-color 0.2s ease-out;
 
         &:hover {
@@ -51,7 +52,7 @@ $resizer-size-large: 14px;
           content: '';
           position: absolute;
           width: 100%;
-          height: 20px;
+          height: 16px;
         }
       }
 

--- a/ui/appui-react/src/appui-react/content/split-pane/Resizer.tsx
+++ b/ui/appui-react/src/appui-react/content/split-pane/Resizer.tsx
@@ -68,6 +68,8 @@ export function Resizer(props: ResizerProps) {
           onDoubleClick(event.nativeEvent);
         }
       }}
-    />
+    >
+      <div className="nz-resizer-grip" />
+    </span>
   );
 }


### PR DESCRIPTION
## Changes

Made grip handles of `Resizer` more like side panel grip handles: 1px thick border with 5px thick outline that goes from transparent to blue when hovered over transparent 11px thick bounding box.
![handle grips](https://github.com/iTwin/appui/assets/124153238/a2232487-ac85-40a7-b509-1225c4ca7f96)

## Testing

Tested by nesting multiple vertical and horizontal splits and manually dragging them (as shown in the gif), making sure their bounding box is set up correctly.
