### PR TITLE
Clean unused lint comment as well

### DIFF
--- a/test-apps/appui-test-app/appui-test-providers/src/store/index.ts
+++ b/test-apps/appui-test-app/appui-test-providers/src/store/index.ts
@@ -33,7 +33,6 @@ const initialState = {
   showCustomViewOverlay: false,
 } as TestProviderState;
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const TestProviderSliceName = "testProviderState";
 
 /** the TestProvider "slice" of Redux state" */

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/components/ViewDefinitionSelector.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/components/ViewDefinitionSelector.tsx
@@ -34,13 +34,11 @@ export interface RulesetSelectorState {
 export default function ViewDefinitionSelector(
   props: ViewDefinitionSelectorProps
 ) {
-  // eslint-disable-line @typescript-eslint/naming-convention
   const [selectOptions, setSelectOptions] = React.useState<
     SelectOption<string>[]
   >([]);
   React.useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    getViewDefinitions(props.imodel).then((result) => {
+    void getViewDefinitions(props.imodel).then((result) => {
       const options = result.map((definition) => ({
         value: definition.id,
         label: definition.label,

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/components/ViewsTable.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/components/ViewsTable.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable react/display-name */
 
 import * as React from "react";
 import { Table } from "@itwin/itwinui-react";
@@ -20,8 +19,7 @@ export function ViewsTable() {
 
   React.useEffect(() => {
     if (activeIModelConnection) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      getViewDefinitions(activeIModelConnection).then((result) => {
+      void getViewDefinitions(activeIModelConnection).then((result) => {
         setIModelViews(result);
       });
     }

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/dialogs/PopoutDialog.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/dialogs/PopoutDialog.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable react/display-name */
 
 import * as React from "react";
 import { ViewsTable } from "../components/ViewsTable";

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/dialogs/SampleModalDialog.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/dialogs/SampleModalDialog.tsx
@@ -12,7 +12,6 @@ import { AppUiTestProviders } from "../../AppUiTestProviders";
 /**
  *  This is an example of how to create a React-based modal dialog that can be opened via a toolbutton or a key-in.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function SampleModalDialog() {
   const title = React.useRef(
     AppUiTestProviders.translate("Dialogs.SampleModal.title")

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/dialogs/SynchronizedFloatingViewComponent.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/dialogs/SynchronizedFloatingViewComponent.tsx
@@ -169,8 +169,7 @@ export function SynchronizedFloatingView({ contentId }: { contentId: string }) {
       "BisCore:DrawingViewDefinition",
       "BisCore:SheetViewDefinition",
     ];
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    getViewDefinitions(activeIModelConnection).then(
+    void getViewDefinitions(activeIModelConnection).then(
       (viewDefinitions: SynchronizedViewDefInterfaceLocal[]) => {
         const localThreeTwoDViewDefs = viewDefinitions.filter((def: any) => {
           return acceptedSpatialViewClasses.indexOf(def.class) > -1;
@@ -206,8 +205,7 @@ export function SynchronizedFloatingView({ contentId }: { contentId: string }) {
 
         if (initialViewIdToLoad) {
           // This block is twisted beyond recognition. We need a better way to fit view from core team here.
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          activeIModelConnection.views
+          void activeIModelConnection.views
             .load(initialViewIdToLoad)
             .then((viewState: ViewState) => {
               setInitialViewState(viewState);

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/SynchronizedFloatingViewport.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/SynchronizedFloatingViewport.tsx
@@ -73,7 +73,6 @@ export class SynchronizedFloatingViewportContentGroupProvider extends ContentGro
   public override async contentGroup(
     config: FrontstageConfig
   ): Promise<ContentGroup> {
-    // eslint-disable-line deprecation/deprecation
     const savedViewLayoutProps = await getSavedViewLayoutProps(
       config.id,
       UiFramework.getIModelConnection()

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/WidgetApiStage.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/WidgetApiStage.tsx
@@ -48,7 +48,6 @@ import {
  * a single content view and also defines a custom view overlay. The display of the view overlay in its applicationData.
  */
 export class WidgetApiStageContentGroupProvider extends ContentGroupProvider {
-  /* eslint-disable react/jsx-key */
   public static supplyViewOverlay = (viewport: ScreenViewport) => {
     if (viewport.view) {
       return <MyCustomViewOverlay />;
@@ -270,7 +269,6 @@ export function getToggleCustomOverlayCommandItemDef() {
  * Simple View overlay that just displays static React component. The display of the overlay is controlled
  * based on a variable in the Redux store which can be seen in file `..\appui-test-providers\src\store\index.ts`.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function MyCustomViewOverlay() {
   const showOverlay = useSelector(
     (state: { testProviderState: TestProviderState }) => {

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable react/display-name */
 
 import * as React from "react";
 import {

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PopoutWindowsStageUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PopoutWindowsStageUiItemsProvider.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable react/display-name */
 
 import * as React from "react";
 import {

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/WidgetApiStageUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/WidgetApiStageUiItemsProvider.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable react/display-name */
 
 import * as React from "react";
 import {

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/statusfields/DisplayStyleField.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/statusfields/DisplayStyleField.tsx
@@ -30,7 +30,6 @@ import { CommonProps } from "@itwin/core-react";
  * This component is designed to be specified in a status bar definition to select the display style in the active IModel view.
  * It is used to enable/disable display of shadows.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function DisplayStyleField(props: CommonProps) {
   const [viewport, setViewport] = React.useState<ScreenViewport | undefined>();
   const [displayStyles, setDisplayStyles] = React.useState(
@@ -105,8 +104,9 @@ export function DisplayStyleField(props: CommonProps) {
       );
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    setStateFromActiveContent(UiFramework.content.getActiveContentControl());
+    void setStateFromActiveContent(
+      UiFramework.content.getActiveContentControl()
+    );
 
     return UiFramework.frontstages.onContentControlActivatedEvent.addListener(
       handleContentControlActivatedEvent

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/LayoutWidget.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/LayoutWidget.tsx
@@ -38,7 +38,6 @@ function usePanelSize(location: StagePanelLocation) {
     setSize(panelDef?.size);
   }, [panelDef]);
   React.useEffect(() => {
-    // eslint-disable-next-line deprecation/deprecation
     const remove =
       InternalFrontstageManager.onPanelSizeChangedEvent.addListener((e) => {
         if (e.panelDef.location === location) setSize(e.size);
@@ -684,7 +683,6 @@ export function FloatingLayoutInfo() {
     getFloatingWidgetContainerBounds(frontstageDef, floatingWidgetId)
   );
   React.useEffect(() => {
-    // eslint-disable-next-line deprecation/deprecation
     return InternalFrontstageManager.onFrontstageNineZoneStateChangedEvent.addListener(
       (e: any) => {
         if (e.frontstageDef !== frontstageDef) return;

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/SelectedElementDataWidget.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/SelectedElementDataWidget.tsx
@@ -27,7 +27,6 @@ export function useIdOfSelectedElements() {
   return locatedIds;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function SelectedElementDataWidgetComponent() {
   const idList = useIdOfSelectedElements();
   const widgetDef = useSpecificWidgetDef(

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/ViewAttributesWidget.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/ViewAttributesWidget.tsx
@@ -12,7 +12,6 @@ export function useWidgetDef(id: string) {
   const frontstageDef = useActiveFrontstageDef();
   return frontstageDef?.findWidgetDef(id);
 }
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function ToggleCameraItem() {
   const activeViewport = useActiveViewport();
   const [cameraOn, setCameraOn] = React.useState(activeViewport?.isCameraOn);
@@ -41,7 +40,6 @@ export function ToggleCameraItem() {
     />
   );
 }
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function ViewFlagItem(flagName: string) {
   const activeViewport = useActiveViewport();
 
@@ -111,7 +109,6 @@ export function ViewFlagItem(flagName: string) {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function ViewAttributesWidgetComponent() {
   const items: JSX.Element[] = [];
   items.push(ViewFlagItem("acs"));

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/ViewportWidget.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/ViewportWidget.tsx
@@ -13,7 +13,7 @@ import {
 import { Id64, Id64String } from "@itwin/core-bentley";
 import { useRefState } from "@itwin/core-react";
 import ViewDefinitionSelector from "../components/ViewDefinitionSelector";
-// eslint-disable-next-line @typescript-eslint/naming-convention
+
 export function ViewportWidgetComponent() {
   const activeIModelConnection = useActiveIModelConnection();
   const [viewState, setViewState] = React.useState(
@@ -40,12 +40,11 @@ export function ViewportWidgetComponent() {
           const newViewState = await activeIModelConnection?.views.load(
             defaultViewId
           );
-          // eslint-disable-next-line react-hooks/exhaustive-deps
           newViewState && setViewState(newViewState.clone());
         }
       }
     }
-    setupView(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void setupView();
   }, [activeIModelConnection, viewState]);
 
   React.useEffect(() => {

--- a/test-apps/appui-test-app/connected/src/frontend/appui/frontstages/SignInFrontstage.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/appui/frontstages/SignInFrontstage.tsx
@@ -39,7 +39,7 @@ class SignInControl extends ContentControl {
       IModelApp.authorizationClient instanceof BrowserAuthorizationClient ||
       IModelApp.authorizationClient instanceof ElectronRendererAuthorization
     ) {
-      IModelApp.authorizationClient.signIn(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void IModelApp.authorizationClient.signIn();
     }
   };
 

--- a/test-apps/appui-test-app/connected/src/frontend/appui/imodelopen/IModelOpen.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/appui/imodelopen/IModelOpen.tsx
@@ -33,7 +33,7 @@ export function IModelOpen(props: IModelOpenProps) {
       const token = await IModelApp.getAccessToken();
       setAccessToken(token);
     }
-    fetchAccessToken(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void fetchAccessToken();
   }, []);
 
   React.useEffect(() => {
@@ -47,7 +47,7 @@ export function IModelOpen(props: IModelOpenProps) {
         if (iTwins.length) setCurrentITwin(iTwins[0]);
       } catch {}
     }
-    fetchProjects(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void fetchProjects();
   }, [accessToken]);
 
   const selectITwin = React.useCallback(async (iTwin: ITwin) => {

--- a/test-apps/appui-test-app/connected/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/index.tsx
@@ -851,7 +851,6 @@ const SampleAppViewer2 = () => {
 
 // If we are using a browser, close the current iModel before leaving
 window.addEventListener("beforeunload", async () => {
-  // eslint-disable-line @typescript-eslint/no-misused-promises
   await SampleAppIModelApp.closeCurrentIModel();
 });
 
@@ -884,7 +883,7 @@ async function main() {
   Logger.logInfo(
     "Configuration",
     JSON.stringify(SampleAppIModelApp.testAppConfiguration)
-  ); // eslint-disable-line no-console
+  );
 
   const mapLayerOpts = {
     BingMaps: SampleAppIModelApp.testAppConfiguration.bingMapsKey
@@ -947,4 +946,4 @@ async function main() {
 }
 
 // Entry point - run the main function
-main(); // eslint-disable-line @typescript-eslint/no-floating-promises
+void main();

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/BlankConnection.ts
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/BlankConnection.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable deprecation/deprecation */
 import { UiFramework } from "@itwin/appui-react";
 import { Logger } from "@itwin/core-bentley";
 import { Cartographic, ColorDef, RenderMode } from "@itwin/core-common";

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable deprecation/deprecation */
 import * as React from "react";
 import { Id64String } from "@itwin/core-bentley";
 import { IModelReadRpcInterface, ViewQueryParams } from "@itwin/core-common";
@@ -32,7 +31,7 @@ import {
 } from "@itwin/appui-react";
 import { SampleAppIModelApp, SampleAppUiActionId } from "../..";
 import { LocalFileSupport } from "../LocalFileSupport";
-import { Button, Headline } from "@itwin/itwinui-react";
+import { Button, Text } from "@itwin/itwinui-react";
 import {
   ConditionalBooleanValue,
   StandardContentLayouts,
@@ -293,7 +292,7 @@ function LocalFilePage(props: LocalFilePageProps) {
   return (
     <>
       <div style={{ position: "absolute", top: "16px", left: "100px" }}>
-        <Headline>{title.current}</Headline>
+        <Text variant="headline">{title.current}</Text>
       </div>
       <FillCentered>
         {!isElectronApp.current && (

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -608,7 +608,6 @@ function AppViewerContent() {
 
 // If we are using a browser, close the current iModel before leaving
 window.addEventListener("beforeunload", async () => {
-  // eslint-disable-line @typescript-eslint/no-misused-promises
   await SampleAppIModelApp.closeCurrentIModel();
 });
 
@@ -643,7 +642,7 @@ async function main() {
   Logger.logInfo(
     "Configuration",
     JSON.stringify(SampleAppIModelApp.testAppConfiguration)
-  ); // eslint-disable-line no-console
+  );
 
   const mapLayerOpts = {
     BingMaps: SampleAppIModelApp.testAppConfiguration.bingMapsKey
@@ -696,4 +695,4 @@ async function main() {
 }
 
 // Entry point - run the main function
-main(); // eslint-disable-line @typescript-eslint/no-floating-promises
+void main();

--- a/ui/appui-layout-react/src/appui-layout-react/base/DragManager.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/DragManager.tsx
@@ -747,25 +747,25 @@ export class DragManager {
 }
 
 /** @internal */
-export const DragManagerContext = React.createContext<DragManager>(null!); // eslint-disable-line: completed-docs @typescript-eslint/naming-convention
+export const DragManagerContext = React.createContext<DragManager>(null!);
 DragManagerContext.displayName = "nz:DragManagerContext";
 
 /** @internal */
 export const DraggedWidgetIdContext = React.createContext<
   WidgetState["id"] | undefined
->(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+>(undefined);
 DraggedWidgetIdContext.displayName = "nz:DraggedWidgetIdContext";
 
 /** @internal */
 export const DraggedPanelSideContext = React.createContext<
   PanelSide | undefined
->(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+>(undefined);
 DraggedPanelSideContext.displayName = "nz:DraggedPanelSideContext";
 
 /** @internal */
 export const DraggedResizeHandleContext = React.createContext<
   FloatingWidgetResizeHandle | undefined
->(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+>(undefined);
 DraggedResizeHandleContext.displayName = "nz:DraggedResizeHandleContext";
 
 /** @internal */

--- a/ui/appui-layout-react/src/appui-layout-react/base/NineZone.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/NineZone.tsx
@@ -59,7 +59,7 @@ export interface NineZoneLabels {
 
 /** @internal */
 export function NineZone(props: NineZoneProps) {
-  const { children, ...providerProps } = props; // eslint-disable-line @typescript-eslint/no-unused-vars
+  const { children, ...providerProps } = props;
   const measurerRef = React.useRef<HTMLDivElement>(null);
   const measure = React.useCallback<() => Rectangle>(() => {
     assert(!!measurerRef.current);
@@ -68,7 +68,7 @@ export function NineZone(props: NineZoneProps) {
   return (
     <NineZoneProvider measure={measure} {...providerProps}>
       <Measurer ref={measurerRef} />
-      {props.children}
+      {children}
     </NineZoneProvider>
   );
 }
@@ -129,62 +129,62 @@ export function NineZoneProvider(props: NineZoneProviderProps) {
 /** @internal */
 export const NineZoneDispatchContext = React.createContext<NineZoneDispatch>(
   null!
-); // eslint-disable-line @typescript-eslint/naming-convention
+);
 NineZoneDispatchContext.displayName = "nz:NineZoneDispatchContext";
 
 /** @internal */
 export const NineZoneLabelsContext = React.createContext<
   NineZoneLabels | undefined
->(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+>(undefined);
 NineZoneLabelsContext.displayName = "nz:NineZoneLabelsContext";
 
 /** @internal */
 export const CursorTypeContext = React.createContext<CursorType | undefined>(
   undefined
-); // eslint-disable-line @typescript-eslint/naming-convention
+);
 CursorTypeContext.displayName = "nz:CursorTypeContext";
 
 /** @internal */
 export const WidgetContentNodeContext =
-  React.createContext<React.ReactNode>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+  React.createContext<React.ReactNode>(undefined);
 WidgetContentNodeContext.displayName = "nz:WidgetContentNodeContext";
 
 /** @internal */
-export const ShowWidgetIconContext = React.createContext<boolean>(false); // eslint-disable-line @typescript-eslint/naming-convention
+export const ShowWidgetIconContext = React.createContext<boolean>(false);
 ShowWidgetIconContext.displayName = "nz:ShowWidgetIconContext";
 
 /** @internal */
 export const AutoCollapseUnpinnedPanelsContext =
-  React.createContext<boolean>(false); // eslint-disable-line @typescript-eslint/naming-convention
+  React.createContext<boolean>(false);
 AutoCollapseUnpinnedPanelsContext.displayName =
   "nz:AutoCollapseUnpinnedPanelsContext";
 
 /** @internal */
 export const AnimateDockedToolSettingsContext =
-  React.createContext<boolean>(false); // eslint-disable-line @typescript-eslint/naming-convention
+  React.createContext<boolean>(false);
 AnimateDockedToolSettingsContext.displayName =
   "nz:AnimateDockedToolSettingsContext";
 
 /** @internal */
 export const ToolSettingsNodeContext =
-  React.createContext<React.ReactNode>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+  React.createContext<React.ReactNode>(undefined);
 ToolSettingsNodeContext.displayName = "nz:ToolSettingsNodeContext";
 
 /** @internal */
-export const TabNodeContext = React.createContext<React.ReactNode>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+export const TabNodeContext = React.createContext<React.ReactNode>(undefined);
 TabNodeContext.displayName = "nz:TabNodeContext";
 
 /** @internal */
 export const FloatingWidgetNodeContext =
-  React.createContext<React.ReactNode>(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+  React.createContext<React.ReactNode>(undefined);
 FloatingWidgetNodeContext.displayName = "nz:FloatingWidgetNodeContext";
 
 /** @internal */
-export const MeasureContext = React.createContext<() => Rectangle>(null!); // eslint-disable-line @typescript-eslint/naming-convention
+export const MeasureContext = React.createContext<() => Rectangle>(null!);
 MeasureContext.displayName = "nz:MeasureContext";
 
 /** @internal */
-export const UiIsVisibleContext = React.createContext<boolean>(false); // eslint-disable-line @typescript-eslint/naming-convention
+export const UiIsVisibleContext = React.createContext<boolean>(false);
 UiIsVisibleContext.displayName = "nz:UiIsVisibleContext";
 
 function CursorTypeProvider(props: { children?: React.ReactNode }) {
@@ -204,7 +204,6 @@ function CursorTypeProvider(props: { children?: React.ReactNode }) {
 }
 
 const Measurer = React.forwardRef<HTMLDivElement>(function Measurer(_, ref) {
-  // eslint-disable-line @typescript-eslint/naming-convention, no-shadow
   const size = React.useRef<{ height?: number; width?: number }>({});
   const dispatch = React.useContext(NineZoneDispatchContext);
   const handleResize = React.useCallback(

--- a/ui/appui-layout-react/src/appui-layout-react/tool-settings/Docked.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/tool-settings/Docked.tsx
@@ -22,7 +22,6 @@ import { CSSTransition, TransitionGroup } from "react-transition-group";
 export function onOverflowLabelAndEditorResize() {}
 
 /** This component takes a DockedToolSetting "wrapper" component and extract only the label and editor components from it */
-// eslint-disable-next-line @typescript-eslint/naming-convention, no-shadow
 function OverflowLabelAndEditor({ wrapper }: { wrapper: React.ReactNode }) {
   assert(React.isValidElement(wrapper));
   const entryValue = React.useMemo<DockedToolSettingsEntryContextArgs>(
@@ -126,7 +125,6 @@ export function DockedToolSettings(props: DockedToolSettingsProps) {
         return acc;
       }, [])
     : [];
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const PanelContainer = props.panelContainer
     ? props.panelContainer
     : DefaultPanelContainer;
@@ -372,7 +370,6 @@ interface DockedToolSettingsEntryContextArgs {
   readonly onResize: (w: number) => void;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const DockedToolSettingsEntryContext =
   React.createContext<DockedToolSettingsEntryContextArgs>(null!);
 DockedToolSettingsEntryContext.displayName =

--- a/ui/appui-layout-react/src/appui-layout-react/tool-settings/Overflow.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/tool-settings/Overflow.tsx
@@ -31,8 +31,6 @@ export const DockedToolSettingsOverflow = React.forwardRef<
   HTMLDivElement,
   DockedToolSettingsOverflowProps
 >(function DockedToolSettingsOverflow(props, ref) {
-  // eslint-disable-line @typescript-eslint/naming-convention, react/display-name
-  // eslint-disable-line @typescript-eslint/naming-convention, no-shadow
   const roRef = useResizeObserver<HTMLDivElement>(props.onResize);
   const refs = useRefs(roRef, ref);
   const className = classnames("nz-toolSettings-overflow", props.className);

--- a/ui/appui-layout-react/src/appui-layout-react/tool-settings/Panel.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/tool-settings/Panel.tsx
@@ -26,7 +26,6 @@ export interface ToolSettingsOverflowPanelProps extends CommonProps {
 /** Displays overflown tool settings.
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function ToolSettingsOverflowPanel(
   props: ToolSettingsOverflowPanelProps
 ) {

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Content.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Content.tsx
@@ -29,8 +29,6 @@ export const WidgetPanelsContent = React.forwardRef<
   HTMLDivElement,
   WidgetPanelsContentProps
 >(function WidgetPanelsContent(props, ref) {
-  // eslint-disable-line react/display-name
-  // eslint-disable-line @typescript-eslint/no-shadow
   const className = classnames(
     "nz-widgetPanels-content",
     props.pinnedLeft && "nz-pinned-left",

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.tsx
@@ -230,7 +230,7 @@ export const useResizeGrip = <T extends HTMLElement>(): [
       handlePointerCaptorRef(instance);
     },
     [handlePointerCaptorRef]
-  ); // eslint-disable-line react-hooks/exhaustive-deps
+  );
   return [handleRef, resizing, active];
 };
 

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panel.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panel.tsx
@@ -170,7 +170,7 @@ export function WidgetPanel() {
 /** @internal */
 export const PanelSideContext = React.createContext<PanelSide | undefined>(
   undefined
-); // eslint-disable-line @typescript-eslint/naming-convention
+);
 PanelSideContext.displayName = "nz:PanelSideContext";
 
 /** @internal */

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panels.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Panels.tsx
@@ -61,10 +61,10 @@ function WidgetPanelsComponent(props: CommonProps) {
 }
 
 /** @internal */
-export const ContentNodeContext = React.createContext<React.ReactNode>(null); // eslint-disable-line @typescript-eslint/naming-convention
+export const ContentNodeContext = React.createContext<React.ReactNode>(null);
 ContentNodeContext.displayName = "nz:ContentNodeContext";
 
 /** @internal */
 export const CenterContentNodeContext =
-  React.createContext<React.ReactNode>(null); // eslint-disable-line @typescript-eslint/naming-convention
+  React.createContext<React.ReactNode>(null);
 CenterContentNodeContext.displayName = "nz:CenterContentNodeContext";

--- a/ui/appui-layout-react/src/appui-layout-react/widget/ContentManager.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/ContentManager.tsx
@@ -79,5 +79,5 @@ export interface WidgetContentManagerContextArgs {
 
 /** @internal */
 export const WidgetContentManagerContext =
-  React.createContext<WidgetContentManagerContextArgs>(null!); // eslint-disable-line @typescript-eslint/naming-convention
+  React.createContext<WidgetContentManagerContextArgs>(null!);
 WidgetContentManagerContext.displayName = "nz:WidgetContentManagerContext";

--- a/ui/appui-layout-react/src/appui-layout-react/widget/ContentRenderer.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/ContentRenderer.tsx
@@ -88,7 +88,7 @@ export function WidgetContentRenderer(props: WidgetContentRendererProps) {
 /** @internal */
 export const TabIdContext = React.createContext<TabState["id"] | undefined>(
   undefined
-); // eslint-disable-line @typescript-eslint/naming-convention
+);
 TabIdContext.displayName = "nz:TabIdContext";
 
 /** @internal */

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Overflow.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Overflow.tsx
@@ -78,7 +78,7 @@ interface WidgetOverflowContextArgs {
 /** @internal */
 export const WidgetOverflowContext = React.createContext<
   WidgetOverflowContextArgs | undefined
->(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+>(undefined);
 WidgetOverflowContext.displayName = "nz:WidgetOverflowContext";
 
 function usePanelPopup(onClose: () => void) {

--- a/ui/appui-layout-react/src/appui-layout-react/widget/PanelWidget.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/PanelWidget.tsx
@@ -32,9 +32,8 @@ export interface PanelWidgetProps {
 }
 
 /** @internal */
-export const PanelWidget = React.forwardRef<HTMLDivElement, PanelWidgetProps>( // eslint-disable-line react/display-name
+export const PanelWidget = React.forwardRef<HTMLDivElement, PanelWidgetProps>(
   function PanelWidget({ widgetId }, ref) {
-    // eslint-disable-line @typescript-eslint/naming-convention
     const side = React.useContext(PanelSideContext);
     assert(!!side);
     const widgetsLength = useLayout((state) => {

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Tabs.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Tabs.tsx
@@ -126,7 +126,7 @@ interface WidgetTabsEntryContextArgs {
 /** @internal */
 export const WidgetTabsEntryContext = React.createContext<
   WidgetTabsEntryContextArgs | undefined
->(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+>(undefined);
 WidgetTabsEntryContext.displayName = "nz:WidgetTabsEntryContext";
 
 /** @internal */

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Widget.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Widget.tsx
@@ -50,9 +50,8 @@ export interface WidgetProps extends CommonProps {
 }
 
 /** @internal */
-export const Widget = React.forwardRef<HTMLDivElement, WidgetProps>( // eslint-disable-line react/display-name, @typescript-eslint/naming-convention
+export const Widget = React.forwardRef<HTMLDivElement, WidgetProps>(
   function Widget(props, forwardedRef) {
-    // eslint-disable-line @typescript-eslint/naming-convention
     const dispatch = React.useContext(NineZoneDispatchContext);
     const side = React.useContext(PanelSideContext);
     const id = React.useContext(WidgetIdContext);
@@ -184,7 +183,7 @@ export const Widget = React.forwardRef<HTMLDivElement, WidgetProps>( // eslint-d
 /** @internal */
 export const WidgetIdContext = React.createContext<
   WidgetState["id"] | undefined
->(undefined); // eslint-disable-line @typescript-eslint/naming-convention
+>(undefined);
 WidgetIdContext.displayName = "nz:WidgetIdContext";
 
 /** @internal */
@@ -193,7 +192,7 @@ export interface WidgetContextArgs {
 }
 
 /** @internal */
-export const WidgetContext = React.createContext<WidgetContextArgs>(null!); // eslint-disable-line @typescript-eslint/naming-convention
+export const WidgetContext = React.createContext<WidgetContextArgs>(null!);
 WidgetContext.displayName = "nz:WidgetContext";
 
 const minWidth = 200;

--- a/ui/appui-layout-react/src/test/base/DragManager.test.tsx
+++ b/ui/appui-layout-react/src/test/base/DragManager.test.tsx
@@ -55,7 +55,7 @@ describe("useTabTarget", () => {
       {
         wrapper: (props) => (
           <DragManagerContext.Provider value={dragManager} {...props} />
-        ), // eslint-disable-line react/display-name
+        ),
       }
     );
 
@@ -100,7 +100,7 @@ describe("useTabTarget", () => {
       {
         wrapper: (props) => (
           <DragManagerContext.Provider value={dragManager} {...props} />
-        ), // eslint-disable-line react/display-name
+        ),
       }
     );
 
@@ -140,7 +140,7 @@ describe("usePanelTarget", () => {
       {
         wrapper: (props) => (
           <DragManagerContext.Provider value={dragManager} {...props} />
-        ), // eslint-disable-line react/display-name
+        ),
       }
     );
 
@@ -173,7 +173,7 @@ describe("useWidgetTarget", () => {
       {
         wrapper: (props) => (
           <DragManagerContext.Provider value={dragManager} {...props} />
-        ), // eslint-disable-line react/display-name
+        ),
       }
     );
 
@@ -199,7 +199,7 @@ describe("useIsDraggedType", () => {
     const { result } = renderHook(() => useIsDraggedType("tab"), {
       wrapper: (props) => (
         <DragManagerContext.Provider value={dragManager} {...props} />
-      ), // eslint-disable-line react/display-name
+      ),
     });
     result.current.should.false;
 
@@ -222,7 +222,7 @@ describe("useDraggedItem", () => {
     const { result } = renderHook(() => useDraggedItem(), {
       wrapper: (props) => (
         <DragManagerContext.Provider value={dragManager} {...props} />
-      ), // eslint-disable-line react/display-name
+      ),
     });
     should().equal(result.current, undefined);
 
@@ -262,7 +262,7 @@ describe("useTargeted", () => {
     const { result } = renderHook(() => useTargeted(), {
       wrapper: (props) => (
         <DragManagerContext.Provider value={dragManager} {...props} />
-      ), // eslint-disable-line react/display-name
+      ),
     });
     expect(result.current).to.be.undefined;
 

--- a/ui/appui-layout-react/src/test/base/NineZone.test.tsx
+++ b/ui/appui-layout-react/src/test/base/NineZone.test.tsx
@@ -35,7 +35,7 @@ describe("<NineZone />", () => {
   });
 
   it("should measure NineZone bounds", () => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention, react/display-name
+    // eslint-disable-next-line react/display-name
     const Measurer = React.forwardRef<{ measure: () => Rectangle }>(
       (_, ref) => {
         const measure = React.useContext(MeasureContext);
@@ -75,7 +75,7 @@ describe("<NineZone />", () => {
     sinon
       .stub(ResizeObserverMock.prototype, "observe")
       .callsFake(function (this: ResizeObserverMock, element: Element) {
-        resizeObserver = this; // eslint-disable-line @typescript-eslint/no-this-alias
+        resizeObserver = this;
         measurer = element;
       });
 
@@ -117,7 +117,7 @@ describe("<NineZone />", () => {
     sinon
       .stub(ResizeObserverMock.prototype, "observe")
       .callsFake(function (this: ResizeObserverMock, element: Element) {
-        resizeObserver = this; // eslint-disable-line @typescript-eslint/no-this-alias
+        resizeObserver = this;
         measurer = element;
       });
 
@@ -160,7 +160,6 @@ describe("useLabel", () => {
     const labels: NineZoneLabels = {
       dockToolSettingsTitle: "test",
     };
-    // eslint-disable-next-line react/display-name
     const { result } = renderHook(() => useLabel("dockToolSettingsTitle"), {
       wrapper: (props: {}) => (
         <NineZoneLabelsContext.Provider value={labels} {...props} />

--- a/ui/appui-layout-react/src/test/outline/PanelOutline.test.tsx
+++ b/ui/appui-layout-react/src/test/outline/PanelOutline.test.tsx
@@ -55,9 +55,9 @@ describe("PanelOutline", () => {
     let state = createNineZoneState();
     state = updatePanelState(state, "bottom", { span: true });
     const { container } = render(<PanelOutline />, {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => <Wrapper defaultState={state} side="bottom" {...props} />,
+      wrapper: (props) => (
+        <Wrapper defaultState={state} side="bottom" {...props} />
+      ),
     });
     container
       .getElementsByClassName("nz-outline-panelOutline nz-span")
@@ -88,9 +88,9 @@ describe("useHidden", () => {
   it("should return `true` if target is not a panel", () => {
     const dragManagerRef = React.createRef<DragManager>();
     const { result } = renderHook(() => useHidden(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => <Wrapper dragManagerRef={dragManagerRef} {...props} />,
+      wrapper: (props) => (
+        <Wrapper dragManagerRef={dragManagerRef} {...props} />
+      ),
     });
     act(() => {
       dragManagerRef.current?.handleDragStart(createDragStartArgs());
@@ -104,9 +104,9 @@ describe("useHidden", () => {
   it("should return `true` if target is not a current panel", () => {
     const dragManagerRef = React.createRef<DragManager>();
     const { result } = renderHook(() => useHidden(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => <Wrapper dragManagerRef={dragManagerRef} {...props} />,
+      wrapper: (props) => (
+        <Wrapper dragManagerRef={dragManagerRef} {...props} />
+      ),
     });
     act(() => {
       dragManagerRef.current?.handleDragStart(createDragStartArgs());
@@ -122,9 +122,9 @@ describe("useHidden", () => {
   it("should return `false` if target is a current panel", () => {
     const dragManagerRef = React.createRef<DragManager>();
     const { result } = renderHook(() => useHidden(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => <Wrapper dragManagerRef={dragManagerRef} {...props} />,
+      wrapper: (props) => (
+        <Wrapper dragManagerRef={dragManagerRef} {...props} />
+      ),
     });
     act(() => {
       dragManagerRef.current?.handleDragStart(createDragStartArgs());
@@ -150,7 +150,7 @@ describe("useHidden", () => {
 
     useActiveSendBackWidgetIdStore.setState("w1");
     const { result } = renderHook(() => useHidden(), {
-      wrapper: (props) => <Wrapper defaultState={state} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <Wrapper defaultState={state} {...props} />,
     });
 
     result.current.should.false;
@@ -169,7 +169,7 @@ describe("useHidden", () => {
 
     useActiveSendBackWidgetIdStore.setState("w1");
     const { result } = renderHook(() => useHidden(), {
-      wrapper: (props) => <Wrapper defaultState={state} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <Wrapper defaultState={state} {...props} />,
     });
 
     result.current.should.true;

--- a/ui/appui-layout-react/src/test/outline/SectionOutline.test.tsx
+++ b/ui/appui-layout-react/src/test/outline/SectionOutline.test.tsx
@@ -49,7 +49,7 @@ describe("SectionOutline", () => {
     const { container } = render(<SectionOutline sectionIndex={0} />, {
       wrapper: (props) => (
         <Wrapper defaultState={state} dragManagerRef={dragManager} {...props} />
-      ), // eslint-disable-line react/display-name
+      ),
     });
 
     act(() => {

--- a/ui/appui-layout-react/src/test/target/PanelTarget.test.tsx
+++ b/ui/appui-layout-react/src/test/target/PanelTarget.test.tsx
@@ -18,9 +18,7 @@ import { useAllowedPanelTarget } from "../../appui-layout-react/target/useAllowe
 describe("useAllowedPanelTarget", () => {
   it("should return `true`", () => {
     const { result } = renderHook(() => useAllowedPanelTarget(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <TestNineZoneProvider>
           <PanelSideContext.Provider value="left">
             {props.children}
@@ -37,9 +35,7 @@ describe("useAllowedPanelTarget", () => {
     });
     state = addTab(state, "t1", { allowedPanelTargets: ["right"] });
     const { result } = renderHook(() => useAllowedPanelTarget(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <TestNineZoneProvider defaultState={state}>
           <PanelSideContext.Provider value="left">
             {props.children}
@@ -55,9 +51,7 @@ describe("useAllowedPanelTarget", () => {
     state = addTab(state, "t1", { allowedPanelTargets: ["right"] });
     state = addPanelWidget(state, "left", "w1", ["t1"]);
     const { result } = renderHook(() => useAllowedPanelTarget(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <TestNineZoneProvider defaultState={state}>
           <PanelSideContext.Provider value="left">
             <DraggedWidgetIdContext.Provider value="w1">
@@ -76,9 +70,7 @@ describe("useAllowedPanelTarget", () => {
     state = addTab(state, "t2", { allowedPanelTargets: ["right"] });
     state = addPanelWidget(state, "left", "w1", ["t1", "t2"]);
     const { result } = renderHook(() => useAllowedPanelTarget(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <TestNineZoneProvider defaultState={state}>
           <PanelSideContext.Provider value="left">
             <DraggedWidgetIdContext.Provider value="w1">

--- a/ui/appui-layout-react/src/test/target/SectionTarget.test.tsx
+++ b/ui/appui-layout-react/src/test/target/SectionTarget.test.tsx
@@ -21,9 +21,7 @@ import { createDraggedTabState } from "../../appui-layout-react/state/internal/T
 describe("useTargetDirection", () => {
   it("should return `horizontal`", () => {
     const { result } = renderHook(() => useTargetDirection(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <PanelSideContext.Provider value="bottom">
           {props.children}
         </PanelSideContext.Provider>
@@ -34,9 +32,7 @@ describe("useTargetDirection", () => {
 
   it("should return `vertical`", () => {
     const { result } = renderHook(() => useTargetDirection(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <PanelSideContext.Provider value="left">
           {props.children}
         </PanelSideContext.Provider>
@@ -83,7 +79,7 @@ describe("useAllowedPanelTarget", () => {
     state = addTab(state, "t3");
     state = addPanelWidget(state, "left", "w2", ["t3"]);
     const { container } = render(<SectionTargets widgetId="w2" />, {
-      wrapper: (props) => <DragWidgetWrapper defaultState={state} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <DragWidgetWrapper defaultState={state} {...props} />,
     });
     container.getElementsByClassName("nz-hidden").length.should.eq(3);
   });
@@ -96,7 +92,7 @@ describe("useAllowedPanelTarget", () => {
     state = addTab(state, "t2");
     state = addPanelWidget(state, "left", "w1", ["t2"]);
     const { container } = render(<SectionTargets widgetId="w1" />, {
-      wrapper: (props) => <DragTabWrapper defaultState={state} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <DragTabWrapper defaultState={state} {...props} />,
     });
     container.getElementsByClassName("nz-hidden").length.should.eq(3);
   });

--- a/ui/appui-layout-react/src/test/target/TabTarget.test.tsx
+++ b/ui/appui-layout-react/src/test/target/TabTarget.test.tsx
@@ -45,7 +45,7 @@ describe("TabTarget", () => {
     const { container } = render(<TabTarget />, {
       wrapper: (props) => (
         <Wrapper defaultState={state} widgetId="w1" {...props} />
-      ), // eslint-disable-line react/display-name
+      ),
     });
     container.getElementsByClassName("nz-target-tabTarget").length.should.eq(1);
   });
@@ -58,9 +58,7 @@ describe("TabTarget", () => {
     state = addTab(state, "t3", { allowedPanelTargets: ["right"] });
     state = addPanelWidget(state, "right", "w2", ["t2", "t3"]);
     const { result } = renderHook(() => useAllowedWidgetTarget("w1"), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <TestNineZoneProvider defaultState={state}>
           <DraggedWidgetIdContext.Provider value="w2">
             {props.children}
@@ -79,9 +77,7 @@ describe("TabTarget", () => {
     state = addTab(state, "t2", { allowedPanelTargets: ["right"] });
     state = addPanelWidget(state, "left", "w1", ["t1"]);
     const { result } = renderHook(() => useAllowedWidgetTarget("w1"), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <TestNineZoneProvider defaultState={state}>
           {props.children}
         </TestNineZoneProvider>
@@ -98,9 +94,7 @@ describe("TabTarget", () => {
     state = addTab(state, "t4", { allowedPanelTargets: ["right"] });
     state = addPanelWidget(state, "left", "w2", ["t2", "t3", "t4"]);
     const { result } = renderHook(() => useAllowedWidgetTarget("w1"), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <TestNineZoneProvider defaultState={state}>
           <DraggedWidgetIdContext.Provider value="w2">
             {props.children}

--- a/ui/appui-layout-react/src/test/target/WidgetTarget.test.tsx
+++ b/ui/appui-layout-react/src/test/target/WidgetTarget.test.tsx
@@ -41,7 +41,7 @@ describe("WidgetTarget", () => {
     const { container } = render(<WidgetTarget />, {
       wrapper: (props) => (
         <Wrapper defaultState={state} widgetId="fw1" {...props} />
-      ), // eslint-disable-line react/display-name
+      ),
     });
     container
       .getElementsByClassName("nz-target-mergeTarget")

--- a/ui/appui-layout-react/src/test/target/useAllowedWidgetTarget.test.tsx
+++ b/ui/appui-layout-react/src/test/target/useAllowedWidgetTarget.test.tsx
@@ -10,7 +10,7 @@ import { TestNineZoneProvider } from "../Providers";
 describe("useAllowedWidgetTarget", () => {
   it("should return `false` for popout widget", () => {
     const { result } = renderHook(() => useAllowedWidgetTarget("w1"), {
-      wrapper: (props) => <TestNineZoneProvider {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <TestNineZoneProvider {...props} />,
     });
     result.current.should.eq(false);
   });

--- a/ui/appui-layout-react/src/test/tool-settings/Docked.test.tsx
+++ b/ui/appui-layout-react/src/test/tool-settings/Docked.test.tsx
@@ -39,7 +39,6 @@ describe("DockedToolSettings", () => {
   });
 
   it("should render overflow button", () => {
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     sinon
       .stub(Element.prototype, "getBoundingClientRect")
       .callsFake(function (this: HTMLElement) {
@@ -64,7 +63,6 @@ describe("DockedToolSettings", () => {
   });
 
   it("should render overflown entries", () => {
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     sinon
       .stub(Element.prototype, "getBoundingClientRect")
       .callsFake(function (this: HTMLElement) {
@@ -95,7 +93,6 @@ describe("DockedToolSettings", () => {
   });
 
   it("should render panel container", () => {
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     sinon
       .stub(Element.prototype, "getBoundingClientRect")
       .callsFake(function (this: HTMLElement) {
@@ -131,7 +128,6 @@ describe("DockedToolSettings", () => {
   });
 
   it("should close overflow panel on outside click", () => {
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     sinon
       .stub(Element.prototype, "getBoundingClientRect")
       .callsFake(function (this: HTMLElement) {
@@ -175,7 +171,6 @@ describe("DockedToolSettings", () => {
 
   it("should recalculate overflow on resize", async () => {
     let width = 100;
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     sinon
       .stub(Element.prototype, "getBoundingClientRect")
       .callsFake(function (this: HTMLElement) {
@@ -196,7 +191,7 @@ describe("DockedToolSettings", () => {
       .stub(ResizeObserverMock.prototype, "observe")
       .callsFake(function (this: ResizeObserverMock, element: Element) {
         if (element.classList.contains("nz-toolSettings-docked")) {
-          resizeObserver = this; // eslint-disable-line @typescript-eslint/no-this-alias
+          resizeObserver = this;
           target = element;
         }
       });
@@ -234,7 +229,6 @@ describe("DockedToolSettings", () => {
 
   it("should recalculate overflow on entry resize", async () => {
     let width = 50;
-    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
     sinon
       .stub(Element.prototype, "getBoundingClientRect")
       .callsFake(function (this: HTMLElement) {
@@ -259,7 +253,7 @@ describe("DockedToolSettings", () => {
           element.classList.contains("nz-toolSettings-setting") &&
           queryByText(element, "Entry 1")
         ) {
-          resizeObserver = this; // eslint-disable-line @typescript-eslint/no-this-alias
+          resizeObserver = this;
           target = element;
         }
       });

--- a/ui/appui-layout-react/src/test/widget-panels/Grip.test.tsx
+++ b/ui/appui-layout-react/src/test/widget-panels/Grip.test.tsx
@@ -197,10 +197,7 @@ describe("useResizeGrip", () => {
     const { children, side, defaultState, ...nzProps } = props;
     const nineZone = defaultState || createNineZoneState();
     return (
-      <TestNineZoneProvider // eslint-disable-line react/display-name
-        defaultState={nineZone}
-        {...nzProps}
-      >
+      <TestNineZoneProvider defaultState={nineZone} {...nzProps}>
         <WidgetPanelContext.Provider
           value={{ getBounds: () => new Rectangle() }}
         >

--- a/ui/appui-layout-react/src/test/widget-panels/Panel.test.tsx
+++ b/ui/appui-layout-react/src/test/widget-panels/Panel.test.tsx
@@ -163,7 +163,7 @@ describe("WidgetPanelProvider", () => {
     state = addPanelWidget(state, "left", "w1", ["t1"]);
     const layout = createLayoutStore(state);
     const { container } = render(<WidgetPanelProvider side="left" />, {
-      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />,
     });
 
     const panel = container.getElementsByClassName(
@@ -208,7 +208,7 @@ describe("WidgetPanelProvider", () => {
     });
     const layout = createLayoutStore(state);
     const { container } = render(<WidgetPanelProvider side="left" />, {
-      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />,
     });
 
     const panel = container.getElementsByClassName(
@@ -247,7 +247,7 @@ describe("WidgetPanelProvider", () => {
     });
     const layout = createLayoutStore(state);
     const { container } = render(<WidgetPanelProvider side="left" />, {
-      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />,
     });
 
     const panel = container.getElementsByClassName(
@@ -305,7 +305,7 @@ describe("WidgetPanelProvider", () => {
     const { container } = render(<WidgetPanelProvider side="left" />, {
       wrapper: (props) => (
         <TestNineZoneProvider layout={layout} dispatch={dispatch} {...props} />
-      ), // eslint-disable-line react/display-name
+      ),
     });
 
     const panel = container.getElementsByClassName(
@@ -340,7 +340,7 @@ describe("WidgetPanelProvider", () => {
     const layout = createLayoutStore(state);
     const { container } = render(<WidgetPanelProvider side="left" />, {
       wrapper: (props) => (
-        <TestNineZoneProvider // eslint-disable-line react/display-name
+        <TestNineZoneProvider
           layout={layout}
           dragManagerRef={dragManager}
           {...props}
@@ -380,12 +380,7 @@ describe("WidgetPanelProvider", () => {
     });
     const layout = createLayoutStore(state);
     const { container } = render(<WidgetPanelProvider side="left" />, {
-      wrapper: (props) => (
-        <TestNineZoneProvider // eslint-disable-line react/display-name
-          layout={layout}
-          {...props}
-        />
-      ),
+      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />,
     });
     const panel = container.getElementsByClassName(
       "nz-widgetPanels-panel"
@@ -435,12 +430,7 @@ describe("WidgetPanelProvider", () => {
     });
     const layout = createLayoutStore(state);
     const { container } = render(<WidgetPanelProvider side="left" />, {
-      wrapper: (props) => (
-        <TestNineZoneProvider // eslint-disable-line react/display-name
-          layout={layout}
-          {...props}
-        />
-      ),
+      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />,
     });
 
     const panel = container.getElementsByClassName(
@@ -469,12 +459,7 @@ describe("WidgetPanelProvider", () => {
 
     const layout = createLayoutStore(state);
     const { container } = render(<WidgetPanelProvider side="top" />, {
-      wrapper: (props) => (
-        <TestNineZoneProvider // eslint-disable-line react/display-name
-          layout={layout}
-          {...props}
-        />
-      ),
+      wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />,
     });
 
     const panel = container.getElementsByClassName(
@@ -518,7 +503,7 @@ describe("WidgetPanelProvider", () => {
     const { container } = render(<WidgetPanelProvider side="left" />, {
       wrapper: (props) => (
         <TestNineZoneProvider defaultState={state} {...props} />
-      ), // eslint-disable-line react/display-name
+      ),
     });
 
     const panel = container.getElementsByClassName("nz-widgetPanels-panel")[0];

--- a/ui/appui-layout-react/src/test/widget/ContentRenderer.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/ContentRenderer.test.tsx
@@ -63,7 +63,6 @@ describe("useTransientState", () => {
     const onSave =
       sinon.stub<NonNullable<Parameters<typeof useTransientState>[0]>>();
     renderHook(() => useTransientState(onSave), {
-      // eslint-disable-next-line react/display-name
       wrapper: (props: { children?: React.ReactNode }) => (
         <WidgetContentManagerContext.Provider value={widgetContentManager}>
           <TabIdContext.Provider value="t1">
@@ -73,7 +72,6 @@ describe("useTransientState", () => {
       ),
     });
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       onSaveTransientState.raiseEvent("t1");
     });
     sinon.assert.calledOnceWithExactly(onSave);
@@ -91,7 +89,6 @@ describe("useTransientState", () => {
     const onRestore =
       sinon.stub<NonNullable<Parameters<typeof useTransientState>[1]>>();
     renderHook(() => useTransientState(undefined, onRestore), {
-      // eslint-disable-next-line react/display-name
       wrapper: (props: { children?: React.ReactNode }) => (
         <WidgetContentManagerContext.Provider value={widgetContentManager}>
           <TabIdContext.Provider value="t1">
@@ -101,7 +98,6 @@ describe("useTransientState", () => {
       ),
     });
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       onRestoreTransientState.raiseEvent("t1");
     });
     sinon.assert.calledOnceWithExactly(onRestore);

--- a/ui/appui-layout-react/src/test/widget/FloatingWidget.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/FloatingWidget.test.tsx
@@ -222,9 +222,7 @@ describe("useFloatingWidgetId", () => {
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
     const { result } = renderHook(() => useFloatingWidgetId(), {
-      wrapper: (
-        props // eslint-disable-line react/display-name
-      ) => (
+      wrapper: (props) => (
         <TestNineZoneProvider layout={createLayoutStore(state)}>
           <WidgetIdContext.Provider value="w1" {...props} />
         </TestNineZoneProvider>
@@ -235,7 +233,7 @@ describe("useFloatingWidgetId", () => {
 
   it("should return `undefined` if WidgetIdContext is not provided", () => {
     const { result } = renderHook(() => useFloatingWidgetId(), {
-      wrapper: (props) => <TestNineZoneProvider {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <TestNineZoneProvider {...props} />,
     });
     expect(result.current).to.be.undefined;
   });

--- a/ui/appui-layout-react/src/test/widget/MenuTab.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/MenuTab.test.tsx
@@ -54,12 +54,7 @@ describe("MenuTab", () => {
     state = addPanelWidget(state, "top", "w1", ["t1"]);
     const { container } = render(<WidgetMenuTab />, {
       wrapper: (props) => (
-        <Wrapper // eslint-disable-line react/display-name
-          defaultState={state}
-          widgetId="w1"
-          tabId="t1"
-          {...props}
-        />
+        <Wrapper defaultState={state} widgetId="w1" tabId="t1" {...props} />
       ),
     });
     container.getElementsByClassName("nz-widget-menuTab").length.should.eq(1);
@@ -75,12 +70,7 @@ describe("MenuTab", () => {
       </ShowWidgetIconContext.Provider>,
       {
         wrapper: (props) => (
-          <Wrapper // eslint-disable-line react/display-name
-            defaultState={state}
-            widgetId="w1"
-            tabId="t1"
-            {...props}
-          />
+          <Wrapper defaultState={state} widgetId="w1" tabId="t1" {...props} />
         ),
       }
     );
@@ -102,12 +92,7 @@ describe("MenuTab", () => {
       </WidgetOverflowContext.Provider>,
       {
         wrapper: (props) => (
-          <Wrapper // eslint-disable-line react/display-name
-            defaultState={state}
-            widgetId="w1"
-            tabId="t1"
-            {...props}
-          />
+          <Wrapper defaultState={state} widgetId="w1" tabId="t1" {...props} />
         ),
       }
     );

--- a/ui/appui-layout-react/src/test/widget/PanelWidget.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/PanelWidget.test.tsx
@@ -230,7 +230,7 @@ describe("useMode", () => {
     state = addPanelWidget(state, "left", "w2", ["t2"]);
     state = addPanelWidget(state, "left", "w3", ["t3"], { minimized: true });
     const { result } = renderHook(() => useMode("w2"), {
-      wrapper: (props) => <Provider defaultState={state} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <Provider defaultState={state} {...props} />,
     });
     result.current.should.eq("fill");
   });
@@ -245,7 +245,7 @@ describe("useMode", () => {
     state = addPanelWidget(state, "left", "w2", ["t2"]);
     state = addPanelWidget(state, "left", "w3", ["t3"]);
     const { result } = renderHook(() => useMode("w2"), {
-      wrapper: (props) => <Provider defaultState={state} {...props} />, // eslint-disable-line react/display-name
+      wrapper: (props) => <Provider defaultState={state} {...props} />,
     });
     result.current.should.eq("fit");
   });

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -342,7 +342,6 @@ export class UiFramework {
    */
   public static get frameworkState(): FrameworkState | undefined {
     try {
-      // eslint-disable-next-line dot-notation
       return UiFramework.store.getState()[UiFramework.frameworkStateKey];
     } catch (_e) {
       return undefined;

--- a/ui/appui-react/src/appui-react/accudraw/CalculatorEngine.ts
+++ b/ui/appui-react/src/appui-react/accudraw/CalculatorEngine.ts
@@ -7,7 +7,7 @@
  */
 
 /** @internal */
-export enum CalculatorOperator { // eslint-disable-line: completed-docs
+export enum CalculatorOperator {
   None,
   Clear,
   ClearAll,

--- a/ui/appui-react/src/appui-react/configurableui/state.ts
+++ b/ui/appui-react/src/appui-react/configurableui/state.ts
@@ -71,7 +71,6 @@ const initialState: ConfigurableUiState = {
  * @public
  */
 export const ConfigurableUiActions = {
-  // eslint-disable-line @typescript-eslint/naming-convention
   setSnapMode: (snapMode: number) =>
     createAction(ConfigurableUiActionId.SetSnapMode, snapMode),
   setTheme:

--- a/ui/appui-react/src/appui-react/content/IModelViewport.tsx
+++ b/ui/appui-react/src/appui-react/content/IModelViewport.tsx
@@ -33,7 +33,7 @@ import type { FrameworkState } from "../redux/FrameworkState";
 export const IModelConnectedViewport = connectIModelConnectionAndViewState(
   null,
   null
-)(ViewportComponent); // eslint-disable-line @typescript-eslint/naming-convention
+)(ViewportComponent);
 
 /** [[IModelViewportControl]] options. These options are set in the applicationData property of the [[ContentProps]].
  * @public

--- a/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
+++ b/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
@@ -191,8 +191,7 @@ export class InternalContentViewManager {
               activeContentControl.viewport !==
                 IModelApp.viewManager.selectedView
             ) {
-              // eslint-disable-next-line @typescript-eslint/no-floating-promises
-              IModelApp.viewManager.setSelectedView(
+              void IModelApp.viewManager.setSelectedView(
                 activeContentControl.viewport
               );
             }

--- a/ui/appui-react/src/appui-react/content/split-pane/SplitPane.tsx
+++ b/ui/appui-react/src/appui-react/content/split-pane/SplitPane.tsx
@@ -286,7 +286,6 @@ export function SplitPane(props: SplitPaneProps) {
               return;
             }
             // Integer division
-            // eslint-disable-next-line no-bitwise
             positionDelta = ~~(positionDelta / step) * step;
           }
           let sizeDelta = isPrimaryFirst ? positionDelta : -positionDelta;

--- a/ui/appui-react/src/appui-react/pickers/ListPicker.tsx
+++ b/ui/appui-react/src/appui-react/pickers/ListPicker.tsx
@@ -30,7 +30,7 @@ import {
  * @beta
  */
 export enum ListItemType {
-  Item = 0, // eslint-disable-line @typescript-eslint/no-shadow
+  Item = 0,
   Separator = 1,
   Container = 2,
 }

--- a/ui/appui-react/src/appui-react/pickers/ViewSelector.tsx
+++ b/ui/appui-react/src/appui-react/pickers/ViewSelector.tsx
@@ -425,7 +425,7 @@ export class ViewSelector extends React.Component<
     });
 
     // Set state to show enabled the view that got selected
-    this.updateState(item.key); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.updateState(item.key);
   };
 
   // Hook on the category selector being expanded so that we may initialize if needed
@@ -475,4 +475,4 @@ export class ViewSelector extends React.Component<
 export const IModelConnectedViewSelector = connectIModelConnection(
   null,
   null
-)(ViewSelector); // eslint-disable-line @typescript-eslint/naming-convention
+)(ViewSelector);

--- a/ui/appui-react/src/appui-react/popup/KeyinPalettePanel.tsx
+++ b/ui/appui-react/src/appui-react/popup/KeyinPalettePanel.tsx
@@ -39,8 +39,10 @@ export function clearKeyinPaletteHistory() {
   const uiSettingsStorage = UiFramework.getUiStateStorage();
   // istanbul ignore else
   if (uiSettingsStorage) {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    uiSettingsStorage.deleteSetting(KEYIN_PALETTE_NAMESPACE, KEYIN_HISTORY_KEY);
+    void uiSettingsStorage.deleteSetting(
+      KEYIN_PALETTE_NAMESPACE,
+      KEYIN_HISTORY_KEY
+    );
   }
 }
 
@@ -87,13 +89,12 @@ export function KeyinPalettePanel({
       }
     }
 
-    fetchState(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void fetchState();
   }, [uiSettingsStorage]);
 
   // istanbul ignore next
   const storeHistoryKeyins = React.useCallback(
     async (value: string[]) => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       const result = await uiSettingsStorage.saveSetting(
         KEYIN_PALETTE_NAMESPACE,
         KEYIN_HISTORY_KEY,

--- a/ui/appui-react/src/appui-react/redux/FrameworkState.ts
+++ b/ui/appui-react/src/appui-react/redux/FrameworkState.ts
@@ -24,7 +24,6 @@ export interface FrameworkState {
  * @public
  */
 export const FrameworkReducer = combineReducers({
-  // eslint-disable-line @typescript-eslint/naming-convention
   configurableUiState: ConfigurableUiReducer,
   sessionState: SessionStateReducer,
 });

--- a/ui/appui-react/src/appui-react/redux/ReducerRegistry.ts
+++ b/ui/appui-react/src/appui-react/redux/ReducerRegistry.ts
@@ -78,5 +78,4 @@ export class ReducerRegistry {
 /** ReducerRegistryInstance singleton instance of Reducer Registry
  * @beta
  */
-/* eslint-disable @typescript-eslint/naming-convention */
 export const ReducerRegistryInstance = new ReducerRegistry();

--- a/ui/appui-react/src/appui-react/redux/SessionState.ts
+++ b/ui/appui-react/src/appui-react/redux/SessionState.ts
@@ -106,7 +106,6 @@ export interface SessionStateActionsProps {
  * @public
  */
 export const SessionStateActions = {
-  // eslint-disable-line @typescript-eslint/naming-convention
   setActiveIModelId:
     // istanbul ignore next
     (iModelId: string) =>

--- a/ui/appui-react/src/appui-react/redux/connectIModel.ts
+++ b/ui/appui-react/src/appui-react/redux/connectIModel.ts
@@ -91,7 +91,7 @@ export const connectIModelConnection = (
  *    myData: string;
  *  }
  *
- *  export const ConnectControl = connectIModelConnection(null, sessionStateMapDispatchToProps)(ComponentClass); // eslint-disable-line @typescript-eslint/naming-convention
+ *  export const ConnectControl = connectIModelConnection(null, sessionStateMapDispatchToProps)(ComponentClass);
  *
  *  //  this then allows connected control to update the store using a call like shown below.
  *  this.props.setNumItemsSelected(30);

--- a/ui/appui-react/src/appui-react/settings/quantityformatting/QuantityFormat.tsx
+++ b/ui/appui-react/src/appui-react/settings/quantityformatting/QuantityFormat.tsx
@@ -429,7 +429,10 @@ function SaveFormatModalDialog({
   }, [onDialogClose, onDialogCloseArgs]);
 
   const handleOK = React.useCallback(() => {
-    IModelApp.quantityFormatter.setOverrideFormat(quantityType, formatProps); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void IModelApp.quantityFormatter.setOverrideFormat(
+      quantityType,
+      formatProps
+    );
     handleClose();
   }, [formatProps, handleClose, quantityType]);
 

--- a/ui/appui-react/src/appui-react/settings/quantityformatting/UnitSystemSelector.tsx
+++ b/ui/appui-react/src/appui-react/settings/quantityformatting/UnitSystemSelector.tsx
@@ -25,7 +25,6 @@ export interface UnitSystemSelectorProps {
  * @alpha
  */
 export function UnitSystemSelector(props: UnitSystemSelectorProps) {
-  // eslint-disable-line @typescript-eslint/naming-convention
   const label = React.useRef(
     UiFramework.translate("presentationUnitSystem.selector-label")
   );

--- a/ui/appui-react/src/appui-react/statusbar/Overflow.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/Overflow.tsx
@@ -31,7 +31,6 @@ export const StatusBarOverflow = React.forwardRef<
   HTMLDivElement,
   StatusBarOverflowProps
 >(function StatusBarOverflow(props, ref) {
-  // eslint-disable-line @typescript-eslint/no-shadow, @typescript-eslint/naming-convention
   const roRef = useResizeObserver<HTMLDivElement>(props.onResize);
   const refs = useRefs(roRef, ref);
   const className = classnames("uifw-statusbar-overflow", props.className);

--- a/ui/appui-react/src/appui-react/statusbar/StatusBarComposer.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBarComposer.tsx
@@ -109,7 +109,6 @@ interface DockedStatusBarEntryProps {
 }
 
 /** Wrapper for status bar entries so their size can be used to determine if the status bar container can display them or if they will need to be placed in an overflow panel. */
-// eslint-disable-next-line @typescript-eslint/naming-convention, no-shadow
 function DockedStatusBarEntry({
   children,
   entryKey,

--- a/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionScope.tsx
@@ -92,7 +92,7 @@ function mapStateToProps(state: any) {
  * display the active selection scope that is used by the PresentationManager to determine what elements are added to the selection nap mode.
  * This React component is Redux connected.
  * @public
- */ // eslint-disable-next-line @typescript-eslint/naming-convention
+ */
 export const SelectionScopeField = connect(mapStateToProps)(
   SelectionScopeFieldComponent
 );

--- a/ui/appui-react/src/appui-react/statusfields/SnapMode.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/SnapMode.tsx
@@ -175,5 +175,5 @@ function mapStateToProps(state: any) {
  * display the active snap mode that AccuSnap will use and allow the user to select a new snap mode.
  * This Field React component is Redux connected.
  * @public
- */ // eslint-disable-next-line @typescript-eslint/naming-convention
+ */
 export const SnapModeField = connect(mapStateToProps)(SnapModeFieldComponent);

--- a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
@@ -248,7 +248,7 @@ export class SyncUiEventDispatcher {
 
             // if this is the first view being opened up start the default tool so tool admin is happy.
             if (undefined === args.previous) {
-              IModelApp.toolAdmin.startDefaultTool(); // eslint-disable-line @typescript-eslint/no-floating-promises
+              void IModelApp.toolAdmin.startDefaultTool();
             } else {
               // istanbul ignore next
               if (

--- a/ui/appui-react/src/appui-react/theme/ThemeManager.tsx
+++ b/ui/appui-react/src/appui-react/theme/ThemeManager.tsx
@@ -148,4 +148,4 @@ class ThemeManagerComponent extends React.Component<
  * This React component is Redux connected.
  * @public
  */
-export const ThemeManager = connect(mapStateToProps)(ThemeManagerComponent); // eslint-disable-line @typescript-eslint/naming-convention
+export const ThemeManager = connect(mapStateToProps)(ThemeManagerComponent);

--- a/ui/appui-react/src/appui-react/toolbar/DragInteraction.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/DragInteraction.tsx
@@ -11,4 +11,4 @@ import * as React from "react";
 /** Context used to enable toolbar drag interaction.
  * @beta
  */
-export const ToolbarDragInteractionContext = React.createContext(false); // eslint-disable-line @typescript-eslint/naming-convention
+export const ToolbarDragInteractionContext = React.createContext(false);

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
@@ -296,7 +296,7 @@ export function ToolbarComposer(props: ExtensibleToolbarProps) {
   );
   React.useEffect(() => {
     setDefaultItemsManager(new ToolbarItemsManager(props.items));
-  }, [props.items]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [props.items]);
 
   // process default items
   const defaultItems = useDefaultToolbarItems(defaultItemsManager);

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
@@ -146,7 +146,7 @@ export class StandardStatusbarUiItemsProvider implements UiItemsProvider {
           30,
           <SelectionInfoField />
         )
-      ); // eslint-disable-line deprecation/deprecation
+      );
     }
 
     return statusBarItems;

--- a/ui/appui-react/src/appui-react/utils/PropsHelper.tsx
+++ b/ui/appui-react/src/appui-react/utils/PropsHelper.tsx
@@ -52,7 +52,6 @@ export class PropsHelper {
   }
 
   /** Get JSX element that defines an icon. If iconSpec is a string, then a web-font icon class is used otherwise a ReactNode holding an SVG icon is assumed.  */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   public static getIcon(
     iconSpec: string | ConditionalStringValue | React.ReactNode
   ): JSX.Element | undefined {

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -222,16 +222,14 @@ export function useNineZoneDispatch(frontstageDef: FrontstageDef) {
       }
       // istanbul ignore if
       if (action.type === "TOOL_SETTINGS_DRAG_START") {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        UiFramework.postTelemetry(
+        void UiFramework.postTelemetry(
           "Tool Settings Undocking",
           "28B04E07-AE73-4533-A0BA-8E2A8DC99ADF"
         );
       }
       // istanbul ignore if
       if (action.type === "TOOL_SETTINGS_DOCK") {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        UiFramework.postTelemetry(
+        void UiFramework.postTelemetry(
           "Tool Settings Docking to Settings Bar",
           "BEDE684B-B3DB-4637-B3AF-DC3CBA223F94"
         );

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -474,7 +474,6 @@ export class WidgetDef {
   }
 
   public onWidgetStateChanged(): void {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.widgetControl &&
       UiFramework.postTelemetry(
         `Widget ${

--- a/ui/appui-react/src/test/TestUtils.ts
+++ b/ui/appui-react/src/test/TestUtils.ts
@@ -54,7 +54,6 @@ export interface RootState {
   testDifferentFrameworkKey?: FrameworkState;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const SampleAppActions = {
   // eslint-disable-next-line jsdoc/require-jsdoc
   example: () => createAction("SampleApp:EXAMPLE"),
@@ -516,4 +515,4 @@ export function selectAllBeforeType() {
   };
 }
 
-export default TestUtils; // eslint-disable-line: no-default-export
+export default TestUtils;

--- a/ui/appui-react/src/test/backstage/BackstageManager.test.tsx
+++ b/ui/appui-react/src/test/backstage/BackstageManager.test.tsx
@@ -87,10 +87,10 @@ describe("BackstageManager", () => {
 
   it("getBackstageToggleCommand generates toggle button", () => {
     const command = BackstageManager.getBackstageToggleCommand();
-    const initialState = UiFramework.backstage.isOpen; // eslint-disable-line deprecation/deprecation
+    const initialState = UiFramework.backstage.isOpen;
     command.execute();
 
-    expect(UiFramework.backstage.isOpen).to.eq(!initialState); // eslint-disable-line deprecation/deprecation
+    expect(UiFramework.backstage.isOpen).to.eq(!initialState);
   });
 
   it("getBackstageToggleCommand handles icon override", () => {
@@ -178,7 +178,7 @@ describe("useBackstageManager", () => {
     await MockRender.App.startup();
 
     const { result } = renderHook(() => useBackstageManager());
-    expect(result.current).to.equal(UiFramework.backstage); // eslint-disable-line deprecation/deprecation
+    expect(result.current).to.equal(UiFramework.backstage);
 
     await MockRender.App.shutdown();
     TestUtils.terminateUiFramework();

--- a/ui/appui-react/src/test/content/ContentLayoutManager.test.ts
+++ b/ui/appui-react/src/test/content/ContentLayoutManager.test.ts
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable deprecation/deprecation */
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import { getUniqueId } from "@itwin/appui-layout-react";
 import { expect } from "chai";

--- a/ui/appui-react/src/test/dialog/ContentDialogManager.test.tsx
+++ b/ui/appui-react/src/test/dialog/ContentDialogManager.test.tsx
@@ -16,7 +16,6 @@ import TestUtils, { userEvent } from "../TestUtils";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MockRender } from "@itwin/core-frontend";
 import { InternalContentDialogManager } from "../../appui-react/dialog/InternalContentDialogManager";
-/* eslint-disable deprecation/deprecation */
 
 describe("ContentDialogManager", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;

--- a/ui/appui-react/src/test/dialog/ModelessDialogManager.test.tsx
+++ b/ui/appui-react/src/test/dialog/ModelessDialogManager.test.tsx
@@ -16,7 +16,6 @@ import TestUtils, { userEvent } from "../TestUtils";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MockRender } from "@itwin/core-frontend";
 import { InternalModelessDialogManager } from "../../appui-react/dialog/InternalModelessDialogManager";
-/* eslint-disable deprecation/deprecation */
 
 describe("ModelessDialogManager", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;

--- a/ui/appui-react/src/test/frontstage/FrontstageManager.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageManager.test.tsx
@@ -37,7 +37,6 @@ import {
   TestFrontstage3,
 } from "./FrontstageTestUtils";
 import { InternalFrontstageManager } from "../../appui-react/frontstage/InternalFrontstageManager";
-/* eslint-disable deprecation/deprecation */
 
 const mySessionStorage = storageMock();
 
@@ -313,8 +312,7 @@ describe("FrontstageManager", () => {
 
       InternalFrontstageManager.isInitialized = false;
       InternalFrontstageManager.initialize();
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      IModelApp.viewManager.setSelectedView(viewportMock.object);
+      void IModelApp.viewManager.setSelectedView(viewportMock.object);
     });
 
     it("CoreTools.selectElementCommand", async () => {

--- a/ui/appui-react/src/test/frontstage/ModalSettingsStage.test.tsx
+++ b/ui/appui-react/src/test/frontstage/ModalSettingsStage.test.tsx
@@ -175,7 +175,7 @@ describe("ModalSettingsStage", () => {
     });
     sinon
       .stub(UiFramework.frontstages, "activeFrontstageDef")
-      .get(() => frontstageDef); // eslint-disable-line deprecation/deprecation
+      .get(() => frontstageDef);
 
     settingsManager.addSettingsProvider(new TestSettingsProvider());
     // const modalFrontstage = new SettingsModalFrontstage();
@@ -225,7 +225,7 @@ describe("ModalSettingsStage", () => {
     });
     sinon
       .stub(UiFramework.frontstages, "activeFrontstageDef")
-      .get(() => frontstageDef); // eslint-disable-line deprecation/deprecation
+      .get(() => frontstageDef);
 
     settingsManager.addSettingsProvider(new TestSettingsProvider());
     SettingsModalFrontstage.showSettingsStage("page-3");
@@ -258,7 +258,7 @@ describe("ModalSettingsStage", () => {
     });
     sinon
       .stub(UiFramework.frontstages, "activeFrontstageDef")
-      .get(() => frontstageDef); // eslint-disable-line deprecation/deprecation
+      .get(() => frontstageDef);
 
     settingsManager.addSettingsProvider(new TestSettingsProvider());
     SettingsModalFrontstage.showSettingsStage("page2");

--- a/ui/appui-react/src/test/hooks/useActiveIModelConnection.test.tsx
+++ b/ui/appui-react/src/test/hooks/useActiveIModelConnection.test.tsx
@@ -44,7 +44,6 @@ describe("useActiveIModelConnection", () => {
     const ss = new SelectionSet(imodelMock.object);
     imodelMock.setup((x) => x.selectionSet).returns(() => ss);
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const HookTester = () => {
       const activeIModelConnection = useActiveIModelConnection();
       // I expected the following to work

--- a/ui/appui-react/src/test/redux/ConnectedComponents.test.tsx
+++ b/ui/appui-react/src/test/redux/ConnectedComponents.test.tsx
@@ -90,7 +90,7 @@ describe("ConnectedContent", () => {
     const ConnectControl = connectIModelConnection(
       localMapStateToProps,
       sessionStateMapDispatchToProps
-    )(TestComponent); // eslint-disable-line @typescript-eslint/naming-convention
+    )(TestComponent);
     const renderedComponent = render(
       <Provider store={TestUtils.store}>
         <ConnectControl />

--- a/ui/appui-react/src/test/statusbar/StatusBarComposer.test.tsx
+++ b/ui/appui-react/src/test/statusbar/StatusBarComposer.test.tsx
@@ -280,7 +280,7 @@ describe("StatusBarComposer", () => {
       });
       sinon
         .stub(UiFramework.frontstages, "activeFrontstageDef")
-        .get(() => frontstageDef); // eslint-disable-line deprecation/deprecation
+        .get(() => frontstageDef);
 
       const items: StatusBarItem[] = [
         StatusBarItemUtilities.createCustomItem(
@@ -334,7 +334,7 @@ describe("StatusBarComposer", () => {
       });
       sinon
         .stub(UiFramework.frontstages, "activeFrontstageDef")
-        .get(() => frontstageDef); // eslint-disable-line deprecation/deprecation
+        .get(() => frontstageDef);
 
       const items: StatusBarItem[] = [
         StatusBarItemUtilities.createCustomItem(
@@ -437,7 +437,7 @@ describe("StatusBarComposer", () => {
       });
       sinon
         .stub(UiFramework.frontstages, "activeFrontstageDef")
-        .get(() => frontstageDef); // eslint-disable-line deprecation/deprecation
+        .get(() => frontstageDef);
 
       // make sure we have enough size to render without overflow
       sinon
@@ -510,7 +510,7 @@ describe("StatusBarComposer", () => {
       });
       sinon
         .stub(UiFramework.frontstages, "activeFrontstageDef")
-        .get(() => frontstageDef); // eslint-disable-line deprecation/deprecation
+        .get(() => frontstageDef);
 
       // make sure we have enough size to render without overflow
       sinon
@@ -573,7 +573,6 @@ describe("StatusBarComposer", () => {
     });
 
     it("will render 4 items without overflow", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sinon
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -670,7 +669,6 @@ describe("StatusBarComposer", () => {
     });
 
     it("will render 1 item with overflow - 4 in overflow panel", async () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sinon
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {

--- a/ui/appui-react/src/test/statusfields/SelectionInfo.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SelectionInfo.test.tsx
@@ -14,8 +14,6 @@ import {
 } from "../../appui-react";
 import TestUtils from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("SelectionInfoField", () => {
   beforeEach(async () => {
     await TestUtils.initializeUiFramework();

--- a/ui/appui-react/src/test/syncui/SyncUiEventDispatcher.test.ts
+++ b/ui/appui-react/src/test/syncui/SyncUiEventDispatcher.test.ts
@@ -22,7 +22,6 @@ import type {
 } from "../../appui-react";
 import { SyncUiEventDispatcher, UiFramework } from "../../appui-react";
 import TestUtils from "../TestUtils";
-/* eslint-disable deprecation/deprecation */
 
 const timeToWaitForUiSyncCallback = 60;
 

--- a/ui/appui-react/src/test/widget-panels/Frontstage.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/Frontstage.test.tsx
@@ -640,7 +640,7 @@ describe("Frontstage local storage wrapper", () => {
         });
         const frontstageDef = new FrontstageDef();
         renderHook(() => useSavedFrontstageState(frontstageDef), {
-          wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+          wrapper: (props) => <UiStateStorageHandler {...props} />,
         });
         await TestUtils.flushAsyncOperations();
         frontstageDef.nineZoneState?.should.matchSnapshot();
@@ -654,7 +654,7 @@ describe("Frontstage local storage wrapper", () => {
 
         const spy = sinon.spy(uiStateStorage, "getSetting");
         renderHook(() => useSavedFrontstageState(frontstageDef), {
-          wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+          wrapper: (props) => <UiStateStorageHandler {...props} />,
         });
         spy.notCalled.should.true;
       });
@@ -673,7 +673,7 @@ describe("Frontstage local storage wrapper", () => {
 
         sinon.stub(frontstageDef, "version").get(() => setting.version + 1);
         renderHook(() => useSavedFrontstageState(frontstageDef), {
-          wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+          wrapper: (props) => <UiStateStorageHandler {...props} />,
         });
         await TestUtils.flushAsyncOperations();
         expect(frontstageDef.nineZoneState).to.exist;
@@ -703,7 +703,7 @@ describe("Frontstage local storage wrapper", () => {
         sinon.stub(frontstageDef, "leftPanel").get(() => leftPanel);
 
         renderHook(() => useSavedFrontstageState(frontstageDef), {
-          wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+          wrapper: (props) => <UiStateStorageHandler {...props} />,
         });
         await TestUtils.flushAsyncOperations();
 
@@ -724,7 +724,7 @@ describe("Frontstage local storage wrapper", () => {
 
         const layout = createLayoutStore();
         renderHook(() => useSaveFrontstageSettings(frontstageDef, layout), {
-          wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+          wrapper: (props) => <UiStateStorageHandler {...props} />,
         });
         fakeTimers.tick(1000);
         fakeTimers.restore();
@@ -750,7 +750,7 @@ describe("Frontstage local storage wrapper", () => {
 
         const layout = createLayoutStore(frontstageDef.nineZoneState);
         renderHook(() => useSaveFrontstageSettings(frontstageDef, layout), {
-          wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+          wrapper: (props) => <UiStateStorageHandler {...props} />,
         });
         fakeTimers.tick(1000);
         fakeTimers.restore();
@@ -838,7 +838,7 @@ describe("Frontstage local storage wrapper", () => {
 
           const spy = sinon.spy(uiStateStorage, "deleteSetting");
           renderHook(() => useFrontstageManager(frontstageDef), {
-            wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+            wrapper: (props) => <UiStateStorageHandler {...props} />,
           });
           InternalFrontstageManager.onFrontstageRestoreLayoutEvent.emit({
             frontstageDef,
@@ -853,7 +853,7 @@ describe("Frontstage local storage wrapper", () => {
           await UiFramework.setUiStateStorage(uiStateStorage);
 
           renderHook(() => useFrontstageManager(frontstageDef), {
-            wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+            wrapper: (props) => <UiStateStorageHandler {...props} />,
           });
           const frontstageDef1 = new FrontstageDef();
           sinon.stub(frontstageDef1, "id").get(() => "f1");
@@ -2115,7 +2115,7 @@ describe("Frontstage local storage wrapper", () => {
             <WidgetPanelsFrontstage />
           </Provider>,
           {
-            wrapper: (props) => <UiStateStorageHandler {...props} />, // eslint-disable-line react/display-name
+            wrapper: (props) => <UiStateStorageHandler {...props} />,
           }
         );
         await findByText("Left Start 1");

--- a/ui/appui-react/src/test/widget-panels/ToolSettings.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/ToolSettings.test.tsx
@@ -204,7 +204,6 @@ describe("useHorizontalToolSettingNodes", () => {
   it("should not return undefined if activeToolSettingsProvider is unset", () => {
     const { result } = renderHook(() => useHorizontalToolSettingNodes());
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       UiFramework.frontstages.onToolActivatedEvent.emit({ toolId: "t1" });
     });
     (result.current === undefined).should.false;
@@ -240,7 +239,6 @@ describe("useHorizontalToolSettingNodes", () => {
     const sut = renderHook(() => useHorizontalToolSettingNodes());
 
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       sinon
         .stub(InternalFrontstageManager, "activeToolSettingsProvider")
         .get(

--- a/ui/appui-react/src/test/widget-panels/useWidgetDirection.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/useWidgetDirection.test.tsx
@@ -30,9 +30,7 @@ describe("useWidgetDirection", () => {
 
     const layout = createLayoutStore();
     const { result } = renderHook(() => useWidgetDirection(), {
-      wrapper: (
-        { children } // eslint-disable-line react/display-name
-      ) => (
+      wrapper: ({ children }) => (
         <NineZone layout={layout} dispatch={() => {}}>
           {children}
         </NineZone>
@@ -49,9 +47,7 @@ describe("useWidgetDirection", () => {
     state = addPanelWidget(state, "top", "w1", ["t1"]);
     const layout = createLayoutStore(state);
     const { result } = renderHook(() => useWidgetDirection(), {
-      wrapper: (
-        { children } // eslint-disable-line react/display-name
-      ) => (
+      wrapper: ({ children }) => (
         <Provider store={TestUtils.store}>
           <NineZone layout={layout} dispatch={() => {}}>
             <TabIdContext.Provider value="t1">{children}</TabIdContext.Provider>
@@ -70,9 +66,7 @@ describe("useWidgetDirection", () => {
     state = addPanelWidget(state, "left", "w1", ["t1"]);
     const layout = createLayoutStore(state);
     const { result } = renderHook(() => useWidgetDirection(), {
-      wrapper: (
-        { children } // eslint-disable-line react/display-name
-      ) => (
+      wrapper: ({ children }) => (
         <Provider store={TestUtils.store}>
           <NineZone layout={layout} dispatch={() => {}}>
             <TabIdContext.Provider value="t1">{children}</TabIdContext.Provider>

--- a/ui/components-react/src/components-react/common/UseDebouncedAsyncValue.ts
+++ b/ui/components-react/src/components-react/common/UseDebouncedAsyncValue.ts
@@ -27,7 +27,7 @@ import {
 export function useDebouncedAsyncValue<TReturn>(
   valueToBeResolved: undefined | (() => Promise<TReturn>)
 ) {
-  const scheduler = useMemo(() => new SubscriptionScheduler<TReturn>(), []); // eslint-disable-line react-hooks/exhaustive-deps
+  const scheduler = useMemo(() => new SubscriptionScheduler<TReturn>(), []);
 
   const [value, setValue] = useState<TReturn>();
   const [inProgress, setInProgress] = useState(false);

--- a/ui/components-react/src/components-react/editors/CustomNumberEditor.tsx
+++ b/ui/components-react/src/components-react/editors/CustomNumberEditor.tsx
@@ -180,7 +180,7 @@ export class CustomNumberEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -191,7 +191,7 @@ export class CustomNumberEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 
@@ -229,8 +229,6 @@ export class CustomNumberEditor
         UiComponents.loggerCategory(this),
         "PropertyRecord must be defined to use CustomNumberPropertyEditor"
       );
-      // eslint-disable-next-line no-console
-      // console.log("PropertyRecord must be defined to use CustomNumberPropertyEditor");
       return;
     }
     // istanbul ignore else
@@ -250,8 +248,6 @@ export class CustomNumberEditor
         UiComponents.loggerCategory(this),
         `CustomFormattedNumberParams must be defined for property ${record.property.name}`
       );
-      // eslint-disable-next-line no-console
-      // console.log(`CustomFormattedNumberParams must be defined for property ${record!.property!.name}`);
       return;
     }
 
@@ -357,7 +353,6 @@ export class CustomNumberEditor
     );
 
     const inputProps: Omit<InputProps, "size"> = {
-      // eslint-disable-line deprecation/deprecation
       className,
       style: this.props.style ? this.props.style : minWidthStyle,
       readOnly,

--- a/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
+++ b/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
@@ -121,8 +121,7 @@ export class DateTimeEditor
         );
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      this.processDateChange(this.state.typeConverter, newValue);
+      void this.processDateChange(this.state.typeConverter, newValue);
     }
   };
 
@@ -142,7 +141,7 @@ export class DateTimeEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -153,7 +152,7 @@ export class DateTimeEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/editors/EditorContainer.tsx
+++ b/ui/components-react/src/components-react/editors/EditorContainer.tsx
@@ -138,7 +138,7 @@ export class EditorContainer extends React.PureComponent<EditorContainerProps> {
       this._propertyEditor &&
       this._propertyEditor.containerHandlesBlur
     )
-      this._handleContainerCommit(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this._handleContainerCommit();
   };
 
   private _handleContainerBlur = (e: React.FocusEvent) => {
@@ -185,7 +185,7 @@ export class EditorContainer extends React.PureComponent<EditorContainerProps> {
     if (this._propertyEditor && this._propertyEditor.containerHandlesEnter) {
       // istanbul ignore else
       if (this._editorRef && this._editorRef.hasFocus) e.stopPropagation();
-      this._handleContainerCommit(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this._handleContainerCommit();
     }
   }
 
@@ -193,7 +193,7 @@ export class EditorContainer extends React.PureComponent<EditorContainerProps> {
     // istanbul ignore else
     if (this._propertyEditor && this._propertyEditor.containerHandlesTab) {
       e.stopPropagation();
-      this._handleContainerCommit(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this._handleContainerCommit();
     }
   }
 
@@ -241,7 +241,7 @@ export class EditorContainer extends React.PureComponent<EditorContainerProps> {
   }
 
   private _handleEditorCommit = (args: PropertyUpdatedArgs): void => {
-    this._commit(args); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this._commit(args);
   };
 
   private _handleContainerCommit = async (): Promise<void> => {
@@ -249,7 +249,10 @@ export class EditorContainer extends React.PureComponent<EditorContainerProps> {
       this._editorRef && (await this._editorRef.getPropertyValue());
     // istanbul ignore else
     if (newValue !== undefined) {
-      this._commit({ propertyRecord: this.props.propertyRecord, newValue }); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this._commit({
+        propertyRecord: this.props.propertyRecord,
+        newValue,
+      });
     }
   };
 

--- a/ui/components-react/src/components-react/editors/EnumButtonGroupEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumButtonGroupEditor.tsx
@@ -90,13 +90,13 @@ export class EnumButtonGroupEditor
 
   /** @internal */
   public override componentDidMount() {
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/editors/EnumEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumEditor.tsx
@@ -110,7 +110,7 @@ export class EnumEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -121,7 +121,7 @@ export class EnumEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/editors/IconEditor.tsx
+++ b/ui/components-react/src/components-react/editors/IconEditor.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable deprecation/deprecation */
 /** @packageDocumentation
  * @module PropertyEditors
  */
@@ -141,7 +140,7 @@ export class IconEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -152,7 +151,7 @@ export class IconEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
+++ b/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
@@ -114,7 +114,7 @@ export class NumericInputEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -125,7 +125,7 @@ export class NumericInputEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/editors/SliderEditor.tsx
+++ b/ui/components-react/src/components-react/editors/SliderEditor.tsx
@@ -107,7 +107,7 @@ export class SliderEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -118,7 +118,7 @@ export class SliderEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/editors/TextEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextEditor.tsx
@@ -106,7 +106,7 @@ export class TextEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -117,7 +117,7 @@ export class TextEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/editors/TextareaEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextareaEditor.tsx
@@ -105,7 +105,7 @@ export class TextareaEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -116,7 +116,7 @@ export class TextareaEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/editors/ToggleEditor.tsx
+++ b/ui/components-react/src/components-react/editors/ToggleEditor.tsx
@@ -101,7 +101,7 @@ export class ToggleEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -112,7 +112,7 @@ export class ToggleEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/components-react/src/components-react/iconpicker/IconPickerButton.tsx
+++ b/ui/components-react/src/components-react/iconpicker/IconPickerButton.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable deprecation/deprecation */
 /** @packageDocumentation
  * @module IconPicker
  */

--- a/ui/components-react/src/components-react/properties/ItemStyle.ts
+++ b/ui/components-react/src/components-react/properties/ItemStyle.ts
@@ -75,7 +75,6 @@ function getForegroundColor(
  * Style provider for stylable items like [[TreeNodeItem]]
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ItemStyleProvider = {
   /**
    * Create CSS style from [[ItemStyle]]
@@ -95,7 +94,6 @@ export const ItemStyleProvider = {
  * Style provider for table rows
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const TableRowStyleProvider = {
   /**
    * Create CSS style from [[ItemStyle]]

--- a/ui/components-react/src/components-react/properties/renderers/PrimitivePropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/PrimitivePropertyRenderer.tsx
@@ -40,7 +40,7 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
 
   /** @internal */
   public override render() {
-    const { indentation, highlight, ...props } = this.props; // eslint-disable-line @typescript-eslint/no-unused-vars
+    const { indentation, highlight, ...props } = this.props;
     const displayLabel = this.props.propertyRecord.property.displayLabel;
     const offset = CommonPropertyRenderer.getLabelOffset(
       indentation,

--- a/ui/components-react/src/components-react/properties/renderers/value/MultilineTextPropertyValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/MultilineTextPropertyValueRenderer.tsx
@@ -8,7 +8,6 @@
  */
 
 import * as React from "react";
-// eslint-disable-next-line no-duplicate-imports
 import { useLayoutEffect, useRef, useState } from "react";
 import { assert } from "@itwin/core-bentley";
 import type { PrimitiveValue, PropertyRecord } from "@itwin/appui-abstract";

--- a/ui/components-react/src/components-react/selectable-content/SelectableContent.tsx
+++ b/ui/components-react/src/components-react/selectable-content/SelectableContent.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable deprecation/deprecation */
 /** @packageDocumentation
  * @module SelectableContent
  */

--- a/ui/components-react/src/components-react/toolbar/OverflowPanel.tsx
+++ b/ui/components-react/src/components-react/toolbar/OverflowPanel.tsx
@@ -43,7 +43,6 @@ export interface ToolbarOverflowPanelProps extends CommonProps {
 /** Displays overflown tool settings.
  * @internal
  */
-// eslint-disable-next-line react/display-name
 export function ToolbarOverflowPanel(props: ToolbarOverflowPanelProps) {
   const {
     toolbarOpacitySetting,

--- a/ui/components-react/src/components-react/toolbar/PopupItem.tsx
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.tsx
@@ -29,7 +29,6 @@ export interface ToolbarPopupContextProps {
  * Context used by Toolbar items in popups to close the popup panel.
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ToolbarPopupContext =
   React.createContext<ToolbarPopupContextProps>({
     /** function used to close popup panel */

--- a/ui/components-react/src/components-react/toolbar/Toolbar.tsx
+++ b/ui/components-react/src/components-react/toolbar/Toolbar.tsx
@@ -77,8 +77,6 @@ export function Toolbar(props: ToolbarProps) {
     setTimeout(() => {
       setPopupPanelCount((prev) => {
         const nextCount = isOpening ? prev + 1 : prev - 1;
-        // eslint-disable-next-line no-console
-        // console.log(`new popup count = ${nextCount}`);
         return nextCount < 0 ? /* istanbul ignore next */ 0 : nextCount;
       });
     });

--- a/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/components-react/src/components-react/toolbar/ToolbarWithOverflow.tsx
@@ -56,7 +56,6 @@ export interface CustomToolbarItem extends CustomButtonDefinition {
  * Context used by Toolbar items to know if popup panel should be hidden - via AutoHide.
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ToolbarPopupAutoHideContext = React.createContext<boolean>(false);
 
 /**
@@ -153,7 +152,6 @@ export interface ToolbarOverflowContextProps {
  * Context used by Toolbar component to provide Direction to child components.
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ToolbarWithOverflowDirectionContext =
   React.createContext<ToolbarOverflowContextProps>({
     expandsTo: Direction.Bottom,
@@ -409,8 +407,6 @@ export function ToolbarWithOverflow(props: ToolbarWithOverflowProps) {
       setPopupPanelCount((prev) => {
         /* istanbul ignore next */
         const nextCount = isOpening ? prev + 1 : prev - 1;
-        // eslint-disable-next-line no-console
-        // console.log(`new popup count = ${nextCount}`);
         return nextCount < 0 ? /* istanbul ignore next */ 0 : nextCount;
       });
     });
@@ -800,7 +796,6 @@ export interface ToolbarItemContextArgs {
 /** Interface toolbars use to define context for its items.
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ToolbarItemContext = React.createContext<ToolbarItemContextArgs>(
   null!
 );

--- a/ui/components-react/src/components-react/tree/controlled/component/NodeContent.tsx
+++ b/ui/components-react/src/components-react/tree/controlled/component/NodeContent.tsx
@@ -42,7 +42,6 @@ export interface TreeNodeContentProps extends CommonProps {
  */
 export function TreeNodeContent(props: TreeNodeContentProps) {
   const { node, valueRendererManager, onLabelRendered, highlightProps } = props;
-  // eslint-disable-next-line @typescript-eslint/promise-function-async
   const label = React.useMemo(
     () => getLabel(node, valueRendererManager, highlightProps),
     [node, valueRendererManager, highlightProps]

--- a/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -298,7 +298,7 @@ function getNodeKey(node: TreeModelNode | TreeModelNodePlaceholder): string {
   return `${node.parentId || ""}-${node.childIndex}`;
 }
 
-const Node = React.memo<React.FC<ListChildComponentProps>>(function Node( // eslint-disable-line @typescript-eslint/naming-convention
+const Node = React.memo<React.FC<ListChildComponentProps>>(function Node(
   props: ListChildComponentProps
 ) {
   const { index, style } = props;

--- a/ui/components-react/src/test/TestUtils.ts
+++ b/ui/components-react/src/test/TestUtils.ts
@@ -608,4 +608,4 @@ export type SinonSpy<T extends (...args: any) => any> = sinon.SinonSpy<
   ReturnType<T>
 >;
 
-export default TestUtils; // eslint-disable-line: no-default-export
+export default TestUtils;

--- a/ui/components-react/src/test/properties/renderers/PropertyRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/PropertyRenderer.test.tsx
@@ -379,7 +379,7 @@ describe("PropertyRenderer", () => {
 
     const myCustomRenderer = {
       canRender: () => true,
-      render: () => <div>My value</div>, // eslint-disable-line react/display-name
+      render: () => <div>My value</div>,
     };
 
     PropertyValueRendererManager.defaultManager.registerRenderer(

--- a/ui/components-react/src/test/propertygrid/component/internal/FlatPropertyRenderer.test.tsx
+++ b/ui/components-react/src/test/propertygrid/component/internal/FlatPropertyRenderer.test.tsx
@@ -323,7 +323,6 @@ describe("FlatPropertyRenderer", () => {
 
     const myCustomRenderer = {
       canRender: () => true,
-      // eslint-disable-next-line react/display-name
       render: () => <div>My value</div>,
     };
 

--- a/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
@@ -8,7 +8,6 @@ import sinon from "sinon";
 import * as moq from "typemoq";
 import { PropertyGridCommons } from "../../../../components-react/propertygrid/component/PropertyGridCommons";
 
-/* eslint-disable @typescript-eslint/naming-convention */
 describe("PropertyGrid Commons", () => {
   describe("getLinks", () => {
     it("detects url link", () => {

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/GridCategory.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/GridCategory.test.ts
@@ -917,7 +917,6 @@ describe("GridCategory", () => {
       );
 
       // Test current gridCategory descendants against flattened propertyCategory
-      // eslint-disable-next-line deprecation/deprecation
       const descendants = gridCategory.getDescendantsAndSelf();
       const flattenedPropertyCategories = GridUtils.flattenPropertyCategories(
         [propertyCategory],
@@ -934,7 +933,6 @@ describe("GridCategory", () => {
       );
 
       // Test current gridCategory children parent-child category relationship (recursive)
-      // eslint-disable-next-line deprecation/deprecation
       const childCategories = gridCategory.getChildren();
       const childPropertyCategories = propertyCategory.childCategories ?? [];
       expect(childCategories.length).to.be.equal(
@@ -971,7 +969,6 @@ describe("GridCategory", () => {
           gridItemFactory
         );
 
-        // eslint-disable-next-line deprecation/deprecation
         const childCategories = gridCategory.getChildren();
         expect(gridCategory.getDescendantsAndSelf()).to.deep.equal([
           gridCategory,

--- a/ui/components-react/src/test/propertygrid/dataproviders/FilteringDataProvider.test.ts
+++ b/ui/components-react/src/test/propertygrid/dataproviders/FilteringDataProvider.test.ts
@@ -354,7 +354,6 @@ describe("FilteringDataProvider", () => {
     };
 
     it("Should return expected filtered data if filter is enabled and there are matches", async () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const expectedFilteredData = {
         label: originalPropertyData.label,
         description: originalPropertyData.description,

--- a/ui/components-react/src/test/selectable-content/SelectableContent.test.tsx
+++ b/ui/components-react/src/test/selectable-content/SelectableContent.test.tsx
@@ -7,8 +7,6 @@ import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import { SelectableContent } from "../../components-react/selectable-content/SelectableContent";
 
-/* eslint-disable react/display-name */
-
 describe("<SelectableContent />", () => {
   it("lists all given content components in select box", async () => {
     const { getByText, getByTestId, queryAllByText } = render(

--- a/ui/components-react/src/test/toolbar/ToolbarWithOverflow.test.tsx
+++ b/ui/components-react/src/test/toolbar/ToolbarWithOverflow.test.tsx
@@ -115,7 +115,6 @@ describe("<ToolbarWithOverflow />", () => {
     });
 
     it("will render 6 items without overflow", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -137,7 +136,6 @@ describe("<ToolbarWithOverflow />", () => {
     });
 
     it("will render 6 items without overflow - simulate horizontal toolbar at bottom right of window.", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -164,7 +162,6 @@ describe("<ToolbarWithOverflow />", () => {
     });
 
     it("will render 3 items with overflow - simulate horizontal toolbar right of window.", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -205,7 +202,6 @@ describe("<ToolbarWithOverflow />", () => {
     });
 
     it("will render with 3 items + overflow", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -240,7 +236,6 @@ describe("<ToolbarWithOverflow />", () => {
     });
 
     it("will auto-hide rendered with 3 items + overflow", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -344,7 +339,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -427,7 +421,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -498,7 +491,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -569,7 +561,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -645,7 +636,6 @@ describe("<ToolbarWithOverflow />", () => {
     ];
 
     it("will render 6 items without overflow", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -670,7 +660,6 @@ describe("<ToolbarWithOverflow />", () => {
     });
 
     it("will render 6 items without overflow - simulate vertical bar in Navigation Area", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -695,7 +684,6 @@ describe("<ToolbarWithOverflow />", () => {
     });
 
     it("will render with 3 items + overflow", () => {
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -734,7 +722,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -772,7 +759,6 @@ describe("<ToolbarWithOverflow />", () => {
 
       const toolbarItems: CommonToolbarItem[] = [getCustomDefWithPopupPanel()];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -820,7 +806,6 @@ describe("<ToolbarWithOverflow />", () => {
 
       const toolbarItems: CommonToolbarItem[] = [getCustomDefWithPopupPanel()];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -875,7 +860,6 @@ describe("<ToolbarWithOverflow />", () => {
 
       const toolbarItems: CommonToolbarItem[] = [getCustomDefWithPopupPanel()];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -939,7 +923,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -1264,7 +1247,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -1560,7 +1542,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -1772,7 +1753,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -1861,7 +1841,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2024,7 +2003,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2123,7 +2101,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2186,7 +2163,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2276,7 +2252,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2363,7 +2338,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2434,7 +2408,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2494,7 +2467,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2580,7 +2552,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2662,7 +2633,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2753,7 +2723,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {
@@ -2915,7 +2884,6 @@ describe("<ToolbarWithOverflow />", () => {
         ),
       ];
 
-      // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
       sandbox
         .stub(Element.prototype, "getBoundingClientRect")
         .callsFake(function (this: HTMLElement) {

--- a/ui/core-react/src/core-react/base/DivWithOutsideClick.tsx
+++ b/ui/core-react/src/core-react/base/DivWithOutsideClick.tsx
@@ -15,4 +15,4 @@ import type { CommonDivProps } from "../utils/Props";
  */
 export const DivWithOutsideClick = withOnOutsideClick(
   (props: CommonDivProps) => <div {...props} />
-); // eslint-disable-line @typescript-eslint/naming-convention
+);

--- a/ui/core-react/src/core-react/contextmenu/GlobalContextMenu.tsx
+++ b/ui/core-react/src/core-react/contextmenu/GlobalContextMenu.tsx
@@ -90,7 +90,7 @@ export class GlobalContextMenu extends React.PureComponent<
       top: y,
     };
 
-    const CtxMenu = contextMenuComponent || ContextMenu; // eslint-disable-line @typescript-eslint/naming-convention
+    const CtxMenu = contextMenuComponent || ContextMenu;
 
     return (
       <div ref={this._handleRefSet} style={{ display: "none" }}>

--- a/ui/core-react/src/core-react/elementseparator/ElementSeparator.tsx
+++ b/ui/core-react/src/core-react/elementseparator/ElementSeparator.tsx
@@ -15,7 +15,7 @@ import {
   useMemo,
   useRef,
   useState,
-} from "react"; // eslint-disable-line no-duplicate-imports
+} from "react";
 import classnames from "classnames";
 import { Orientation } from "../enums/Orientation";
 import type { CommonProps } from "../utils/Props";
@@ -232,7 +232,6 @@ function getStyle(
 /** A movable button, which allows to change the ratio between left element and right element
  * @public
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const ElementSeparator = (props: ElementSeparatorProps) => {
   const label = useRef(UiCore.translate("elementSeparator.label"));
   const [hasHoverHappened, setHasHoverHappened] = useState(false);

--- a/ui/core-react/src/core-react/focustrap/FocusTrap.tsx
+++ b/ui/core-react/src/core-react/focustrap/FocusTrap.tsx
@@ -277,7 +277,6 @@ export function FocusTrap(props: FocusTrapProps) {
         ref={focusContainer}
         /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
         tabIndex={0}
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         style={{ outline: "none", WebkitTapHighlightColor: "rgba(0,0,0,0)" }}
       >
         {props.children}

--- a/ui/core-react/src/core-react/hocs/withIsPressed.tsx
+++ b/ui/core-react/src/core-react/hocs/withIsPressed.tsx
@@ -22,7 +22,6 @@ export interface WithIsPressedProps {
  * @public
  */
 export const withIsPressed = <ComponentProps extends {}>(
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   Component: React.ComponentType<ComponentProps>
 ) => {
   return class WithIsPressed extends React.PureComponent<

--- a/ui/core-react/src/core-react/hocs/withOnOutsideClick.tsx
+++ b/ui/core-react/src/core-react/hocs/withOnOutsideClick.tsx
@@ -22,7 +22,6 @@ export interface WithOnOutsideClickProps {
  * @public
  */
 export const withOnOutsideClick = <ComponentProps extends {}>(
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   Component: React.ComponentType<ComponentProps>,
   defaultOnOutsideClick?: (event: MouseEvent) => any,
   useCapture: boolean = true,

--- a/ui/core-react/src/core-react/hocs/withTimeout.tsx
+++ b/ui/core-react/src/core-react/hocs/withTimeout.tsx
@@ -23,7 +23,6 @@ export interface WithTimeoutProps {
  * @public
  */
 export const withTimeout = <ComponentProps extends {}>(
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   Component: React.ComponentType<ComponentProps>
 ) => {
   return class WithTimeout extends React.PureComponent<

--- a/ui/core-react/src/core-react/icons/IconComponent.tsx
+++ b/ui/core-react/src/core-react/icons/IconComponent.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/* eslint-disable deprecation/deprecation */
 /** @packageDocumentation
  * @module Icon
  */
@@ -70,7 +69,7 @@ export function Icon(props: IconProps) {
       const sanitizedIconString = sanitizer.sanitize(svgDiv, sanitizerConfig);
       const webComponentNode = (
         // we can safely disable jam3/no-sanitizer-with-danger as we are sanitizing above
-        // eslint-disable-next-line @typescript-eslint/naming-convention, jam3/no-sanitizer-with-danger
+        // eslint-disable-next-line jam3/no-sanitizer-with-danger
         <div dangerouslySetInnerHTML={{ __html: sanitizedIconString }}></div>
       );
       return (

--- a/ui/core-react/src/core-react/inputs/Input.tsx
+++ b/ui/core-react/src/core-react/inputs/Input.tsx
@@ -27,7 +27,7 @@ export interface InputProps
 }
 
 // Defined using following pattern (const Input at bottom) to ensure useful API documentation is extracted
-const ForwardRefInput = React.forwardRef<HTMLInputElement, InputProps>( // eslint-disable-line deprecation/deprecation
+const ForwardRefInput = React.forwardRef<HTMLInputElement, InputProps>(
   function ForwardRefInput(props, ref) {
     const {
       className,
@@ -82,4 +82,4 @@ const ForwardRefInput = React.forwardRef<HTMLInputElement, InputProps>( // eslin
 /** Basic text input, is a wrapper for the `<input type="text">` HTML element.
  * @internal
  */
-export const Input: (props: InputProps) => JSX.Element | null = ForwardRefInput; // eslint-disable-line deprecation/deprecation
+export const Input: (props: InputProps) => JSX.Element | null = ForwardRefInput;

--- a/ui/core-react/src/core-react/inputs/iconinput/IconInput.tsx
+++ b/ui/core-react/src/core-react/inputs/iconinput/IconInput.tsx
@@ -16,7 +16,6 @@ import { Input } from "../Input"; // NEEDSWORK - for nativeKeyHandler
  * @public
  */
 export interface IconInputProps extends Omit<InputProps, "size"> {
-  // eslint-disable-line deprecation/deprecation
   /** Icon displayed to the left of the Input field within the IconInput component */
   icon: React.ReactNode;
   /** CSS class name for the IconInput component container div */
@@ -40,7 +39,6 @@ const ForwardRefIconInput = React.forwardRef<HTMLInputElement, IconInputProps>(
       <div
         className={classnames("core-iconInput-container", containerClassName)}
       >
-        {/* eslint-disable-next-line deprecation/deprecation */}
         <Input ref={ref} {...otherProps} />
         <div className="core-iconInput-icon">{icon}</div>
       </div>

--- a/ui/core-react/src/core-react/listbox/Listbox.tsx
+++ b/ui/core-react/src/core-react/listbox/Listbox.tsx
@@ -73,7 +73,7 @@ export interface ListboxContextProps {
 // istanbul ignore next
 export const ListboxContext = React.createContext<ListboxContextProps>({
   onListboxValueChange: (_newValue: ListboxValue | undefined) => {},
-}); // eslint-disable-line @typescript-eslint/naming-convention
+});
 
 function makeId(...args: Array<string | number | null | undefined>) {
   return args.filter((val) => val != null).join("--");
@@ -193,10 +193,9 @@ export function Listbox(props: ListboxProps) {
       if (itemIndex >= 0 && itemIndex < optionValues.length) {
         const newSelection = optionValues[itemIndex];
         const listElement = listRef.current as HTMLUListElement;
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        const optionToFocus = listElement.querySelector(
+        const optionToFocus = listElement.querySelector<HTMLLIElement>(
           `li[data-value="${newSelection.value}"]`
-        ) as HTMLLIElement | null;
+        );
         // istanbul ignore else
         if (optionToFocus && listElement) {
           let newScrollTop = listElement.scrollTop;

--- a/ui/core-react/src/core-react/tree/Tree.tsx
+++ b/ui/core-react/src/core-react/tree/Tree.tsx
@@ -60,7 +60,6 @@ export class Tree extends React.PureComponent<TreeProps> {
 
     // istanbul ignore next
     if (!Element.prototype.scrollTo) {
-      // eslint-disable-line @typescript-eslint/unbound-method
       // workaround for Edge scrollTo issue https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15534521/
       element.scrollIntoView();
       return;

--- a/ui/core-react/src/core-react/utils/hooks/ResizeObserverPolyfill.tsx
+++ b/ui/core-react/src/core-react/utils/hooks/ResizeObserverPolyfill.tsx
@@ -20,4 +20,4 @@ function getModule(mod: any) {
 /** @internal */
 export const ResizeObserver: ResizeObserverType = getModule(
   ResizeObserverPolyfill
-); // eslint-disable-line @typescript-eslint/naming-convention
+);

--- a/ui/core-react/src/core-react/utils/hooks/useWidgetOpacityContext.tsx
+++ b/ui/core-react/src/core-react/utils/hooks/useWidgetOpacityContext.tsx
@@ -20,7 +20,6 @@ export interface WidgetOpacityContextProps {
  * Context used by Widgets and child components to process opacity changes based on mouse proximity.
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export const WidgetOpacityContext =
   React.createContext<WidgetOpacityContextProps>({
     onElementRef: /* istanbul ignore next */ (

--- a/ui/core-react/src/test/TestUtils.ts
+++ b/ui/core-react/src/test/TestUtils.ts
@@ -117,4 +117,4 @@ export function classesFromElement(e: Element | null | undefined) {
   return Array.from(e!.classList.values());
 }
 
-export default TestUtils; // eslint-disable-line: no-default-export
+export default TestUtils;

--- a/ui/core-react/src/test/hocs/withIsPressed.test.tsx
+++ b/ui/core-react/src/test/hocs/withIsPressed.test.tsx
@@ -15,7 +15,7 @@ describe("withIsPressed", () => {
     theUserTo = userEvent.setup();
   });
 
-  const WithIsPressedDiv = withIsPressed((props) => <div {...props} />); // eslint-disable-line @typescript-eslint/naming-convention
+  const WithIsPressedDiv = withIsPressed((props) => <div {...props} />);
 
   it("mousedown event", async () => {
     let iAmPressed = false;

--- a/ui/core-react/src/test/hocs/withOnOutsideClick.test.tsx
+++ b/ui/core-react/src/test/hocs/withOnOutsideClick.test.tsx
@@ -17,7 +17,7 @@ describe("WithOnOutsideClick", async () => {
 
   const WithOnOutsideClickDiv = withOnOutsideClick<{
     children?: React.ReactNode;
-  }>((props) => <div {...props} />, undefined, true, false); // eslint-disable-line @typescript-eslint/naming-convention
+  }>((props) => <div {...props} />, undefined, true, false);
 
   const defaultOnClose = sinon.spy();
   const WithOnOutsideClickAndDefaultDiv = withOnOutsideClick(
@@ -25,20 +25,20 @@ describe("WithOnOutsideClick", async () => {
     defaultOnClose,
     true,
     false
-  ); // eslint-disable-line @typescript-eslint/naming-convention
+  );
 
   const WithOnOutsidePointerDiv = withOnOutsideClick(
     (props) => <div {...props} />,
     undefined,
     true
-  ); // eslint-disable-line @typescript-eslint/naming-convention
+  );
 
   const WithOnOutsidePointerAndDefaultDiv = withOnOutsideClick(
     (props) => <div {...props} />,
     defaultOnClose,
     true,
     true
-  ); // eslint-disable-line @typescript-eslint/naming-convention
+  );
 
   it("should handle document click", async () => {
     const spyOnClose = sinon.spy();

--- a/ui/core-react/src/test/hocs/withTimeout.test.tsx
+++ b/ui/core-react/src/test/hocs/withTimeout.test.tsx
@@ -9,7 +9,7 @@ import * as sinon from "sinon";
 import { withTimeout } from "../../core-react";
 
 describe("withTimeout", () => {
-  const WithTimeoutDiv = withTimeout((props) => <div {...props} />); // eslint-disable-line @typescript-eslint/naming-convention
+  const WithTimeoutDiv = withTimeout((props) => <div {...props} />);
 
   it("should start timer on mount", async () => {
     const spy = sinon.spy();

--- a/ui/core-react/src/test/inputs/Input.test.tsx
+++ b/ui/core-react/src/test/inputs/Input.test.tsx
@@ -8,8 +8,6 @@ import { fireEvent, render } from "@testing-library/react";
 import { Input } from "../../core-react/inputs/Input";
 import * as sinon from "sinon";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<Input />", () => {
   it("renders", () => {
     const input = render(<Input />);

--- a/ui/core-react/src/test/loading/LoadingSpinner.test.tsx
+++ b/ui/core-react/src/test/loading/LoadingSpinner.test.tsx
@@ -8,8 +8,6 @@ import * as React from "react";
 import { LoadingSpinner } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<LoadingSpinner />", () => {
   it("renders with message correctly", () => {
     render(<LoadingSpinner message="test" />);

--- a/ui/core-react/src/test/tree/Tree.test.tsx
+++ b/ui/core-react/src/test/tree/Tree.test.tsx
@@ -9,8 +9,6 @@ import * as sinon from "sinon";
 import { Tree } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable @typescript-eslint/unbound-method */
-
 describe("<Tree />", () => {
   const createRect = (
     x0: number,

--- a/ui/core-react/src/test/uisettings/UiStateEntry.test.ts
+++ b/ui/core-react/src/test/uisettings/UiStateEntry.test.ts
@@ -33,7 +33,7 @@ describe("UiStateEntry", () => {
   describe("saveSetting", () => {
     const localUiSettings = new LocalStateStorage({
       localStorage: storageMock(),
-    } as Window); // eslint-disable-line deprecation/deprecation
+    } as Window);
 
     it("Should save setting correctly", async () => {
       const uiSetting = new UiStateEntry<boolean>(

--- a/ui/core-react/src/test/utils/hooks/useOnOutsideClick.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useOnOutsideClick.test.tsx
@@ -7,8 +7,6 @@ import { fireEvent } from "@testing-library/react";
 import { act, renderHook } from "@testing-library/react-hooks";
 import { useOnOutsideClick } from "../../../core-react";
 
-/* eslint-disable @typescript-eslint/no-floating-promises */
-
 function setRefValue<T>(ref: React.Ref<T>, value: T) {
   if (typeof ref === "function") {
     ref(value);

--- a/ui/core-react/src/test/utils/hooks/useProximityToMouse.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useProximityToMouse.test.tsx
@@ -22,7 +22,6 @@ import {
   WidgetElementSet,
 } from "../../../core-react/utils/hooks/useProximityToMouse";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const ProximityToMouse = () => {
   const ref = React.useRef<HTMLDivElement>(null);
   const elementSet = new WidgetElementSet();

--- a/ui/core-react/src/test/utils/hooks/useRefEffect.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useRefEffect.test.tsx
@@ -11,7 +11,6 @@ describe("useRefEffect", () => {
     const callback = sinon.spy((_: string | null) => {});
     const { result } = renderHook(() => useRefEffect(callback, []));
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current("abc");
     });
 
@@ -34,11 +33,9 @@ describe("useRefEffect", () => {
     });
     const { result } = renderHook(() => useRefEffect(callback, []));
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current("abc");
     });
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current("abcd");
     });
 

--- a/ui/core-react/src/test/utils/hooks/useRefs.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useRefs.test.tsx
@@ -18,7 +18,6 @@ describe("useRefs", () => {
       return useRefs(ref, mutableRef, callbackRef);
     });
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current("abc");
     });
 
@@ -39,7 +38,6 @@ describe("mergeRefs", () => {
       return mergeRefs(ref, mutableRef, callbackRef);
     });
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current("abc");
     });
 

--- a/ui/core-react/src/test/utils/hooks/useResizeObserver.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useResizeObserver.test.tsx
@@ -51,7 +51,6 @@ describe("useResizeObserver", () => {
     const { result } = renderHook(() => useResizeObserver());
     const element = document.createElement("div");
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current(element);
     });
     await TestUtils.flushAsyncOperations();
@@ -66,11 +65,9 @@ describe("useResizeObserver", () => {
     const { result } = renderHook(() => useResizeObserver());
     const element = document.createElement("div");
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current(element);
     });
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current(null);
     });
     await TestUtils.flushAsyncOperations();
@@ -86,7 +83,6 @@ describe("useResizeObserver", () => {
     const { result } = renderHook(() => useResizeObserver(spy));
     const element = document.createElement("div");
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current(element);
     });
     await TestUtils.flushAsyncOperations();
@@ -117,7 +113,6 @@ describe("useResizeObserver", () => {
     const { result } = renderHook(() => useResizeObserver(spy));
     const element = document.createElement("div");
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current(element);
     });
     await TestUtils.flushAsyncOperations();
@@ -149,7 +144,6 @@ describe("useResizeObserver", () => {
     const { result } = renderHook(() => useResizeObserver(spy));
     const element = document.createElement("div");
     act(() => {
-      // eslint-disable-line @typescript-eslint/no-floating-promises
       result.current(element);
     });
 

--- a/ui/core-react/src/test/utils/hooks/useTargeted.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useTargeted.test.tsx
@@ -8,7 +8,6 @@ import { expect } from "chai";
 import * as React from "react";
 import { useTargeted } from "../../../core-react/utils/hooks/useTargeted";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const Targeted = () => {
   const ref = React.useRef<HTMLButtonElement>(null);
   const targeted = useTargeted(ref);

--- a/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.tsx
@@ -113,13 +113,13 @@ export class ColorEditor
 
   /** @internal */
   public override componentDidMount() {
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.tsx
@@ -123,7 +123,7 @@ export class WeightEditor
   /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
-    this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void this.setStateFromProps();
   }
 
   /** @internal */
@@ -134,7 +134,7 @@ export class WeightEditor
   /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
-      this.setStateFromProps(); // eslint-disable-line @typescript-eslint/no-floating-promises
+      void this.setStateFromProps();
     }
   }
 

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/Swatch.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/Swatch.tsx
@@ -42,10 +42,7 @@ export class LineWeightSwatch extends React.PureComponent<LineWeightSwatchProps>
     super(props);
   }
 
-  public override componentDidMount() {
-    // eslint-disable-next-line no-console
-    // console.log(`LineWeightSwatchProps.componentDidMount setFocusRef=${this.props.setFocusRef} focusRef=${this.props.focusRef && this.props.focusRef.current ? "set" : "unset"}`);
-  }
+  public override componentDidMount() {}
 
   public override render() {
     const {
@@ -54,7 +51,6 @@ export class LineWeightSwatch extends React.PureComponent<LineWeightSwatchProps>
       weight,
       hideLabel,
       className, // do not pass on color swatch specific props
-      // eslint-disable-next-line comma-dangle
       disabled,
       readonly,
       ...otherProps // pass-through props

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.tsx
@@ -91,8 +91,6 @@ export class WeightPickerButton extends React.PureComponent<
   };
 
   public override componentDidMount() {
-    // eslint-disable-next-line no-console
-    // console.log(`WeightPickerButton.componentDidMount focusRef=${this._focusTarget && this._focusTarget.current ? "set" : "unset"}`);
     this.setState({ targetElement: this._target.current });
   }
 

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/Cube.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/Cube.tsx
@@ -141,7 +141,6 @@ export class CubeFace extends React.Component<CubeFaceProps> {
     const transform = `matrix3d(${list.join(", ")})`;
     const s: React.CSSProperties = {
       transform,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       WebkitTransform: transform,
       ...style,
     };

--- a/ui/imodel-components-react/src/imodel-components-react/quantityformat/FormatPanel.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/quantityformat/FormatPanel.tsx
@@ -124,7 +124,7 @@ export function FormatPanel(props: FormatPanelProps) {
       }
       isMounted.current && setFormatSpec(newFormatSpec);
     }
-    if (!formatSpec) fetchFormatSpec(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    if (!formatSpec) void fetchFormatSpec();
   }, [
     formatProps,
     formatSpec,

--- a/ui/imodel-components-react/src/imodel-components-react/quantityformat/misc/UnitDescr.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/quantityformat/misc/UnitDescr.tsx
@@ -158,7 +158,7 @@ export function UnitDescr(props: UnitDescrProps) {
         }
       }
     }
-    fetchAllowableUnitSelections(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    void fetchAllowableUnitSelections();
   }, [index, label, name, parentUnitName, unitsProvider]);
 
   const handleOnUnitChange = React.useCallback(

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/InlineEdit.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/InlineEdit.tsx
@@ -42,7 +42,6 @@ export class InlineEdit extends React.Component<
     prevProps: InlineEditProps,
     _prevState: InlineEditState
   ) {
-    // eslint-disable-line @typescript-eslint/naming-convention
     if (prevProps.defaultValue !== this.props.defaultValue) {
       this.setState((_, props) => {
         return { value: props.defaultValue, originalValue: props.defaultValue };

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/SpeedTimeline.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/SpeedTimeline.tsx
@@ -22,7 +22,6 @@ interface SpeedProps extends CommonProps {
 /** Speed Timeline used in Solar Timeline component
  * @internal
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function SpeedTimeline(props: SpeedProps) {
   // istanbul ignore next - WIP
   const onChange = (values: ReadonlyArray<number>) => {

--- a/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
@@ -343,7 +343,7 @@ export function ViewportComponent(props: ViewportProps) {
         setInitialViewState(currentViewState?.clone());
       }
     }
-    if (undefined === initialViewState) fetchInitialViewstate(); // eslint-disable-line @typescript-eslint/no-floating-promises
+    if (undefined === initialViewState) void fetchInitialViewstate();
   }, [imodel, initialViewState, viewDefinitionId, viewState]);
 
   const [viewOverlay, setViewOverlay] = React.useState<React.ReactNode>(null);

--- a/ui/imodel-components-react/src/test/TestUtils.ts
+++ b/ui/imodel-components-react/src/test/TestUtils.ts
@@ -541,4 +541,4 @@ export function styleMatch(style: Partial<CSSStyleDeclaration>) {
   };
 }
 
-export default TestUtils; // eslint-disable-line: no-default-export
+export default TestUtils;

--- a/ui/imodel-components-react/src/test/color/ColorPickerPopup.test.tsx
+++ b/ui/imodel-components-react/src/test/color/ColorPickerPopup.test.tsx
@@ -213,7 +213,6 @@ describe("<ColorPickerPopup/>", () => {
   });
 
   it("ensure update prop is handled", async () => {
-    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
     const renderedComponent = render(
       <div>
         <ColorPickerPopup
@@ -248,7 +247,6 @@ describe("<ColorPickerPopup/>", () => {
   it("ensure closing X is shown", async () => {
     const spyOnClick = sinon.spy();
 
-    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
     const renderedComponent = render(
       <div>
         <ColorPickerPopup
@@ -280,7 +278,6 @@ describe("<ColorPickerPopup/>", () => {
   it("ensure closing X is NOT shown", async () => {
     const spyOnClick = sinon.spy();
 
-    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
     const renderedComponent = render(
       <div>
         <ColorPickerPopup
@@ -308,7 +305,6 @@ describe("<ColorPickerPopup/>", () => {
     const spyOnClick = sinon.spy();
     const spyOnChange = sinon.spy();
 
-    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
     const renderedComponent = render(
       <div>
         <ColorPickerPopup
@@ -341,7 +337,6 @@ describe("<ColorPickerPopup/>", () => {
     const spyOnClick = sinon.spy();
     const spyOnChange = sinon.spy();
 
-    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
     const renderedComponent = render(
       <div>
         <ColorPickerPopup
@@ -373,7 +368,6 @@ describe("<ColorPickerPopup/>", () => {
   });
 
   it("should not show swatches", async () => {
-    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
     const renderedComponent = render(
       <div>
         <ColorPickerPopup

--- a/ui/imodel-components-react/src/test/editors/WeightEditor.test.tsx
+++ b/ui/imodel-components-react/src/test/editors/WeightEditor.test.tsx
@@ -54,7 +54,6 @@ describe("<WeightEditor />", () => {
     // ====== Example of how to see contents of portal <Popup> component ==========
     // const portalDiv = await waitForElement(() => renderedComponent.getByTestId("core-popup"));
     // expect(portalDiv).not.to.be.undefined;
-    // eslint-disable-next-line no-console
     // console.log(portalDiv.outerHTML);
     // =================================
 

--- a/ui/imodel-components-react/src/test/inputs/QuantityInput.test.tsx
+++ b/ui/imodel-components-react/src/test/inputs/QuantityInput.test.tsx
@@ -139,8 +139,6 @@ describe("QuantityInput", () => {
       overrideLengthFormats
     );
     await TestUtils.flushAsyncOperations();
-    // eslint-disable-next-line no-console
-    // console.log(`input.value = ${input.value}`);
     expect(input.value).to.eq("39.3701 in");
     await IModelApp.quantityFormatter.clearOverrideFormats(QuantityType.Length);
     await TestUtils.flushAsyncOperations();

--- a/ui/imodel-components-react/src/test/timeline/TimelineComponent.test.tsx
+++ b/ui/imodel-components-react/src/test/timeline/TimelineComponent.test.tsx
@@ -532,8 +532,7 @@ describe("<TimelineComponent showDuration={true} />", () => {
     fakeTimers = sinon.useFakeTimers();
     const dataProvider = new TestTimelineDataProvider();
     const spyOnPlayPause = sinon.spy();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const renderedComponent = render(
+    render(
       <TimelineComponent
         initialDuration={dataProvider.initialDuration}
         totalDuration={dataProvider.duration}
@@ -711,7 +710,6 @@ describe("<TimelineComponent showDuration={true} />", () => {
   it("should call onForward on forward button click", () => {
     const dataProvider = new TestTimelineDataProvider();
     const spyOnJump = sinon.spy();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const renderedComponent = render(
       <TimelineComponent
         initialDuration={dataProvider.initialDuration}
@@ -731,7 +729,6 @@ describe("<TimelineComponent showDuration={true} />", () => {
   it("should call onBackward on back button click", () => {
     const dataProvider = new TestTimelineDataProvider();
     const spyOnJump = sinon.spy();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const renderedComponent = render(
       <TimelineComponent
         initialDuration={dataProvider.initialDuration}


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

This is removing most useless lint comment we have in the code base that I could find, on top of the prettier fix. The idea is that the prettier fix merge will already affect a ton of files, and this is good to be cleaned as well, and would create another "cleanup" PR when reviewing file history. Having them combined would reduce that history walk, however I'm open to discussion if we think that this could be harmful. (Hence the PR -> PR rather than a commit on the existing branch)

## Testing

Ran `rush lint` without any error locally, will monitor if the CI picks up anything else.