### PR TITLE
Do not emit Hidden widget state changed event when dragging a widget

### DIFF
--- a/common/changes/@itwin/appui-react/fix-onWidgetStateChanged_2023-10-24-09-22.json
+++ b/common/changes/@itwin/appui-react/fix-onWidgetStateChanged_2023-10-24-09-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix an issue where a hidden widget state change event is emitted when a widget tab is dragged.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -191,6 +191,11 @@ export class FrontstageDef {
         }
       }
 
+      if (nineZone.draggedTab?.tabId === widgetId) {
+        widgetMap.set(widgetDef, WidgetState.Closed);
+        continue;
+      }
+
       const tabLocation = getTabLocation(nineZone, widgetId);
       if (!tabLocation) {
         widgetMap.set(widgetDef, WidgetState.Hidden);


### PR DESCRIPTION
## Changes

This PR fixes an issue where a Hidden widget state changed event is emitted when dragging a widget tab.

## Testing

Tested via the test app.
