### PR TITLE
Correctly emit `onWidgetStateChangedEvent` for hidden widgets.

### DIFF
--- a/common/changes/@itwin/appui-react/emit-hidden-state_2023-10-12-10-25.json
+++ b/common/changes/@itwin/appui-react/emit-hidden-state_2023-10-12-10-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix an issue where `onWidgetStateChangedEvent` is not emitted for a hidden widget.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -237,6 +237,15 @@ export class FrontstageDef {
     );
     this.populateStateMaps(newState, newPanelStateMap, newWidgetStateMap);
 
+    for (const [widgetDef, widgetState] of originalWidgetStateMap) {
+      if (
+        newWidgetStateMap.has(widgetDef) ||
+        widgetState === WidgetState.Hidden
+      )
+        continue;
+      newWidgetStateMap.set(widgetDef, WidgetState.Hidden);
+    }
+
     // Now walk and trigger set state events
     newWidgetStateMap.forEach((newWidgetState, widgetDef) => {
       const originalState = originalWidgetStateMap.get(widgetDef);


### PR DESCRIPTION
## Changes

Fixes #522 by correctly emitting `onWidgetStateChangedEvent` for hidden widgets.

## Testing

Added an additional unit test.
