### PR TITLE
Add empty state stories

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -20,6 +20,7 @@ importers:
       '@itwin/core-quantity': 4.0.0-dev.104
       '@itwin/core-react': workspace:*
       '@itwin/itwinui-icons-react': ^2.1.0
+      '@itwin/itwinui-react': ^2.11.11
       '@originjs/vite-plugin-commonjs': ~1.0.3
       '@storybook/addon-essentials': ^7.0.20
       '@storybook/addon-interactions': ^7.0.20
@@ -62,6 +63,7 @@ importers:
       '@itwin/core-quantity': 4.0.0-dev.104_be9786c2146472f5e05bafea59511dc9
       '@itwin/core-react': link:../../ui/core-react
       '@itwin/itwinui-icons-react': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-react': 2.11.11_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-redux: 7.2.9_react-dom@17.0.2+react@17.0.2

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -20,6 +20,7 @@ importers:
       '@itwin/core-quantity': ^3.7.0
       '@itwin/core-react': workspace:*
       '@itwin/itwinui-icons-react': ^2.1.0
+      '@itwin/itwinui-react': ^2.11.11
       '@originjs/vite-plugin-commonjs': ~1.0.3
       '@storybook/addon-essentials': ^7.0.20
       '@storybook/addon-interactions': ^7.0.20
@@ -62,6 +63,7 @@ importers:
       '@itwin/core-quantity': 3.7.0_@itwin+core-bentley@3.7.0
       '@itwin/core-react': link:../../ui/core-react
       '@itwin/itwinui-icons-react': 2.1.0_react-dom@17.0.2+react@17.0.2
+      '@itwin/itwinui-react': 2.11.11_react-dom@17.0.2+react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-redux: 7.2.9_react-dom@17.0.2+react@17.0.2

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -26,6 +26,7 @@
     "@itwin/core-react": "workspace:*",
     "@itwin/components-react": "workspace:*",
     "@itwin/itwinui-icons-react": "^2.1.0",
+    "@itwin/itwinui-react": "^2.11.11",
     "@itwin/appui-abstract": "^3.7.0",
     "@itwin/core-frontend": "^3.7.0",
     "react": "^17.0.0",

--- a/docs/storybook/src/widget/CanPopout.stories.tsx
+++ b/docs/storybook/src/widget/CanPopout.stories.tsx
@@ -22,8 +22,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Enabled: Story = {
   args: {
     canPopout: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    canPopout: false,
   },
 };

--- a/docs/storybook/src/widget/EmptyState.stories.tsx
+++ b/docs/storybook/src/widget/EmptyState.stories.tsx
@@ -1,0 +1,34 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { Meta, StoryObj } from "@storybook/react";
+import { EmptyStateStory } from "./EmptyState";
+import { AppUiDecorator } from "../AppUiDecorator";
+import { Page } from "../AppUiStory";
+
+const meta = {
+  title: "Widget/Empty State",
+  component: EmptyStateStory,
+  tags: ["autodocs"],
+  decorators: [AppUiDecorator],
+  parameters: {
+    docs: {
+      page: () => <Page />,
+    },
+  },
+  args: {
+    hideOnEmptyState: true,
+  },
+} satisfies Meta<typeof EmptyStateStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const HideWidget: Story = {};
+
+export const ShowEmptyState: Story = {
+  args: {
+    hideOnEmptyState: false,
+  },
+};

--- a/docs/storybook/src/widget/EmptyState.tsx
+++ b/docs/storybook/src/widget/EmptyState.tsx
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from "react";
+import {
+  StagePanelState,
+  UiItemsProvider,
+  WidgetState,
+  useSpecificWidgetDef,
+} from "@itwin/appui-react";
+import { Button } from "@itwin/itwinui-react";
+import { AppUiStory } from "../AppUiStory";
+
+interface EmptyStateStoryProps {
+  /** Toggle this on to hide the widget when there is no data to display. */
+  hideOnEmptyState: boolean;
+}
+
+/** Showcases different strategies to display widgets in an empty state.
+ * A combination of [useSpecificWidgetDef](https://www.itwinjs.org/reference/appui-react/frontstage/usespecificwidgetdef/) and
+ * [setWidgetState](https://www.itwinjs.org/reference/appui-react/widget/widgetdef/#setwidgetstate) APIs can be used to
+ * hide widgets in an empty state.
+ */
+export function EmptyStateStory(props: EmptyStateStoryProps) {
+  const provider = {
+    id: "widgets",
+    provideWidgets: () => [
+      {
+        id: "w1",
+        label: "Widget 1",
+        content: <Widget hideOnEmptyState={props.hideOnEmptyState} />,
+      },
+    ],
+  } satisfies UiItemsProvider;
+  return (
+    <AppUiStory
+      itemProviders={[provider]}
+      frontstage={{
+        leftPanelProps: {
+          defaultState: StagePanelState.Open,
+        },
+      }}
+    />
+  );
+}
+
+function Widget(props: Pick<EmptyStateStoryProps, "hideOnEmptyState">) {
+  const [data, resetData] = useWidgetData();
+  useHideWidget(props.hideOnEmptyState, data);
+  return (
+    <div style={{ padding: "0.5em" }}>
+      {!data ? (
+        <div>No data</div>
+      ) : (
+        <>
+          <div>{data}</div>
+          <Button onClick={resetData} styleType="cta" size="small">
+            Reset data
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+// Hides the widget w/o data.
+function useHideWidget(enabled: boolean, data: string | undefined) {
+  const widgetDef = useSpecificWidgetDef("w1");
+  React.useEffect(() => {
+    if (!enabled) return;
+    widgetDef?.setWidgetState(data ? WidgetState.Open : WidgetState.Hidden);
+  }, [data, enabled, widgetDef]);
+}
+
+// Simulates a data fetch with a capability to re-fetch.
+function useWidgetData(): [string | undefined, () => void] {
+  const [data, setData] = React.useState<string>();
+  React.useEffect(() => {
+    if (data) return;
+    setTimeout(() => {
+      setData("Widget data");
+    }, 2000);
+  }, [data]);
+  const reset = () => {
+    setData(undefined);
+  };
+  return [data, reset];
+}


### PR DESCRIPTION
## Changes

Add stories to showcase different strategies to display the empty state of a widget.

## Testing

N/A
