### PR TITLE
Fix pipeline formatting mismatch for NextVersion.md

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -112,7 +112,7 @@ jobs:
                   New-Item $sourceFile
 
                   # Update NextVersion.md with template
-                  "---`npublish: false`n---`n`n# NextVersion <!-- omit from toc -->`n" + (Get-Content $sourceFile | Out-String) | Set-Content $sourceFile -NoNewline
+                  "---`npublish: false`n---`n`n# NextVersion <!-- omit from toc -->`n" | Set-Content $sourceFile -NoNewline
               }
 
             failOnStderr: true

--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -100,7 +100,10 @@ jobs:
                   (Get-Content $sourceFile | Select-Object -Skip 3) | Set-Content $sourceFile
 
                   # Add relevant frontmatter
-                  "---`ndeltaDoc: true`nversion: `"$(getVersion.version)`"`n---`n" + (Get-Content $sourceFile | Out-String) | Set-Content $sourceFile
+                  "---`ndeltaDoc: true`nversion: `"$(getVersion.version)`"`n---`n" + (Get-Content $sourceFile | Out-String) | Set-Content $sourceFile -NoNewline
+
+                  # Remove carriage return characters
+                  (Get-Content $sourceFile -Raw) -replace "`r", "" | Set-Content $sourceFile -NoNewline
 
                   # Rename NextVersion
                   Rename-Item -Path $sourceFile -NewName "$(getVersion.version).md"
@@ -109,7 +112,7 @@ jobs:
                   New-Item $sourceFile
 
                   # Update NextVersion.md with template
-                  "---`npublish: false`n---`n# NextVersion`n" + (Get-Content $sourceFile | Out-String) | Set-Content $sourceFile
+                  "---`npublish: false`n---`n`n# NextVersion <!-- omit from toc -->`n" + (Get-Content $sourceFile | Out-String) | Set-Content $sourceFile -NoNewline
               }
 
             failOnStderr: true

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -2,4 +2,4 @@
 publish: false
 ---
 
-# NextVersion
+# NextVersion <!-- omit from toc -->


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

- NextVersion.md file now ignores first TOC element.
- Version bump powershell script for NextVersion.md now correctly formats following version .md and new NextVersion.md files.

## Testing

Ran script locally to check if prettier still complains about formatting.
