### PR TITLE
Fix desynced element hiding and clearing

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4464,6 +4464,8 @@ export enum SyncUiEventId {
     ShowHideManagerSettingChange = "show-hide-setting-change",
     ToolActivated = "toolactivated",
     UiStateStorageChanged = "uistatestoragechanged",
+    // (undocumented)
+    ViewedModelsChanged = "viewedmodelschanged",
     ViewStateChanged = "viewstatechanged",
     WidgetStateChanged = "widgetstatechanged"
 }

--- a/common/changes/@itwin/appui-react/fix-clear-hide-desync_2023-07-25-12-58.json
+++ b/common/changes/@itwin/appui-react/fix-clear-hide-desync_2023-07-25-12-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `clearHideIsolateEmphasizeElements` and `hideElements` button display when view changes happen outside AppUI's API.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -18,7 +18,7 @@ Table of contents:
 
 - Fixed store initialization when iModelConnection is set.
 - Fixed store reset when iModelConnection is cleared.
--
+- Fixed `clearHideIsolateEmphasizeElements` and `hideElements` button display when view changes happen outside AppUI's API.
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/selection/HideIsolateEmphasizeManager.ts
+++ b/ui/appui-react/src/appui-react/selection/HideIsolateEmphasizeManager.ts
@@ -277,6 +277,7 @@ export class HideIsolateEmphasizeManager extends HideIsolateEmphasizeActionHandl
    */
   public static clearEmphasize(vp: Viewport | undefined) {
     if (vp) {
+      EmphasizeElements.getOrCreate(vp).clearEmphasizedElements(vp);
       EmphasizeElements.clear(vp);
     }
   }
@@ -492,6 +493,7 @@ export class HideIsolateEmphasizeManager extends HideIsolateEmphasizeActionHandl
       emphasizeElementsProvider.isActive(vp)
     )
       return true;
+    else if (vp.neverDrawn && vp.neverDrawn.size > 0) return true;
 
     const modelOverrideProvider =
       vp.findFeatureOverrideProviderOfType<ModelOverrideProvider>(

--- a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
@@ -221,65 +221,27 @@ export class SyncUiEventDispatcher {
         if (undefined === args.previous) {
           void IModelApp.toolAdmin.startDefaultTool();
         } else {
-          // istanbul ignore next
-          if (
-            args.previous.onViewChanged &&
-            typeof args.previous.onViewChanged.removeListener === "function"
-          )
-            // not set during unit test
-            args.previous.onViewChanged.removeListener(
-              SyncUiEventDispatcher._dispatchViewChange
-            );
-          // istanbul ignore next
-          if (
-            args.previous.onFeatureOverridesChanged &&
-            typeof args.previous.onFeatureOverridesChanged.removeListener ===
-              "function"
-          )
-            // not set during unit test
-            args.previous.onFeatureOverridesChanged.removeListener(
-              SyncUiEventDispatcher._dispatchFeatureOverridesChange
-            );
-          // istanbul ignore next
-          if (
-            args.previous.onViewedModelsChanged &&
-            typeof args.previous.onViewedModelsChanged.removeListener ===
-              "function"
-          )
-            // not set during unit test
-            args.previous.onViewedModelsChanged.removeListener(
-              SyncUiEventDispatcher._dispatchViewedModelsChanged
-            );
+          args.previous.onViewChanged.removeListener(
+            SyncUiEventDispatcher._dispatchViewChange
+          );
+          args.previous.onFeatureOverridesChanged.removeListener(
+            SyncUiEventDispatcher._dispatchFeatureOverridesChange
+          );
+          args.previous.onViewedModelsChanged.removeListener(
+            SyncUiEventDispatcher._dispatchViewedModelsChanged
+          );
         }
         // istanbul ignore next
         if (args.current) {
-          if (
-            args.current.onViewChanged &&
-            typeof args.current.onViewChanged.addListener === "function"
-          )
-            // not set during unit test
-            args.current.onViewChanged.addListener(
-              SyncUiEventDispatcher._dispatchViewChange
-            );
-          // istanbul ignore next
-          if (
-            args.current.onFeatureOverridesChanged &&
-            typeof args.current.onFeatureOverridesChanged.addListener ===
-              "function"
-          )
-            // not set during unit test
-            args.current.onFeatureOverridesChanged.addListener(
-              SyncUiEventDispatcher._dispatchFeatureOverridesChange
-            );
-          // istanbul ignore next
-          if (
-            args.current.onViewedModelsChanged &&
-            typeof args.current.onViewedModelsChanged.addListener === "function"
-          )
-            // not set during unit test
-            args.current.onViewedModelsChanged.addListener(
-              SyncUiEventDispatcher._dispatchViewedModelsChanged
-            );
+          args.current.onViewChanged.addListener(
+            SyncUiEventDispatcher._dispatchViewChange
+          );
+          args.current.onFeatureOverridesChanged.addListener(
+            SyncUiEventDispatcher._dispatchFeatureOverridesChange
+          );
+          args.current.onViewedModelsChanged.addListener(
+            SyncUiEventDispatcher._dispatchViewedModelsChanged
+          );
         }
       })
     );

--- a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
@@ -63,6 +63,7 @@ export enum SyncUiEventId {
   ShowHideManagerSettingChange = "show-hide-setting-change",
   /** The list of feature overrides applied has been changed */
   FeatureOverridesChanged = "featureoverrideschanged",
+  ViewedModelsChanged = "viewedmodelschanged",
 }
 
 /** This class is used to send eventIds to interested UI components so the component can determine if it needs
@@ -144,6 +145,13 @@ export class SyncUiEventDispatcher {
   private static _dispatchFeatureOverridesChange() {
     SyncUiEventDispatcher._uiEventDispatcher.dispatchSyncUiEvent(
       SyncUiEventId.FeatureOverridesChanged
+    );
+  }
+
+  // istanbul ignore next
+  private static _dispatchViewedModelsChanged() {
+    SyncUiEventDispatcher._uiEventDispatcher.dispatchSyncUiEvent(
+      SyncUiEventId.ViewedModelsChanged
     );
   }
 
@@ -232,6 +240,16 @@ export class SyncUiEventDispatcher {
             args.previous.onFeatureOverridesChanged.removeListener(
               SyncUiEventDispatcher._dispatchFeatureOverridesChange
             );
+          // istanbul ignore next
+          if (
+            args.previous.onViewedModelsChanged &&
+            typeof args.previous.onViewedModelsChanged.removeListener ===
+              "function"
+          )
+            // not set during unit test
+            args.previous.onViewedModelsChanged.removeListener(
+              SyncUiEventDispatcher._dispatchViewedModelsChanged
+            );
         }
         // istanbul ignore next
         if (args.current) {
@@ -252,6 +270,15 @@ export class SyncUiEventDispatcher {
             // not set during unit test
             args.current.onFeatureOverridesChanged.addListener(
               SyncUiEventDispatcher._dispatchFeatureOverridesChange
+            );
+          // istanbul ignore next
+          if (
+            args.current.onViewedModelsChanged &&
+            typeof args.current.onViewedModelsChanged.addListener === "function"
+          )
+            // not set during unit test
+            args.current.onViewedModelsChanged.addListener(
+              SyncUiEventDispatcher._dispatchViewedModelsChanged
             );
         }
       })

--- a/ui/appui-react/src/test/widgets/BasicToolWidget.test.tsx
+++ b/ui/appui-react/src/test/widgets/BasicToolWidget.test.tsx
@@ -47,6 +47,7 @@ describe("BasicToolWidget", () => {
           },
           iModel: {
             selectionSet: {
+              elements: new Set<string>([""]),
               size: 1,
             },
           },
@@ -88,6 +89,7 @@ describe("BasicToolWidget", () => {
           },
           iModel: {
             selectionSet: {
+              elements: new Set<string>([""]),
               size: 1,
             },
           },


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Buttons `clearHideIsolateEmphasizeElements` and `hideElements` now display correctly* when individual elements' visibility in the view is toggled.

*`clearHideIsolateEmphasizeElements` button should not be displayed if no element in the current view is hidden. `hideElements` button should only be displayed if elements in the active selection (if one exists) are not hidden.

## Testing

Set up a cospace with viewer-components-react & appui and tested button updating their states while toggling individual element visibility from Models Tree.
