### PR TITLE
Missing refresh of tool setting source on mount

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-widgetToolSettingsRefresh_2023-11-10-21-44.json
+++ b/common/changes/@itwin/appui-react/raplemie-widgetToolSettingsRefresh_2023-11-10-21-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Refresh tool setting values when undocking",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -99,6 +99,7 @@ Table of contents:
 - Removed unneeded `changeView` call in `FloatingViewportComponent`.
 - Fixed reference error in case `applicationData` is not provided for `IModelViewportControl`.
 - Hidden widget will now float to `defaultSize` and `defaultPosition` of `canFloat` property when set to floating.
+- Fixed an issue with tool settings not being refreshed from tool when floating/docking tool settings.
 
 ## @itwin/imodel-components-react
 

--- a/full-stack-tests/ui/tests/tool-settings.test.ts
+++ b/full-stack-tests/ui/tests/tool-settings.test.ts
@@ -201,4 +201,35 @@ test.describe("tool settings", () => {
     await expect(alabamaCity).toBeVisible();
     await expect(californiaCity).not.toBeVisible();
   });
+
+  test("should display tool updated tool settings when switching widget/docked mode", async ({
+    page,
+  }) => {
+    const toolButton = page.getByTitle("Sample Tool");
+    await toolButton.click();
+
+    const widgetToolSettings = tabLocator(page, "Tool Settings");
+    const defaultStateField = page.locator("[value='PA']");
+    await expect(defaultStateField).toBeVisible();
+
+    // Test undocking after initial edit of tool settings by the tool.
+    await page.type(".nz-widgetPanels-appContent", "q");
+
+    const updatedStateField = page.locator("[value='qPA']");
+    await expect(widgetToolSettings).not.toBeVisible();
+    await expect(updatedStateField).toBeVisible();
+    await setWidgetState(page, "WidgetApi:ToolSettings", WidgetState.Floating);
+    await expect(widgetToolSettings).toBeVisible();
+    await expect(updatedStateField).toBeVisible();
+
+    // Test docking back after second edit of tool settings by the tool.
+    await page.type(".nz-widgetPanels-appContent", "q");
+
+    const finalStateField = page.locator("[value='qqPA']");
+    await expect(widgetToolSettings).toBeVisible();
+    await expect(finalStateField).toBeVisible();
+    await page.getByTitle("Dock to top").click();
+    await expect(widgetToolSettings).not.toBeVisible();
+    await expect(finalStateField).toBeVisible();
+  });
 });

--- a/full-stack-tests/ui/tests/tool-settings.test.ts
+++ b/full-stack-tests/ui/tests/tool-settings.test.ts
@@ -222,10 +222,16 @@ test.describe("tool settings", () => {
     await expect(widgetToolSettings).toBeVisible();
     await expect(updatedStateField).toBeVisible();
 
+    // Type something at the end of the state field to simulate user editing the tool settings.
+    await updatedStateField.focus();
+    await updatedStateField.press("End"); // type("type in field") only would add to the start of the filed, we want to validate the "e" wasn't added by the tool behavior.
+    await updatedStateField.type("type in field");
+    await page.locator("[value='qPAtype in field']").blur();
+
     // Test docking back after second edit of tool settings by the tool.
     await page.type(".nz-widgetPanels-appContent", "q");
 
-    const finalStateField = page.locator("[value='qqPA']");
+    const finalStateField = page.locator("[value='qqPAtype in field']");
     await expect(widgetToolSettings).toBeVisible();
     await expect(finalStateField).toBeVisible();
     await page.getByTitle("Dock to top").click();

--- a/test-apps/appui-test-app/appui-test-providers/src/tools/SampleTool.ts
+++ b/test-apps/appui-test-app/appui-test-providers/src/tools/SampleTool.ts
@@ -443,6 +443,22 @@ export class SampleTool extends PrimitiveTool {
     );
   }
 
+  public override async onKeyTransition(
+    down: boolean,
+    ev: KeyboardEvent
+  ): Promise<EventHandled> {
+    if (down && ev.key === "q") {
+      this._stateValue.value = ev.key.concat(
+        (this._stateValue.value as string) ?? ""
+      );
+      this.syncToolSettingsProperties([
+        { propertyName: SampleTool._stateName, value: this._stateValue },
+      ]);
+    }
+
+    return EventHandled.Yes;
+  }
+
   public override async onDataButtonDown(
     ev: BeButtonEvent
   ): Promise<EventHandled> {
@@ -592,7 +608,7 @@ export class SampleTool extends PrimitiveTool {
       editorPosition: { rowPriority: 10, columnIndex: 2 },
     });
     toolSettings.push({
-      value: this._stateValue,
+      value: { ...this._stateValue },
       property: SampleTool._getStateDescription(),
       editorPosition: { rowPriority: 10, columnIndex: 4 },
     });

--- a/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
@@ -80,12 +80,7 @@ export function WidgetPanelsToolSettings() {
 /** @internal */
 export function ToolSettingsDockedContent() {
   const settings = useHorizontalToolSettingNodes();
-  const [forceRefreshKey, setForceRefreshKey] = React.useState(Date.now());
-  React.useEffect(() => {
-    // We cant work with the content of the settings, but we can force refresh when
-    // the array is different.
-    setForceRefreshKey(Date.now());
-  }, [settings]);
+  const forceRefreshKey = useRefreshKey(settings);
   // for the overflow to work properly each setting in the DockedToolSettings should be wrapped by a DockedToolSetting component
   return (
     <DockedToolSettings
@@ -107,6 +102,10 @@ export function ToolSettingsDockedContent() {
 
 /** @internal */
 export function useHorizontalToolSettingNodes() {
+  React.useEffect(() => {
+    UiFramework.frontstages.activeToolInformation?.toolUiProvider?.reloadPropertiesFromTool();
+  }, []);
+
   const [settings, setSettings] = React.useState(
     InternalFrontstageManager.activeToolSettingsProvider
       ?.horizontalToolSettingNodes
@@ -171,6 +170,9 @@ export function ToolSettingsGrid({ settings }: ToolSettingsGridProps) {
 
 /** @internal */
 export function useToolSettingsNode() {
+  React.useEffect(() => {
+    UiFramework.frontstages.activeToolInformation?.toolUiProvider?.reloadPropertiesFromTool();
+  }, []);
   const [settings, setSettings] = React.useState(
     InternalFrontstageManager.activeToolSettingsProvider?.toolSettingsNode
   );
@@ -221,6 +223,8 @@ export function ToolSettingsContent() {
 export function ToolSettingsWidgetContent() {
   const floatingToolSettingsContainerRef = React.useRef<HTMLDivElement>(null);
   const node = useToolSettingsNode();
+  const forceRefreshKey = useRefreshKey(node);
+
   // if no tool settings hide the floating widgets tab
   React.useEffect(() => {
     // istanbul ignore else
@@ -247,8 +251,24 @@ export function ToolSettingsWidgetContent() {
       data-toolsettings-provider={providerId}
       className="uifw-floating-toolsettings-container"
       ref={floatingToolSettingsContainerRef}
+      key={forceRefreshKey}
     >
       <ScrollableWidgetContent>{node}</ScrollableWidgetContent>
     </div>
   );
+}
+
+/**
+ * Hook that returns a key that can be used to force refresh the tool settings.
+ * @param toolSettingNodes Nodes that are used to determine if the tool settings should be refreshed.
+ * @returns a new key if the dependency changes.
+ */
+function useRefreshKey(toolSettingNodes: any) {
+  const [forceRefreshKey, setForceRefreshKey] = React.useState(Date.now());
+  React.useEffect(() => {
+    // We cant work with the content of the settings, but we can force refresh when
+    // the array is different.
+    setForceRefreshKey(Date.now());
+  }, [toolSettingNodes]);
+  return forceRefreshKey;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
When mounting toolSettings in Docked or Widget form, will refresh the settings from the tool.
Added same forceRefresh fix on node changes to Widget form than always existed in Docked form


## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Validated cover and e2e.
Added relevant e2e test to validate that tool settings gets correctly updating when changing docked/widget.

## Issue
Resolves #378