### PR TITLE
Fix `useSpecificWidgetDef` to correctly return re-created `WidgetDef`

### DIFF
--- a/common/changes/@itwin/appui-react/issue-480_2023-09-08-08-04.json
+++ b/common/changes/@itwin/appui-react/issue-480_2023-09-08-08-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix an issue with `useSpecificWidgetDef` to correctly return re-created WidgetDef.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/appui-react](#itwinappui-react)
+  - [Fixes](#fixes)
+
+## @itwin/appui-react
+
+### Fixes
+
+- Fixed `useSpecificWidgetDef` to correctly return re-created `WidgetDef`.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,12 +1,1 @@
 # NextVersion <!-- omit from toc -->
-
-Table of contents:
-
-- [@itwin/appui-react](#itwinappui-react)
-  - [Fixes](#fixes)
-
-## @itwin/appui-react
-
-### Fixes
-
-- Fixed `useSpecificWidgetDef` to correctly return re-created `WidgetDef`.

--- a/full-stack-tests/ui/tests/widget-state.test.ts
+++ b/full-stack-tests/ui/tests/widget-state.test.ts
@@ -288,14 +288,11 @@ test.describe("widget state", () => {
     await expect(widget).toHaveCount(2);
   });
 
-  test("should float a widget that is hidden by default", async ({
-    context,
-    page,
-  }) => {
+  test("should float a widget that is hidden by default", async ({ page }) => {
     const tab = tabLocator(page, "FW-H1");
     await expect(tab).toBeHidden();
 
-    setWidgetState(page, "FW-H1", WidgetState.Floating);
+    await setWidgetState(page, "FW-H1", WidgetState.Floating);
     await expect(tab).toBeVisible();
   });
 });

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -669,6 +669,10 @@ export class FrontstageDef {
         allStageWidgetDefs
       );
     });
+
+    InternalFrontstageManager.onFrontstageWidgetsChangedEvent.emit({
+      frontstageDef: this,
+    });
   }
 
   /** @beta */
@@ -1208,5 +1212,17 @@ export function useActiveFrontstageDef() {
  */
 export function useSpecificWidgetDef(widgetId: string) {
   const frontstageDef = useActiveFrontstageDef();
-  return frontstageDef?.findWidgetDef(widgetId);
+  const [widgetDef, setWidgetDef] = React.useState(() =>
+    frontstageDef?.findWidgetDef(widgetId)
+  );
+  React.useEffect(() => {
+    setWidgetDef(frontstageDef?.findWidgetDef(widgetId));
+    return InternalFrontstageManager.onFrontstageWidgetsChangedEvent.addListener(
+      (args) => {
+        if (args.frontstageDef !== frontstageDef) return;
+        setWidgetDef(frontstageDef.findWidgetDef(widgetId));
+      }
+    );
+  }, [frontstageDef, widgetId]);
+  return widgetDef;
 }

--- a/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
+++ b/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
@@ -269,6 +269,10 @@ export class InternalFrontstageManager {
   public static readonly onFrontstageRestoreLayoutEvent =
     new UiEvent<FrontstageEventArgs>();
 
+  /** @internal */
+  public static readonly onFrontstageWidgetsChangedEvent =
+    new UiEvent<FrontstageEventArgs>();
+
   /** Get panel state changed event.
    * @alpha
    */

--- a/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "@itwin/appui-layout-react";
 import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
 import { ProcessDetector } from "@itwin/core-bentley";
-import { renderHook } from "@testing-library/react-hooks";
+import { act, renderHook } from "@testing-library/react-hooks";
 import type {
   FrontstageConfig,
   UiItemsProvider,
@@ -932,6 +932,16 @@ describe("float and dock widget", () => {
 });
 
 describe("useSpecificWidgetDef", () => {
+  before(async () => {
+    await NoRenderApp.startup();
+    await TestUtils.initializeUiFramework();
+  });
+
+  after(async () => {
+    await IModelApp.shutdown();
+    TestUtils.terminateUiFramework();
+  });
+
   it("should return widgetDef from active frontstage", () => {
     const frontstageDef = new FrontstageDef();
     const widgetDef = new WidgetDef();
@@ -952,5 +962,37 @@ describe("useSpecificWidgetDef", () => {
     const { result } = renderHook(() => useSpecificWidgetDef("t1"));
 
     expect(result.current).to.be.undefined;
+  });
+
+  it("should return re-created dynamic widgetDef", async () => {
+    const frontstageDef = new FrontstageDef();
+    await frontstageDef.initializeFromConfig(defaultFrontstageConfig);
+    UiItemsManager.register({
+      id: "provider1",
+      provideWidgets: () => [
+        {
+          id: "w1",
+        },
+      ],
+    });
+    await UiFramework.frontstages.setActiveFrontstageDef(frontstageDef);
+
+    const initialDef = frontstageDef.findWidgetDef("w1");
+    const { result } = renderHook(() => useSpecificWidgetDef("w1"));
+    expect(initialDef).to.exist;
+    expect(initialDef).to.eq(result.current);
+
+    await act(async () => {
+      // Re-creates dynamic widgets.
+      await UiFramework.frontstages.setActiveFrontstageDef(undefined);
+      await UiFramework.frontstages.setActiveFrontstageDef(frontstageDef);
+    });
+
+    const recreatedDef = frontstageDef.findWidgetDef("w1");
+    expect(recreatedDef).to.exist;
+    expect(recreatedDef).to.not.eq(initialDef);
+    expect(recreatedDef).to.eq(result.current);
+
+    UiItemsManager.unregister("provider1");
   });
 });


### PR DESCRIPTION
## Changes

This PR fixes #480 by correctly returning an updated `WidgetDef` instance in `useSpecificWidgetDef`.

## Testing

Additional unit test is added.
