### PR TITLE
Fix unneeded `changeView` call being done on mount

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-ViewportExcessiveChangeViews_2023-10-27-20-34.json
+++ b/common/changes/@itwin/appui-react/raplemie-ViewportExcessiveChangeViews_2023-10-27-20-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Remove unneeded `changeView` call on `FloatingViewportComponent`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/imodel-components-react/raplemie-ViewportExcessiveChangeViews_2023-10-27-20-34.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-ViewportExcessiveChangeViews_2023-10-27-20-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Remove additional `changeView` call on `ViewportComponent` mount.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -6,10 +6,12 @@ Table of contents:
   - [Additions](#additions)
   - [Changes](#changes)
   - [Fixes](#fixes)
-- [@itwin/components-react](#itwincomponents-react)
+- [@itwin/imodel-components-react](#itwinimodel-components-react)
   - [Fixes](#fixes-1)
-- [@itwin/core-react](#itwincore-react)
+- [@itwin/components-react](#itwincomponents-react)
   - [Fixes](#fixes-2)
+- [@itwin/core-react](#itwincore-react)
+  - [Fixes](#fixes-3)
 
 ## @itwin/appui-react
 
@@ -67,6 +69,13 @@ Table of contents:
 - Unmount `ChildWindowManager` whenever child window is closed.
 - Whenever widget is popped out and `window.open` fails, widget no longer disappears.
 - Fix error when `HTMLElement` used in `NotifyMessageDetails` messages.
+- Remove unneeded `changeView` call in `FloatingViewportComponent`.
+
+## @itwin/imodel-components-react
+
+### Fixes
+
+- Remove unneeded `changeView` call when mounting `ViewportComponent`.
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/content/FloatingViewportContent.tsx
+++ b/ui/appui-react/src/appui-react/content/FloatingViewportContent.tsx
@@ -120,9 +120,8 @@ export function useFloatingViewport(args: FloatingViewportContentProps) {
       if (null === contentControl.current.reactNode) {
         contentControl.current.reactNode = viewportControl;
       }
-      void contentControl.current.viewport.changeView(viewState);
     }
-  }, [viewState, viewport, viewportControl]);
+  }, [viewport, viewportControl]);
 
   React.useEffect(() => {
     const onViewClose = (vp: ScreenViewport) => {

--- a/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
@@ -294,14 +294,7 @@ export function ViewportComponent(props: ViewportProps) {
 
   const [initialViewState, setInitialViewState] = React.useState<
     ViewState | undefined
-  >(() => {
-    if (viewState) {
-      if (typeof viewState === "function") return viewState().clone();
-      else return viewState.clone();
-    }
-    return undefined;
-  });
-
+  >(undefined);
   React.useEffect(() => {
     setInitialViewState(undefined);
   }, [viewDefinitionId, viewState]);


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
- `ViewportComponent`: Remove the default evaluation of the `viewState` in the `useState` initialiser because it gets automatically reset to `undefined` afterwards, but was causing a creation of the viewport (fulfilling the `viewportRef` then reassigned the `viewState` value that had just been recalculated. Since we want to reset the view when a new viewState is provided, we can't remove the "set...(undefined)", so simply starting with undefined resolves this issue.

- `FloatingViewportContent`: The `changeView` call is not necessary because a new `viewstate` cause the viewportControl to be rememoized, which handles the viewstate change itself. However having it was causing any changes to the viewport (for example in the ref call) to be ignored/reset.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Tested manually in many scenario, mainly using "Content Layout" and "Content popout" fronstages. All unit and visual tests passes.

## Issue
fixes #371 
