### PR TITLE
ControlledTree: cleanup copiled SparseTree code

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -2544,6 +2544,7 @@ export class SparseArray<T> implements Iterable<T | undefined> {
     // (undocumented)
     [immerable]: boolean;
     [Symbol.iterator](): IterableIterator<T | undefined>;
+    constructor();
     get(index: number): T | undefined;
     getIndex(lookupValue: T): number | undefined;
     getLength(): number;
@@ -2558,6 +2559,7 @@ export class SparseArray<T> implements Iterable<T | undefined> {
 export class SparseTree<T extends Node_2> {
     // (undocumented)
     [immerable]: boolean;
+    constructor();
     // (undocumented)
     deleteSubtree(parentId: string | undefined, deleteParent?: boolean): void;
     // (undocumented)

--- a/common/changes/@itwin/components-react/controlled_tree_js_fix_2023-07-03-14-43.json
+++ b/common/changes/@itwin/components-react/controlled_tree_js_fix_2023-07-03-14-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/tree/controlled/internal/SparseTree.ts
+++ b/ui/components-react/src/components-react/tree/controlled/internal/SparseTree.ts
@@ -21,11 +21,15 @@ export interface Node {
  * @internal
  */
 export class SparseTree<T extends Node> {
-  public [immerable] = true;
+  public [immerable]: boolean;
 
   private _rootNodes = new SparseArray<string>();
   private _parentToChildren: Record<string, SparseArray<string>> = {};
   private _idToNode: Record<string, T> = {};
+
+  constructor() {
+    this[immerable] = true;
+  }
 
   public getNode(nodeId: string): T | undefined {
     return this._idToNode[nodeId];
@@ -196,10 +200,14 @@ export class SparseTree<T extends Node> {
  * @public
  */
 export class SparseArray<T> implements Iterable<T | undefined> {
-  public [immerable] = true;
+  public [immerable]: boolean;
 
   private _length = 0;
   private _array: Array<[T, number]> = [];
+
+  constructor() {
+    this[immerable] = true;
+  }
 
   /** Returns length of array including intermediate 'undefined' values */
   public getLength(): number {


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

`SparseArray` class has two symbol properties defined: `immerable` and `Symbol.iterator`. For some reason compiled javascript looks like this:

```typescript
var _b;

export class SparseArray {
  constructor() {
      this[_b] = true;
      // ...
  }
 
  [(_b = immerable, Symbol.iterator)]() {
    // ...
  }
}
```

This causes some problems for terser when minimizing code and removing dead code to reduce bundle size. Minimized code looks like this:

```javascript
(_b = lC), Symbol.iterator;
```

Which under `"use strict"` mode throws runtime error because `_b` is not defined: https://github.com/iTwin/viewer/issues/283

Setting `immerable` property value in constructor seems to result in cleaner compiled javascript code which does not cause problems for terser:

Compiled javascript code:
```typescript
export class SparseArray {
  constructor() {
      // ...
      this[immerable] = true;
  }
  [Symbol.iterator]() {
    // ...
  }
}
```

Terser output:
```javascript
Symbol.iterator;
```

This probably should be fixed at `terser` or `typescript` level (maybe some changes to `tsconfig` would solve this). But at least for now this provides a workaround to avoid runtime error when building apps with `@bentley/react-scripts`

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Building locally with different configurations.
