### PR TITLE
Remove `require` call in `TypeConverterManager`

### DIFF
--- a/common/changes/@itwin/components-react/raplemie-defaultTypeconverterRequire_2023-08-30-17-21.json
+++ b/common/changes/@itwin/components-react/raplemie-defaultTypeconverterRequire_2023-08-30-17-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Remove `require` call in `TypeConverterManager`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/components-react](#itwincomponents-react)
+  - [Fixes](#fixes)
+
+## @itwin/components-react
+
+### Fixes
+
+- Removed `require` call from `TypeConverterManager` (No `require` calls remaining in any of the packages.)

--- a/ui/components-react/src/components-react/converters/StringTypeConverter.ts
+++ b/ui/components-react/src/components-react/converters/StringTypeConverter.ts
@@ -7,9 +7,7 @@
  */
 
 import type { Primitives } from "@itwin/appui-abstract";
-import { StandardTypeNames } from "@itwin/appui-abstract";
 import { TypeConverter } from "./TypeConverter";
-import { TypeConverterManager } from "./TypeConverterManager";
 
 /** Operators for string types
  * @public
@@ -157,15 +155,6 @@ export class StringTypeConverter
   }
 }
 
-TypeConverterManager.registerConverter(
-  StandardTypeNames.Text,
-  StringTypeConverter
-);
-TypeConverterManager.registerConverter(
-  StandardTypeNames.String,
-  StringTypeConverter
-);
-TypeConverterManager.registerConverter(
-  StandardTypeNames.URL,
-  StringTypeConverter
-);
+/*
+NOTE: As this is the default type converter, it's registrations are directly in TypeConverterManager file.
+*/

--- a/ui/components-react/src/components-react/converters/TypeConverterManager.ts
+++ b/ui/components-react/src/components-react/converters/TypeConverterManager.ts
@@ -6,7 +6,9 @@
  * @module TypeConverters
  */
 
+import { StandardTypeNames } from "@itwin/appui-abstract";
 import type { TypeConverter } from "./TypeConverter";
+import { StringTypeConverter } from "./StringTypeConverter";
 
 /**
  * Manages Type Converters. Type Converters are registered with and obtained from the manager.
@@ -75,11 +77,23 @@ export class TypeConverterManager {
       return TypeConverterManager._converters[fullConverterName];
 
     if (!TypeConverterManager._defaultTypeConverter) {
-      const {
-        StringTypeConverter,
-      } = require("../converters/StringTypeConverter"); // eslint-disable-line @typescript-eslint/no-var-requires
       TypeConverterManager._defaultTypeConverter = new StringTypeConverter();
     }
     return TypeConverterManager._defaultTypeConverter;
   }
 }
+
+// Register these here as this is also the default type register, we always want it to be registered
+// and if moved to the StringTypeConverter it causes a dependency loop issue.
+TypeConverterManager.registerConverter(
+  StandardTypeNames.Text,
+  StringTypeConverter
+);
+TypeConverterManager.registerConverter(
+  StandardTypeNames.String,
+  StringTypeConverter
+);
+TypeConverterManager.registerConverter(
+  StandardTypeNames.URL,
+  StringTypeConverter
+);


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Removed `require` call in `TypeConverterManager` and moved `StringTypeConverter` registration within that file as this is the default converter, it is expected to always be registered. (Instead of doing the lazy initialization we had in 3.x that could cause an issue if StringTypeConverter was never registered.
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

Built applications and ran tests.
<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

fixes #465