### PR TITLE
Context sub menu arrow size decrease

### DIFF
--- a/common/changes/@itwin/core-react/joeh-ContextSubMenuArrowSizeDecrease_2023-08-03-16-21.json
+++ b/common/changes/@itwin/core-react/joeh-ContextSubMenuArrowSizeDecrease_2023-08-03-16-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Decrease size of arrows in ContextSubMenu",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
+++ b/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
@@ -221,6 +221,8 @@ $uicore-menu-top-bottom-padding: calc(#{$uicore-menu-padding} * 0.6667);
         font-size: calc(var(--iui-font-size-2) * 0.5);
         line-height: var(--iui-size-l);
         text-align: center;
+        position: relative;
+        top: 4px;
       }
     }
   }

--- a/ui/core-react/src/core-react/contextmenu/ContextSubMenu.tsx
+++ b/ui/core-react/src/core-react/contextmenu/ContextSubMenu.tsx
@@ -17,7 +17,7 @@ import { ContextMenuDirection } from "./ContextMenuDirection";
 import { TildeFinder } from "./TildeFinder";
 import { BadgeUtilities } from "../badge/BadgeUtilities";
 import { Icon } from "../icons/IconComponent";
-import { SvgCaretRight } from "@itwin/itwinui-icons-react";
+import { SvgCaretRightSmall } from "@itwin/itwinui-icons-react";
 
 /** Properties for the [[ContextSubMenu]] component
  * @public
@@ -161,7 +161,7 @@ export class ContextSubMenu extends React.Component<
           <div className={classnames("core-context-menu-icon", "icon", icon)} />
           <div className={"core-context-menu-content"}>{this._parsedLabel}</div>
           <div className={classnames("core-context-submenu-arrow", "icon")}>
-            <Icon iconSpec={<SvgCaretRight />} />
+            <Icon iconSpec={<SvgCaretRightSmall />} />
           </div>
           {badge && <div className="core-context-menu-badge">{badge}</div>}
         </div>


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes
- Decrease arrow size and center it in ContextSubMenu
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing
-I tested the changes by running the storybook and seeing how the ContextMenu and ContextSubMenu looked in there.

Had to create a new pull request for this because there were git problems with the CLA

resolves https://github.com/iTwin/appui/issues/426
<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
