### PR TITLE
Improve instructions for apps to use icons webfont

### DIFF
--- a/docs/changehistory/4.0.0.md
+++ b/docs/changehistory/4.0.0.md
@@ -556,4 +556,8 @@ Removed `Table`, `Breadcrumb` and other previously deprecated APIs and component
 
 ## @bentley/icons-generic-webfont
 
-With the 4.0 release, AppUI has removed its dependency on the icons-generic-webfont package in favor of React or SVG icons. Webfont icons and their identifying names are still supported by the AppUI platform, but applications or packages that use a webfont for icons will have to include the webfont package in their direct dependencies.
+With the 4.0 release, AppUI has removed its dependency on the icons-generic-webfont package in favor of React or SVG icons. Webfont icons and their identifying names are still supported by the AppUI platform, but applications or packages that use a webfont for icons will have to include the webfont package in their direct dependencies as well as adding the following line of code to one of their TypeScript files:
+
+```ts
+import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
+```


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Updated the @bentley/icons-generic-webfont section of the 4.0.0 changehistory file to provide improved instructions for applications that need to continue to use the webfont.