### PR TITLE
Use single code snippet for docs

### DIFF
--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/CustomFrontstage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/CustomFrontstage.tsx
@@ -37,10 +37,7 @@ class CustomContentControl extends ContentControl {
 }
 // __PUBLISH_EXTRACT_END__
 
-// __PUBLISH_EXTRACT_START__ Example_Custom_Frontstage_Provider_1
-// __PUBLISH_EXTRACT_END__
-
-// __PUBLISH_EXTRACT_START__ Example_Custom_Frontstage_Provider_2
+// __PUBLISH_EXTRACT_START__ Example_Custom_Frontstage_Provider
 export class CustomFrontstageProvider extends FrontstageProvider {
   public override get id(): string {
     return "example:CustomFrontstage";

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/ViewportFrontstage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/ViewportFrontstage.tsx
@@ -14,9 +14,7 @@ import {
 } from "@itwin/appui-react";
 import React from "react";
 
-// __PUBLISH_EXTRACT_START__ Example_Viewport_Frontstage_Group_Provider_1
-// __PUBLISH_EXTRACT_END__
-// __PUBLISH_EXTRACT_START__ Example_Viewport_Frontstage_Group_Provider_2
+// __PUBLISH_EXTRACT_START__ Example_Viewport_Frontstage_Group_Provider
 export class ViewportFrontstageGroupProvider extends ContentGroupProvider {
   public override async contentGroup(): Promise<ContentGroup> {
     return new ContentGroup({


### PR DESCRIPTION
## Changes

Remove code snippets previously used for the same code block to avoid deprecated APIs in the docs.

## Testing

N/A
