### PR TITLE
Fix `zustand` deprecation warning

### DIFF
--- a/common/changes/@itwin/appui-layout-react/issue-456_2023-09-13-08-59.json
+++ b/common/changes/@itwin/appui-layout-react/issue-456_2023-09-13-08-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Fix `zustand` deprecation warning by replacing `useStore` with `useStoreWithEqualityFn`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -523,7 +523,7 @@ importers:
       ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ^5.0.2
-      zustand: ^4.3.6
+      zustand: ^4.4.1
     dependencies:
       '@itwin/itwinui-icons-react': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@itwin/itwinui-variables': 2.0.0
@@ -531,7 +531,7 @@ importers:
       immer: 9.0.6
       lodash: 4.17.21
       react-transition-group: 4.4.5_react-dom@17.0.2+react@17.0.2
-      zustand: 4.3.6_immer@9.0.6+react@17.0.2
+      zustand: 4.4.1_b4b4c799a5a2f4488606d88d938fa77d
     devDependencies:
       '@itwin/appui-abstract': 4.0.0-dev.104_be9786c2146472f5e05bafea59511dc9
       '@itwin/build-tools': 4.0.0-dev.87_@types+node@18.11.5
@@ -21062,18 +21062,22 @@ packages:
       commander: 9.5.0
     dev: true
 
-  /zustand/4.3.6_immer@9.0.6+react@17.0.2:
-    resolution: {integrity: sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==}
+  /zustand/4.4.1_b4b4c799a5a2f4488606d88d938fa77d:
+    resolution: {integrity: sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
+      '@types/react': '>=16.8'
       immer: '>=9.0'
       react: '>=16.8'
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
       immer:
         optional: true
       react:
         optional: true
     dependencies:
+      '@types/react': 17.0.53
       immer: 9.0.6
       react: 17.0.2
       use-sync-external-store: 1.2.0_react@17.0.2

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -523,7 +523,7 @@ importers:
       ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~5.0.2
-      zustand: ^4.3.6
+      zustand: ^4.4.1
     dependencies:
       '@itwin/itwinui-icons-react': 2.1.0_react-dom@17.0.2+react@17.0.2
       '@itwin/itwinui-variables': 2.0.0
@@ -531,7 +531,7 @@ importers:
       immer: 9.0.6
       lodash: 4.17.21
       react-transition-group: 4.4.5_react-dom@17.0.2+react@17.0.2
-      zustand: 4.3.6_immer@9.0.6+react@17.0.2
+      zustand: 4.4.1_b4b4c799a5a2f4488606d88d938fa77d
     devDependencies:
       '@itwin/appui-abstract': 3.7.0_@itwin+core-bentley@3.7.0
       '@itwin/build-tools': 3.7.4
@@ -21162,18 +21162,22 @@ packages:
       commander: 9.5.0
     dev: true
 
-  /zustand/4.3.6_immer@9.0.6+react@17.0.2:
-    resolution: {integrity: sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==}
+  /zustand/4.4.1_b4b4c799a5a2f4488606d88d938fa77d:
+    resolution: {integrity: sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
+      '@types/react': '>=16.8'
       immer: '>=9.0'
       react: '>=16.8'
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
       immer:
         optional: true
       react:
         optional: true
     dependencies:
+      '@types/react': 17.0.53
       immer: 9.0.6
       react: 17.0.2
       use-sync-external-store: 1.2.0_react@17.0.2

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,7 @@
 # NextVersion <!-- omit from toc -->
+
+## @itwin/appui-react
+
+### Fixes
+
+- Fix `zustand` deprecation warning by replacing `useStore` with `useStoreWithEqualityFn`.

--- a/ui/appui-layout-react/package.json
+++ b/ui/appui-layout-react/package.json
@@ -103,7 +103,7 @@
     "immer": "9.0.6",
     "lodash": "^4.17.10",
     "react-transition-group": "^4.4.2",
-    "zustand": "^4.3.6"
+    "zustand": "^4.4.1"
   },
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc",

--- a/ui/appui-layout-react/src/appui-layout-react/base/LayoutStore.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/base/LayoutStore.tsx
@@ -8,7 +8,8 @@
 
 import * as React from "react";
 import type { StoreApi } from "zustand";
-import { createStore, useStore } from "zustand";
+import { createStore } from "zustand";
+import { useStoreWithEqualityFn } from "zustand/traditional";
 import { shallow } from "zustand/shallow";
 import { assert } from "@itwin/core-bentley";
 import type { NineZoneState } from "../state/NineZoneState";
@@ -44,5 +45,9 @@ export function useLayout<SelectorOutput>(
   multipleSlices = false
 ) {
   const store = useLayoutStore();
-  return useStore(store, selector, multipleSlices ? shallow : undefined);
+  return useStoreWithEqualityFn(
+    store,
+    selector,
+    multipleSlices ? shallow : undefined
+  );
 }


### PR DESCRIPTION
## Changes

This PR fixes #456 by replacing `useStore` with `useStoreWithEqualityFn` to fix the deprecation warning.

## Testing

Tested by updating `zustand` (deprecation is in 4.4.0) and launching the test-app.