### PR TITLE
New `enableMaximizedFloatingWidget` preview feature

### DIFF
--- a/common/api/appui-layout-react.api.md
+++ b/common/api/appui-layout-react.api.md
@@ -1568,7 +1568,10 @@ export interface UsePanelTargetArgs {
 export const usePointerCaptor: <T extends HTMLElement>(onPointerDown?: ((args: PointerCaptorArgs, e: PointerCaptorEvent) => void) | undefined, onPointerMove?: ((args: PointerCaptorArgs, e: PointerCaptorEvent) => void) | undefined, onPointerUp?: ((e: PointerCaptorEvent) => void) | undefined) => (instance: T | null) => void;
 
 // @internal
-export const usePreviewFeatures: () => PreviewFeaturesState;
+export const usePreviewFeatures: () => KnownPreviewFeatures & {
+    previewState: PreviewFeatureState;
+    previewDispatch: React_2.Dispatch<PreviewActions>;
+};
 
 // @internal (undocumented)
 export const useResizeGrip: <T extends HTMLElement>() => [(instance: T | null) => void, boolean, boolean];
@@ -1589,10 +1592,12 @@ export function useSendBackHomeState(): {
 } | undefined;
 
 // @internal (undocumented)
-export function useTabInteractions<T extends HTMLElement>({ onClick, onDoubleClick, onDragStart, }: UseTabInteractionsArgs): (instance: T | null | undefined) => void;
+export function useTabInteractions<T extends HTMLElement>({ onClick, onDoubleClick, onDragStart, clickOnly, }: UseTabInteractionsArgs): (instance: T | null | undefined) => void;
 
 // @internal (undocumented)
 export interface UseTabInteractionsArgs {
+    // (undocumented)
+    clickOnly?: boolean;
     // (undocumented)
     onClick?: () => void;
     // (undocumented)

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3511,7 +3511,7 @@ export interface PresentationSelectionScope {
     label: string;
 }
 
-// @beta
+// @public
 export interface PreviewFeatures extends Partial<KnownPreviewFeatures> {
     // (undocumented)
     [featureName: string]: any;

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -921,7 +921,7 @@ export enum ConfigurableUiActionId {
 // @public
 export const ConfigurableUiActions: {
     setSnapMode: (snapMode: number) => ActionWithPayload<ConfigurableUiActionId.SetSnapMode, number>;
-    setTheme: (theme: ThemeId) => ActionWithPayload<ConfigurableUiActionId.SetTheme, "inherit" | "dark" | "light" | "SYSTEM_PREFERRED" | "high-contrast-light" | "high-contrast-dark" | DeepReadonlyObject<string & {}>>;
+    setTheme: (theme: string) => ActionWithPayload<ConfigurableUiActionId.SetTheme, string>;
     setToolPrompt: (toolPrompt: string) => ActionWithPayload<ConfigurableUiActionId.SetToolPrompt, string>;
     setWidgetOpacity: (opacity: number) => ActionWithPayload<ConfigurableUiActionId.SetWidgetOpacity, number>;
     setDragInteraction: (dragInteraction: boolean) => ActionWithPayload<ConfigurableUiActionId.SetDragInteraction, boolean>;
@@ -931,7 +931,11 @@ export const ConfigurableUiActions: {
     setAnimateToolSettings: (animateToolSettings: boolean) => ActionWithPayload<ConfigurableUiActionId.AnimateToolSettings, boolean>;
     setUseToolAsToolSettingsLabel: (useToolAsToolSettingsLabel: boolean) => ActionWithPayload<ConfigurableUiActionId.UseToolAsToolSettingsLabel, boolean>;
     setToolbarOpacity: (opacity: number) => ActionWithPayload<ConfigurableUiActionId.SetToolbarOpacity, number>;
-    setPreviewFeatures: (features: PreviewFeatures) => ActionWithPayload<ConfigurableUiActionId.SetPreviewFeatures, DeepReadonlyObject<PreviewFeatures>>;
+    setPreviewFeatures: (features: {
+        [featureName: string]: any;
+    }) => ActionWithPayload<ConfigurableUiActionId.SetPreviewFeatures, DeepReadonlyObject<    {
+    [featureName: string]: any;
+    }>>;
 };
 
 // @public
@@ -1000,14 +1004,14 @@ export interface ConfigurableUiState {
     animateToolSettings: boolean;
     // (undocumented)
     autoCollapseUnpinnedPanels: boolean;
-    // (undocumented)
+    // @beta (undocumented)
     previewFeatures?: PreviewFeatures;
     // (undocumented)
     showWidgetIcon: boolean;
     // (undocumented)
     snapMode: number;
     // (undocumented)
-    theme: ThemeId;
+    theme: string;
     // (undocumented)
     toolbarOpacity: number;
     // (undocumented)
@@ -2048,7 +2052,9 @@ export interface FrameworkKeyboardShortcuts {
 export const FrameworkReducer: (state: CombinedReducerState<    {
 configurableUiState: typeof ConfigurableUiReducer;
 sessionState: typeof SessionStateReducer;
-}>, action: DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetSnapMode, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetTheme, "inherit" | "dark" | "light" | "SYSTEM_PREFERRED" | "high-contrast-light" | "high-contrast-dark" | DeepReadonlyObject<string & {}>>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetToolPrompt, string>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetWidgetOpacity, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetDragInteraction, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetShowWidgetIcon, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.AutoCollapseUnpinnedPanels, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetViewOverlayDisplay, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.AnimateToolSettings, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.UseToolAsToolSettingsLabel, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetToolbarOpacity, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetPreviewFeatures, DeepReadonlyObject<PreviewFeatures>>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetActiveIModelId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetAvailableSelectionScopes, DeepReadonlyArray<PresentationSelectionScope>>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultIModelViewportControlId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultViewId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultViewState, any>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetNumItemsSelected, number>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetIModelConnection, any>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetSelectionScope, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.UpdateCursorMenu, DeepReadonlyObject<CursorMenuData>>>) => CombinedReducerState<    {
+}>, action: DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetSnapMode, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetTheme, string>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetToolPrompt, string>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetWidgetOpacity, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetDragInteraction, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetShowWidgetIcon, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.AutoCollapseUnpinnedPanels, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetViewOverlayDisplay, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.AnimateToolSettings, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.UseToolAsToolSettingsLabel, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetToolbarOpacity, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetPreviewFeatures, DeepReadonlyObject<    {
+[featureName: string]: any;
+}>>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetActiveIModelId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetAvailableSelectionScopes, DeepReadonlyArray<PresentationSelectionScope>>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultIModelViewportControlId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultViewId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultViewState, any>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetNumItemsSelected, number>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetIModelConnection, any>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetSelectionScope, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.UpdateCursorMenu, DeepReadonlyObject<CursorMenuData>>>) => CombinedReducerState<    {
 configurableUiState: typeof ConfigurableUiReducer;
 sessionState: typeof SessionStateReducer;
 }>;
@@ -3505,7 +3511,7 @@ export interface PresentationSelectionScope {
     label: string;
 }
 
-// @public
+// @beta
 export interface PreviewFeatures extends Partial<KnownPreviewFeatures> {
     // (undocumented)
     [featureName: string]: any;

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4779,9 +4779,6 @@ export interface TrackingTime {
     startTime: Date;
 }
 
-// @internal
-export function trimToKnownFeaturesOnly(previewFeatures: PreviewFeatures): PreviewFeatures;
-
 // @public
 export function UiDataProvidedDialog({ uiDataProvider, id, isModal, ...dialogProps }: UiDataProvidedDialogProps): JSX.Element;
 
@@ -5081,9 +5078,6 @@ export function useLayoutStore(frontstageDef: FrontstageDef | undefined): Layout
 
 // @internal (undocumented)
 export function useNineZoneDispatch(frontstageDef: FrontstageDef): NineZoneDispatch;
-
-// @internal
-export function usePreviewFeatures(): PreviewFeatures;
 
 // @public
 export interface UserSettingsProvider {

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3511,7 +3511,7 @@ export interface PresentationSelectionScope {
     label: string;
 }
 
-// @public
+// @beta
 export interface PreviewFeatures extends Partial<KnownPreviewFeatures> {
     // (undocumented)
     [featureName: string]: any;
@@ -4779,6 +4779,9 @@ export interface TrackingTime {
     startTime: Date;
 }
 
+// @internal
+export function trimToKnownFeaturesOnly(previewFeatures: PreviewFeatures): PreviewFeatures;
+
 // @public
 export function UiDataProvidedDialog({ uiDataProvider, id, isModal, ...dialogProps }: UiDataProvidedDialogProps): JSX.Element;
 
@@ -5078,6 +5081,9 @@ export function useLayoutStore(frontstageDef: FrontstageDef | undefined): Layout
 
 // @internal (undocumented)
 export function useNineZoneDispatch(frontstageDef: FrontstageDef): NineZoneDispatch;
+
+// @internal
+export function usePreviewFeatures(): PreviewFeatures;
 
 // @public
 export interface UserSettingsProvider {

--- a/common/api/summary/appui-layout-react.exports.csv
+++ b/common/api/summary/appui-layout-react.exports.csv
@@ -262,7 +262,7 @@ internal;useMode(widgetId: string): "fit" | "fill" | "minimized"
 internal;usePanelsAutoCollapse
 internal;UsePanelTargetArgs
 internal;usePointerCaptor: 
-internal;usePreviewFeatures: () => PreviewFeaturesState
+internal;usePreviewFeatures: () => KnownPreviewFeatures &
 internal;useResizeGrip: 
 internal;useSendBackHomeState():
 internal;useTabInteractions

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -358,7 +358,7 @@ beta;PositionPopup
 beta;PositionPopupContent(props: CommonDivProps): JSX.Element
 beta;PositionPopupProps 
 public;PresentationSelectionScope
-public;PreviewFeatures 
+beta;PreviewFeatures 
 public;PropsHelper
 public;ProviderItem
 beta;QuantityFormatSettingsPage({ initialQuantityType, availableUnitSystems, }: QuantityFormatterSettingsOptions): JSX.Element

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -519,7 +519,6 @@ public;ToolWidgetComposer(props: ToolWidgetComposerProps): JSX.Element
 public;ToolWidgetComposerProps 
 internal;toPanelSide(location: StagePanelLocation): PanelSide
 internal;TrackingTime
-internal;trimToKnownFeaturesOnly(previewFeatures: PreviewFeatures): PreviewFeatures
 public;UiDataProvidedDialog({ uiDataProvider, id, isModal, ...dialogProps }: UiDataProvidedDialogProps): JSX.Element
 public;UiDataProvidedDialogProps
 public;UiFramework
@@ -560,7 +559,6 @@ internal;useItemsManager(frontstageDef: FrontstageDef): void
 internal;useLabels(): NineZoneLabels
 internal;useLayoutStore(frontstageDef: FrontstageDef | undefined): LayoutStore
 internal;useNineZoneDispatch(frontstageDef: FrontstageDef): NineZoneDispatch
-internal;usePreviewFeatures(): PreviewFeatures
 public;UserSettingsProvider
 internal;useSavedFrontstageState(frontstageDef: FrontstageDef): void
 internal;useSaveFrontstageSettings(frontstageDef: FrontstageDef, store: LayoutStore): void

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -358,7 +358,7 @@ beta;PositionPopup
 beta;PositionPopupContent(props: CommonDivProps): JSX.Element
 beta;PositionPopupProps 
 public;PresentationSelectionScope
-beta;PreviewFeatures 
+public;PreviewFeatures 
 public;PropsHelper
 public;ProviderItem
 beta;QuantityFormatSettingsPage({ initialQuantityType, availableUnitSystems, }: QuantityFormatterSettingsOptions): JSX.Element

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -358,7 +358,7 @@ beta;PositionPopup
 beta;PositionPopupContent(props: CommonDivProps): JSX.Element
 beta;PositionPopupProps 
 public;PresentationSelectionScope
-public;PreviewFeatures 
+beta;PreviewFeatures 
 public;PropsHelper
 public;ProviderItem
 beta;QuantityFormatSettingsPage({ initialQuantityType, availableUnitSystems, }: QuantityFormatterSettingsOptions): JSX.Element
@@ -519,6 +519,7 @@ public;ToolWidgetComposer(props: ToolWidgetComposerProps): JSX.Element
 public;ToolWidgetComposerProps 
 internal;toPanelSide(location: StagePanelLocation): PanelSide
 internal;TrackingTime
+internal;trimToKnownFeaturesOnly(previewFeatures: PreviewFeatures): PreviewFeatures
 public;UiDataProvidedDialog({ uiDataProvider, id, isModal, ...dialogProps }: UiDataProvidedDialogProps): JSX.Element
 public;UiDataProvidedDialogProps
 public;UiFramework
@@ -559,6 +560,7 @@ internal;useItemsManager(frontstageDef: FrontstageDef): void
 internal;useLabels(): NineZoneLabels
 internal;useLayoutStore(frontstageDef: FrontstageDef | undefined): LayoutStore
 internal;useNineZoneDispatch(frontstageDef: FrontstageDef): NineZoneDispatch
+internal;usePreviewFeatures(): PreviewFeatures
 public;UserSettingsProvider
 internal;useSavedFrontstageState(frontstageDef: FrontstageDef): void
 internal;useSaveFrontstageSettings(frontstageDef: FrontstageDef, store: LayoutStore): void

--- a/common/changes/@itwin/appui-layout-react/raplemie-previewMaximizeFloating_2023-11-09-19-21.json
+++ b/common/changes/@itwin/appui-layout-react/raplemie-previewMaximizeFloating_2023-11-09-19-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/appui-react/raplemie-previewMaximizeFloating_2023-11-09-19-21.json
+++ b/common/changes/@itwin/appui-react/raplemie-previewMaximizeFloating_2023-11-09-19-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Added `enableMaximizedFloatingWidget` preview features",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -17,6 +17,8 @@ Table of contents:
 
 ### Additions
 
+#### UiItemsProvider improvements
+
 - `UiItemsProvider` is enhanced by additional properties `getToolbarItems`, `getStatusBarItems`, `getBackstageItems`, `getWidgets` with an intention to replace existing `provideToolbarItems`, `provideStatusBarItems`, `provideBackstageItems`, `provideWidgets` to facilitate overriding scenarios.
   Additionally `layout` property is added to `ToolbarItem` and `Widget` types to define additional layout-specific properties of an item.
   Location arguments of `UiItemsProvider.provide*` methods are moved to `layout.standard`. #504
@@ -60,6 +62,8 @@ Table of contents:
   UiItemsManager.register(provider, { stageIds: ["stage1"] });
   ```
 
+#### Preview features
+
 - Introduce preview features.
 
   `UiFramework.setPreviewFeatures()` method allows to enable preview features for the application. The interface is built so the application can enable preview features and will not break when new preview features are added or removed in the future.
@@ -76,7 +80,11 @@ Table of contents:
   });
   ```
 
-- `contentAlwaysMaxSize` is the first preview features that is introduced. When enabled, the content no longer gets resized by panels or docking the tool settings. This allows for a more consistent experience when the content is always the same size, regardless of the panels or tool settings being open, closed or floating.
+  Note that every wanted preview features need to be set at the same time, as the method will override the existing preview features.
+
+- `contentAlwaysMaxSize` feature preview. When enabled, the content no longer gets resized by panels or docking the tool settings. This allows for a more consistent experience when the content is always the same size, regardless of the panels or tool settings being open, closed or floating.
+
+- `enableMaximizedFloatingWidget` feature preview. When enabled, floating widgets can be maximized to fill the entire screen. In this mode the widgets can still be popped out, or restored to their original size.
 
 ### Changes
 

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
@@ -15,6 +15,10 @@ import * as React from "react";
 
 const featureList = [
   { id: "contentAlwaysMaxSize", label: "Content is always maximum size" },
+  {
+    id: "enableMaximizedFloatingWidget",
+    label: "Enable maximized floating widgets",
+  },
 ];
 function PreviewFeatureList() {
   const [activeFeatureList, setActiveFeatureList] = React.useState<string[]>(
@@ -24,6 +28,9 @@ function PreviewFeatureList() {
   React.useEffect(() => {
     UiFramework.setPreviewFeatures({
       contentAlwaysMaxSize: activeFeatureList.includes("contentAlwaysMaxSize"),
+      enableMaximizedFloatingWidget: activeFeatureList.includes(
+        "enableMaximizedFloatingWidget"
+      ),
     });
   }, [activeFeatureList]);
 

--- a/ui/appui-layout-react/src/appui-layout-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/preview/PreviewFeatures.tsx
@@ -8,22 +8,70 @@
 
 import * as React from "react";
 
-interface PreviewFeaturesState {
+interface KnownPreviewFeatures {
   contentAlwaysMaxSize?: boolean;
+  enableMaximizedFloatingWidget?: boolean;
 }
+
+/**
+ * Internal state for preview features that must not be saved to local storage.
+ */
+interface PreviewFeatureState {
+  tested?: boolean;
+  maximizedWidget?: string;
+}
+
+/**
+ * Actions for preview features.
+ */
+type PreviewActions =
+  | {
+      type: "TEST_ACTION";
+    }
+  | {
+      type: "SET_MAXIMIZED_WIDGET";
+      id: string | undefined;
+    };
 
 /**
  * Context containing all configuration for preview features.
  */
-const PreviewFeaturesContext = React.createContext<PreviewFeaturesState>({});
+const PreviewFeaturesContext = React.createContext<
+  KnownPreviewFeatures & {
+    previewState: PreviewFeatureState;
+    previewDispatch: React.Dispatch<PreviewActions>;
+  }
+>({ previewState: {}, previewDispatch: () => {} });
 
 /**
  * Properties of `PreviewFeaturesProvider`.
  * @internal
  */
-interface PreviewFeaturesProviderProps extends PreviewFeaturesState {
+interface PreviewFeaturesProviderProps extends KnownPreviewFeatures {
   children?: React.ReactNode;
   [key: string]: any;
+}
+
+/**
+ * Using reducer to facilitate move between preview and ninezoneReducer.
+ */
+// istanbul ignore next (preview)
+function previewReducer(state: PreviewFeatureState, action: PreviewActions) {
+  switch (action.type) {
+    // Keep for testing purposes
+    case "TEST_ACTION":
+      return {
+        ...state,
+        tested: true,
+      };
+    case "SET_MAXIMIZED_WIDGET":
+      return {
+        ...state,
+        maximizedWidget: action.id,
+      };
+    default:
+      return state;
+  }
 }
 
 /**
@@ -34,8 +82,11 @@ export const PreviewFeaturesProvider = ({
   children,
   ...props
 }: PreviewFeaturesProviderProps) => {
+  const [previewState, previewDispatch] = React.useReducer(previewReducer, {});
   return (
-    <PreviewFeaturesContext.Provider value={props}>
+    <PreviewFeaturesContext.Provider
+      value={{ ...props, previewState, previewDispatch }}
+    >
       {children}
     </PreviewFeaturesContext.Provider>
   );

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Buttons.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Buttons.tsx
@@ -19,8 +19,14 @@ import { PinToggle } from "./PinToggle";
 import { PopoutToggle } from "./PopoutToggle";
 import { useLayout } from "../base/LayoutStore";
 import { useFloatingWidgetId, useWidgetAllowedToDock } from "./FloatingWidget";
+import { usePreviewFeatures } from "../preview/PreviewFeatures";
+import { PreviewMaximizeToggle } from "./PreviewMaximizeToggle";
 /** @internal */
 export function TabBarButtons() {
+  const {
+    enableMaximizedFloatingWidget: previewEnableMaximizedFloatingWidget,
+    previewState,
+  } = usePreviewFeatures();
   const isToolSettings = useIsToolSettingsTab();
   const floatingWidgetId = useFloatingWidgetId();
   const canBeDocked = useWidgetAllowedToDock();
@@ -31,10 +37,22 @@ export function TabBarButtons() {
     const tab = state.tabs[tabId];
     return tab.canPopout;
   });
+  // istanbul ignore next (preview)
+  const isMaximized =
+    previewState.maximizedWidget === floatingWidgetId &&
+    previewEnableMaximizedFloatingWidget;
   return (
     <div className="nz-widget-tabBarButtons">
       {canPopout && <PopoutToggle />}
-      {floatingWidgetId && !isToolSettings && canBeDocked && <SendBack />}
+      {
+        // istanbul ignore next (preview)
+        previewEnableMaximizedFloatingWidget &&
+          !isToolSettings &&
+          floatingWidgetId && <PreviewMaximizeToggle />
+      }
+      {!isMaximized && floatingWidgetId && !isToolSettings && canBeDocked && (
+        <SendBack />
+      )}
       {isToolSettings && <Dock />}
       {isMainPanelWidget && <PinToggle />}
     </div>

--- a/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/FloatingWidget.scss
@@ -48,6 +48,21 @@
       visibility: hidden;
     }
   }
+
+  &.preview-enableMaximizedFloatingWidget-maximized {
+    transform: unset !important;
+    height: unset !important;
+    width: unset !important;
+    max-height: unset !important;
+    max-width: unset !important;
+    opacity: 1 !important;
+    border-radius: unset !important;
+    inset: 0;
+
+    .nz-widget-floatingWidget_handle {
+      visibility: hidden;
+    }
+  }
 }
 
 .nz-widget-floatingWidget_handle {

--- a/ui/appui-layout-react/src/appui-layout-react/widget/PreviewMaximizeToggle.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/PreviewMaximizeToggle.tsx
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import "./PopoutToggle.scss";
+import * as React from "react";
+import { Icon } from "@itwin/core-react";
+import {
+  SvgWindowMaximize,
+  SvgWindowMinimize,
+} from "@itwin/itwinui-icons-react";
+import { usePreviewFeatures } from "../preview/PreviewFeatures";
+import { useFloatingWidgetId } from "./FloatingWidget";
+
+/** @internal */
+// istanbul ignore next (preview)
+export function PreviewMaximizeToggle() {
+  const {
+    enableMaximizedFloatingWidget: previewEnableMaximizedFloatingWidget,
+    previewState,
+    previewDispatch,
+  } = usePreviewFeatures();
+  const floatingWidgetId = useFloatingWidgetId();
+
+  const { id, title, iconSpec } =
+    previewState.maximizedWidget === floatingWidgetId &&
+    previewEnableMaximizedFloatingWidget
+      ? {
+          id: undefined,
+          title: "Minimize",
+          iconSpec: <SvgWindowMinimize />,
+        }
+      : {
+          id: floatingWidgetId,
+          title: "Maximize",
+          iconSpec: <SvgWindowMaximize />,
+        };
+
+  return (
+    <button
+      // Reusing for simplification
+      className="nz-widget-popoutToggle"
+      onClick={() => {
+        previewDispatch({
+          type: "SET_MAXIMIZED_WIDGET",
+          id,
+        });
+      }}
+      title={title}
+    >
+      <Icon iconSpec={iconSpec} />
+    </button>
+  );
+}

--- a/ui/appui-layout-react/src/appui-layout-react/widget/PreviewMaximizeToggle.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/PreviewMaximizeToggle.tsx
@@ -31,7 +31,7 @@ export function PreviewMaximizeToggle() {
     previewEnableMaximizedFloatingWidget
       ? {
           id: undefined,
-          title: "Minimize",
+          title: "Restore",
           iconSpec: <SvgWindowMinimize />,
         }
       : {

--- a/ui/appui-layout-react/src/appui-layout-react/widget/Tab.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/Tab.tsx
@@ -47,6 +47,7 @@ import { useLayout, useLayoutStore } from "../base/LayoutStore";
 import { useFloatingWidgetId } from "./FloatingWidget";
 import { getWidgetState } from "../state/internal/WidgetStateHelpers";
 import { SpecialKey } from "@itwin/appui-abstract";
+import { usePreviewFeatures } from "../preview/PreviewFeatures";
 
 /** @internal */
 export interface WidgetTabProviderProps extends TabPositionContextArgs {
@@ -119,10 +120,18 @@ function WidgetTabComponent(props: WidgetTabProps) {
     (state) => getWidgetState(state, widgetId).minimized
   );
 
+  const { enableMaximizedFloatingWidget, previewState } = usePreviewFeatures();
+  const floatingWidgetId = useFloatingWidgetId();
+  // istanbul ignore next (preview)
+  const maximized =
+    !!floatingWidgetId &&
+    previewState.maximizedWidget === floatingWidgetId &&
+    enableMaximizedFloatingWidget;
+
   const resizeObserverRef = useResizeObserver<HTMLDivElement>(
     widgetTabsEntryContext?.onResize
   );
-  const pointerCaptorRef = useTabInteractions({});
+  const pointerCaptorRef = useTabInteractions({ clickOnly: maximized });
   const refs = useRefs<HTMLDivElement>(resizeObserverRef, pointerCaptorRef);
 
   const active = activeTabId === id;
@@ -166,6 +175,7 @@ export interface UseTabInteractionsArgs {
   onClick?: () => void;
   onDoubleClick?: () => void;
   onDragStart?: () => void;
+  clickOnly?: boolean;
 }
 
 /** @internal */
@@ -173,6 +183,7 @@ export function useTabInteractions<T extends HTMLElement>({
   onClick,
   onDoubleClick,
   onDragStart,
+  clickOnly,
 }: UseTabInteractionsArgs) {
   const id = React.useContext(TabIdContext);
   const widgetContext = React.useContext(WidgetContext);
@@ -211,6 +222,8 @@ export function useTabInteractions<T extends HTMLElement>({
     onClick?.();
   }, [dispatch, widgetId, id, side, onClick]);
   const handleDoubleClick = React.useCallback(() => {
+    // istanbul ignore next (preview)
+    if (clickOnly) return;
     dispatch({
       type: "WIDGET_TAB_DOUBLE_CLICK",
       side,
@@ -219,13 +232,23 @@ export function useTabInteractions<T extends HTMLElement>({
       id,
     });
     onDoubleClick?.();
-  }, [dispatch, floatingWidgetId, widgetId, id, side, onDoubleClick]);
+  }, [
+    clickOnly,
+    dispatch,
+    floatingWidgetId,
+    widgetId,
+    id,
+    side,
+    onDoubleClick,
+  ]);
 
   const handleDragTabStart = useDragTab({
     tabId: id,
   });
   const handleDragStart = React.useCallback(
     (pointerPosition: Point) => {
+      // istanbul ignore next (preview)
+      if (clickOnly) return;
       assert(!!ref.current);
       assert(!!initialPointerPosition.current);
       const nzBounds = measure();
@@ -272,6 +295,7 @@ export function useTabInteractions<T extends HTMLElement>({
       initialPointerPosition.current = undefined;
     },
     [
+      clickOnly,
       measure,
       widgetContext,
       handleDragTabStart,

--- a/ui/appui-layout-react/src/appui-layout-react/widget/TabBar.scss
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/TabBar.scss
@@ -22,6 +22,10 @@
     position: absolute;
     cursor: auto;
     user-select: none;
+
+    .preview-enableMaximizedFloatingWidget-maximized & {
+      pointer-events: none;
+    }
   }
 
   > .nz-widget-tabBarButtons {

--- a/ui/appui-layout-react/src/test/preview/PreviewFeatures.test.tsx
+++ b/ui/appui-layout-react/src/test/preview/PreviewFeatures.test.tsx
@@ -7,11 +7,11 @@ import {
   PreviewFeaturesProvider,
   usePreviewFeatures,
 } from "../../appui-layout-react";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { expect } from "chai";
 
 describe("PreviewFeatures", () => {
-  it("should expose all props as context values", () => {
+  it("should expose all props as context values, plus `previewState` and `previewDispatch`", () => {
     const testContext: { renderedContext: any } = {
       renderedContext: null,
     };
@@ -25,9 +25,62 @@ describe("PreviewFeatures", () => {
       </PreviewFeaturesProvider>
     );
 
-    expect(testContext.renderedContext).to.deep.equal({
+    const { previewState, previewDispatch, ...additionalContext } =
+      testContext.renderedContext;
+
+    expect(additionalContext).to.deep.equal({
       contentAlwaysMaxSize: true,
       randomProp: "randomValue",
     });
+    expect(previewState).to.deep.equal({});
+    expect(previewDispatch).to.be.a("function");
+  });
+  it("should expose `previewDispatch` which updates `previewState`", () => {
+    const testContext: { renderedContext: any } = {
+      renderedContext: null,
+    };
+    function TestComponent() {
+      testContext.renderedContext = usePreviewFeatures();
+      return (
+        <button
+          onClick={() => {
+            testContext.renderedContext.previewDispatch({
+              type: "TEST_ACTION",
+            });
+          }}
+        >
+          Rendered
+        </button>
+      );
+    }
+    render(
+      <PreviewFeaturesProvider contentAlwaysMaxSize randomProp={"randomValue"}>
+        <TestComponent />
+      </PreviewFeaturesProvider>
+    );
+
+    expect(testContext.renderedContext.previewState).to.deep.equal({});
+
+    fireEvent.click(document.querySelector("button")!);
+
+    expect(testContext.renderedContext.previewState).to.deep.equal({
+      tested: true,
+    });
+  });
+  it("usePreviewFeatures().previewDispatch should not crash if provider is not used.", () => {
+    const testContext: { renderedContext: any } = {
+      renderedContext: null,
+    };
+    function TestComponent() {
+      testContext.renderedContext = usePreviewFeatures();
+      return <div>Rendered</div>;
+    }
+    render(<TestComponent />);
+
+    const { previewState, previewDispatch } = testContext.renderedContext;
+
+    expect(previewState).to.deep.equal({});
+    expect(previewDispatch).to.be.a("function");
+    expect(previewDispatch).to.not.throw();
   });
 });

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -116,7 +116,7 @@ export * from "./appui-react/popup/PopupManager";
 export * from "./appui-react/popup/PositionPopup";
 export * from "./appui-react/popup/ToolbarPopup";
 
-export { PreviewFeatures } from "./appui-react/preview/PreviewFeatures";
+export * from "./appui-react/preview/PreviewFeatures";
 
 export * from "./appui-react/redux/SessionState";
 export * from "./appui-react/redux/StateManager";

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -116,7 +116,7 @@ export * from "./appui-react/popup/PopupManager";
 export * from "./appui-react/popup/PositionPopup";
 export * from "./appui-react/popup/ToolbarPopup";
 
-export * from "./appui-react/preview/PreviewFeatures";
+export { PreviewFeatures } from "./appui-react/preview/PreviewFeatures";
 
 export * from "./appui-react/redux/SessionState";
 export * from "./appui-react/redux/StateManager";

--- a/ui/appui-react/src/appui-react/configurableui/state.ts
+++ b/ui/appui-react/src/appui-react/configurableui/state.ts
@@ -45,7 +45,7 @@ export enum ConfigurableUiActionId {
 export interface ConfigurableUiState {
   snapMode: number;
   toolPrompt: string;
-  theme: ThemeId;
+  theme: string;
   widgetOpacity: number;
   useDragInteraction: boolean;
   showWidgetIcon: boolean;
@@ -54,6 +54,7 @@ export interface ConfigurableUiState {
   animateToolSettings: boolean;
   useToolAsToolSettingsLabel: boolean;
   toolbarOpacity: number;
+  /** @beta */
   previewFeatures?: PreviewFeatures;
 }
 
@@ -80,8 +81,11 @@ export const ConfigurableUiActions = {
   setSnapMode: (snapMode: number) =>
     createAction(ConfigurableUiActionId.SetSnapMode, snapMode),
   setTheme:
-    // istanbul ignore next
-    (theme: ThemeId) => createAction(ConfigurableUiActionId.SetTheme, theme),
+    /**
+     * Use `UiFramework.setColorTheme` instead which is conveniently typed with available theme union.
+     * @param theme ThemeId
+     */
+    (theme: string) => createAction(ConfigurableUiActionId.SetTheme, theme),
   setToolPrompt:
     // istanbul ignore next
     (toolPrompt: string) =>
@@ -116,7 +120,11 @@ export const ConfigurableUiActions = {
     ),
   setToolbarOpacity: (opacity: number) =>
     createAction(ConfigurableUiActionId.SetToolbarOpacity, opacity),
-  setPreviewFeatures: (features: PreviewFeatures) =>
+  /**
+   * Use `UiFramework.setPreviewFeatures` instead which is conveniently typed with current available features.
+   * @param features PreviewFeatures
+   */
+  setPreviewFeatures: (features: { [featureName: string]: any }) =>
     createAction(ConfigurableUiActionId.SetPreviewFeatures, features),
 };
 

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-// Defined as an object so we can access the keys for runtime validation.
-
 import { useSelector } from "react-redux";
 import type { FrameworkRootState } from "../redux/StateManager";
 import { UiFramework } from "../UiFramework";
@@ -17,6 +15,10 @@ interface KnownPreviewFeatures {
    * The content will never change size.
    */
   contentAlwaysMaxSize: boolean;
+  /**
+   * If true, the floating widget will have a "maximize" button.
+   */
+  enableMaximizedFloatingWidget: boolean;
 }
 
 /**
@@ -25,6 +27,7 @@ interface KnownPreviewFeatures {
  */
 const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
   contentAlwaysMaxSize: undefined,
+  enableMaximizedFloatingWidget: undefined,
 };
 
 /**
@@ -32,7 +35,7 @@ const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
  * This list is expected to change over time, the interface is made
  * so that new features can be added or removed without breaking existing code.
  * A console warning will simply appear if unknown features are passed.
- * @public
+ * @beta
  */
 export interface PreviewFeatures extends Partial<KnownPreviewFeatures> {
   [featureName: string]: any;

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
@@ -38,7 +38,7 @@ const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
  * This list is expected to change over time, the interface is made
  * so that new features can be added or removed without breaking existing code.
  * A console warning will simply appear if unknown features are passed.
- * @beta
+ * @public
  */
 export interface PreviewFeatures extends Partial<KnownPreviewFeatures> {
   [featureName: string]: any;

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
@@ -2,12 +2,13 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { useSelector } from "react-redux";
-import type { FrameworkRootState } from "../redux/StateManager";
-import { UiFramework } from "../UiFramework";
 /** @packageDocumentation
  * @module Utilities
  */
+
+import { useSelector } from "react-redux";
+import type { FrameworkRootState } from "../redux/StateManager";
+import { UiFramework } from "../UiFramework";
 
 /**
  * List of known preview features.

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
@@ -5,6 +5,9 @@
 import { useSelector } from "react-redux";
 import type { FrameworkRootState } from "../redux/StateManager";
 import { UiFramework } from "../UiFramework";
+/** @packageDocumentation
+ * @module Utilities
+ */
 
 /**
  * List of known preview features.

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
@@ -38,7 +38,7 @@ const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
  * This list is expected to change over time, the interface is made
  * so that new features can be added or removed without breaking existing code.
  * A console warning will simply appear if unknown features are passed.
- * @public
+ * @beta
  */
 export interface PreviewFeatures extends Partial<KnownPreviewFeatures> {
   [featureName: string]: any;


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
### Preview feature

* Added new preview feature to allow floating widgets to have a maximize button, once clicked, the widget will take all the visible space of the ConfigurableUI, SendBack is disabled in this state, however "Popout" is still available.
* Added a `previewState` and `previewDispatch` to the appui-layout-react `usePreviewFeatures` so it is now possible to save state for a preview feature without having to change the existing code (NinezoneState actually get saved to localstorage, so I did not want the preview feature to be saved there, that's the main reason, the second is to centralize so we dont have to create a new context for each new feature)

### Actions
* Removed "PreviewFeatures" type from the redux actions and replaced with a more general one because of the way the type was being computed, the *beta* tag was lost and cause extract-api to complain. Added a note to the action to directly use the properly typed public method instead if possible.
* Removed "ThemeId" type from the redux actions and replaced with "string". The type computation of the string union was causing extract-api to change the order from time to time, causing more pain than anything else. I removed that and also mention in the action to use `UiFramework.setColorTheme` which is properly typed. 


## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Updated tests, ran multiple time and attempted to break, there are still some issue with focus (which I think are edge cases for this experiment)