### PR TITLE
Fix toolbar doc

### DIFF
--- a/common/changes/@itwin/appui-react/fix-toolbar-doc_2023-07-27-21-54.json
+++ b/common/changes/@itwin/appui-react/fix-toolbar-doc_2023-07-27-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Remove obsolete ninezone term from API doc comments.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
@@ -17,9 +17,9 @@ import type { IconSpec } from "@itwin/core-react";
  * @public
  */
 export enum ToolbarUsage {
-  /** Contains tools to Create Update and Delete content - in ninezone this is in top left of content area. */
+  /** Contains tools to Create Update and Delete content - in AppUI this is in top left of content area. */
   ContentManipulation = 0,
-  /** Manipulate view/camera - in ninezone this is in top right of content area. */
+  /** Manipulate view/camera - in AppUI this is in top right of content area. */
   ViewNavigation = 1,
 }
 


### PR DESCRIPTION
A colleague from User Success pointed out that we are using the obsolete term "ninezone" in our toolbar documentation. Changed the comment to be harvested into the API docs to read "AppUI."
