### PR TITLE
Cache IconWebComponent svg content.

### DIFF
--- a/common/changes/@itwin/core-react/raplemie-CacheIconWebComponent_2023-06-08-18-32.json
+++ b/common/changes/@itwin/core-react/raplemie-CacheIconWebComponent_2023-06-08-18-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Cache IconWebComponent svg content.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/ui/core-react/src/core-react/utils/IconWebComponent.ts
+++ b/ui/core-react/src/core-react/utils/IconWebComponent.ts
@@ -14,6 +14,101 @@ import { UiCore } from "../UiCore";
 import DOMPurify, * as DOMPurifyNS from "dompurify";
 
 /**
+ * Completed SVG cache
+ * (If we get it once, we use it from there afterwards)
+ */
+const svgCache = new Map<string, HTMLElement>();
+/**
+ * Active "getSource" list
+ * (if multiple icon require the same thing at the same time,
+ * only do the fetch once, and have all icon use the same result,
+ * clear result afterwards, good or bad.)
+ */
+const getList = new Map<string, Promise<HTMLElement>>();
+
+/**
+ * Get the source (fetch and parse for url, or decode and parse for data: url)
+ * @param src URL of the content to download/parse
+ * @param element Element for logging purpose.
+ * @returns HTMLElement (svg)
+ */
+async function getSource(src: string, element: any) {
+  if (src.startsWith("data:")) {
+    const dataUriParts = src.split(",");
+
+    if (
+      dataUriParts.length !== 2 ||
+      "data:image/svg+xml;base64" !== dataUriParts[0]
+    ) {
+      Logger.logError(UiCore.loggerCategory(element), "Unable to load icon.");
+    }
+
+    // the esm build of dompurify has a default import but the cjs build does not
+    // if there is a default export, use it (likely esm), otherwise use the namespace
+    // istanbul ignore next
+    const sanitizer = DOMPurify ?? DOMPurifyNS;
+    // eslint-disable-next-line deprecation/deprecation
+    const sanitizedSvg = sanitizer.sanitize(atob(dataUriParts[1]));
+
+    const parsedSvg = new window.DOMParser().parseFromString(
+      sanitizedSvg,
+      "text/xml"
+    );
+    const errorNode = parsedSvg.querySelector("parsererror");
+    if (
+      errorNode ||
+      "svg" !== parsedSvg.documentElement.nodeName.toLowerCase()
+    ) {
+      throw new UiError(UiCore.loggerCategory(element), "Unable to load icon.");
+    }
+
+    return parsedSvg.documentElement;
+  } else {
+    const response = await fetch(src).catch((_error) => {
+      Logger.logError(UiCore.loggerCategory(element), "Unable to load icon.");
+    });
+    if (!response || !response.ok) {
+      throw new UiError(UiCore.loggerCategory(element), "Unable to load icon.");
+    }
+    const str = await response.text();
+    if (str === undefined) {
+      throw new UiError(UiCore.loggerCategory(element), "Unable to load icon.");
+    }
+    const data = new window.DOMParser().parseFromString(str, "text/xml");
+    return data.documentElement;
+  }
+}
+
+/**
+ * Call `getSource` or wait for the previous result if
+ * it was already called for this `src`, and reuse the result.
+ * @param src URL of the content to download/parse
+ * @param element Element for logging purpose
+ * @returns HTMLElement (svg)
+ */
+async function callOrReuseGetSource(src: string, element: any) {
+  // Check if already getting the source svg
+  let getPromise = getList.get(src);
+  if (!getPromise) {
+    // if not, get the source, make this reusable for other icons.
+    getPromise = getSource(src, element);
+    getList.set(src, getPromise);
+  }
+
+  try {
+    const svg = await getPromise;
+    if (!svgCache.has(src) && svg) {
+      // Cache the end result, so we don't have to await promise once that's done.
+      svgCache.set(src, svg);
+    }
+    return svg;
+  } finally {
+    // Success or failure, we don't want to keep the promise once we have the svg (or it failed, try again).
+    getList.delete(src);
+  }
+}
+
+/**
  * IconWebComponent loads icon from an svg path
  */
 export class IconWebComponent extends HTMLElement {
@@ -28,65 +123,13 @@ export class IconWebComponent extends HTMLElement {
 
     const src = this.getAttribute("src") || "";
 
-    if (src.startsWith("data:")) {
-      const dataUriParts = src.split(",");
-
-      if (
-        dataUriParts.length !== 2 ||
-        "data:image/svg+xml;base64" !== dataUriParts[0]
-      ) {
-        Logger.logError(UiCore.loggerCategory(this), "Unable to load icon.");
-      }
-
-      // the esm build of dompurify has a default import but the cjs build does not
-      // if there is a default export, use it (likely esm), otherwise use the namespace
-      // istanbul ignore next
-      const sanitizer = DOMPurify ?? DOMPurifyNS;
-      // eslint-disable-next-line deprecation/deprecation
-      const sanitizedSvg = sanitizer.sanitize(atob(dataUriParts[1]));
-
-      const parsedSvg = new window.DOMParser().parseFromString(
-        sanitizedSvg,
-        "text/xml"
-      );
-      const errorNode = parsedSvg.querySelector("parsererror");
-      if (
-        errorNode ||
-        "svg" !== parsedSvg.documentElement.nodeName.toLowerCase()
-      ) {
-        throw new UiError(UiCore.loggerCategory(this), "Unable to load icon.");
-      }
-
-      !this.childNodes.length && this.append(parsedSvg.documentElement);
-      return;
+    // if svg was already downloaded, use it;
+    let svg = svgCache.get(src);
+    if (!svg) {
+      svg = await callOrReuseGetSource(src, this);
     }
-
-    await fetch(src)
-      .catch((_error) => {
-        Logger.logError(UiCore.loggerCategory(this), "Unable to load icon.");
-      })
-      .then(async (response) => {
-        if (response && response.ok) {
-          return response.text();
-        } else {
-          throw new UiError(
-            UiCore.loggerCategory(this),
-            "Unable to load icon."
-          );
-        }
-      })
-      .then((str) => {
-        if (str !== undefined) {
-          return new window.DOMParser().parseFromString(str, "text/xml");
-        } else {
-          throw new UiError(
-            UiCore.loggerCategory(this),
-            "Unable to load icon."
-          );
-        }
-      })
-      .then(
-        (data) => !this.childNodes.length && this.append(data.documentElement)
-      );
+    if (svg && !this.childNodes.length) {
+      this.append(svg.cloneNode(true));
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
IconWebComponent now caches its SVG source so if the same url is requested many times, it will reuse the content across multiple icons. (making subsequent display instantaneous)

The fetching will also only occur once even if multiple icon require the same URL at the same time, reducing the network hits even in this case.


## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Tested through changing the "SnapMode.tsx" and assigning all the same icon, and ensuring that all icons were displayed and the network was not hit more than once, and the display time was close to 0 ms on subsequent render of the same icon.
Through this testing I realized that caching the SVG instead of the fetch promise was taking less time on subsequent calls, so I added the `svgCache` and `getList` different caching for this reason (instead of just caching the `getList` and always reusing the promises.