### PR TITLE
Remove file write mode from test app

### DIFF
--- a/test-apps/appui-test-app/connected/src/frontend/appui/ExternalIModel.ts
+++ b/test-apps/appui-test-app/connected/src/frontend/appui/ExternalIModel.ts
@@ -127,7 +127,7 @@ export class ExternalIModel {
           SampleAppIModelApp.loggerCategory(this),
           `openIModel (external): iTwinId=${this.iTwinId}&iModelId=${
             this.iModelId
-          } mode=${SampleAppIModelApp.allowWrite ? "ReadWrite" : "Readonly"}`
+          } mode=${"Readonly"}`
         );
       } catch (err: any) {
         Logger.logInfo(

--- a/test-apps/appui-test-app/connected/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/index.tsx
@@ -418,7 +418,7 @@ export class SampleAppIModelApp {
     Logger.logInfo(
       SampleAppIModelApp.loggerCategory(this),
       `openIModelAndViews: iTwinId=${iTwinId}&iModelId=${iModelId} mode=${
-        this.allowWrite ? "ReadWrite" : "Readonly"
+        "Readonly"
       }`
     );
 
@@ -529,7 +529,7 @@ export class SampleAppIModelApp {
       Logger.logInfo(
         SampleAppIModelApp.loggerCategory(this),
         `showIModel: iTwinId = ${iTwinId}& iModelId=${iModelId} mode = ${
-          this.allowWrite ? "ReadWrite" : "Readonly"
+          "Readonly"
         } `
       );
 
@@ -674,10 +674,6 @@ export class SampleAppIModelApp {
 
   public static isEnvVarOn(envVar: string): boolean {
     return process.env[envVar] === "1" || process.env[envVar] === "true";
-  }
-
-  public static get allowWrite() {
-    return SampleAppIModelApp.isEnvVarOn("IMJS_UITESTAPP_ALLOW_WRITE");
   }
 
   public static setTestProperty(value: string, immediateSync = false) {

--- a/test-apps/appui-test-app/connected/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/index.tsx
@@ -417,9 +417,7 @@ export class SampleAppIModelApp {
 
     Logger.logInfo(
       SampleAppIModelApp.loggerCategory(this),
-      `openIModelAndViews: iTwinId=${iTwinId}&iModelId=${iModelId} mode=${
-        "Readonly"
-      }`
+      `openIModelAndViews: iTwinId=${iTwinId}&iModelId=${iModelId} mode=${"Readonly"}`
     );
 
     let iModelConnection: IModelConnection | undefined;
@@ -528,9 +526,7 @@ export class SampleAppIModelApp {
       // open the imodel
       Logger.logInfo(
         SampleAppIModelApp.loggerCategory(this),
-        `showIModel: iTwinId = ${iTwinId}& iModelId=${iModelId} mode = ${
-          "Readonly"
-        } `
+        `showIModel: iTwinId = ${iTwinId}& iModelId=${iModelId} mode = ${"Readonly"} `
       );
 
       try {

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/LocalFileSupport.ts
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/LocalFileSupport.ts
@@ -8,8 +8,7 @@ import {
   SnapshotConnection,
 } from "@itwin/core-frontend";
 import { SampleAppIModelApp } from "../index";
-import { IModelStatus, Logger, OpenMode } from "@itwin/core-bentley";
-import { IModelError } from "@itwin/core-common";
+import { Logger, OpenMode } from "@itwin/core-bentley";
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
 
 // cSpell:ignore TESTAPP FILEPATH
@@ -37,7 +36,6 @@ export class LocalFileSupport {
 
   public static openLocalFile = async (
     fileSpec: string,
-    writable: boolean,
     definesFullPath = false
   ): Promise<IModelConnection | undefined> => {
     // Close the current iModelConnection
@@ -51,12 +49,12 @@ export class LocalFileSupport {
       filePath = fileSpec;
       Logger.logInfo(
         SampleAppIModelApp.loggerCategory(LocalFileSupport),
-        `openLocalFile: Opening standalone. path=${filePath} writable=${writable}`
+        `openLocalFile: Opening standalone. path=${filePath}`
       );
       try {
         iModelConnection = await BriefcaseConnection.openStandalone(
           filePath,
-          writable ? OpenMode.ReadWrite : OpenMode.Readonly,
+          OpenMode.Readonly,
           { key: filePath }
         );
       } catch (err: any) {
@@ -64,20 +62,8 @@ export class LocalFileSupport {
           SampleAppIModelApp.loggerCategory(LocalFileSupport),
           `openLocalFile: BriefcaseConnection.openStandalone failed.`
         );
-
-        if (
-          writable &&
-          err instanceof IModelError &&
-          err.errorNumber === IModelStatus.ReadOnly
-        ) {
-          iModelConnection = await SnapshotConnection.openFile(filePath);
-          alert(
-            `Local file (${filePath}) could not be opened as writable. Special bytes are required in the props table of the iModel to make it editable. File opened as read-only instead.`
-          );
-        } else {
-          alert(err.message);
-          iModelConnection = undefined;
-        }
+        alert(err.message);
+        iModelConnection = undefined;
       }
     } else {
       if (

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
@@ -264,10 +264,7 @@ function LocalFilePage(props: LocalFilePageProps) {
 
     const filePath = val.filePaths[0];
     if (filePath) {
-      const connection = await LocalFileSupport.openLocalFile(
-        filePath,
-        true
-      );
+      const connection = await LocalFileSupport.openLocalFile(filePath, true);
       if (connection) {
         SampleAppIModelApp.setIsIModelLocal(true, true);
         const viewId = await getDefaultViewId(connection);

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
@@ -92,7 +92,6 @@ class LocalFileOpenControl extends ContentControl {
       <LocalFilePage
         onClose={this._handleClose}
         onViewsSelected={this._handleViewsSelected}
-        writable={SampleAppIModelApp.allowWrite}
       />
     );
   }
@@ -156,7 +155,6 @@ export class LocalFileOpenFrontstage {
     if (fullBimFileName) {
       const connection = await LocalFileSupport.openLocalFile(
         fullBimFileName,
-        SampleAppIModelApp.allowWrite,
         true
       );
       if (connection) {
@@ -212,12 +210,11 @@ interface LocalFilePageProps {
     views: Id64String[]
   ) => void;
   onClose: () => void;
-  writable: boolean;
 }
 
 /** LocalFilePage displays the file picker and view picker. */
 function LocalFilePage(props: LocalFilePageProps) {
-  const { onViewsSelected, writable } = props;
+  const { onViewsSelected } = props;
 
   const title = React.useRef(
     UiFramework.localization.getLocalizedString(
@@ -243,7 +240,6 @@ function LocalFilePage(props: LocalFilePageProps) {
         if (file) {
           const connection = await LocalFileSupport.openLocalFile(
             file.name,
-            writable,
             false
           );
           // const hasSavedContent = await hasSavedViewLayoutProps(MainFrontstage.stageId, connection);
@@ -255,7 +251,7 @@ function LocalFilePage(props: LocalFilePageProps) {
         }
       }
     },
-    [onViewsSelected, writable]
+    [onViewsSelected]
   );
 
   const handleElectronFileOpen = React.useCallback(async () => {
@@ -270,7 +266,6 @@ function LocalFilePage(props: LocalFilePageProps) {
     if (filePath) {
       const connection = await LocalFileSupport.openLocalFile(
         filePath,
-        writable,
         true
       );
       if (connection) {
@@ -279,7 +274,7 @@ function LocalFilePage(props: LocalFilePageProps) {
         if (undefined !== viewId) onViewsSelected(connection, [viewId]);
       }
     }
-  }, [onViewsSelected, writable]);
+  }, [onViewsSelected]);
 
   const handleButtonClick = React.useCallback(async () => {
     if (isElectronApp.current) {

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -436,10 +436,6 @@ export class SampleAppIModelApp {
     return process.env[envVar] === "1" || process.env[envVar] === "true";
   }
 
-  public static get allowWrite() {
-    return SampleAppIModelApp.isEnvVarOn("IMJS_UITESTAPP_ALLOW_WRITE");
-  }
-
   public static setTestProperty(value: string, immediateSync = false) {
     if (value !== SampleAppIModelApp.getTestProperty()) {
       UiFramework.dispatchActionToStore(


### PR DESCRIPTION
Brien pointed out that when creating the new test apps, we brought along part of the write-mode, but none of the testing. For now, removing write mode from the standalone app, since file mode does not figure into our testing.