### PR TITLE
Fix custom hooks not working in React 18 strict mode

### DIFF
--- a/common/changes/@itwin/components-react/hooks_fix_2023-10-20-12-48.json
+++ b/common/changes/@itwin/components-react/hooks_fix_2023-10-20-12-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fixed `useAsyncValue` hook to work in React 18 strict mode.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/hooks_fix_2023-10-20-12-48.json
+++ b/common/changes/@itwin/core-react/hooks_fix_2023-10-20-12-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Fixed `useDisposable` hook to work in React 18 strict mode.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -776,8 +776,8 @@ importers:
       raf: ^3.4.0
       react: ^17.0.0
       react-dom: ^17.0.0
-      react-highlight-words: ^0.17.0
-      react-window: ^1.8.2
+      react-highlight-words: ^0.20.0
+      react-window: ^1.8.9
       rimraf: ^3.0.2
       rxjs: ^7.8.1
       shortid: ~2.2.15
@@ -796,8 +796,8 @@ importers:
       immer: 9.0.6
       linkify-it: 2.2.0
       lodash: 4.17.21
-      react-highlight-words: 0.17.0_react@17.0.2
-      react-window: 1.8.8_react-dom@17.0.2+react@17.0.2
+      react-highlight-words: 0.20.0_react@17.0.2
+      react-window: 1.8.9_react-dom@17.0.2+react@17.0.2
       rxjs: 7.8.1
       shortid: 2.2.16
     devDependencies:
@@ -18687,10 +18687,10 @@ packages:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
     dev: true
 
-  /react-highlight-words/0.17.0_react@17.0.2:
-    resolution: {integrity: sha512-uX1Qh5IGjnLuJT0Zok234QDwRC8h4hcVMnB99Cb7aquB1NlPPDiWKm0XpSZOTdSactvnClCk8LOmVlP+75dgHA==}
+  /react-highlight-words/0.20.0_react@17.0.2:
+    resolution: {integrity: sha512-asCxy+jCehDVhusNmCBoxDf2mm1AJ//D+EzDx1m5K7EqsMBIHdZ5G4LdwbSEXqZq1Ros0G0UySWmAtntSph7XA==}
     peerDependencies:
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
       highlight-words-core: 1.2.2
       memoize-one: 4.0.3
@@ -18861,8 +18861,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /react-window/1.8.8_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-D4IiBeRtGXziZ1n0XklnFGu7h9gU684zepqyKzgPNzrsrk7xOCxni+TCckjg2Nr/DiaEEGVVmnhYSlT2rB47dQ==}
+  /react-window/1.8.9_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==}
     engines: {node: '>8.0.0'}
     peerDependencies:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -776,8 +776,8 @@ importers:
       raf: ^3.4.0
       react: ^17.0.0
       react-dom: ^17.0.0
-      react-highlight-words: ^0.17.0
-      react-window: ^1.8.2
+      react-highlight-words: ^0.20.0
+      react-window: ^1.8.9
       rimraf: ^3.0.2
       rxjs: ^7.8.1
       shortid: ~2.2.15
@@ -796,8 +796,8 @@ importers:
       immer: 9.0.6
       linkify-it: 2.2.0
       lodash: 4.17.21
-      react-highlight-words: 0.17.0_react@17.0.2
-      react-window: 1.8.8_react-dom@17.0.2+react@17.0.2
+      react-highlight-words: 0.20.0_react@17.0.2
+      react-window: 1.8.9_react-dom@17.0.2+react@17.0.2
       rxjs: 7.8.1
       shortid: 2.2.16
     devDependencies:
@@ -18758,10 +18758,10 @@ packages:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
     dev: true
 
-  /react-highlight-words/0.17.0_react@17.0.2:
-    resolution: {integrity: sha512-uX1Qh5IGjnLuJT0Zok234QDwRC8h4hcVMnB99Cb7aquB1NlPPDiWKm0XpSZOTdSactvnClCk8LOmVlP+75dgHA==}
+  /react-highlight-words/0.20.0_react@17.0.2:
+    resolution: {integrity: sha512-asCxy+jCehDVhusNmCBoxDf2mm1AJ//D+EzDx1m5K7EqsMBIHdZ5G4LdwbSEXqZq1Ros0G0UySWmAtntSph7XA==}
     peerDependencies:
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0
+      react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
       highlight-words-core: 1.2.2
       memoize-one: 4.0.3
@@ -18932,8 +18932,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /react-window/1.8.8_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-D4IiBeRtGXziZ1n0XklnFGu7h9gU684zepqyKzgPNzrsrk7xOCxni+TCckjg2Nr/DiaEEGVVmnhYSlT2rB47dQ==}
+  /react-window/1.8.9_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==}
     engines: {node: '>8.0.0'}
     peerDependencies:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,6 +5,10 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Changes](#changes)
   - [Fixes](#fixes)
+- [@itwin/components-react](#itwincomponents-react)
+  - [Fixes](#fixes-1)
+- [@itwin/core-react](#itwincore-react)
+  - [Fixes](#fixes-2)
 
 ## @itwin/appui-react
 
@@ -17,3 +21,15 @@ Table of contents:
 - Unmount `ChildWindowManager` whenever child window is closed.
 - Whenever widget is popped out and `window.open` fails, widget no longer disappears.
 - Fix error when `HTMLElement` used in `NotifyMessageDetails` messages.
+
+## @itwin/components-react
+
+### Fixes
+
+- Fixed `useAsyncValue` hook to work in React 18 strict mode.
+
+## @itwin/core-react
+
+### Fixes
+
+- Fixed `useDisposable` hook to work in React 18 strict mode.

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -119,8 +119,8 @@
     "immer": "9.0.6",
     "linkify-it": "~2.2.0",
     "lodash": "^4.17.10",
-    "react-highlight-words": "^0.17.0",
-    "react-window": "^1.8.2",
+    "react-highlight-words": "^0.20.0",
+    "react-window": "^1.8.9",
     "rxjs": "^7.8.1",
     "shortid": "~2.2.15"
   },

--- a/ui/components-react/src/components-react/common/UseAsyncValue.tsx
+++ b/ui/components-react/src/components-react/common/UseAsyncValue.tsx
@@ -7,44 +7,32 @@
  */
 
 import * as React from "react";
-import { from, Subject, takeUntil } from "rxjs";
-import { isPromiseLike, useEffectSkipFirst } from "@itwin/core-react";
+import { from } from "rxjs";
+import { isPromiseLike } from "@itwin/core-react";
 
 /**
  * Custom hook for working with possibly async values.
  * @public
  */
 export function useAsyncValue<T>(value: T | PromiseLike<T>): T | undefined {
-  const cancelled = React.useMemo(() => new Subject<void>(), []);
-  // cancel any pending promises on unmount
-  React.useEffect(() => () => cancelled.next(), [cancelled]);
-
   const [result, setResult] = React.useState(() => {
     if (isPromiseLike(value)) {
-      from(value)
-        .pipe(takeUntil(cancelled))
-        .subscribe({ next: (resolvedValue) => setResult(resolvedValue) });
       return undefined;
     }
     return value;
   });
 
-  useEffectSkipFirst(() => {
-    const updateValue = (newValue: T) => {
-      cancelled.next();
-      setResult(newValue);
-    };
-
+  React.useEffect(() => {
     if (isPromiseLike(value)) {
-      const subscription = from(value)
-        .pipe(takeUntil(cancelled))
-        .subscribe({ next: (resolvedValue) => updateValue(resolvedValue) });
+      const subscription = from(value).subscribe({
+        next: (resolvedValue) => setResult(resolvedValue),
+      });
       return () => subscription.unsubscribe();
     }
 
-    updateValue(value);
-    return undefined;
-  }, [value, cancelled]);
+    setResult(value);
+    return;
+  }, [value]);
 
   return result;
 }

--- a/ui/components-react/src/components-react/common/UseDebouncedAsyncValue.ts
+++ b/ui/components-react/src/components-react/common/UseDebouncedAsyncValue.ts
@@ -6,7 +6,7 @@
  * @module Common
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { defer, share } from "rxjs";
 import {
   scheduleSubscription,
@@ -25,26 +25,26 @@ import {
 export function useDebouncedAsyncValue<TReturn>(
   valueToBeResolved: undefined | (() => Promise<TReturn>)
 ) {
-  const scheduler = useMemo(() => new SubscriptionScheduler<TReturn>(), []);
+  const [scheduler] = useState(() => new SubscriptionScheduler<TReturn>());
 
-  const [value, setValue] = useState<TReturn>();
-  const [inProgress, setInProgress] = useState(false);
-  const [errorState, setErrorState] = useState<{
-    error: Error | undefined;
-    hasError: boolean;
+  const [{ result, inProgress }, setState] = useState<{
+    result: TReturn | ErrorResult | undefined;
+    inProgress: boolean;
   }>({
-    error: undefined,
-    hasError: false,
+    result: undefined,
+    inProgress: false,
   });
 
   useEffect(() => {
     if (!valueToBeResolved) {
-      setValue(undefined);
-      setInProgress(false);
+      setState((prev) => ({ ...prev, result: undefined, inProgress: false }));
       return;
     }
 
-    setInProgress(true);
+    setState((prev) => ({
+      ...prev,
+      inProgress: true,
+    }));
     // schedule and subscribe to the observable emitting value from valueToBeResolved promise
     const subscription = defer(valueToBeResolved)
       .pipe(
@@ -57,12 +57,14 @@ export function useDebouncedAsyncValue<TReturn>(
       )
       .subscribe({
         next: (data) => {
-          setValue(data);
-          setInProgress(false);
+          setState((prev) => ({ ...prev, result: data, inProgress: false }));
         },
         error: (err) => {
-          setErrorState({ error: err, hasError: true });
-          setInProgress(false);
+          setState((prev) => ({
+            ...prev,
+            result: { error: err, hasError: true },
+            inProgress: false,
+          }));
         },
       });
 
@@ -71,10 +73,20 @@ export function useDebouncedAsyncValue<TReturn>(
     };
   }, [valueToBeResolved, scheduler]);
 
-  if (errorState.hasError)
-    throw (
-      errorState.error ?? new Error("Exception in `useDebouncedAsyncValue`")
-    );
+  if (isErrorResult(result)) {
+    throw result.error ?? new Error("Exception in `useDebouncedAsyncValue`");
+  }
 
-  return { value, inProgress };
+  return { value: result, inProgress };
+}
+
+interface ErrorResult {
+  error: Error | undefined;
+  hasError: boolean;
+}
+
+function isErrorResult<TResult>(
+  obj?: TResult | ErrorResult
+): obj is ErrorResult {
+  return obj !== undefined && (obj as ErrorResult).hasError;
 }

--- a/ui/components-react/src/test/common/UseDebouncedAsyncValue.test.tsx
+++ b/ui/components-react/src/test/common/UseDebouncedAsyncValue.test.tsx
@@ -58,8 +58,9 @@ describe("useDebouncedAsyncValue", () => {
   describe("rethrows exceptions capturable by react error boundary", () => {
     it("rethrows `Error` exceptions", async () => {
       const promise = Promise.reject(new Error("test error"));
+      const asyncValue = async () => promise;
       function TestComponent() {
-        useDebouncedAsyncValue(async () => promise);
+        useDebouncedAsyncValue(asyncValue);
         return null;
       }
       const errorSpy = sinon.spy();
@@ -77,8 +78,9 @@ describe("useDebouncedAsyncValue", () => {
 
     it("throws generic `Error` when promise rejects with `undefined`", async () => {
       const promise = Promise.reject(undefined);
+      const asyncValue = async () => promise;
       function TestComponent() {
-        useDebouncedAsyncValue(async () => promise);
+        useDebouncedAsyncValue(asyncValue);
         return null;
       }
       const errorSpy = sinon.spy();

--- a/ui/core-react/src/core-react/utils/hooks/useDisposable.ts
+++ b/ui/core-react/src/core-react/utils/hooks/useDisposable.ts
@@ -6,7 +6,7 @@
  * @module Utilities
  */
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { IDisposable } from "@itwin/core-bentley";
 
 /**
@@ -29,14 +29,22 @@ export function useDisposable<TDisposable extends IDisposable>(
 export function useOptionalDisposable<TDisposable extends IDisposable>(
   createDisposable: () => TDisposable | undefined
 ): TDisposable | undefined {
-  const previous = useRef<TDisposable>();
-  const value = useMemo(() => {
-    if (previous.current) previous.current.dispose();
+  const [value, setValue] = useState(() => createDisposable());
+  const initialValue = useRef(true);
 
-    previous.current = createDisposable();
-    return previous.current;
+  useEffect(() => {
+    if (!initialValue.current) {
+      setValue(createDisposable());
+    }
+
+    initialValue.current = false;
+    return () => {
+      setValue((prev) => {
+        prev?.dispose();
+        return prev;
+      });
+    };
   }, [createDisposable]);
 
-  useEffect(() => () => previous.current && previous.current.dispose(), []);
   return value;
 }

--- a/ui/core-react/src/core-react/utils/hooks/useDisposable.ts
+++ b/ui/core-react/src/core-react/utils/hooks/useDisposable.ts
@@ -40,7 +40,7 @@ export function useOptionalDisposable<TDisposable extends IDisposable>(
     initialValue.current = false;
     return () => {
       setValue((prev) => {
-        prev?.dispose();
+        prev && prev.dispose();
         return prev;
       });
     };


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Fixed `useAsyncValue` hook not working in React 18 strict mode because `useEffect` was not symmetrical.
Fixed `useDisposable` hook not working in React 18 strict mode because `useEffect` was not symmetrical.
Cleaned up `useDebouncedAsyncValue` hook.
Bumped `react-window` and `react-highlight-words` versions to the ones that has React 18 as peerDependency.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Manual testing in viewer app running with React 18 in strict mode.
