### PR TITLE
Add `badgeType` to all items and handle group `items`

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-improveToUIAToolbarItem_2023-06-14-19-51.json
+++ b/common/changes/@itwin/appui-react/raplemie-improveToUIAToolbarItem_2023-06-14-19-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix toolbar item badges not displaying",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/CustomContentStageUiProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/CustomContentStageUiProvider.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import {
+  BadgeType,
   ConditionalBooleanValue,
   IconSpecUtilities,
   ToolbarItemUtilities,
@@ -127,6 +128,7 @@ export class CustomContentStageUiProvider implements UiItemsProvider {
 
       const dialogId = "sampleModeless";
       const openSampleModelessItem = new CommandItemDef({
+        badgeType: BadgeType.New,
         iconSpec: <SvgWindowAdd />,
         labelKey: "SampleApp:buttons.sampleModelessDialog",
         execute: () => {

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/MessageUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/MessageUiItemsProvider.tsx
@@ -2,10 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { ToolbarItemUtilities } from "@itwin/appui-abstract";
+import { BadgeType } from "@itwin/appui-abstract";
 import {
   StageUsage,
   ToolbarItem,
+  ToolbarItemUtilities,
   ToolbarOrientation,
   ToolbarUsage,
   UiItemsProvider,
@@ -37,13 +38,13 @@ export class MessageUiItemsProvider implements UiItemsProvider {
       orientatipn === ToolbarOrientation.Vertical
     ) {
       return [
-        ToolbarItemUtilities.createGroupButton(
+        ToolbarItemUtilities.createGroupItem(
           `${this.id}:group`,
           10,
           "icon-placeholder",
           "Messages",
           [
-            ToolbarItemUtilities.createActionButton(
+            ToolbarItemUtilities.createActionItem(
               `${this.id}:activity`,
               1,
               "icon-placeholder",
@@ -75,7 +76,7 @@ export class MessageUiItemsProvider implements UiItemsProvider {
                 details = undefined;
               }
             ),
-            ToolbarItemUtilities.createActionButton(
+            ToolbarItemUtilities.createActionItem(
               `${this.id}:toast`,
               1,
               "icon-placeholder",
@@ -91,7 +92,7 @@ export class MessageUiItemsProvider implements UiItemsProvider {
                 );
               }
             ),
-            ToolbarItemUtilities.createActionButton(
+            ToolbarItemUtilities.createActionItem(
               `${this.id}:sticky`,
               1,
               "icon-placeholder",
@@ -107,7 +108,7 @@ export class MessageUiItemsProvider implements UiItemsProvider {
                 );
               }
             ),
-            ToolbarItemUtilities.createActionButton(
+            ToolbarItemUtilities.createActionItem(
               `${this.id}:alert`,
               1,
               "icon-placeholder",
@@ -121,7 +122,8 @@ export class MessageUiItemsProvider implements UiItemsProvider {
                     OutputMessageType.Alert
                   )
                 );
-              }
+              },
+              { badge: BadgeType.New }
             ),
           ]
         ),

--- a/ui/appui-react/src/appui-react/toolbar/toUIAToolbarItem.ts
+++ b/ui/appui-react/src/appui-react/toolbar/toUIAToolbarItem.ts
@@ -9,7 +9,7 @@
 import type { CommonToolbarItem as UIA_CommonToolbarItem } from "@itwin/appui-abstract";
 import type { CustomToolbarItem } from "@itwin/components-react";
 import type { ToolbarItem } from "./ToolbarItem";
-import { isToolbarCustomItem } from "./ToolbarItem";
+import { isToolbarCustomItem, isToolbarGroupItem } from "./ToolbarItem";
 
 /** @internal */
 export function toUIAToolbarItem(item: ToolbarItem): UIA_CommonToolbarItem {
@@ -17,11 +17,22 @@ export function toUIAToolbarItem(item: ToolbarItem): UIA_CommonToolbarItem {
     // eslint-disable-next-line deprecation/deprecation
     const customItem: CustomToolbarItem = {
       ...item,
+      badgeType: item.badge,
       isCustom: true,
       icon: item.icon as string,
       panelContentNode: item.panelContent,
     };
     return customItem;
   }
-  return item as UIA_CommonToolbarItem;
+  if (isToolbarGroupItem(item)) {
+    return {
+      ...item,
+      items: item.items.map(toUIAToolbarItem),
+      badgeType: item.badge,
+    } as UIA_CommonToolbarItem;
+  }
+  return {
+    ...item,
+    badgeType: item.badge,
+  } as UIA_CommonToolbarItem;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Improves internal function to take into account groups and missing `badgeType` conversion, however, this seems like this process was meant to be updated and maybe forgotten, so @GerardasB can you confirm what was the plan ? 

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Added 2 badges in our test apps so we actually see them somewhere, one in action, one in a group.

## Issue
resolves #361 