### PR TITLE
Push back deprecation for codemod availability

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4671,7 +4671,7 @@ export enum ToolbarUsage {
     ViewNavigation = 1
 }
 
-// @beta @deprecated
+// @beta
 export function ToolbarWithOverflow(props: ToolbarWithOverflowProps): JSX.Element;
 
 // @beta

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -503,7 +503,6 @@ beta;ToolbarPopupProps
 beta;ToolbarProps 
 public;ToolbarUsage
 beta;ToolbarWithOverflow(props: ToolbarWithOverflowProps): JSX.Element
-deprecated;ToolbarWithOverflow(props: ToolbarWithOverflowProps): JSX.Element
 beta;ToolbarWithOverflowProps 
 public;ToolIconChangedEvent 
 public;ToolIconChangedEventArgs

--- a/common/changes/@itwin/appui-react/raplemie-pushbackToolbarDeprecation_2023-08-14-14-21.json
+++ b/common/changes/@itwin/appui-react/raplemie-pushbackToolbarDeprecation_2023-08-14-14-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -27,7 +27,6 @@ Table of contents:
 
 ### Deprecations
 
-- `ToolbarWithOverflow` is now deprecated in favor of the `Toolbar` with `enableOverflow` prop set to `true`.
 - `useUiItemsProviderToolbarItems` is now deprecated in favor of the fixed `Toolbar` [^1].
 - `useDefaultToolbarItems` is now deprecated in favor of the fixed `Toolbar` [^1].
 

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarWithOverflow.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarWithOverflow.tsx
@@ -42,7 +42,6 @@ export interface ToolbarWithOverflowProps extends CommonProps, NoChildrenProps {
 /** Component that displays toolbar items, displaying only the elements that can fit in the available space,
  * and put the other items into a single panel.
  * @beta
- * @deprecated in 4.4.0. Use Toolbar component with "enableOverflow" prop to {overflowExpandsTo: props.overflowExpandsTo}.
  */
 export function ToolbarWithOverflow(props: ToolbarWithOverflowProps) {
   const { overflowExpandsTo, ...toolbarProps } = props;


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Removed deprecation tag on `ToolbarWithOverflow` component, (we should add it back when we have the proper codemod available, until then, both component do the same thing and will not cause issues to the users anyway.

Removed line in NextVersion as the component is no longer deprecated.
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
N/A