### PR TITLE
disable text selection when resizing a stage panel

### DIFF
--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/CursorOverlay.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/CursorOverlay.scss
@@ -11,6 +11,7 @@ body {
     &.nz-#{$cursor} {
       * {
         cursor: $cursor !important;
+        user-select: none;
       }
     }
   }


### PR DESCRIPTION
## Changes

Fixed the issue where text of panel selects sometimes while resizing the panel. 

## Testing

Ran a standalone test app.
