### PR TITLE
Filter builder: Ability to build filter ignoring errors

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -192,6 +192,11 @@ export class BooleanTypeConverter extends TypeConverter {
     sortCompare(a: Primitives.Boolean, b: Primitives.Boolean, _ignoreCase?: boolean): number;
 }
 
+// @beta
+export interface BuildFilterOptions {
+    ignoreErrors?: boolean;
+}
+
 // @internal (undocumented)
 export function buildPropertyFilter(groupItem: PropertyFilterBuilderRuleGroupItem): PropertyFilter | undefined;
 
@@ -3536,11 +3541,7 @@ export function usePropertyData(props: {
 };
 
 // @beta
-export function usePropertyFilterBuilder(props?: UsePropertyFilterBuilderProps): {
-    rootGroup: PropertyFilterBuilderRuleGroup;
-    actions: PropertyFilterBuilderActions;
-    buildFilter: () => PropertyFilter | undefined;
-};
+export function usePropertyFilterBuilder(props?: UsePropertyFilterBuilderProps): UsePropertyFilterBuilderResult;
 
 // @beta
 export interface UsePropertyFilterBuilderProps {
@@ -3551,7 +3552,7 @@ export interface UsePropertyFilterBuilderProps {
 // @beta
 export interface UsePropertyFilterBuilderResult {
     actions: PropertyFilterBuilderActions;
-    buildFilter: () => PropertyFilter | undefined;
+    buildFilter: (options?: BuildFilterOptions) => PropertyFilter | undefined;
     rootGroup: PropertyFilterBuilderRuleGroup;
 }
 

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -16,6 +16,7 @@ public;BasicPropertyEditor
 public;BooleanEditor 
 public;BooleanPropertyEditor 
 public;BooleanTypeConverter 
+beta;BuildFilterOptions
 internal;buildPropertyFilter(groupItem: PropertyFilterBuilderRuleGroupItem): PropertyFilter | undefined
 public;CategorizedPropertyItem 
 public;CategorizedPropertyTypes = FlatGridItemType.Array | FlatGridItemType.Primitive | FlatGridItemType.Struct
@@ -396,7 +397,7 @@ public;useControlledTreeLayoutStorage
 beta;useDebouncedAsyncValue
 public;usePagedTreeNodeLoader
 public;usePropertyData(props:
-beta;usePropertyFilterBuilder(props?: UsePropertyFilterBuilderProps):
+beta;usePropertyFilterBuilder(props?: UsePropertyFilterBuilderProps): UsePropertyFilterBuilderResult
 beta;UsePropertyFilterBuilderProps
 beta;UsePropertyFilterBuilderResult
 public;usePropertyGridEventHandler(props:

--- a/common/changes/@itwin/components-react/filter_builder_ability_to_ignore_errors_2023-08-29-11-48.json
+++ b/common/changes/@itwin/components-react/filter_builder_ability_to_ignore_errors_2023-08-29-11-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "`usePropertyFilterBuilder`: Added ability to build filter without showing errors.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/components-react](#itwincomponents-react)
+  - [Additions](#additions)
+
+## @itwin/components-react
+
+### Additions
+
+- `usePropertyFilterBuilder`: Added ability to build filter without showing errors.

--- a/ui/components-react/src/components-react/filter-builder/FilterBuilderContext.tsx
+++ b/ui/components-react/src/components-react/filter-builder/FilterBuilderContext.tsx
@@ -158,6 +158,13 @@ export function useActiveRuleGroupContextProps(
 function useSetTimeout() {
   const timeoutRef = React.useRef<number>();
 
+  React.useEffect(() => {
+    // clear pending timeout on unmount
+    return () => {
+      window.clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
   return (callback: () => void) => {
     window.clearTimeout(timeoutRef.current);
     timeoutRef.current = window.setTimeout(callback);

--- a/ui/components-react/src/test/filter-builder/FilterBuilderState.test.ts
+++ b/ui/components-react/src/test/filter-builder/FilterBuilderState.test.ts
@@ -661,6 +661,21 @@ describe("usePropertyFilterBuilder", () => {
         (rootGroup.items[0] as PropertyFilterBuilderRule).errorMessage
       ).to.be.eq(customErrorMessage);
     });
+
+    it("does not save errors if options specify to ignore them", () => {
+      const errorMessage = "My error";
+      const { result } = renderHook(() =>
+        usePropertyFilterBuilder({ ruleValidator: () => errorMessage })
+      );
+      const { buildFilter } = result.current;
+
+      buildFilter({ ignoreErrors: true });
+
+      const { rootGroup } = result.current;
+
+      expect((rootGroup.items[0] as PropertyFilterBuilderRule).errorMessage).to
+        .be.undefined;
+    });
   });
 
   describe("rule group", () => {


### PR DESCRIPTION
Add ability to get filter without persisting encountered errors in a state. This is useful if component want to do some actions with filter but does not want to show errors in UI.

Prerequisite for https://github.com/iTwin/presentation/issues/221