### PR TITLE
Add storybook for floating widget options

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -725,15 +725,10 @@ export type CalculatorPropsProps = Pick<CalculatorProps, "engine">;
 
 // @public
 export interface CanFloatWidgetOptions {
-    // (undocumented)
     readonly containerId?: string;
-    // (undocumented)
     readonly defaultPosition?: PointProps;
-    // (undocumented)
     readonly defaultSize?: SizeProps;
-    // (undocumented)
     readonly hideWithUi?: boolean;
-    // (undocumented)
     readonly isResizable?: boolean;
 }
 
@@ -2263,7 +2258,7 @@ export class FrontstageDef {
     get panelDefs(): StagePanelDef[];
     // @beta
     popoutWidget(widgetId: string, position?: PointProps, size?: SizeProps): void;
-    // @beta (undocumented)
+    // @beta
     restoreLayout(): void;
     // (undocumented)
     get rightPanel(): StagePanelDef | undefined;

--- a/common/changes/@itwin/appui-layout-react/floating-widget-options_2023-09-18-07-47.json
+++ b/common/changes/@itwin/appui-layout-react/floating-widget-options_2023-09-18-07-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/appui-react/floating-widget-options_2023-09-18-07-47.json
+++ b/common/changes/@itwin/appui-react/floating-widget-options_2023-09-18-07-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Disable user select when dragging a widget tab.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/appui-react/floating-widget-options_2023-09-18-07-47.json
+++ b/common/changes/@itwin/appui-react/floating-widget-options_2023-09-18-07-47.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Disable user select when dragging a widget tab.",
+      "comment": "Disable user select when dragging or resizing a widget.",
       "type": "none"
     }
   ],

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -11,4 +11,4 @@ Table of contents:
 
 - Fix `zustand` deprecation warning by replacing `useStore` with `useStoreWithEqualityFn`.
 - Can now pass a blank array into `allowedPanelTargets` that will prevent widget from being able to to dock to any target.
-- Disable `user-select` of a widget tab bar to avoid content selection when dragging a widget.
+- Disable `user-select` of a widget tab bar and resize handle to avoid content selection when dragging a widget.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -11,3 +11,4 @@ Table of contents:
 
 - Fix `zustand` deprecation warning by replacing `useStore` with `useStoreWithEqualityFn`.
 - Can now pass a blank array into `allowedPanelTargets` that will prevent widget from being able to to dock to any target.
+- Disable `user-select` of a widget tab bar to avoid content selection when dragging a widget.

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build:storybook": "npm run copy:webfont && cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" storybook build",
-    "dev": "npm run copy:webfont && storybook dev -p 6006",
+    "start": "npm run copy:webfont && storybook dev -p 6006",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "copy:webfont": "cpx ./node_modules/@bentley/icons-generic-webfont/dist/**/* ./lib/webfont",
     "build": "",

--- a/docs/storybook/src/AppUiDecorator.tsx
+++ b/docs/storybook/src/AppUiDecorator.tsx
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+// TODO: use https://vitejs.dev/config/server-options.html#server-fs-allow instead
+import "../lib/webfont/bentley-icons-generic-webfont.css";
+import type { Decorator } from "@storybook/react";
+import { StateManager, ThemeManager } from "@itwin/appui-react";
+import { Provider } from "react-redux";
+
+export const AppUiDecorator: Decorator = (Story) => {
+  new StateManager();
+  return (
+    <Provider store={StateManager.store}>
+      <ThemeManager>
+        <Story />
+      </ThemeManager>
+    </Provider>
+  );
+};

--- a/docs/storybook/src/AppUiDecorator.tsx
+++ b/docs/storybook/src/AppUiDecorator.tsx
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 // TODO: use https://vitejs.dev/config/server-options.html#server-fs-allow instead
 import "../lib/webfont/bentley-icons-generic-webfont.css";
+import { Provider } from "react-redux";
 import type { Decorator } from "@storybook/react";
 import { StateManager, ThemeManager } from "@itwin/appui-react";
-import { Provider } from "react-redux";
 
 export const AppUiDecorator: Decorator = (Story) => {
   new StateManager();

--- a/docs/storybook/src/components/ContextMenu.stories.tsx
+++ b/docs/storybook/src/components/ContextMenu.stories.tsx
@@ -3,15 +3,15 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import type { Meta, StoryObj } from "@storybook/react";
-import { StateManager, ThemeManager } from "@itwin/appui-react";
 import { ContextMenuItem, ContextSubMenu } from "@itwin/core-react";
 import { ContextMenu } from "@itwin/core-react/src/core-react/contextmenu/ContextMenu";
-import { Provider } from "react-redux";
+import { AppUiDecorator } from "../AppUiDecorator";
 
 const meta = {
   title: "Components/ContextMenu",
   component: ContextMenu,
   tags: ["autodocs"],
+  decorators: [AppUiDecorator],
 } satisfies Meta<typeof ContextMenu>;
 
 export default meta;
@@ -22,24 +22,18 @@ export const Basic: Story = {
     opened: true,
   },
   render: (props) => {
-    // TODO:
-    new StateManager();
     return (
-      <Provider store={StateManager.store}>
-        <ThemeManager>
-          <ContextMenu {...props}>
-            <ContextSubMenu label="Test 1" id="1">
-              <ContextMenuItem>Test 1.1</ContextMenuItem>
-            </ContextSubMenu>
-            <ContextSubMenu label="Test 2" id="2">
-              <ContextMenuItem>Test 2.1</ContextMenuItem>
-              <ContextSubMenu label="Test 2.2" id="22">
-                <ContextMenuItem>Test 2.2.1</ContextMenuItem>
-              </ContextSubMenu>
-            </ContextSubMenu>
-          </ContextMenu>
-        </ThemeManager>
-      </Provider>
+      <ContextMenu {...props}>
+        <ContextSubMenu label="Test 1" id="1">
+          <ContextMenuItem>Test 1.1</ContextMenuItem>
+        </ContextSubMenu>
+        <ContextSubMenu label="Test 2" id="2">
+          <ContextMenuItem>Test 2.1</ContextMenuItem>
+          <ContextSubMenu label="Test 2.2" id="22">
+            <ContextMenuItem>Test 2.2.1</ContextMenuItem>
+          </ContextSubMenu>
+        </ContextSubMenu>
+      </ContextMenu>
     );
   },
 };

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import type { Meta, StoryObj } from "@storybook/react";
+import { BadgeType } from "@itwin/appui-abstract";
 import {
   CommandItemDef,
   ToolbarHelper,
@@ -11,7 +12,7 @@ import {
   ToolbarUsage,
   UiFramework,
 } from "@itwin/appui-react";
-import { ToolbarComposer } from "@itwin/appui-react/src/appui-react/toolbar/ToolbarComposer";
+import { ConditionalIconItem, IconHelper } from "@itwin/core-react";
 import {
   Svg2D,
   Svg3D,
@@ -20,8 +21,7 @@ import {
   SvgClipboard,
   SvgExport,
 } from "@itwin/itwinui-icons-react";
-import { BadgeType } from "@itwin/appui-abstract";
-import { ConditionalIconItem, IconHelper } from "@itwin/core-react";
+import { ToolbarComposer } from "@itwin/appui-react/src/appui-react/toolbar/ToolbarComposer";
 
 UiFramework.initialize(undefined);
 

--- a/docs/storybook/src/components/TreeWidget.stories.tsx
+++ b/docs/storybook/src/components/TreeWidget.stories.tsx
@@ -2,9 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { PropertyRecord } from "@itwin/appui-abstract";
-import { StateManager, ThemeManager, UiFramework } from "@itwin/appui-react";
+import { UiFramework } from "@itwin/appui-react";
 import {
   ImmediatelyLoadedTreeNodeItem,
   SimpleTreeDataProviderHierarchy,
@@ -17,14 +18,14 @@ import {
   ControlledTree,
   SelectionMode,
 } from "@itwin/components-react";
-import React from "react";
-import { Provider } from "react-redux";
 import { IModelApp } from "@itwin/core-frontend";
+import { AppUiDecorator } from "../AppUiDecorator";
 
 const meta = {
   title: "Components/ControlledTree",
   component: TreeWidgetComponent,
   tags: ["autodocs"],
+  decorators: [AppUiDecorator],
 } satisfies Meta<typeof TreeWidgetComponent>;
 
 export default meta;
@@ -124,11 +125,5 @@ function TreeWidgetComponent(props: ControlledTreeProps) {
   };
 
   if (!initialized) return null;
-  return (
-    <Provider store={StateManager.store}>
-      <ThemeManager>
-        <ControlledTree {...defaultProps} />
-      </ThemeManager>
-    </Provider>
-  );
+  return <ControlledTree {...defaultProps} />;
 }

--- a/docs/storybook/src/hooks/useIsBackstageOpen.stories.tsx
+++ b/docs/storybook/src/hooks/useIsBackstageOpen.stories.tsx
@@ -2,8 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-// TODO: use https://vitejs.dev/config/server-options.html#server-fs-allow instead
-import "../../lib/webfont/bentley-icons-generic-webfont.css";
+import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import {
@@ -13,15 +12,12 @@ import {
   IModelViewportControl,
   StageUsage,
   StandardFrontstageProvider,
-  StateManager,
-  ThemeManager,
   UiFramework,
   useBackstageManager,
   useIsBackstageOpen,
 } from "@itwin/appui-react";
 import { IModelApp } from "@itwin/core-frontend";
-import React from "react";
-import { Provider } from "react-redux";
+import { AppUiDecorator } from "../AppUiDecorator";
 
 function Demo() {
   const [initialized, setInitialized] = React.useState(false);
@@ -74,14 +70,10 @@ function Initialized() {
       <pre>
         <code>isOpen: {String(isOpen)}</code>
       </pre>
-      <Provider store={StateManager.store}>
-        <ThemeManager>
-          <ConfigurableUiContent
-            style={{ height: 300 }}
-            appBackstage={<BackstageComposer />}
-          />
-        </ThemeManager>
-      </Provider>
+      <ConfigurableUiContent
+        style={{ height: 300 }}
+        appBackstage={<BackstageComposer />}
+      />
     </>
   );
 }
@@ -89,6 +81,7 @@ function Initialized() {
 const meta: Meta = {
   title: "Hooks/useIsBackstageOpen",
   component: Demo,
+  decorators: [AppUiDecorator],
 } satisfies Meta<typeof Demo>;
 
 export default meta;

--- a/docs/storybook/src/widget/CanFloatOptions.stories.tsx
+++ b/docs/storybook/src/widget/CanFloatOptions.stories.tsx
@@ -36,7 +36,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Defaults: Story = {};
+export const Default: Story = {};
 
 export const Resizable: Story = {
   args: {
@@ -44,7 +44,7 @@ export const Resizable: Story = {
   },
 };
 
-export const DefaultPosition: Story = {
+export const Position: Story = {
   args: {
     defaultPosition: {
       x: 10,
@@ -53,7 +53,7 @@ export const DefaultPosition: Story = {
   },
 };
 
-export const DefaultSize: Story = {
+export const Size: Story = {
   args: {
     defaultSize: {
       height: 100,
@@ -65,6 +65,15 @@ export const DefaultSize: Story = {
 export const HideWithUI: Story = {
   args: {
     hideWithUi: true,
+  },
+};
+
+export const AllOptions: Story = {
+  args: {
+    ...Resizable.args,
+    ...Position.args,
+    ...Size.args,
+    ...HideWithUI.args,
   },
 };
 

--- a/docs/storybook/src/widget/CanFloatOptions.stories.tsx
+++ b/docs/storybook/src/widget/CanFloatOptions.stories.tsx
@@ -2,6 +2,13 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import {
+  Title,
+  Subtitle,
+  Description,
+  Primary,
+  Controls,
+} from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AppUiDecorator } from "../AppUiDecorator";
 import { CanFloatOptions } from "./CanFloatOptions";
@@ -11,6 +18,19 @@ const meta = {
   component: CanFloatOptions,
   tags: ["autodocs"],
   decorators: [AppUiDecorator],
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+          <Controls />
+        </>
+      ),
+    },
+  },
 } satisfies Meta<typeof CanFloatOptions>;
 
 export default meta;

--- a/docs/storybook/src/widget/CanFloatOptions.stories.tsx
+++ b/docs/storybook/src/widget/CanFloatOptions.stories.tsx
@@ -68,17 +68,18 @@ export const HideWithUI: Story = {
   },
 };
 
-export const AllOptions: Story = {
+export const ContainerId: Story = {
+  args: {
+    containerId: "container-1",
+  },
+};
+
+export const MultipleOptions: Story = {
   args: {
     ...Resizable.args,
     ...Position.args,
     ...Size.args,
     ...HideWithUI.args,
+    ...ContainerId.args,
   },
 };
-
-// export const ContainerId: Story = {
-//   args: {
-//     containerId: "container-1",
-//   },
-// };

--- a/docs/storybook/src/widget/CanFloatOptions.stories.tsx
+++ b/docs/storybook/src/widget/CanFloatOptions.stories.tsx
@@ -11,26 +11,45 @@ const meta = {
   component: CanFloatOptions,
   tags: ["autodocs"],
   decorators: [AppUiDecorator],
-  args: {
-    isResizable: false,
-  },
 } satisfies Meta<typeof CanFloatOptions>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {
+export const Defaults: Story = {};
+
+export const Resizable: Story = {
   args: {
     isResizable: true,
+  },
+};
+
+export const DefaultPosition: Story = {
+  args: {
     defaultPosition: {
-      x: 250,
-      y: 50,
+      x: 10,
+      y: 200,
     },
+  },
+};
+
+export const DefaultSize: Story = {
+  args: {
     defaultSize: {
       height: 100,
       width: 100,
     },
-    containerId: "container-1",
+  },
+};
+
+export const HideWithUI: Story = {
+  args: {
     hideWithUi: true,
   },
 };
+
+// export const ContainerId: Story = {
+//   args: {
+//     containerId: "container-1",
+//   },
+// };

--- a/docs/storybook/src/widget/CanFloatOptions.stories.tsx
+++ b/docs/storybook/src/widget/CanFloatOptions.stories.tsx
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { Meta, StoryObj } from "@storybook/react";
+import { AppUiDecorator } from "../AppUiDecorator";
+import { CanFloatOptions } from "./CanFloatOptions";
+
+const meta = {
+  title: "Widget/canFloat Options",
+  component: CanFloatOptions,
+  tags: ["autodocs"],
+  decorators: [AppUiDecorator],
+  args: {
+    isResizable: false,
+  },
+} satisfies Meta<typeof CanFloatOptions>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    isResizable: true,
+    defaultPosition: {
+      x: 250,
+      y: 50,
+    },
+    defaultSize: {
+      height: 100,
+      width: 100,
+    },
+    containerId: "container-1",
+    hideWithUi: true,
+  },
+};

--- a/docs/storybook/src/widget/CanFloatOptions.tsx
+++ b/docs/storybook/src/widget/CanFloatOptions.tsx
@@ -85,5 +85,5 @@ export function CanFloatOptions(props: CanFloatWidgetOptions) {
     };
   }, [props]);
   if (!initialized) return null;
-  return <ConfigurableUiContent style={{ height: "400px" }} />;
+  return <ConfigurableUiContent style={{ height: "calc(100vh - 2rem)" }} />;
 }

--- a/docs/storybook/src/widget/CanFloatOptions.tsx
+++ b/docs/storybook/src/widget/CanFloatOptions.tsx
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from "react";
+import { StandardContentLayouts } from "@itwin/appui-abstract";
+import {
+  CanFloatWidgetOptions,
+  ConfigurableUiContent,
+  IModelViewportControl,
+  StageUsage,
+  StandardFrontstageProvider,
+  UiFramework,
+  UiItemsManager,
+  UiItemsProvider,
+  Widget,
+  WidgetState,
+} from "@itwin/appui-react";
+import { IModelApp } from "@itwin/core-frontend";
+
+function Content() {
+  return <>Widget content</>;
+}
+
+function createFloatingWidget(canFloat: CanFloatWidgetOptions): Widget {
+  return {
+    id: "w1",
+    content: <Content />,
+    defaultState: WidgetState.Floating,
+    canFloat,
+  };
+}
+
+/** [canFloat](https://www.itwinjs.org/reference/appui-react/widget/widget/canfloat) property can be used to configure a floating widget. */
+export function CanFloatOptions(props: CanFloatWidgetOptions) {
+  const [initialized, setInitialized] = React.useState(false);
+  React.useEffect(() => {
+    const providers: UiItemsProvider[] = [
+      {
+        id: "widgets",
+        provideWidgets: () => [createFloatingWidget(props)],
+      },
+    ];
+    void (async function () {
+      await IModelApp.startup();
+      await UiFramework.initialize(undefined);
+      UiFramework.frontstages.addFrontstageProvider(
+        new StandardFrontstageProvider({
+          id: "main-frontstage",
+          usage: StageUsage.Private,
+          version: Math.random(),
+          contentGroupProps: {
+            id: "ViewportContentGroup",
+            layout: StandardContentLayouts.singleView,
+            contents: [
+              {
+                id: "ViewportContent",
+                classId: IModelViewportControl,
+                applicationData: {},
+              },
+            ],
+          },
+          hideStatusBar: true,
+          hideToolSettings: true,
+          hideNavigationAid: true,
+        })
+      );
+      for (const provider of providers) {
+        UiItemsManager.register(provider);
+      }
+
+      await UiFramework.frontstages.setActiveFrontstage("main-frontstage");
+      setInitialized(true);
+    })();
+    return () => {
+      UiFramework.frontstages.clearFrontstageProviders();
+      for (const provider of providers) {
+        UiItemsManager.unregister(provider.id);
+      }
+    };
+  }, [props]);
+  if (!initialized) return null;
+  return <ConfigurableUiContent style={{ height: "400px" }} />;
+}

--- a/docs/storybook/src/widget/CanFloatOptions.tsx
+++ b/docs/storybook/src/widget/CanFloatOptions.tsx
@@ -13,6 +13,7 @@ import {
   UiFramework,
   UiItemsManager,
   UiItemsProvider,
+  Widget,
   WidgetState,
 } from "@itwin/appui-react";
 import { IModelApp } from "@itwin/core-frontend";
@@ -21,26 +22,25 @@ function createProvider(props: CanFloatWidgetOptions): UiItemsProvider {
   return {
     id: "widgets",
     provideWidgets: () => {
-      const floatingWidget = {
+      const widget1: Widget = {
         id: "w1",
+        label: "Widget 1",
         content: <>Widget 1 content </>,
         defaultState: WidgetState.Floating,
         canFloat: props,
       };
-      if (props.containerId) {
-        return [
-          floatingWidget,
-          {
-            id: "w2",
-            content: <>Widget 2 content</>,
-            defaultState: WidgetState.Floating,
-            canFloat: {
+      const widget2: Widget = {
+        id: "w2",
+        label: "Widget 2",
+        content: <>Widget 2 content </>,
+        defaultState: props.containerId ? WidgetState.Floating : undefined,
+        canFloat: props.containerId
+          ? {
               containerId: props.containerId,
-            },
-          },
-        ];
-      }
-      return [floatingWidget];
+            }
+          : undefined,
+      };
+      return [widget1, widget2];
     },
   };
 }

--- a/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.scss
@@ -55,6 +55,7 @@
   $cornerSize: 1em;
 
   position: absolute;
+  user-select: none;
 
   &.nz-left,
   &.nz-right {

--- a/ui/appui-layout-react/src/appui-layout-react/widget/TabBar.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/TabBar.scss
@@ -21,6 +21,7 @@
     height: 100%;
     position: absolute;
     cursor: auto;
+    user-select: none;
   }
 
   > .nz-widget-tabBarButtons {

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -682,7 +682,9 @@ export class FrontstageDef {
     });
   }
 
-  /** @beta */
+  /** Restores frontstage layout to initial configuration.
+   * @beta
+   */
   public restoreLayout() {
     for (const panelDef of this.panelDefs) {
       panelDef.size = panelDef.defaultSize;

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -348,8 +348,9 @@ export function appendWidgets(
       widgetDef.isFloatingStateSupported &&
       widgetDef.defaultState === WidgetState.Floating
     ) {
-      const floatingContainerId =
-        widgetDef.floatingContainerId ?? getUniqueId();
+      const floatingContainerId = widgetDef.floatingContainerId
+        ? widgetDef.floatingContainerId
+        : getUniqueId();
       const widgetContainerId = getWidgetId(location, section);
       const home: FloatingWidgetHomeState = {
         side,

--- a/ui/appui-react/src/appui-react/widgets/Widget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/Widget.tsx
@@ -19,10 +19,15 @@ import type { WidgetState } from "./WidgetState";
  * @public
  */
 export interface CanFloatWidgetOptions {
+  /** Describes if the widget is resizable. */
   readonly isResizable?: boolean;
+  /** Describes the preferred default position of a floating widget. */
   readonly defaultPosition?: PointProps;
+  /** Describes the preferred default size of a floating widget. */
   readonly defaultSize?: SizeProps;
+  /** Describes to which container the floating widget is assigned. This allows the grouping of multiple widgets within the same floating widget. */
   readonly containerId?: string;
+  /** Describes if the floating widget should hide together with other UI elements. */
   readonly hideWithUi?: boolean;
 }
 


### PR DESCRIPTION
## Changes

This PR adds a story to showcase different [CanFloatWidgetOptions ](https://www.itwinjs.org/reference/appui-react/widget/canfloatwidgetoptions).
This PR also disables user selection when dragging a widget tab to avoid unintentional selection.
Documentation of related APIs is updated.

## Testing

N/A
