### PR TITLE
Fix and test `closeAll` methods

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-dialogManagersCloseAll_2023-06-09-18-43.json
+++ b/common/changes/@itwin/appui-react/raplemie-dialogManagersCloseAll_2023-06-09-18-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/dialog/InternalContentDialogManager.tsx
+++ b/ui/appui-react/src/appui-react/dialog/InternalContentDialogManager.tsx
@@ -140,6 +140,10 @@ export class InternalContentDialogManager {
   /** @internal */
   public static closeAll(): void {
     InternalContentDialogManager.dialogManager.closeAll();
+    InternalContentDialogManager._dialogMap.clear();
+    InternalContentDialogManager._idArray = [];
+    InternalContentDialogManager._topZIndex =
+      InternalContentDialogManager.getDialogZIndexDefault();
   }
 
   /** Update the dialogs */

--- a/ui/appui-react/src/appui-react/dialog/InternalModelessDialogManager.tsx
+++ b/ui/appui-react/src/appui-react/dialog/InternalModelessDialogManager.tsx
@@ -119,6 +119,8 @@ export class InternalModelessDialogManager {
   /** @internal */
   public static closeAll(): void {
     InternalModelessDialogManager.dialogManager.closeAll();
+    InternalModelessDialogManager._dialogMap.clear();
+    InternalModelessDialogManager._idArray = [];
   }
 
   /** Update the dialogs */

--- a/ui/appui-react/src/test/dialog/ContentDialogManager.test.tsx
+++ b/ui/appui-react/src/test/dialog/ContentDialogManager.test.tsx
@@ -247,4 +247,32 @@ describe("ContentDialogManager", () => {
 
     UiFramework.content.dialogs.close(dialogId2);
   });
+
+  it("internal: closeAll should not leave active dialogs", () => {
+    expect(UiFramework.content.dialogs.count).to.eq(0);
+    const dialogId = "closeAll1";
+    UiFramework.content.dialogs.open(<div />, dialogId);
+    expect(UiFramework.content.dialogs.count).to.eq(1);
+    expect(UiFramework.content.dialogs.active).to.not.be.undefined;
+    InternalContentDialogManager.closeAll();
+    expect(UiFramework.content.dialogs.count).to.eq(0);
+    expect(UiFramework.content.dialogs.active).to.be.undefined;
+  });
+
+  it("internal: closeAll should clear dialog ids", async () => {
+    expect(UiFramework.content.dialogs.count).to.eq(0);
+    const dialogId = "closeAll2";
+    UiFramework.content.dialogs.open(<div />, dialogId);
+    await waitFor(() => {
+      expect(UiFramework.content.dialogs.count).to.eq(1);
+    });
+    InternalContentDialogManager.closeAll();
+    await waitFor(() => {
+      expect(UiFramework.content.dialogs.count).to.eq(0);
+    });
+    UiFramework.content.dialogs.open(<div />, dialogId);
+    await waitFor(() => {
+      expect(UiFramework.content.dialogs.count).to.eq(1);
+    });
+  });
 });

--- a/ui/appui-react/src/test/dialog/ModelessDialogManager.test.tsx
+++ b/ui/appui-react/src/test/dialog/ModelessDialogManager.test.tsx
@@ -217,4 +217,32 @@ describe("ModelessDialogManager", () => {
     UiFramework.dialogs.modeless.close(dialogId2);
     expect(UiFramework.dialogs.modeless.count).to.eq(0);
   });
+
+  it("internal: closeAll should not leave active dialogs", () => {
+    expect(UiFramework.dialogs.modeless.count).to.eq(0);
+    const dialogId = "closeAll1";
+    UiFramework.dialogs.modeless.open(<div />, dialogId);
+    expect(UiFramework.dialogs.modeless.count).to.eq(1);
+    expect(UiFramework.dialogs.modeless.active).to.not.be.undefined;
+    InternalModelessDialogManager.closeAll();
+    expect(UiFramework.dialogs.modeless.count).to.eq(0);
+    expect(UiFramework.dialogs.modeless.active).to.be.undefined;
+  });
+
+  it("internal: closeAll should clear dialog ids", async () => {
+    expect(UiFramework.dialogs.modeless.count).to.eq(0);
+    const dialogId = "closeAll2";
+    UiFramework.dialogs.modeless.open(<div />, dialogId);
+    await waitFor(() => {
+      expect(UiFramework.dialogs.modeless.count).to.eq(1);
+    });
+    InternalModelessDialogManager.closeAll();
+    await waitFor(() => {
+      expect(UiFramework.dialogs.modeless.count).to.eq(0);
+    });
+    UiFramework.dialogs.modeless.open(<div />, dialogId);
+    await waitFor(() => {
+      expect(UiFramework.dialogs.modeless.count).to.eq(1);
+    });
+  });
 });


### PR DESCRIPTION
## Issue
resolves #147 

<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Completely clean `InternalContentDialogManager` and `InternalModelessDialogManager` when `closeAll` is called.

This method is internal and only used in tests.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Added failing tests that pointed out the issues and ensured they now passed.