### PR TITLE
Fix an issue with unintentionally removing tool settings

### DIFF
--- a/common/changes/@itwin/appui-layout-react/tool-settings-fix_2023-08-14-12-55.json
+++ b/common/changes/@itwin/appui-layout-react/tool-settings-fix_2023-08-14-12-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Fix unintentional removal of tool settings while removing widgets.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/ui/appui-layout-react/src/appui-layout-react/state/TabState.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/TabState.ts
@@ -150,7 +150,9 @@ export function removeTab(
   if (!(tabId in state.tabs)) throw new UiError(category, "Tab does not exist");
 
   state = removeTabFromWidget(state, tabId);
-  state = removeToolSettings(state);
+  if (state.toolSettings?.tabId === tabId) {
+    state = removeToolSettings(state);
+  }
   return produce(state, (draft) => {
     delete draft.tabs[tabId];
   });

--- a/ui/appui-layout-react/src/test/state/TabState.test.ts
+++ b/ui/appui-layout-react/src/test/state/TabState.test.ts
@@ -2,12 +2,15 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { should } from "chai";
+import { expect, should } from "chai";
 import {
+  addDockedToolSettings,
+  addFloatingWidget,
   addPanelWidget,
   addPopoutWidget,
   addTab,
   addTabToWidget,
+  addWidgetToolSettings,
   createNineZoneState,
   insertTabToWidget,
   removeTab,
@@ -99,6 +102,41 @@ describe("removeTab", () => {
 
     should().not.exist(newState.popoutWidgets.byId.pow1);
     should().not.exist(newState.tabs.t1);
+  });
+
+  it("should remove docked tool settings tab", () => {
+    let state = createNineZoneState();
+    state = addTabs(state, ["t1"]);
+    state = addDockedToolSettings(state, "t1");
+    const newState = removeTab(state, "t1");
+
+    expect(newState.tabs.t1).to.not.exist;
+    expect(newState.toolSettings).to.not.exist;
+  });
+
+  it("should remove widget tool settings tab", () => {
+    let state = createNineZoneState();
+    state = addTabs(state, ["t1"]);
+    state = addFloatingWidget(state, "w1", ["t1"]);
+    state = addWidgetToolSettings(state, "t1");
+    const newState = removeTab(state, "t1");
+
+    expect(newState.tabs.t1).to.not.exist;
+    expect(newState.toolSettings).to.not.exist;
+  });
+
+  it("should keep tool settings if other tab is removed", () => {
+    let state = createNineZoneState();
+    state = addTabs(state, ["t1", "t2"]);
+    state = addFloatingWidget(state, "w1", ["t1"]);
+    state = addDockedToolSettings(state, "t2");
+    const newState = removeTab(state, "t1");
+
+    expect(newState.tabs.t2).to.exist;
+    expect(newState.toolSettings).to.eql({
+      type: "docked",
+      tabId: "t2",
+    });
   });
 });
 

--- a/ui/appui-layout-react/src/test/state/ToolSettingsState.test.ts
+++ b/ui/appui-layout-react/src/test/state/ToolSettingsState.test.ts
@@ -71,6 +71,12 @@ describe("addWidgetToolSettings", () => {
 });
 
 describe("removeToolSettings", () => {
+  it("should not update state w/o tool settings", () => {
+    const state = createNineZoneState();
+    const sut = removeToolSettings(state);
+    expect(sut).to.eq(state);
+  });
+
   it("should remove tab from tool settings", () => {
     let state = createNineZoneState();
     state = addTab(state, "ts");


### PR DESCRIPTION
## Changes

This PR fixes an issue where tool settings would get removed while removing one of the widgets.

## Testing

Added additional unit tests. We can add additional e2e tests after #436
