### PR TITLE
ControlledTree: avoid hanging browser with range selection

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -28,7 +28,7 @@ import type { Localization } from '@itwin/core-common';
 import type { MessageSeverity } from '@itwin/appui-abstract';
 import type { NoChildrenProps } from '@itwin/core-react';
 import type { NodeCheckboxRenderer } from '@itwin/core-react';
-import { Observable as Observable_2 } from 'rxjs/internal/Observable';
+import { Observable as Observable_2 } from 'rxjs';
 import type { OnItemExecutedFunc } from '@itwin/appui-abstract';
 import { Orientation } from '@itwin/core-react';
 import type { ParseResults } from '@itwin/appui-abstract';
@@ -3103,7 +3103,7 @@ export interface TreeEditingParams {
 
 // @internal
 export class TreeEventDispatcher implements TreeActions {
-    constructor(treeEvents: TreeEvents, nodeLoader: ITreeNodeLoader, selectionMode: SelectionMode_2, getVisibleNodes?: () => VisibleTreeNodes);
+    constructor(treeEvents: TreeEvents, nodeLoader: ITreeNodeLoader, selectionMode: SelectionMode_2, getVisibleNodes: () => VisibleTreeNodes);
     // (undocumented)
     onNodeCheckboxClicked(nodeId: string, newState: CheckBoxState): void;
     // (undocumented)
@@ -3122,8 +3122,6 @@ export class TreeEventDispatcher implements TreeActions {
     onTreeKeyDown(event: React.KeyboardEvent): void;
     // (undocumented)
     onTreeKeyUp(event: React.KeyboardEvent): void;
-    // (undocumented)
-    setVisibleNodes(visibleNodes: () => VisibleTreeNodes): void;
 }
 
 // @public

--- a/common/changes/@itwin/appui-react/tree_event_dispatcher_fix_2023-08-25-12-54.json
+++ b/common/changes/@itwin/appui-react/tree_event_dispatcher_fix_2023-08-25-12-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Bump 'rxjs' version.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/tree_event_dispatcher_fix_2023-08-25-12-54.json
+++ b/common/changes/@itwin/components-react/tree_event_dispatcher_fix_2023-08-25-12-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Bump `rxjs` version.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/components-react/tree_event_dispatcher_fix_2023-08-25-12-56.json
+++ b/common/changes/@itwin/components-react/tree_event_dispatcher_fix_2023-08-25-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "`ControlledTree`: Fixed range selection over nodes that are not loaded causing browser to hang.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -637,7 +637,7 @@ importers:
       react-test-renderer: ^17.0.0
       redux: ^4.1.0
       rimraf: ^3.0.2
-      rxjs: ^6.6.2
+      rxjs: ^7.8.1
       sinon: ^15.2.0
       sinon-chai: ^3.2.0
       ts-node: ^10.8.2
@@ -654,7 +654,7 @@ importers:
       immer: 9.0.6
       lodash: 4.17.21
       react-error-boundary: 4.0.3_react@17.0.2
-      rxjs: 6.6.7
+      rxjs: 7.8.1
     devDependencies:
       '@itwin/appui-abstract': 4.0.0-dev.104_be9786c2146472f5e05bafea59511dc9
       '@itwin/appui-layout-react': link:../appui-layout-react
@@ -773,7 +773,7 @@ importers:
       react-highlight-words: ^0.17.0
       react-window: ^1.8.2
       rimraf: ^3.0.2
-      rxjs: ^6.6.2
+      rxjs: ^7.8.1
       shortid: ~2.2.15
       sinon: ^15.2.0
       sinon-chai: ^3.2.0
@@ -792,7 +792,7 @@ importers:
       lodash: 4.17.21
       react-highlight-words: 0.17.0_react@17.0.2
       react-window: 1.8.8_react-dom@17.0.2+react@17.0.2
-      rxjs: 6.6.7
+      rxjs: 7.8.1
       shortid: 2.2.16
     devDependencies:
       '@itwin/appui-abstract': 4.0.0-dev.104_be9786c2146472f5e05bafea59511dc9
@@ -18383,11 +18383,10 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
-  /rxjs/6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
-    engines: {npm: '>=2.0.0'}
+  /rxjs/7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 1.14.1
+      tslib: 2.5.0
     dev: false
 
   /safe-buffer/5.1.1:
@@ -19814,6 +19813,7 @@ packages:
 
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/components-react](#itwincomponents-react)
+  - [Fixes](#fixes)
+
+## @itwin/components-react
+
+### Fixes
+
+- `ControlledTree`: Fixed range selection over nodes that are not loaded causing browser to hang.

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -138,7 +138,7 @@
     "immer": "9.0.6",
     "lodash": "^4.17.10",
     "react-error-boundary": "4.0.3",
-    "rxjs": "^6.6.2"
+    "rxjs": "^7.8.1"
   },
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -121,7 +121,7 @@
     "lodash": "^4.17.10",
     "react-highlight-words": "^0.17.0",
     "react-window": "^1.8.2",
-    "rxjs": "^6.6.2",
+    "rxjs": "^7.8.1",
     "shortid": "~2.2.15"
   },
   "nyc": {

--- a/ui/components-react/src/components-react/common/UseAsyncValue.tsx
+++ b/ui/components-react/src/components-react/common/UseAsyncValue.tsx
@@ -7,9 +7,7 @@
  */
 
 import * as React from "react";
-import { from } from "rxjs/internal/observable/from";
-import { takeUntil } from "rxjs/internal/operators/takeUntil";
-import { Subject } from "rxjs/internal/Subject";
+import { from, Subject, takeUntil } from "rxjs";
 import { isPromiseLike, useEffectSkipFirst } from "@itwin/core-react";
 
 /**

--- a/ui/components-react/src/components-react/common/UseDebouncedAsyncValue.ts
+++ b/ui/components-react/src/components-react/common/UseDebouncedAsyncValue.ts
@@ -7,9 +7,7 @@
  */
 
 import { useEffect, useMemo, useState } from "react";
-import { defer } from "rxjs/internal/observable/defer";
-import { publish } from "rxjs/internal/operators/publish";
-import { refCount } from "rxjs/internal/operators/refCount";
+import { defer, share } from "rxjs";
 import {
   scheduleSubscription,
   SubscriptionScheduler,
@@ -49,7 +47,14 @@ export function useDebouncedAsyncValue<TReturn>(
     setInProgress(true);
     // schedule and subscribe to the observable emitting value from valueToBeResolved promise
     const subscription = defer(valueToBeResolved)
-      .pipe(publish(), refCount(), scheduleSubscription(scheduler))
+      .pipe(
+        share({
+          resetOnError: false,
+          resetOnComplete: false,
+          resetOnRefCountZero: true,
+        }),
+        scheduleSubscription(scheduler)
+      )
       .subscribe({
         next: (data) => {
           setValue(data);

--- a/ui/components-react/src/components-react/tree/controlled/Observable.ts
+++ b/ui/components-react/src/components-react/tree/controlled/Observable.ts
@@ -6,8 +6,7 @@
  * @module Tree
  */
 
-import { from as rxjsFrom } from "rxjs/internal/observable/from";
-import { Observable as RxjsObservable } from "rxjs/internal/Observable";
+import { from as rxjsFrom, Observable as RxjsObservable } from "rxjs";
 
 /**
  * Helper method that creates an Observable from Iterable or Promise.

--- a/ui/components-react/src/components-react/tree/controlled/TreeEventDispatcher.ts
+++ b/ui/components-react/src/components-react/tree/controlled/TreeEventDispatcher.ts
@@ -269,15 +269,12 @@ export class TreeEventDispatcher implements TreeActions {
   }> {
     const deselectedItems = this.collectNodeItems(deselection);
     if (isRangeSelection(selection)) {
-      let firstEmission = true;
       return this.collectNodesBetween(selection.from, selection.to).pipe(
-        map((selectedNodeItems) => {
-          if (firstEmission) {
-            firstEmission = false;
-            return { selectedNodeItems, deselectedNodeItems: deselectedItems };
-          }
-
-          return { selectedNodeItems, deselectedNodeItems: [] };
+        map((selectedNodeItems, index) => {
+          return {
+            selectedNodeItems,
+            deselectedNodeItems: index === 0 ? deselectedItems : [],
+          };
         })
       );
     }

--- a/ui/components-react/src/components-react/tree/controlled/TreeEventHandler.ts
+++ b/ui/components-react/src/components-react/tree/controlled/TreeEventHandler.ts
@@ -6,8 +6,7 @@
  * @module Tree
  */
 
-import { takeUntil } from "rxjs/internal/operators/takeUntil";
-import { Subject } from "rxjs/internal/Subject";
+import { Subject, takeUntil } from "rxjs";
 import type { IDisposable } from "@itwin/core-bentley";
 import { TreeModelMutator } from "./internal/TreeModelMutator";
 import type { Subscription } from "./Observable";
@@ -55,8 +54,8 @@ export class TreeEventHandler implements TreeEvents, IDisposable {
   private _modelMutator: TreeModelMutator;
   private _editingParams?: TreeEditingParams;
 
-  private _disposed = new Subject();
-  private _selectionReplaced = new Subject();
+  private _disposed = new Subject<void>();
+  private _selectionReplaced = new Subject<void>();
 
   constructor(params: TreeEventHandlerParams) {
     this._modelMutator = new TreeModelMutator(

--- a/ui/components-react/src/components-react/tree/controlled/component/ControlledTree.tsx
+++ b/ui/components-react/src/components-react/tree/controlled/component/ControlledTree.tsx
@@ -158,18 +158,10 @@ function useRootNodeLoader(
 
 function useVisibleTreeNodes(model: TreeModel) {
   const visibleNodesRef = React.useRef<VisibleTreeNodes>();
-
-  // istanbul ignore else
-  if (!visibleNodesRef.current) {
-    // initialize initial value
-    visibleNodesRef.current = computeVisibleNodes(model);
-  }
-
-  React.useEffect(() => {
-    // update visible nodes when model changes
-    visibleNodesRef.current = computeVisibleNodes(model);
-  }, [model]);
-
+  visibleNodesRef.current = React.useMemo(
+    () => computeVisibleNodes(model),
+    [model]
+  );
   return React.useCallback(() => visibleNodesRef.current!, []);
 }
 

--- a/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
+++ b/ui/components-react/src/components-react/tree/controlled/component/TreeRenderer.tsx
@@ -14,8 +14,7 @@ import type {
   ListOnItemsRenderedProps,
 } from "react-window";
 import { areEqual, VariableSizeList } from "react-window";
-import { concat } from "rxjs/internal/observable/concat";
-import { timer } from "rxjs/internal/observable/timer";
+import { concat, timer } from "rxjs";
 import { assert } from "@itwin/core-bentley";
 import { Tree as CoreTree, TreeNodePlaceholder } from "@itwin/core-react";
 import { createContextWithMandatoryProvider } from "../../../common/UseContextWithMandatoryProvider";
@@ -35,6 +34,7 @@ import {
 import type { ITreeNodeLoader } from "../TreeNodeLoader";
 import type { TreeNodeRendererProps } from "./TreeNodeRenderer";
 import { TreeNodeRenderer } from "./TreeNodeRenderer";
+import { toRxjsObservable } from "../Observable";
 
 const NODE_LOAD_DELAY = 500;
 
@@ -383,7 +383,7 @@ function useNodeLoading(
 
       const subscription = concat(
         timer(NODE_LOAD_DELAY),
-        nodeLoader.loadNode(parentNode, node.childIndex)
+        toRxjsObservable(nodeLoader.loadNode(parentNode, node.childIndex))
       ).subscribe();
       return () => subscription.unsubscribe();
     },

--- a/ui/components-react/src/components-react/tree/controlled/internal/TreeModelMutator.ts
+++ b/ui/components-react/src/components-react/tree/controlled/internal/TreeModelMutator.ts
@@ -6,7 +6,7 @@
  * @module Tree
  */
 
-import { EMPTY } from "rxjs/internal/observable/empty";
+import { EMPTY } from "rxjs";
 import type { TreeNodeItem } from "../../TreeDataProvider";
 import type { Observable } from "../Observable";
 import type { CheckboxStateChange } from "../TreeEvents";

--- a/ui/components-react/src/components-react/tree/controlled/internal/TreeSelectionManager.ts
+++ b/ui/components-react/src/components-react/tree/controlled/internal/TreeSelectionManager.ts
@@ -6,8 +6,8 @@
  * @module Tree
  */
 
-import { take } from "rxjs/internal/operators/take";
-import { Subject } from "rxjs/internal/Subject";
+import type { Observable } from "rxjs";
+import { Subject, take } from "rxjs";
 import { BeUiEvent } from "@itwin/core-bentley";
 import type {
   MultiSelectionHandler,
@@ -15,7 +15,6 @@ import type {
 } from "../../../common/selection/SelectionHandler";
 import { SelectionHandler } from "../../../common/selection/SelectionHandler";
 import type { SelectionMode } from "../../../common/selection/SelectionModes";
-import type { Observable } from "../Observable";
 import type { TreeActions } from "../TreeActions";
 import type { TreeModelNode, VisibleTreeNodes } from "../TreeModel";
 import { isTreeModelNode } from "../TreeModel";

--- a/ui/components-react/src/components-react/tree/controlled/internal/TreeSelectionManager.ts
+++ b/ui/components-react/src/components-react/tree/controlled/internal/TreeSelectionManager.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Observable } from "rxjs";
-import { Subject, take } from "rxjs";
+import { Subject } from "rxjs";
 import { BeUiEvent } from "@itwin/core-bentley";
 import type {
   MultiSelectionHandler,
@@ -180,11 +180,8 @@ export class TreeSelectionManager
       { once: true }
     );
     this._dragSelectionOperation = new Subject();
-    this._dragSelectionOperation.pipe(take(1)).subscribe((value) => {
-      this.onDragSelection.emit({
-        selectionChanges: this._dragSelectionOperation!,
-      });
-      this._dragSelectionOperation!.next(value);
+    this.onDragSelection.emit({
+      selectionChanges: this._dragSelectionOperation,
     });
   }
 

--- a/ui/components-react/src/test/common/ObservableTestHelpers.ts
+++ b/ui/components-react/src/test/common/ObservableTestHelpers.ts
@@ -2,8 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import type { Observable } from "rxjs/internal/Observable";
-import type { Subscription } from "rxjs/internal/Subscription";
+import type { Observable, Subscription } from "rxjs";
 import { ResolvablePromise } from "../test-helpers/misc";
 
 /** Expects observable to emit nodes in a specific order. The order is defined by the sequence of groups of emitted node ids, e.g. `[[0], [1, 2]]`. */

--- a/ui/components-react/src/test/common/ObservableTestHelpers.ts
+++ b/ui/components-react/src/test/common/ObservableTestHelpers.ts
@@ -16,6 +16,22 @@ export async function extractSequence<T>(
   return sequence;
 }
 
+/** Subscribes to observable and starts collecting emitted values in sequence*/
+export function startExtractingSequence<T>(observable: Observable<T>) {
+  const current: { sequence: T[] } = {
+    sequence: [],
+  };
+  const waitForComplete = waitForUnsubscription(
+    observable.subscribe((value) => {
+      current.sequence.push(value);
+    })
+  );
+  return {
+    current,
+    waitForComplete,
+  };
+}
+
 /** Returns a promise which is resolved when the input subscription is disposed. */
 export async function waitForUnsubscription(
   subscription: Subscription

--- a/ui/components-react/src/test/common/SubscriptionScheduler.test.ts
+++ b/ui/components-react/src/test/common/SubscriptionScheduler.test.ts
@@ -3,17 +3,18 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import type { Observable } from "rxjs/internal/Observable";
-import { concat } from "rxjs/internal/observable/concat";
-import { defer } from "rxjs/internal/observable/defer";
-import { from } from "rxjs/internal/observable/from";
-import { throwError } from "rxjs/internal/observable/throwError";
-import { tap } from "rxjs/internal/operators/tap";
-import { scheduled } from "rxjs/internal/scheduled/scheduled";
-import { asapScheduler } from "rxjs/internal/scheduler/asap";
-import { asyncScheduler } from "rxjs/internal/scheduler/async";
-import { queueScheduler } from "rxjs/internal/scheduler/queue";
-import type { ObservableInput, SchedulerLike } from "rxjs/internal/types";
+import type { Observable, ObservableInput, SchedulerLike } from "rxjs";
+import {
+  asapScheduler,
+  asyncScheduler,
+  concat,
+  defer,
+  from,
+  queueScheduler,
+  scheduled,
+  tap,
+  throwError,
+} from "rxjs";
 import sinon from "sinon";
 import {
   scheduleSubscription,
@@ -165,7 +166,7 @@ describe("SubscriptionScheduler", () => {
         it("notifies subscribers about error in source observable", async () => {
           const error = new Error("TestError");
           const source = createScheduledObservable(
-            throwError(error),
+            throwError(() => error),
             scheduler
           );
           const errorSpy = sinon.spy();
@@ -182,7 +183,7 @@ describe("SubscriptionScheduler", () => {
         it("schedules the following observable when the previous one emits error", async () => {
           const error = new Error("TestError");
           const firstSource = createScheduledObservable(
-            throwError(error),
+            throwError(() => error),
             scheduler
           );
           const secondSource = createScheduledObservable(sequence, scheduler);

--- a/ui/components-react/src/test/tree/controlled/TreeEventDispatcher.test.ts
+++ b/ui/components-react/src/test/tree/controlled/TreeEventDispatcher.test.ts
@@ -3,617 +3,818 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { from } from "rxjs";
 import * as sinon from "sinon";
-import * as moq from "typemoq";
-import { CheckBoxState } from "@itwin/core-react";
 import { SelectionMode } from "../../../components-react/common/selection/SelectionModes";
-import type {
-  RangeSelection,
-  TreeSelectionManager,
-} from "../../../components-react/tree/controlled/internal/TreeSelectionManager";
+import { toRxjsObservable } from "../../../components-react/tree/controlled/Observable";
 import { TreeEventDispatcher } from "../../../components-react/tree/controlled/TreeEventDispatcher";
+import type { TreeEvents } from "../../../components-react/tree/controlled/TreeEvents";
 import type {
-  TreeCheckboxStateChangeEventArgs,
-  TreeEvents,
-  TreeSelectionModificationEventArgs,
-  TreeSelectionReplacementEventArgs,
-} from "../../../components-react/tree/controlled/TreeEvents";
-import type {
-  MutableTreeModelNode,
-  TreeModel,
-  TreeModelNodePlaceholder,
-  VisibleTreeNodes,
+  TreeModelNode,
+  TreeModelRootNode,
 } from "../../../components-react/tree/controlled/TreeModel";
 import {
   computeVisibleNodes,
   isTreeModelNode,
-  isTreeModelRootNode,
   MutableTreeModel,
 } from "../../../components-react/tree/controlled/TreeModel";
-import type { ITreeNodeLoader } from "../../../components-react/tree/controlled/TreeNodeLoader";
-import { extractSequence } from "../../common/ObservableTestHelpers";
-import type { SinonSpy } from "../../TestUtils";
+import type {
+  ITreeNodeLoader,
+  TreeNodeLoadResult,
+} from "../../../components-react/tree/controlled/TreeNodeLoader";
 import {
-  createRandomMutableTreeModelNode,
-  createRandomMutableTreeModelNodes,
-  createTreeNodeInput,
-} from "./TreeHelpers";
-import { toRxjsObservable } from "../../../components-react";
+  extractSequence,
+  startExtractingSequence,
+} from "../../common/ObservableTestHelpers";
+import type { SinonSpy } from "../../TestUtils";
+import { createTreeNodeInput } from "./TreeHelpers";
+import { fireEvent, waitFor } from "@testing-library/react";
+import { asyncScheduler, from, of, scheduled, Subject } from "rxjs";
+import { CheckBoxState } from "@itwin/core-react";
+import type { TreeSelectionManager } from "../../../components-react/tree/controlled/internal/TreeSelectionManager";
 
 describe("TreeEventDispatcher", () => {
-  let dispatcher: TreeEventDispatcher;
-  const treeEventsMock = moq.Mock.ofType<TreeEvents>();
-  const treeNodeLoaderMock = moq.Mock.ofType<ITreeNodeLoader>();
-  const visibleNodesMock = moq.Mock.ofType<VisibleTreeNodes>();
-  const modelMock = moq.Mock.ofType<TreeModel>();
-
-  let selectionManager: TreeSelectionManager;
-
-  let selectedNodes: MutableTreeModelNode[];
-  let deselectedNodes: MutableTreeModelNode[];
-  let placeholderNode: TreeModelNodePlaceholder;
-  let placeholderChildNode: TreeModelNodePlaceholder;
-  let loadedNode: MutableTreeModelNode;
-  let loadedChildNode: MutableTreeModelNode;
-  let testNodes: MutableTreeModelNode[];
-
-  beforeEach(() => {
-    treeEventsMock.reset();
-    treeNodeLoaderMock.reset();
-
-    dispatcher = new TreeEventDispatcher(
-      treeEventsMock.object,
-      treeNodeLoaderMock.object,
-      SelectionMode.Extended,
-      () => visibleNodesMock.object
-    );
-    selectionManager = (dispatcher as any)._selectionManager;
-
-    mockVisibleNodes();
-  });
-
-  const mockVisibleNodes = (
-    addRootLevelPlaceholderNode = false,
-    addChildPlaceholderNode = false
-  ) => {
-    modelMock.reset();
-    visibleNodesMock.reset();
-    treeNodeLoaderMock.reset();
-
-    selectedNodes = createRandomMutableTreeModelNodes(4).map((node) => ({
-      ...node,
-      isSelected: true,
-    }));
-    deselectedNodes = createRandomMutableTreeModelNodes(4).map((node) => ({
-      ...node,
-      isSelected: false,
-    }));
-    placeholderNode = { childIndex: 0, depth: 0 };
-    placeholderChildNode = {
-      childIndex: 0,
-      depth: 1,
-      parentId: selectedNodes[3].id,
-    };
-    loadedNode = createRandomMutableTreeModelNode();
-    loadedChildNode = createRandomMutableTreeModelNode(selectedNodes[3].id);
-    testNodes = [...selectedNodes, ...deselectedNodes];
-
-    const iterator = function* () {
-      for (const node of selectedNodes) yield node;
-
-      if (addChildPlaceholderNode) yield placeholderChildNode;
-
-      if (addRootLevelPlaceholderNode) yield placeholderNode;
-
-      for (const node of deselectedNodes) yield node;
-    };
-
-    visibleNodesMock.setup((x) => x.getModel()).returns(() => modelMock.object);
-    visibleNodesMock
-      .setup((x) => x.getNumNodes())
-      .returns(() => testNodes.length + 2);
-    visibleNodesMock.setup((x) => x[Symbol.iterator]).returns(() => iterator);
-
-    for (const node of testNodes) {
-      modelMock.setup((x) => x.getNode(node.id)).returns(() => node);
-    }
-
-    modelMock
-      .setup((x) => x.getRootNode())
-      .returns(() => ({ depth: -1, id: undefined, numChildren: undefined }));
-    modelMock.setup((x) => x.getNode(loadedNode.id)).returns(() => loadedNode);
-    modelMock
-      .setup((x) => x.getNode(loadedChildNode.id))
-      .returns(() => loadedChildNode);
-    modelMock
-      .setup((x) => x.getNode(selectedNodes[3].id))
-      .returns(() => selectedNodes[3]);
-
-    treeNodeLoaderMock
-      .setup((x) =>
-        x.loadNode(
-          moq.It.is((parent) => isTreeModelRootNode(parent)),
-          0
-        )
-      )
-      .returns(() => from([{ loadedNodes: [loadedNode.item] }]));
-    treeNodeLoaderMock
-      .setup((x) =>
-        x.loadNode(
-          moq.It.is(
-            (parent) =>
-              isTreeModelNode(parent) && parent.id === selectedNodes[3].id
-          ),
-          0
-        )
-      )
-      .returns(() => from([{ loadedNodes: [loadedChildNode.item] }]));
+  const treeEvents = {
+    onSelectionModified: sinon.fake() as SinonSpy<
+      Required<TreeEvents>["onSelectionModified"]
+    >,
+    onSelectionReplaced: sinon.fake() as SinonSpy<
+      Required<TreeEvents>["onSelectionReplaced"]
+    >,
+    onNodeExpanded: sinon.fake() as SinonSpy<
+      Required<TreeEvents>["onNodeExpanded"]
+    >,
+    onNodeCollapsed: sinon.fake() as SinonSpy<
+      Required<TreeEvents>["onNodeCollapsed"]
+    >,
+    onDelayedNodeClick: sinon.fake() as SinonSpy<
+      Required<TreeEvents>["onDelayedNodeClick"]
+    >,
+    onNodeEditorActivated: sinon.fake() as SinonSpy<
+      Required<TreeEvents>["onNodeEditorActivated"]
+    >,
+    onCheckboxStateChanged: sinon.fake() as SinonSpy<
+      Required<TreeEvents>["onCheckboxStateChanged"]
+    >,
   };
 
-  describe("constructor", () => {
-    describe("onDragSelection handler", () => {
-      it("selects range of nodes", async () => {
-        const rangeSelection: RangeSelection = {
-          from: deselectedNodes[0].id,
-          to: deselectedNodes[deselectedNodes.length - 1].id,
-        };
-        const expectedSelectedNodeItems = deselectedNodes.map(
-          (node) => node.item
-        );
-        const spy = sinon.spy();
-        treeEventsMock.setup((x) => x.onSelectionModified).returns(() => spy);
-        selectionManager.onDragSelection.emit({
-          selectionChanges: from([
-            { selectedNodes: rangeSelection, deselectedNodes: [] },
-          ]),
-        });
-        expect(spy).to.be.called;
+  beforeEach(() => {
+    treeEvents.onSelectionModified.resetHistory();
+    treeEvents.onSelectionReplaced.resetHistory();
+    treeEvents.onNodeExpanded.resetHistory();
+    treeEvents.onNodeCollapsed.resetHistory();
+    treeEvents.onDelayedNodeClick.resetHistory();
+    treeEvents.onNodeEditorActivated.resetHistory();
+    treeEvents.onCheckboxStateChanged.resetHistory();
+  });
 
-        const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(
-          toRxjsObservable(spyArgs.modifications)
-        );
-        expect(results).to.not.be.empty;
-        const selectionChange = results[0];
-        expect(selectionChange.selectedNodeItems).to.be.deep.eq(
-          expectedSelectedNodeItems
-        );
-        expect(selectionChange.deselectedNodeItems).to.be.empty;
-      });
+  function setupTreeEventDispatcher(
+    selectionMode: SelectionMode,
+    setupModel: (model: MutableTreeModel) => void,
+    nodeLoader?: ITreeNodeLoader
+  ) {
+    const treeModel = new MutableTreeModel();
+    setupModel(treeModel);
 
-      it("selects range of nodes and loads unloaded nodes", async () => {
-        mockVisibleNodes(false, true);
-        const rangeSelection = {
-          from: selectedNodes[3].id,
-          to: deselectedNodes[0].id,
-        };
-        const expectedSelectedNodeIds = [
-          selectedNodes[3].item,
-          deselectedNodes[0].item,
-          loadedChildNode.item,
-        ];
-        const spy = sinon.spy();
-        treeEventsMock.setup((x) => x.onSelectionModified).returns(() => spy);
-        selectionManager.onDragSelection.emit({
-          selectionChanges: from([
-            { selectedNodes: rangeSelection, deselectedNodes: [] },
-          ]),
-        });
-        expect(spy).to.be.called;
+    const eventDispatcher = new TreeEventDispatcher(
+      treeEvents,
+      nodeLoader ?? { loadNode: sinon.fake() },
+      selectionMode,
+      () => computeVisibleNodes(treeModel)
+    );
+    return {
+      dispatcher: eventDispatcher,
+      treeModel,
+    };
+  }
 
-        const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(
-          toRxjsObservable(spyArgs.modifications)
-        );
-        expect(results).to.not.be.empty;
-        const selectionChange = results[0];
-        expect(selectionChange.selectedNodeItems).to.be.deep.eq(
-          expectedSelectedNodeIds
-        );
-        expect(selectionChange.deselectedNodeItems).to.be.empty;
-      });
-
-      it("selects range of nodes and loads unloaded nodes hierarchy", async () => {
-        mockVisibleNodes(true);
-        const rangeSelection = {
-          from: selectedNodes[3].id,
-          to: deselectedNodes[0].id,
-        };
-
-        treeNodeLoaderMock.reset();
-        treeNodeLoaderMock
-          .setup((x) =>
-            x.loadNode(
-              moq.It.is((parent) => isTreeModelRootNode(parent)),
-              0
-            )
-          )
-          .returns(() =>
-            from([{ loadedNodes: [loadedNode.item, loadedChildNode.item] }])
+  describe("single selection", () => {
+    it("selects node", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Single,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [createTreeNodeInput("A"), createTreeNodeInput("B")],
+            0
           );
+        }
+      );
 
-        const expectedSelectedNodeItems = [
-          selectedNodes[3].item,
-          deselectedNodes[0].item,
-          loadedNode.item,
-          loadedChildNode.item,
-        ];
-        const spy = sinon.spy();
-        treeEventsMock.setup((x) => x.onSelectionModified).returns(() => spy);
-        selectionManager.onDragSelection.emit({
-          selectionChanges: from([
-            { selectedNodes: rangeSelection, deselectedNodes: [] },
-          ]),
-        });
-        expect(spy).to.be.called;
+      dispatcher.onNodeClicked("A", {} as any);
 
-        const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(
-          toRxjsObservable(spyArgs.modifications)
-        );
-        expect(results).to.not.be.empty;
-        const selectionChange = results[0];
-        expect(selectionChange.selectedNodeItems).to.be.deep.eq(
-          expectedSelectedNodeItems
-        );
-        expect(selectionChange.deselectedNodeItems).to.be.empty;
-      });
+      expect(treeEvents.onSelectionReplaced).to.be.calledOnce;
+      const [args0] = treeEvents.onSelectionReplaced.args[0];
+      expect(await extractSequence(toRxjsObservable(args0.replacements)))
+        .to.have.lengthOf(1)
+        .and.containSubset([{ selectedNodeItems: [{ id: "A" }] }]);
 
-      it("does not select nodes if visible nodes are not set", async () => {
-        dispatcher.setVisibleNodes(undefined!);
-        const rangeSelection: RangeSelection = {
-          from: deselectedNodes[0].id,
-          to: deselectedNodes[deselectedNodes.length - 1].id,
-        };
+      dispatcher.onNodeClicked("B", {} as any);
 
-        const spy = sinon.spy();
-        treeEventsMock.setup((x) => x.onSelectionModified).returns(() => spy);
-        selectionManager.onDragSelection.emit({
-          selectionChanges: from([
-            { selectedNodes: rangeSelection, deselectedNodes: [] },
-          ]),
-        });
-        expect(spy).to.be.called;
-
-        const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(
-          toRxjsObservable(spyArgs.modifications)
-        );
-        expect(results).to.not.be.empty;
-        expect(results[0].selectedNodeItems).to.be.empty;
-        expect(results[0].deselectedNodeItems).to.be.empty;
-      });
-    });
-
-    describe("onSelectionChanged handler", () => {
-      it("selects and deselects nodes", async () => {
-        const deselectedNodeIds = selectedNodes.map((node) => node.id);
-        const selectedNodeIds = deselectedNodes.map((node) => node.id);
-
-        const spy = sinon.spy();
-        treeEventsMock.setup((x) => x.onSelectionModified).returns(() => spy);
-        selectionManager.onSelectionChanged.emit({
-          selectedNodes: selectedNodeIds,
-          deselectedNodes: deselectedNodeIds,
-        });
-        expect(spy).to.be.called;
-
-        const selectedNodeItems = deselectedNodes.map((node) => node.item);
-        const deselectedNodeItems = selectedNodes.map((node) => node.item);
-        const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(
-          toRxjsObservable(spyArgs.modifications)
-        );
-        expect(results).to.not.be.empty;
-        const selectionChange = results[0];
-        expect(selectionChange.selectedNodeItems).to.be.deep.eq(
-          selectedNodeItems
-        );
-        expect(selectionChange.deselectedNodeItems).to.be.deep.eq(
-          deselectedNodeItems
-        );
-      });
-    });
-
-    describe("onSelectionReplaced handler", () => {
-      it("replaces selected nodes", async () => {
-        const selectedNodeIds = deselectedNodes.map((node) => node.id);
-        const selectedNodeItems = deselectedNodes.map((node) => node.item);
-
-        const spy = sinon.spy();
-        treeEventsMock.setup((x) => x.onSelectionReplaced).returns(() => spy);
-        selectionManager.onSelectionReplaced.emit({ selectedNodeIds });
-        expect(spy).to.be.called;
-
-        const spyArgs = spy.args[0][0] as TreeSelectionReplacementEventArgs;
-        const results = await extractSequence(
-          toRxjsObservable(spyArgs.replacements)
-        );
-        expect(results).to.not.be.empty;
-        const selectionChange = results[0];
-        expect(selectionChange.selectedNodeItems).to.be.deep.eq(
-          selectedNodeItems
-        );
-      });
-
-      it("replaces selected nodes using range selection from one node", async () => {
-        const selection = {
-          from: deselectedNodes[0].id,
-          to: deselectedNodes[0].id,
-        };
-
-        const spy = sinon.spy();
-        treeEventsMock.setup((x) => x.onSelectionReplaced).returns(() => spy);
-        selectionManager.onSelectionReplaced.emit({
-          selectedNodeIds: selection,
-        });
-        expect(spy).to.be.called;
-
-        const spyArgs = spy.args[0][0] as TreeSelectionReplacementEventArgs;
-        const results = await extractSequence(
-          toRxjsObservable(spyArgs.replacements)
-        );
-        expect(results).to.not.be.empty;
-        const selectionChange = results[0];
-        expect(selectionChange.selectedNodeItems).to.be.deep.eq([
-          deselectedNodes[0].item,
-        ]);
-      });
+      expect(treeEvents.onSelectionReplaced).to.be.calledTwice;
+      const [args1] = treeEvents.onSelectionReplaced.args[1];
+      expect(await extractSequence(toRxjsObservable(args1.replacements)))
+        .to.have.lengthOf(1)
+        .and.containSubset([{ selectedNodeItems: [{ id: "B" }] }]);
     });
   });
 
-  describe("onNodeCheckboxClicked", () => {
-    it("changes state for clicked node", async () => {
-      const expectedAffectedNodeItems = [deselectedNodes[0].item];
-
-      const spy = sinon.spy();
-      treeEventsMock.setup((x) => x.onCheckboxStateChanged).returns(() => spy);
-
-      dispatcher.onNodeCheckboxClicked(deselectedNodes[0].id, CheckBoxState.On);
-
-      expect(spy).to.be.calledOnce;
-      const changes = spy.args[0][0] as TreeCheckboxStateChangeEventArgs;
-      const results = await extractSequence(
-        toRxjsObservable(changes.stateChanges)
+  describe("extended selection", () => {
+    it("selects multiple nodes with CTRL", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [createTreeNodeInput("A"), createTreeNodeInput("B")],
+            0
+          );
+        }
       );
-      expect(results).to.not.be.empty;
-      const affectedNodeItems = results[0].map((change) => change.nodeItem);
-      expect(affectedNodeItems).to.be.deep.eq(expectedAffectedNodeItems);
-    });
 
-    it("changes state for all selected nodes", async () => {
-      const expectedAffectedNodeItems = [
-        ...selectedNodes.map((node) => node.item),
-      ];
-
-      const spy = sinon.spy();
-      treeEventsMock.setup((x) => x.onCheckboxStateChanged).returns(() => spy);
-
-      dispatcher.onNodeCheckboxClicked(selectedNodes[0].id, CheckBoxState.On);
-
-      const changes = spy.args[0][0] as TreeCheckboxStateChangeEventArgs;
-      const results = await extractSequence(
-        toRxjsObservable(changes.stateChanges)
-      );
-      expect(results).to.not.be.empty;
-      const affectedItems = results[0].map((change) => change.nodeItem);
-      expect(affectedItems).to.be.deep.eq(expectedAffectedNodeItems);
-    });
-
-    it("changes state for all selected nodes including pending selection", async () => {
-      // simulate selection event in progress
-      // if selection modified event is still in progress, dispatcher saves on going event data in _activeSelections set
-      (dispatcher as any)._activeSelections.add(
-        from([
+      dispatcher.onNodeClicked("A", {} as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledOnce;
+      const [args0] = treeEvents.onSelectionReplaced.args[0];
+      expect(await extractSequence(toRxjsObservable(args0.replacements)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
           {
-            selectedNodeItems: [deselectedNodes[0].item],
+            selectedNodeItems: [{ id: "A" }],
+          },
+        ]);
+
+      dispatcher.onNodeClicked("B", { ctrlKey: true } as any);
+      expect(treeEvents.onSelectionModified).to.be.calledOnce;
+      const [args1] = treeEvents.onSelectionModified.args[0];
+      expect(await extractSequence(toRxjsObservable(args1.modifications)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          {
+            selectedNodeItems: [{ id: "B" }],
+          },
+        ]);
+    });
+
+    it("deselects node with CTRL", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [
+              createTreeNodeInput("A", { isSelected: true }),
+              createTreeNodeInput("B"),
+            ],
+            0
+          );
+        }
+      );
+
+      dispatcher.onNodeClicked("A", { ctrlKey: true } as any);
+      expect(treeEvents.onSelectionModified).to.be.calledOnce;
+      const [args0] = treeEvents.onSelectionModified.args[0];
+      expect(await extractSequence(toRxjsObservable(args0.modifications)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          {
+            deselectedNodeItems: [{ id: "A" }],
+          },
+        ]);
+    });
+
+    it("selects multiple nodes with SHIFT", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [
+              createTreeNodeInput("A"),
+              createTreeNodeInput("B"),
+              createTreeNodeInput("C"),
+              createTreeNodeInput("D"),
+            ],
+            0
+          );
+        }
+      );
+
+      dispatcher.onNodeClicked("A", {} as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledOnce;
+      const [args0] = treeEvents.onSelectionReplaced.args[0];
+      expect(await extractSequence(toRxjsObservable(args0.replacements)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          {
+            selectedNodeItems: [{ id: "A" }],
+          },
+        ]);
+
+      dispatcher.onNodeClicked("D", { shiftKey: true } as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledTwice;
+      const [args1] = treeEvents.onSelectionReplaced.args[1];
+      expect(await extractSequence(toRxjsObservable(args1.replacements)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          {
+            selectedNodeItems: [
+              { id: "A" },
+              { id: "B" },
+              { id: "C" },
+              { id: "D" },
+            ],
+          },
+        ]);
+    });
+
+    it("selects multiple nodes with SHIFT and loads missing nodes", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setNumChildren(undefined, 3);
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+          model.setChildren(undefined, [createTreeNodeInput("C")], 2);
+        },
+        {
+          loadNode: sinon.fake(() => {
+            // use async scheduler to simulate request
+            return scheduled(
+              [{ loadedNodes: [createTreeNodeInput("B").item] }],
+              asyncScheduler
+            );
+          }),
+        }
+      );
+
+      dispatcher.onNodeClicked("A", {} as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledOnce;
+
+      dispatcher.onNodeClicked("C", { shiftKey: true } as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledTwice;
+      const [args1] = treeEvents.onSelectionReplaced.args[1];
+      expect(await extractSequence(toRxjsObservable(args1.replacements)))
+        .to.have.lengthOf(2)
+        .and.containSubset([
+          {
+            selectedNodeItems: [{ id: "A" }, { id: "C" }],
+          },
+          {
+            selectedNodeItems: [{ id: "B" }],
+          },
+        ]);
+    });
+
+    it("selects multiple nodes with SHIFT in different hierarchy levels", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [
+              createTreeNodeInput("A", { isExpanded: true }),
+              createTreeNodeInput("B"),
+              createTreeNodeInput("C"),
+            ],
+            0
+          );
+          model.setChildren("A", [createTreeNodeInput("A-A")], 0);
+        }
+      );
+
+      dispatcher.onNodeClicked("A", {} as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledOnce;
+
+      dispatcher.onNodeClicked("C", { shiftKey: true } as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledTwice;
+      const [args1] = treeEvents.onSelectionReplaced.args[1];
+      expect(await extractSequence(toRxjsObservable(args1.replacements)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          {
+            selectedNodeItems: [
+              { id: "A" },
+              { id: "A-A" },
+              { id: "B" },
+              { id: "C" },
+            ],
+          },
+        ]);
+    });
+
+    it("selects multiple nodes with SHIFT in different hierarchy levels and loads missing nodes", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [
+              createTreeNodeInput("A", { isExpanded: true }),
+              createTreeNodeInput("B"),
+              createTreeNodeInput("C"),
+            ],
+            0
+          );
+          model.setNumChildren("A", 2);
+          model.setChildren("A", [createTreeNodeInput("A-A")], 0);
+        },
+        {
+          loadNode: sinon.fake((parent: TreeModelNode | TreeModelRootNode) => {
+            expect(isTreeModelNode(parent));
+            return scheduled(
+              [{ loadedNodes: [createTreeNodeInput("A-B").item] }],
+              asyncScheduler
+            );
+          }),
+        }
+      );
+
+      dispatcher.onNodeClicked("A", {} as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledOnce;
+
+      dispatcher.onNodeClicked("C", { shiftKey: true } as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledTwice;
+      const [args1] = treeEvents.onSelectionReplaced.args[1];
+      expect(await extractSequence(toRxjsObservable(args1.replacements)))
+        .to.have.lengthOf(2)
+        .and.containSubset([
+          {
+            selectedNodeItems: [
+              { id: "A" },
+              { id: "A-A" },
+              { id: "B" },
+              { id: "C" },
+            ],
+          },
+          {
+            selectedNodeItems: [{ id: "A-B" }],
+          },
+        ]);
+    });
+
+    it("selects single node with SHIFT", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+        }
+      );
+
+      dispatcher.onNodeClicked("A", {} as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledOnce;
+
+      dispatcher.onNodeClicked("A", { shiftKey: true } as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledTwice;
+      const [args1] = treeEvents.onSelectionReplaced.args[1];
+      expect(await extractSequence(toRxjsObservable(args1.replacements)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          {
+            selectedNodeItems: [{ id: "A" }],
+          },
+        ]);
+    });
+  });
+
+  describe("drag selection", () => {
+    it("selects nodes", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Multiple,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [
+              createTreeNodeInput("A"),
+              createTreeNodeInput("B"),
+              createTreeNodeInput("C"),
+            ],
+            0
+          );
+        }
+      );
+
+      dispatcher.onNodeMouseDown("A");
+
+      expect(treeEvents.onSelectionModified).to.be.calledOnce;
+      const [args0] = treeEvents.onSelectionModified.args[0];
+      const result0 = startExtractingSequence(
+        toRxjsObservable(args0.modifications)
+      );
+
+      dispatcher.onNodeMouseMove("B");
+      dispatcher.onNodeMouseMove("C");
+      fireEvent.mouseUp(window);
+
+      await result0.waitForComplete;
+      expect(result0.current.sequence)
+        .to.have.lengthOf(2)
+        .and.containSubset([
+          {
+            selectedNodeItems: [{ id: "A" }, { id: "B" }],
             deselectedNodeItems: [],
           },
-        ])
-      );
+          {
+            selectedNodeItems: [{ id: "C" }],
+            deselectedNodeItems: [],
+          },
+        ]);
 
-      const expectedAffectedItems = [
-        ...selectedNodes.map((node) => node.item),
-        deselectedNodes[0].item,
-      ];
-
-      const spy = sinon.spy();
-      treeEventsMock.setup((x) => x.onCheckboxStateChanged).returns(() => spy);
-
-      dispatcher.onNodeCheckboxClicked(selectedNodes[0].id, CheckBoxState.On);
-
-      const checkboxChanges = spy
-        .args[0][0] as TreeCheckboxStateChangeEventArgs;
-      const results = await extractSequence(
-        toRxjsObservable(checkboxChanges.stateChanges)
-      );
-      expect(results).to.not.be.empty;
-      const affectedItems = results
-        .reduce((acc, el) => acc.concat(el), [])
-        .map((change) => change.nodeItem);
-      expect(affectedItems).to.be.deep.eq(expectedAffectedItems);
+      expect(treeEvents.onSelectionModified).to.be.calledTwice;
+      const [args1] = treeEvents.onSelectionModified.args[1];
+      expect(await extractSequence(toRxjsObservable(args1.modifications)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          { selectedNodeItems: [{ id: "A" }, { id: "B" }, { id: "C" }] },
+        ]);
     });
 
-    it("does not dispatch event if visibleNodes are not set", async () => {
-      dispatcher.setVisibleNodes(undefined!);
-      const spy = sinon.spy();
-      treeEventsMock.setup((x) => x.onCheckboxStateChanged).returns(() => spy);
+    it("deselects selected nodes", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Multiple,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [
+              createTreeNodeInput("A"),
+              createTreeNodeInput("B", { isSelected: true }),
+              createTreeNodeInput("C"),
+            ],
+            0
+          );
+        }
+      );
 
-      dispatcher.onNodeCheckboxClicked(selectedNodes[0].id, CheckBoxState.On);
-      expect(spy).to.not.be.called;
-    });
+      dispatcher.onNodeMouseDown("A");
+      dispatcher.onNodeMouseMove("B");
+      dispatcher.onNodeMouseMove("C");
 
-    it("does not dispatch event if clicked node is not found", async () => {
-      const spy = sinon.spy();
-      treeEventsMock.setup((x) => x.onCheckboxStateChanged).returns(() => spy);
-      modelMock.setup((x) => x.getNode("NoNode")).returns(() => undefined);
+      fireEvent.mouseUp(window);
 
-      dispatcher.onNodeCheckboxClicked("NoNode", CheckBoxState.On);
-      expect(spy).to.not.be.called;
+      expect(treeEvents.onSelectionModified).to.be.calledThrice;
+
+      const [args0] = treeEvents.onSelectionModified.args[0];
+      expect(
+        await extractSequence(toRxjsObservable(args0.modifications))
+      ).to.have.lengthOf(0);
+
+      const [args2] = treeEvents.onSelectionModified.args[1];
+      expect(await extractSequence(toRxjsObservable(args2.modifications)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          {
+            selectedNodeItems: [{ id: "A" }, { id: "C" }],
+            deselectedNodeItems: [],
+          },
+        ]);
+
+      const [args3] = treeEvents.onSelectionModified.args[2];
+      expect(await extractSequence(toRxjsObservable(args3.modifications)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          {
+            selectedNodeItems: [],
+            deselectedNodeItems: [{ id: "B" }],
+          },
+        ]);
     });
   });
 
-  describe("onNodeExpanded", () => {
-    it("emits tree event", () => {
-      treeEventsMock
-        .setup((x) => x.onNodeExpanded!({ nodeId: testNodes[0].id }))
-        .verifiable(moq.Times.once());
-      dispatcher.onNodeExpanded(testNodes[0].id);
-      treeEventsMock.verifyAll();
+  describe("checkbox click", () => {
+    it("does not raise event if non-existing node is clicked", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Multiple,
+        (model) => {
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+        }
+      );
+
+      dispatcher.onNodeCheckboxClicked("B", CheckBoxState.On);
+      expect(treeEvents.onCheckboxStateChanged).to.not.be.calledOnce;
+    });
+
+    it("checks checkbox state", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Multiple,
+        (model) => {
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+        }
+      );
+
+      dispatcher.onNodeCheckboxClicked("A", CheckBoxState.On);
+
+      expect(treeEvents.onCheckboxStateChanged).to.be.calledOnce;
+      const [args] = treeEvents.onCheckboxStateChanged.args[0];
+      expect(await extractSequence(toRxjsObservable(args.stateChanges)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          [{ nodeItem: { id: "A" }, newState: CheckBoxState.On }],
+        ]);
+    });
+
+    it("unchecks checkbox state", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Multiple,
+        (model) => {
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+        }
+      );
+
+      dispatcher.onNodeCheckboxClicked("A", CheckBoxState.Off);
+
+      expect(treeEvents.onCheckboxStateChanged).to.be.calledOnce;
+      const [args] = treeEvents.onCheckboxStateChanged.args[0];
+      expect(await extractSequence(toRxjsObservable(args.stateChanges)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          [{ nodeItem: { id: "A" }, newState: CheckBoxState.Off }],
+        ]);
+    });
+
+    it("checks selected nodes checkboxes", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Multiple,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [
+              createTreeNodeInput("A", { isSelected: true }),
+              createTreeNodeInput("B"),
+              createTreeNodeInput("C", { isSelected: true }),
+            ],
+            0
+          );
+        }
+      );
+
+      dispatcher.onNodeCheckboxClicked("A", CheckBoxState.On);
+      expect(treeEvents.onCheckboxStateChanged).to.be.calledOnce;
+      const [args] = treeEvents.onCheckboxStateChanged.args[0];
+      expect(await extractSequence(toRxjsObservable(args.stateChanges)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          [
+            { nodeItem: { id: "A" }, newState: CheckBoxState.On },
+            { nodeItem: { id: "C" }, newState: CheckBoxState.On },
+          ],
+        ]);
+    });
+
+    it("checks only unchecked selected nodes checkboxes", async () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Multiple,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [
+              createTreeNodeInput("A", { isSelected: true }),
+              createTreeNodeInput("B", { isSelected: true }),
+              createTreeNodeInput("C", { isSelected: true }),
+            ],
+            0
+          );
+          model.getNode("B")!.checkbox.state = CheckBoxState.On;
+        }
+      );
+
+      dispatcher.onNodeCheckboxClicked("A", CheckBoxState.On);
+      expect(treeEvents.onCheckboxStateChanged).to.be.calledOnce;
+      const [args] = treeEvents.onCheckboxStateChanged.args[0];
+      expect(await extractSequence(toRxjsObservable(args.stateChanges)))
+        .to.have.lengthOf(1)
+        .and.containSubset([
+          [
+            { nodeItem: { id: "A" }, newState: CheckBoxState.On },
+            { nodeItem: { id: "C" }, newState: CheckBoxState.On },
+          ],
+        ]);
+    });
+
+    it("checks selected node checkbox when node is loaded", async () => {
+      const nodeLoadSubject = new Subject<TreeNodeLoadResult>();
+      const { dispatcher, treeModel } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setNumChildren(undefined, 3);
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+          model.setChildren(undefined, [createTreeNodeInput("C")], 2);
+        },
+        {
+          loadNode: sinon.fake(() => nodeLoadSubject),
+        }
+      );
+
+      // make range selection over unloaded node
+      dispatcher.onNodeClicked("A", {} as any);
+      dispatcher.onNodeClicked("C", { shiftKey: true } as any);
+      expect(treeEvents.onSelectionReplaced).to.be.calledTwice;
+      const [selectionArgs] = treeEvents.onSelectionReplaced.args[1];
+      const selectionResult = startExtractingSequence(
+        toRxjsObservable(selectionArgs.replacements)
+      );
+
+      // wait for notification that A and C nodes were selected
+      await waitFor(() => {
+        expect(selectionResult.current.sequence)
+          .to.have.lengthOf(1)
+          .and.containSubset([
+            { selectedNodeItems: [{ id: "A" }, { id: "C" }] },
+          ]);
+      });
+
+      // select nodes in the model
+      treeModel.getNode("A")!.isSelected = true;
+      treeModel.getNode("C")!.isSelected = true;
+
+      dispatcher.onNodeCheckboxClicked("A", CheckBoxState.On);
+      expect(treeEvents.onCheckboxStateChanged).to.be.calledOnce;
+      const [checkboxArgs] = treeEvents.onCheckboxStateChanged.args[0];
+      const checkboxResult = startExtractingSequence(
+        toRxjsObservable(checkboxArgs.stateChanges)
+      );
+
+      // finish node loading
+      of({
+        loadedNodes: [createTreeNodeInput("B").item],
+      }).subscribe(nodeLoadSubject);
+
+      await selectionResult.waitForComplete;
+      await checkboxResult.waitForComplete;
+      expect(checkboxResult.current.sequence)
+        .to.have.lengthOf(3)
+        .and.containSubset([
+          // first notification about A and C checkbox state from immediate click
+          [
+            { nodeItem: { id: "A" }, newState: CheckBoxState.On },
+            { nodeItem: { id: "C" }, newState: CheckBoxState.On },
+          ],
+          // second notification about A and C checkbox state from range selection
+          [
+            { nodeItem: { id: "A" }, newState: CheckBoxState.On },
+            { nodeItem: { id: "C" }, newState: CheckBoxState.On },
+          ],
+          // notification about B checkbox state after it was loaded
+          [{ nodeItem: { id: "B" }, newState: CheckBoxState.On }],
+        ]);
     });
   });
 
-  describe("onNodeCollapsed", () => {
-    it("emits tree event", () => {
-      treeEventsMock
-        .setup((x) => x.onNodeCollapsed!({ nodeId: testNodes[0].id }))
-        .verifiable(moq.Times.once());
-      dispatcher.onNodeCollapsed(testNodes[0].id);
-      treeEventsMock.verifyAll();
+  describe("editor activation", () => {
+    it("does not raise tree event if node is not selected", () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+        }
+      );
+
+      dispatcher.onNodeEditorActivated("A");
+      expect(treeEvents.onNodeEditorActivated).to.not.be.called;
+    });
+
+    it("does not raise tree event if node id in invalid", () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [createTreeNodeInput("A", { isSelected: true })],
+            0
+          );
+        }
+      );
+
+      dispatcher.onNodeEditorActivated("B");
+      expect(treeEvents.onNodeEditorActivated).to.not.be.called;
+    });
+
+    it("raises tree event if node is selected", () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [createTreeNodeInput("A", { isSelected: true })],
+            0
+          );
+        }
+      );
+
+      dispatcher.onNodeEditorActivated("A");
+      expect(treeEvents.onNodeEditorActivated).to.be.calledOnceWith({
+        nodeId: "A",
+      });
     });
   });
 
-  describe("onNodeClicked", () => {
-    it("calls selection manager onNodeClicked", () => {
-      const eventMock =
-        moq.Mock.ofType<React.MouseEvent<Element, MouseEvent>>();
-      const spy = sinon.spy(selectionManager, "onNodeClicked");
-      dispatcher.onNodeClicked(testNodes[0].id, eventMock.object);
-      expect(spy).to.be.calledWith(testNodes[0].id, eventMock.object);
+  describe("delayed click", () => {
+    it("does not raise tree event when clicked node is not selected", () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+        }
+      );
+
+      dispatcher.onNodeClicked("A", {} as any);
+      expect(treeEvents.onDelayedNodeClick).to.not.be.called;
     });
 
-    it("calls tree events onDelayedNodeClick if node is selected", () => {
-      const eventMock =
-        moq.Mock.ofType<React.MouseEvent<Element, MouseEvent>>();
-      testNodes[0].isSelected = true;
-      dispatcher.onNodeClicked(testNodes[0].id, eventMock.object);
-      treeEventsMock.verify(
-        (x) => x.onDelayedNodeClick!({ nodeId: testNodes[0].id }),
-        moq.Times.exactly(2)
+    it("does not raise tree event when clicked node does not exist", () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [createTreeNodeInput("A", { isSelected: true })],
+            0
+          );
+        }
       );
+
+      dispatcher.onNodeClicked("B", {} as any);
+      expect(treeEvents.onDelayedNodeClick).to.not.be.called;
     });
 
-    it("does not call tree events onDelayedNodeClick if node is not selected", () => {
-      const eventMock =
-        moq.Mock.ofType<React.MouseEvent<Element, MouseEvent>>();
-      testNodes[0].isSelected = false;
-      dispatcher.onNodeClicked(testNodes[0].id, eventMock.object);
-      treeEventsMock.verify(
-        (x) => x.onDelayedNodeClick!({ nodeId: testNodes[0].id }),
-        moq.Times.never()
+    it("raises tree event when clicked node is selected", () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(
+            undefined,
+            [createTreeNodeInput("A", { isSelected: true })],
+            0
+          );
+        }
       );
-    });
 
-    it("does not call tree events onDelayedNodeClick if node does not exist", () => {
-      modelMock.reset();
-      const eventMock =
-        moq.Mock.ofType<React.MouseEvent<Element, MouseEvent>>();
-      testNodes[0].isSelected = false;
-      dispatcher.onNodeClicked(testNodes[0].id, eventMock.object);
-      treeEventsMock.verify(
-        (x) => x.onDelayedNodeClick!({ nodeId: testNodes[0].id }),
-        moq.Times.never()
-      );
-    });
-
-    it("does not call tree events onDelayedNodeClick if visible nodes are not set", () => {
-      dispatcher.setVisibleNodes(undefined!);
-      const eventMock =
-        moq.Mock.ofType<React.MouseEvent<Element, MouseEvent>>();
-      testNodes[0].isSelected = false;
-      dispatcher.onNodeClicked(testNodes[0].id, eventMock.object);
-      treeEventsMock.verify(
-        (x) => x.onDelayedNodeClick!({ nodeId: testNodes[0].id }),
-        moq.Times.never()
-      );
+      dispatcher.onNodeClicked("A", {} as any);
+      expect(treeEvents.onDelayedNodeClick).to.be.calledOnceWith({
+        nodeId: "A",
+      });
     });
   });
 
-  describe("onNodeMouseDown", () => {
-    it("calls selection manager onNodeMouseDown", () => {
-      const spy = sinon.spy(selectionManager, "onNodeMouseDown");
-      dispatcher.onNodeMouseDown(testNodes[0].id);
-      expect(spy).to.be.calledWith(testNodes[0].id);
-    });
+  it("raises tree event when node is expanded", () => {
+    const { dispatcher } = setupTreeEventDispatcher(
+      SelectionMode.Extended,
+      (model) => {
+        model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+      }
+    );
+    dispatcher.onNodeExpanded("A");
+    expect(treeEvents.onNodeExpanded).to.be.calledOnceWith({ nodeId: "A" });
   });
 
-  describe("onNodeMouseMove", () => {
-    it("calls selection manager onNodeMouseMove", () => {
-      const spy = sinon.spy(selectionManager, "onNodeMouseMove");
-      dispatcher.onNodeMouseMove(testNodes[0].id);
-      expect(spy).to.be.calledWith(testNodes[0].id);
-    });
+  it("raises tree event when node is collapsed", () => {
+    const { dispatcher } = setupTreeEventDispatcher(
+      SelectionMode.Extended,
+      (model) => {
+        model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+      }
+    );
+    dispatcher.onNodeCollapsed("A");
+    expect(treeEvents.onNodeCollapsed).to.be.calledOnceWith({ nodeId: "A" });
   });
 
-  describe("Keyboard Events", () => {
-    const keyEventMock = moq.Mock.ofType<React.KeyboardEvent>();
-
-    beforeEach(() => {
-      keyEventMock.reset();
-    });
-
-    it("calls selection manager onTreeKeyDown", () => {
-      const spy = sinon.spy(selectionManager, "onTreeKeyDown");
-      dispatcher.onTreeKeyDown(keyEventMock.object);
-      expect(spy).to.be.called;
-    });
-
-    it("calls selection manager onTreeKeyUp", () => {
-      const spy = sinon.spy(selectionManager, "onTreeKeyUp");
-      dispatcher.onTreeKeyUp(keyEventMock.object);
-      expect(spy).to.be.called;
-    });
-  });
-
-  describe("onNodeEditorActivated", () => {
-    it("calls tree events onNodeEditorActivated if node is selected", () => {
-      testNodes[0].isSelected = true;
-      dispatcher.onNodeEditorActivated(testNodes[0].id);
-      treeEventsMock.verify(
-        (x) => x.onNodeEditorActivated!({ nodeId: testNodes[0].id }),
-        moq.Times.exactly(2)
+  describe("keyboard navigation", () => {
+    it("forward events to `TreeSelectionManager", () => {
+      const { dispatcher } = setupTreeEventDispatcher(
+        SelectionMode.Extended,
+        (model) => {
+          model.setChildren(undefined, [createTreeNodeInput("A")], 0);
+        }
       );
-    });
+      const selectionManager = (dispatcher as any)
+        ._selectionManager as TreeSelectionManager;
+      const onKeyDownStub = sinon.stub(selectionManager, "onTreeKeyDown");
+      const onKeyUpStub = sinon.stub(selectionManager, "onTreeKeyUp");
 
-    it("does not call tree events onNodeEditorActivated if node is not selected", () => {
-      testNodes[0].isSelected = false;
-      dispatcher.onNodeEditorActivated(testNodes[0].id);
-      treeEventsMock.verify(
-        (x) => x.onNodeEditorActivated!({ nodeId: testNodes[0].id }),
-        moq.Times.never()
-      );
-    });
+      dispatcher.onTreeKeyDown({} as any);
+      expect(onKeyDownStub).to.be.calledOnce;
 
-    it("does not call tree events onNodeEditorActivated if node id is invalid", () => {
-      const nodeId = "invalid";
-      dispatcher.onNodeEditorActivated(nodeId);
-      treeEventsMock.verify(
-        (x) => x.onNodeEditorActivated!({ nodeId }),
-        moq.Times.never()
-      );
+      dispatcher.onTreeKeyUp({} as any);
+      expect(onKeyUpStub).to.be.calledOnce;
     });
   });
 
   describe("non-selectable node", () => {
-    const treeEvents = {
-      onSelectionModified: sinon.fake() as SinonSpy<
-        Required<TreeEvents>["onSelectionModified"]
-      >,
-      onSelectionReplaced: sinon.fake() as SinonSpy<
-        Required<TreeEvents>["onSelectionReplaced"]
-      >,
-    };
-
-    beforeEach(() => {
-      treeEvents.onSelectionModified.resetHistory();
-      treeEvents.onSelectionReplaced.resetHistory();
-    });
-
     describe("when clicked", () => {
       it("does not select the clicked node", async () => {
-        const treeEventDispatcher = setupTreeEventDispatcher();
-        treeEventDispatcher.onNodeClicked("B", {} as any);
+        const { dispatcher } = setupTreeEventDispatcher(
+          SelectionMode.Extended,
+          (model) => {
+            model.setChildren(
+              undefined,
+              [
+                createTreeNodeInput("A"),
+                createTreeNodeInput("B"),
+                createTreeNodeInput("C"),
+              ],
+              0
+            );
+            model.getNode("B")!.isSelectionDisabled = true;
+          }
+        );
+
+        dispatcher.onNodeClicked("B", {} as any);
 
         expect(treeEvents.onSelectionModified).not.to.have.been.called;
         expect(treeEvents.onSelectionReplaced).to.have.been.calledOnce;
@@ -628,9 +829,24 @@ describe("TreeEventDispatcher", () => {
       });
 
       it("performs range selection without selecting the clicked node", async () => {
-        const treeEventDispatcher = setupTreeEventDispatcher();
-        treeEventDispatcher.onNodeClicked("D", {} as any);
-        treeEventDispatcher.onNodeClicked("B", { shiftKey: true } as any);
+        const { dispatcher } = setupTreeEventDispatcher(
+          SelectionMode.Extended,
+          (model) => {
+            model.setChildren(
+              undefined,
+              [
+                createTreeNodeInput("A"),
+                createTreeNodeInput("B"),
+                createTreeNodeInput("C"),
+                createTreeNodeInput("D"),
+              ],
+              0
+            );
+            model.getNode("B")!.isSelectionDisabled = true;
+          }
+        );
+        dispatcher.onNodeClicked("D", {} as any);
+        dispatcher.onNodeClicked("B", { shiftKey: true } as any);
 
         expect(treeEvents.onSelectionModified).not.to.have.been.called;
         expect(treeEvents.onSelectionReplaced).to.have.been.calledTwice;
@@ -649,9 +865,24 @@ describe("TreeEventDispatcher", () => {
 
     describe("when a non-selectable node is inside selection range", () => {
       it("does not get selected when it is already loaded", async () => {
-        const treeEventDispatcher = setupTreeEventDispatcher();
-        treeEventDispatcher.onNodeClicked("A", {} as any);
-        treeEventDispatcher.onNodeClicked("C", { shiftKey: true } as any);
+        const { dispatcher } = setupTreeEventDispatcher(
+          SelectionMode.Extended,
+          (model) => {
+            model.setChildren(
+              undefined,
+              [
+                createTreeNodeInput("A"),
+                createTreeNodeInput("B"),
+                createTreeNodeInput("C"),
+                createTreeNodeInput("D"),
+              ],
+              0
+            );
+            model.getNode("B")!.isSelectionDisabled = true;
+          }
+        );
+        dispatcher.onNodeClicked("A", {} as any);
+        dispatcher.onNodeClicked("C", { shiftKey: true } as any);
 
         expect(treeEvents.onSelectionModified).not.to.have.been.called;
         expect(treeEvents.onSelectionReplaced).to.have.been.calledTwice;
@@ -668,11 +899,6 @@ describe("TreeEventDispatcher", () => {
       });
 
       it("gets loaded but does not get selected", async () => {
-        const treeModel = new MutableTreeModel();
-        treeModel.setNumChildren(undefined, 3);
-        treeModel.insertChild(undefined, createTreeNodeInput("A"), 0);
-        treeModel.insertChild(undefined, createTreeNodeInput("C"), 2);
-
         const nodeLoader: ITreeNodeLoader = {
           loadNode: sinon.fake(() => {
             const nodeItem = createTreeNodeInput("B").item;
@@ -680,17 +906,18 @@ describe("TreeEventDispatcher", () => {
             return from([{ loadedNodes: [nodeItem] }]);
           }),
         };
-        const treeEventDispatcher = new TreeEventDispatcher(
-          treeEvents,
-          nodeLoader,
-          SelectionMode.Extended
-        );
-        treeEventDispatcher.setVisibleNodes(() =>
-          computeVisibleNodes(treeModel)
+        const { dispatcher } = setupTreeEventDispatcher(
+          SelectionMode.Extended,
+          (model) => {
+            model.setNumChildren(undefined, 3);
+            model.insertChild(undefined, createTreeNodeInput("A"), 0);
+            model.insertChild(undefined, createTreeNodeInput("C"), 2);
+          },
+          nodeLoader
         );
 
-        treeEventDispatcher.onNodeClicked("A", {} as any);
-        treeEventDispatcher.onNodeClicked("C", { shiftKey: true } as any);
+        dispatcher.onNodeClicked("A", {} as any);
+        dispatcher.onNodeClicked("C", { shiftKey: true } as any);
 
         expect(treeEvents.onSelectionModified).not.to.have.been.called;
         expect(treeEvents.onSelectionReplaced).to.have.been.calledTwice;
@@ -707,28 +934,5 @@ describe("TreeEventDispatcher", () => {
         ]);
       });
     });
-
-    function setupTreeEventDispatcher(): TreeEventDispatcher {
-      const treeModel = new MutableTreeModel();
-      treeModel.setChildren(
-        undefined,
-        [
-          createTreeNodeInput("A"),
-          createTreeNodeInput("B"),
-          createTreeNodeInput("C"),
-          createTreeNodeInput("D"),
-        ],
-        0
-      );
-      treeModel.getNode("B")!.isSelectionDisabled = true;
-
-      const eventDispatcher = new TreeEventDispatcher(
-        treeEvents,
-        { loadNode: sinon.fake() },
-        SelectionMode.Extended
-      );
-      eventDispatcher.setVisibleNodes(() => computeVisibleNodes(treeModel));
-      return eventDispatcher;
-    }
   });
 });

--- a/ui/components-react/src/test/tree/controlled/TreeEventDispatcher.test.ts
+++ b/ui/components-react/src/test/tree/controlled/TreeEventDispatcher.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { from as rxjsFrom } from "rxjs/internal/observable/from";
+import { from } from "rxjs";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { CheckBoxState } from "@itwin/core-react";
@@ -12,7 +12,6 @@ import type {
   RangeSelection,
   TreeSelectionManager,
 } from "../../../components-react/tree/controlled/internal/TreeSelectionManager";
-import { from } from "../../../components-react/tree/controlled/Observable";
 import { TreeEventDispatcher } from "../../../components-react/tree/controlled/TreeEventDispatcher";
 import type {
   TreeCheckboxStateChangeEventArgs,
@@ -40,6 +39,7 @@ import {
   createRandomMutableTreeModelNodes,
   createTreeNodeInput,
 } from "./TreeHelpers";
+import { toRxjsObservable } from "../../../components-react";
 
 describe("TreeEventDispatcher", () => {
   let dispatcher: TreeEventDispatcher;
@@ -171,7 +171,9 @@ describe("TreeEventDispatcher", () => {
         expect(spy).to.be.called;
 
         const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(rxjsFrom(spyArgs.modifications));
+        const results = await extractSequence(
+          toRxjsObservable(spyArgs.modifications)
+        );
         expect(results).to.not.be.empty;
         const selectionChange = results[0];
         expect(selectionChange.selectedNodeItems).to.be.deep.eq(
@@ -201,7 +203,9 @@ describe("TreeEventDispatcher", () => {
         expect(spy).to.be.called;
 
         const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(rxjsFrom(spyArgs.modifications));
+        const results = await extractSequence(
+          toRxjsObservable(spyArgs.modifications)
+        );
         expect(results).to.not.be.empty;
         const selectionChange = results[0];
         expect(selectionChange.selectedNodeItems).to.be.deep.eq(
@@ -245,7 +249,9 @@ describe("TreeEventDispatcher", () => {
         expect(spy).to.be.called;
 
         const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(rxjsFrom(spyArgs.modifications));
+        const results = await extractSequence(
+          toRxjsObservable(spyArgs.modifications)
+        );
         expect(results).to.not.be.empty;
         const selectionChange = results[0];
         expect(selectionChange.selectedNodeItems).to.be.deep.eq(
@@ -271,7 +277,9 @@ describe("TreeEventDispatcher", () => {
         expect(spy).to.be.called;
 
         const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(rxjsFrom(spyArgs.modifications));
+        const results = await extractSequence(
+          toRxjsObservable(spyArgs.modifications)
+        );
         expect(results).to.not.be.empty;
         expect(results[0].selectedNodeItems).to.be.empty;
         expect(results[0].deselectedNodeItems).to.be.empty;
@@ -294,7 +302,9 @@ describe("TreeEventDispatcher", () => {
         const selectedNodeItems = deselectedNodes.map((node) => node.item);
         const deselectedNodeItems = selectedNodes.map((node) => node.item);
         const spyArgs = spy.args[0][0] as TreeSelectionModificationEventArgs;
-        const results = await extractSequence(rxjsFrom(spyArgs.modifications));
+        const results = await extractSequence(
+          toRxjsObservable(spyArgs.modifications)
+        );
         expect(results).to.not.be.empty;
         const selectionChange = results[0];
         expect(selectionChange.selectedNodeItems).to.be.deep.eq(
@@ -317,7 +327,9 @@ describe("TreeEventDispatcher", () => {
         expect(spy).to.be.called;
 
         const spyArgs = spy.args[0][0] as TreeSelectionReplacementEventArgs;
-        const results = await extractSequence(rxjsFrom(spyArgs.replacements));
+        const results = await extractSequence(
+          toRxjsObservable(spyArgs.replacements)
+        );
         expect(results).to.not.be.empty;
         const selectionChange = results[0];
         expect(selectionChange.selectedNodeItems).to.be.deep.eq(
@@ -339,7 +351,9 @@ describe("TreeEventDispatcher", () => {
         expect(spy).to.be.called;
 
         const spyArgs = spy.args[0][0] as TreeSelectionReplacementEventArgs;
-        const results = await extractSequence(rxjsFrom(spyArgs.replacements));
+        const results = await extractSequence(
+          toRxjsObservable(spyArgs.replacements)
+        );
         expect(results).to.not.be.empty;
         const selectionChange = results[0];
         expect(selectionChange.selectedNodeItems).to.be.deep.eq([
@@ -360,7 +374,9 @@ describe("TreeEventDispatcher", () => {
 
       expect(spy).to.be.calledOnce;
       const changes = spy.args[0][0] as TreeCheckboxStateChangeEventArgs;
-      const results = await extractSequence(rxjsFrom(changes.stateChanges));
+      const results = await extractSequence(
+        toRxjsObservable(changes.stateChanges)
+      );
       expect(results).to.not.be.empty;
       const affectedNodeItems = results[0].map((change) => change.nodeItem);
       expect(affectedNodeItems).to.be.deep.eq(expectedAffectedNodeItems);
@@ -377,7 +393,9 @@ describe("TreeEventDispatcher", () => {
       dispatcher.onNodeCheckboxClicked(selectedNodes[0].id, CheckBoxState.On);
 
       const changes = spy.args[0][0] as TreeCheckboxStateChangeEventArgs;
-      const results = await extractSequence(rxjsFrom(changes.stateChanges));
+      const results = await extractSequence(
+        toRxjsObservable(changes.stateChanges)
+      );
       expect(results).to.not.be.empty;
       const affectedItems = results[0].map((change) => change.nodeItem);
       expect(affectedItems).to.be.deep.eq(expectedAffectedNodeItems);
@@ -408,7 +426,7 @@ describe("TreeEventDispatcher", () => {
       const checkboxChanges = spy
         .args[0][0] as TreeCheckboxStateChangeEventArgs;
       const results = await extractSequence(
-        rxjsFrom(checkboxChanges.stateChanges)
+        toRxjsObservable(checkboxChanges.stateChanges)
       );
       expect(results).to.not.be.empty;
       const affectedItems = results
@@ -600,7 +618,7 @@ describe("TreeEventDispatcher", () => {
         expect(treeEvents.onSelectionModified).not.to.have.been.called;
         expect(treeEvents.onSelectionReplaced).to.have.been.calledOnce;
         const changes = await extractSequence(
-          rxjsFrom(
+          toRxjsObservable(
             treeEvents.onSelectionReplaced.firstCall.args[0].replacements
           )
         );
@@ -617,7 +635,7 @@ describe("TreeEventDispatcher", () => {
         expect(treeEvents.onSelectionModified).not.to.have.been.called;
         expect(treeEvents.onSelectionReplaced).to.have.been.calledTwice;
         const changes = await extractSequence(
-          rxjsFrom(
+          toRxjsObservable(
             treeEvents.onSelectionReplaced.secondCall.args[0].replacements
           )
         );
@@ -638,7 +656,7 @@ describe("TreeEventDispatcher", () => {
         expect(treeEvents.onSelectionModified).not.to.have.been.called;
         expect(treeEvents.onSelectionReplaced).to.have.been.calledTwice;
         const changes = await extractSequence(
-          rxjsFrom(
+          toRxjsObservable(
             treeEvents.onSelectionReplaced.secondCall.args[0].replacements
           )
         );
@@ -659,7 +677,7 @@ describe("TreeEventDispatcher", () => {
           loadNode: sinon.fake(() => {
             const nodeItem = createTreeNodeInput("B").item;
             nodeItem.isSelectionDisabled = true;
-            return rxjsFrom([{ loadedNodes: [nodeItem] }]);
+            return from([{ loadedNodes: [nodeItem] }]);
           }),
         };
         const treeEventDispatcher = new TreeEventDispatcher(
@@ -678,7 +696,7 @@ describe("TreeEventDispatcher", () => {
         expect(treeEvents.onSelectionReplaced).to.have.been.calledTwice;
         expect(nodeLoader.loadNode).to.have.been.calledOnce;
         const changes = await extractSequence(
-          rxjsFrom(
+          toRxjsObservable(
             treeEvents.onSelectionReplaced.secondCall.args[0].replacements
           )
         );

--- a/ui/components-react/src/test/tree/controlled/TreeEventHandler.test.ts
+++ b/ui/components-react/src/test/tree/controlled/TreeEventHandler.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import type { Subject } from "rxjs/internal/Subject";
+import type { Subject } from "rxjs";
 import * as sinon from "sinon";
 import * as moq from "typemoq";
 import { CheckBoxState } from "@itwin/core-react";

--- a/ui/components-react/src/test/tree/controlled/TreeHelpers.ts
+++ b/ui/components-react/src/test/tree/controlled/TreeHelpers.ts
@@ -13,7 +13,10 @@ import type {
 import type { TreeNodeItem } from "../../../components-react/tree/TreeDataProvider";
 
 /** @internal */
-export function createTreeNodeInput(id: string): TreeModelNodeInput {
+export function createTreeNodeInput(
+  id: string,
+  node?: Partial<TreeModelNodeInput>
+): TreeModelNodeInput {
   const label = PropertyRecord.fromString(id, id);
   return {
     id,
@@ -22,6 +25,7 @@ export function createTreeNodeInput(id: string): TreeModelNodeInput {
     isExpanded: false,
     isLoading: false,
     isSelected: false,
+    ...node,
   };
 }
 

--- a/ui/components-react/src/test/tree/controlled/TreeNodeLoader.test.ts
+++ b/ui/components-react/src/test/tree/controlled/TreeNodeLoader.test.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
 import * as faker from "faker";
-import type { Observable as RxjsObservable } from "rxjs/internal/Observable";
-import { defer } from "rxjs/internal/observable/defer";
-import { from as rxjsFrom } from "rxjs/internal/observable/from";
+import type { Observable as RxjsObservable } from "rxjs";
+import { defer, from as rxjsFrom } from "rxjs";
 import sinon from "sinon";
 import * as moq from "typemoq";
 import { PropertyRecord } from "@itwin/appui-abstract";
-import type {
-  Observable,
-  Observer,
+import {
+  type Observable,
+  type Observer,
+  toRxjsObservable,
 } from "../../../components-react/tree/controlled/Observable";
 import type {
   MutableTreeModelNode,
@@ -114,7 +114,7 @@ const mockDataProvider = (
 };
 
 const extractLoadedNodeIds = async (obs: Observable<TreeNodeLoadResult>) => {
-  const loadResult = await extractSequence(rxjsFrom(obs));
+  const loadResult = await extractSequence(toRxjsObservable(obs));
   if (loadResult.length === 0) return [];
   return loadResult[0]!.loadedNodes.map((item) => item.id);
 };

--- a/ui/components-react/src/test/tree/controlled/component/TreeRenderer.test.tsx
+++ b/ui/components-react/src/test/tree/controlled/component/TreeRenderer.test.tsx
@@ -5,7 +5,7 @@
 import { expect } from "chai";
 import * as React from "react";
 import { VariableSizeList } from "react-window";
-import { Observable } from "rxjs/internal/Observable";
+import { Observable } from "rxjs";
 import sinon from "sinon";
 import * as moq from "typemoq";
 import type { PrimitiveValue } from "@itwin/appui-abstract";

--- a/ui/components-react/src/test/tree/controlled/internal/TreeModelMutator.test.ts
+++ b/ui/components-react/src/test/tree/controlled/internal/TreeModelMutator.test.ts
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { expect } from "chai";
-import { EMPTY } from "rxjs/internal/observable/empty";
+import { EMPTY } from "rxjs";
 import sinon from "sinon";
 import * as moq from "typemoq";
 import { CheckBoxState } from "@itwin/core-react";

--- a/ui/components-react/src/test/tree/controlled/internal/TreeSelectionManager.test.ts
+++ b/ui/components-react/src/test/tree/controlled/internal/TreeSelectionManager.test.ts
@@ -80,13 +80,6 @@ describe("TreeSelectionManager", () => {
     });
   }
 
-  describe("constructor", () => {
-    it("creates new TreeSelectionManager without visible nodes", () => {
-      const selectionManager = new TreeSelectionManager(SelectionMode.Multiple);
-      expect(selectionManager).to.not.be.undefined;
-    });
-  });
-
   describe("onNodeClicked", () => {
     let extendedSelectionManager: TreeSelectionManager;
 
@@ -212,22 +205,6 @@ describe("TreeSelectionManager", () => {
         selectedNodes: [nodes[0].id, nodes[1].id],
         deselectedNodes: [],
       });
-    });
-
-    it("does not select nodes if visible nodes are not set", () => {
-      const nodes = [createTreeModelNode(), createTreeModelNode()];
-      setupModelWithNodes(nodes);
-      multipleSelectionManager.setVisibleNodes(undefined);
-      const spy = sinon.spy(selectionHandler, "completeDragAction");
-      const changeSpy = sinon.spy(
-        multipleSelectionManager.onSelectionChanged,
-        "emit"
-      );
-      multipleSelectionManager.onNodeMouseDown(nodes[0].id);
-      multipleSelectionManager.onNodeMouseMove(nodes[1].id);
-      window.dispatchEvent(new Event("mouseup"));
-      expect(spy).to.be.called;
-      expect(changeSpy).to.not.be.called;
     });
 
     it("selects nodes when there are placeholder visible nodes", () => {


### PR DESCRIPTION
Closes https://github.com/iTwin/appui/issues/462

Browser hang was caused by infinite loop in TreeEventDispatcher:
```
generate({
  initialState: deselectedItems,
  iterate: () => [],
  scheduler: asapScheduler,
})
```

Changed it to not use `generate` and determine if `deselectedItems` array should be emitted based on `selectedNodeItems` observable value index.

Made some additional changes:
* Bumped `rxjs` version to the latest. Refactored usage of deprecated operators and changed imports to the suggested approach `import { operator } from "rxjs";`
* Refactored `TreeEventDispatcher` tests because they were hard to understand and using internal `TreeEventDispatcher` parts.
* Refactored `TreeEventDispatcher` access to `VisbileTreeNodes`. Now `VisibleTreeNodes` getter is always passed to `TreeEventDispatcher` contructor and is always defined. This allows to remove a lot of `undefined` checks in `TreeEventDispatcher` and `TreeSelectionManager`
* Reduced amount of `if` statements and nesting in `TreeSelectionManager` keyboard navigation handling code.