### PR TITLE
Succeed even if no backported changes exists.

### DIFF
--- a/.github/workflows/finalize-release.yaml
+++ b/.github/workflows/finalize-release.yaml
@@ -34,9 +34,11 @@ jobs:
 
           # Stage explicit files;
           #   - Files resolved due to taking master's version
+          git add **/package.json **/version-policies.json docs/changehistory/NextVersion.md
           #   - All changelogs to remove duplicates from master
           #     - They would be duplicated if the same PR is backported to the release branch
-          git add **/package.json **/version-policies.json common/changes docs/changehistory/NextVersion.md
+          #       (On a separate command so it can fail because none exists without blocking masters version files)
+          git add common/changes
 
           commitMessage=$(git log --format=%B -n 1 $commitid)
           git commit -m "$commitMessage Changelogs"


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

The "Finalize-release.yaml" script is taking care of porting back the changes from the release branch back to master (changelogs) and currently failed.

This script is trying to handle "backports" changes even if none were actually created, and this makes the `git add` command crash because it tries to add nothing. While the script itself is set up to handle such failure, the git command itself abort the whole command, also not adding the existing file change.

This attempt at adressing this by splitting the "always there" files and the "maybe there" files (which can fail without breaking the script)

## Testing

Tested manually the commands and validated the error, however, I'll only see once the action triggers if it works correctly within the CI environment.