### PR TITLE
Fix popout location

### DIFF
--- a/common/changes/@itwin/appui-layout-react/raplemie-popoutsLocation_2023-06-22-17-07.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-popoutsLocation_2023-06-22-17-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Do not limit popped out widget location on the screen",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/appui-react/raplemie-popoutsLocation_2023-06-22-17-07.json
+++ b/common/changes/@itwin/appui-react/raplemie-popoutsLocation_2023-06-22-17-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix issue with opening a popout from within an iFrame (Sandboxed iFrames still requires `allow-popups`)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/state/NineZoneState.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/NineZoneState.ts
@@ -231,8 +231,7 @@ export function popoutWidgetToChildWindow(
   if (isPopoutTabLocation(location)) return state;
 
   const popoutWidgetId = getUniqueId();
-  const nzBounds = Rectangle.createFromSize(state.size);
-  const bounds = Rectangle.create(preferredBounds).containIn(nzBounds);
+  const bounds = Rectangle.create(preferredBounds);
 
   if (isPanelTabLocation(location)) {
     const panel = state.panels[location.side];

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -170,7 +170,7 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
         });
       });
 
-      childWindow.onbeforeunload = () => {
+      childWindow.addEventListener("pagehide", () => {
         const frontStageDef = UiFramework.frontstages.activeFrontstageDef;
         if (!frontStageDef) return;
         frontStageDef.saveChildWindowSizeAndPosition(
@@ -178,7 +178,7 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
           childWindow
         );
         this.close(childWindowId, false);
-      };
+      });
     }
   }
 
@@ -216,26 +216,15 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
 
   // istanbul ignore next: Used in `open` which is not tested.
   private adjustWidowLocation(
-    location: ChildWindowLocationProps,
-    center?: boolean
+    location: ChildWindowLocationProps
   ): ChildWindowLocationProps {
     const outLocation = { ...location };
     if (0 === location.top && 0 === location.left) {
-      center = center ?? true;
-      const windowTop = window.top ?? window;
-
-      // Prepare position of the new window to be centered against the 'parent' window.
-      if (center) {
-        outLocation.left =
-          windowTop.outerWidth / 2 + windowTop.screenX - location.width / 2;
-        outLocation.top =
-          windowTop.outerHeight / 2 + windowTop.screenY - location.height / 2;
-      } else {
-        if (undefined !== window.screenLeft && undefined !== window.screenTop) {
-          outLocation.top = window.screenTop + location.top;
-          outLocation.left = window.screenLeft + location.left;
-        }
-      }
+      // If no location is provided, prepare position of the new window to be centered against the current window.
+      outLocation.left =
+        window.outerWidth / 2 + window.screenX - location.width / 2;
+      outLocation.top =
+        window.outerHeight / 2 + window.screenY - location.height / 2;
     }
     return outLocation;
   }


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Modified `adjustWindowLocation` private method of `InternalChildWindowManager` to not use `window.top` properties.
Removed dead code from the private function that was never called.
resolves #379 

Removed a `contain` in appui-layout-react that was unexpectedly trying to contain popped out wigets, now the widget will reappear where they were last closed by the user.
resolves #381 

Using `pagehide` event handler instead of `onbeforeunload` for firefox and overall posible better results.
resolves #380 


## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Visual/Manual testing through `test-apps/standalone` (web)