### PR TITLE
Remove frontmatter from version markdown files

### DIFF
--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -96,12 +96,6 @@ jobs:
                   # Replace placeholder header
                   (Get-Content $sourceFile ) -replace 'NextVersion', "$(getVersion.version) Change Notes" | Set-Content $sourceFile
 
-                  # Remove old frontmatter
-                  (Get-Content $sourceFile | Select-Object -Skip 3) | Set-Content $sourceFile
-
-                  # Add relevant frontmatter
-                  "---`ndeltaDoc: true`nversion: `"$(getVersion.version)`"`n---`n" + (Get-Content $sourceFile | Out-String) | Set-Content $sourceFile -NoNewline
-
                   # Remove carriage return characters
                   (Get-Content $sourceFile -Raw) -replace "`r", "" | Set-Content $sourceFile -NoNewline
 
@@ -112,7 +106,7 @@ jobs:
                   New-Item $sourceFile
 
                   # Update NextVersion.md with template
-                  "---`npublish: false`n---`n`n# NextVersion <!-- omit from toc -->`n" | Set-Content $sourceFile -NoNewline
+                  "# NextVersion <!-- omit from toc -->`n" | Set-Content $sourceFile -NoNewline
               }
 
             failOnStderr: true
@@ -226,7 +220,7 @@ jobs:
               $sourceFile = 'docs/changehistory/NextVersion.md'
 
               # Overwrite everything with just the header
-              "---`npublish: false`n---`n`n# NextVersion <!-- omit from toc -->`n" | Set-Content $sourceFile -NoNewline
+              "# NextVersion <!-- omit from toc -->`n" | Set-Content $sourceFile -NoNewline
             displayName: "Clear current NextVersion.md"
 
           - bash: git add .

--- a/docs/changehistory/4.0.0.md
+++ b/docs/changehistory/4.0.0.md
@@ -1,24 +1,20 @@
----
-deltaDoc: true
-version: "4.0.0"
----
-
 # 4.0.0 Change Notes
 
 Table of contents:
 
-- [Migration strategy](#migration-strategy)
-- [iTwinUI 2.0](#itwinui-20)
-- [@itwin/appui-layout-react](#itwinappui-layout-react)
-- [@itwin/appui-abstract](#itwinappui-abstract)
-- [@itwin/appui-react](#itwinappui-react)
-  - [Component changes](#component-changes)
-  - [Components relocated](#components-relocated)
-  - [Static manager classes](#static-manager-classes)
-- [@itwin/core-react](#itwincore-react)
-  - [SCSS variables](#scss-variables)
-- [@itwin/components-react](#itwincomponents-react)
-- [@bentley/icons-generic-webfont](#bentleyicons-generic-webfont)
+- [4.0.0 Change Notes](#400-change-notes)
+  - [Migration strategy](#migration-strategy)
+  - [iTwinUI 2.0](#itwinui-20)
+  - [@itwin/appui-layout-react](#itwinappui-layout-react)
+  - [@itwin/appui-abstract](#itwinappui-abstract)
+  - [@itwin/appui-react](#itwinappui-react)
+    - [Component changes](#component-changes)
+    - [Components relocated](#components-relocated)
+    - [Static manager classes](#static-manager-classes)
+  - [@itwin/core-react](#itwincore-react)
+    - [SCSS variables](#scss-variables)
+  - [@itwin/components-react](#itwincomponents-react)
+  - [@bentley/icons-generic-webfont](#bentleyicons-generic-webfont)
 
 ## Migration strategy
 

--- a/docs/changehistory/4.0.0.md
+++ b/docs/changehistory/4.0.0.md
@@ -1,20 +1,19 @@
-# 4.0.0 Change Notes
+# 4.0.0 Change Notes <!-- omit from toc -->
 
 Table of contents:
 
-- [4.0.0 Change Notes](#400-change-notes)
-  - [Migration strategy](#migration-strategy)
-  - [iTwinUI 2.0](#itwinui-20)
-  - [@itwin/appui-layout-react](#itwinappui-layout-react)
-  - [@itwin/appui-abstract](#itwinappui-abstract)
-  - [@itwin/appui-react](#itwinappui-react)
-    - [Component changes](#component-changes)
-    - [Components relocated](#components-relocated)
-    - [Static manager classes](#static-manager-classes)
-  - [@itwin/core-react](#itwincore-react)
-    - [SCSS variables](#scss-variables)
-  - [@itwin/components-react](#itwincomponents-react)
-  - [@bentley/icons-generic-webfont](#bentleyicons-generic-webfont)
+- [Migration strategy](#migration-strategy)
+- [iTwinUI 2.0](#itwinui-20)
+- [@itwin/appui-layout-react](#itwinappui-layout-react)
+- [@itwin/appui-abstract](#itwinappui-abstract)
+- [@itwin/appui-react](#itwinappui-react)
+  - [Component changes](#component-changes)
+  - [Components relocated](#components-relocated)
+  - [Static manager classes](#static-manager-classes)
+- [@itwin/core-react](#itwincore-react)
+  - [SCSS variables](#scss-variables)
+- [@itwin/components-react](#itwincomponents-react)
+- [@bentley/icons-generic-webfont](#bentleyicons-generic-webfont)
 
 ## Migration strategy
 

--- a/docs/changehistory/4.1.0.md
+++ b/docs/changehistory/4.1.0.md
@@ -1,17 +1,16 @@
-# 4.1.0 Change Notes
+# 4.1.0 Change Notes <!-- omit from toc -->
 
 Table of contents:
 
-- [4.1.0 Change Notes](#410-change-notes)
-  - [iTwin.js version range](#itwinjs-version-range)
-  - [@itwin/appui-react](#itwinappui-react)
-    - [Widget error handling](#widget-error-handling)
-    - [Added `SelectionCountField` component](#added-selectioncountfield-component)
-    - [`ViewSelector` changes](#viewselector-changes)
-    - [`SplitPane` resize handle visual changes](#splitpane-resize-handle-visual-changes)
-    - [Fixes](#fixes)
-  - [@itwin/core-react](#itwincore-react)
-  - [@itwin/components-react](#itwincomponents-react)
+- [iTwin.js version range](#itwinjs-version-range)
+- [@itwin/appui-react](#itwinappui-react)
+  - [Widget error handling](#widget-error-handling)
+  - [Added `SelectionCountField` component](#added-selectioncountfield-component)
+  - [`ViewSelector` changes](#viewselector-changes)
+  - [`SplitPane` resize handle visual changes](#splitpane-resize-handle-visual-changes)
+  - [Fixes](#fixes)
+- [@itwin/core-react](#itwincore-react)
+- [@itwin/components-react](#itwincomponents-react)
 
 ## iTwin.js version range
 

--- a/docs/changehistory/4.1.0.md
+++ b/docs/changehistory/4.1.0.md
@@ -1,21 +1,17 @@
----
-deltaDoc: true
-version: "4.1.0"
----
-
 # 4.1.0 Change Notes
 
 Table of contents:
 
-- [iTwin.js version range](#itwinjs-version-range)
-- [@itwin/appui-react](#itwinappui-react)
-  - [Widget error handling](#widget-error-handling)
-  - [Added `SelectionCountField` component](#added-selectioncountfield-component)
-  - [`ViewSelector` changes](#viewselector-changes)
-  - [`SplitPane` resize handle visual changes](#splitpane-resize-handle-visual-changes)
-  - [Fixes](#fixes)
-- [@itwin/core-react](#itwincore-react)
-- [@itwin/components-react](#itwincomponents-react)
+- [4.1.0 Change Notes](#410-change-notes)
+  - [iTwin.js version range](#itwinjs-version-range)
+  - [@itwin/appui-react](#itwinappui-react)
+    - [Widget error handling](#widget-error-handling)
+    - [Added `SelectionCountField` component](#added-selectioncountfield-component)
+    - [`ViewSelector` changes](#viewselector-changes)
+    - [`SplitPane` resize handle visual changes](#splitpane-resize-handle-visual-changes)
+    - [Fixes](#fixes)
+  - [@itwin/core-react](#itwincore-react)
+  - [@itwin/components-react](#itwincomponents-react)
 
 ## iTwin.js version range
 

--- a/docs/changehistory/4.2.0.md
+++ b/docs/changehistory/4.2.0.md
@@ -1,17 +1,16 @@
-# 4.2.0 Change Notes
+# 4.2.0 Change Notes <!-- omit from toc -->
 
 Table of contents:
 
-- [4.2.0 Change Notes](#420-change-notes)
-  - [@itwin/appui-react](#itwinappui-react)
-    - [Changes](#changes)
-    - [Fixes](#fixes)
-  - [@itwin/core-react](#itwincore-react)
-    - [Changes](#changes-1)
-    - [Fixes](#fixes-1)
-  - [@itwin/components-react](#itwincomponents-react)
-    - [Additions](#additions)
-    - [Changes](#changes-2)
+- [@itwin/appui-react](#itwinappui-react)
+  - [Changes](#changes)
+  - [Fixes](#fixes)
+- [@itwin/core-react](#itwincore-react)
+  - [Changes](#changes-1)
+  - [Fixes](#fixes-1)
+- [@itwin/components-react](#itwincomponents-react)
+  - [Additions](#additions)
+  - [Changes](#changes-2)
 
 ## @itwin/appui-react
 

--- a/docs/changehistory/4.2.0.md
+++ b/docs/changehistory/4.2.0.md
@@ -1,8 +1,3 @@
----
-deltaDoc: true
-version: "4.2.0"
----
-
 # 4.2.0 Change Notes
 
 Table of contents:

--- a/docs/changehistory/4.3.0.md
+++ b/docs/changehistory/4.3.0.md
@@ -1,8 +1,3 @@
----
-deltaDoc: true
-version: "4.3.0"
----
-
 # 4.3.0 Change Notes <!-- omit from toc -->
 
 Table of contents:

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,5 +1,1 @@
----
-publish: false
----
-
 # NextVersion <!-- omit from toc -->


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Removed legacy frontmatter from NextVersion.md and 4.x.x.md files and updated pipeline to reflect changes.

## Testing

Locally ran PowerShell scripts to confirm correct behavior.
