### PR TITLE
Save pending debounced settings on close

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-lostFrontstageChanges_2023-11-17-18-58.json
+++ b/common/changes/@itwin/appui-react/raplemie-lostFrontstageChanges_2023-11-17-18-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fixed an issue where frontstage state would be lost when it is closed too soon after a change.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/appui-react/raplemie-lostFrontstageChanges_2023-11-17-18-58.json
+++ b/common/changes/@itwin/appui-react/raplemie-lostFrontstageChanges_2023-11-17-18-58.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Fixed an issue where frontstage state would be lost when it is closed too soon after a change.",
+      "comment": "Fixed an issue where frontstage state changes would be lost when it is closed too soon after the change.",
       "type": "none"
     }
   ],

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -100,7 +100,7 @@ Table of contents:
 - Fixed reference error in case `applicationData` is not provided for `IModelViewportControl`.
 - Hidden widget will now float to `defaultSize` and `defaultPosition` of `canFloat` property when set to floating.
 - Fixed an issue with tool settings not being refreshed from tool when floating/docking tool settings.
-- Fixed an issue where frontstage state would be lost when it is closed too soon after a change.
+- Fixed an issue where frontstage state changes would be lost when it is closed too soon after the change.
 
 ## @itwin/imodel-components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -100,6 +100,7 @@ Table of contents:
 - Fixed reference error in case `applicationData` is not provided for `IModelViewportControl`.
 - Hidden widget will now float to `defaultSize` and `defaultPosition` of `canFloat` property when set to floating.
 - Fixed an issue with tool settings not being refreshed from tool when floating/docking tool settings.
+- Fixed an issue where frontstage state would be lost when it is closed too soon after a change.
 
 ## @itwin/imodel-components-react
 

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
@@ -22,7 +22,9 @@ const featureList = [
 ];
 function PreviewFeatureList() {
   const [activeFeatureList, setActiveFeatureList] = React.useState<string[]>(
-    Object.keys(UiFramework.previewFeatures)
+    Object.keys(UiFramework.previewFeatures).filter(
+      (key) => UiFramework.previewFeatures[key]
+    )
   );
 
   React.useEffect(() => {

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
@@ -22,9 +22,7 @@ const featureList = [
 ];
 function PreviewFeatureList() {
   const [activeFeatureList, setActiveFeatureList] = React.useState<string[]>(
-    Object.keys(UiFramework.previewFeatures).filter(
-      (key) => UiFramework.previewFeatures[key]
-    )
+    Object.keys(UiFramework.previewFeatures)
   );
 
   React.useEffect(() => {

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -1045,6 +1045,7 @@ export function useSaveFrontstageSettings(
   store: LayoutStore
 ) {
   const uiSettingsStorage = useUiStateStorageHandler();
+  const pendingSave = React.useRef(() => {});
   const saveSetting = React.useMemo(() => {
     const debounced = debounce(
       async (frontstage: FrontstageDef, state: NineZoneState) => {
@@ -1069,6 +1070,7 @@ export function useSaveFrontstageSettings(
       debounced(frontstage, state);
     };
     save.cancel = debounced.cancel;
+    pendingSave.current = debounced.immediate;
     return save;
   }, [uiSettingsStorage]);
   React.useEffect(() => {
@@ -1085,6 +1087,11 @@ export function useSaveFrontstageSettings(
       saveSetting(frontstageDef, store.getState());
     });
   }, [saveSetting, frontstageDef, store]);
+  React.useEffect(() => {
+    return () => {
+      pendingSave.current();
+    };
+  });
 }
 
 /** @internal */
@@ -1103,16 +1110,29 @@ function debounce<T extends (...args: any[]) => any>(
   duration: number
 ) {
   let timeout: number | undefined;
+  let handler: () => any | undefined;
   const debounced = (...args: Parameters<T>) => {
-    const handler = () => {
+    handler = () => {
       timeout = undefined;
       return func(...args);
     };
     window.clearTimeout(timeout);
     timeout = window.setTimeout(handler, duration);
   };
+  /**
+   * Will cancel the timeout without running the function.
+   */
   debounced.cancel = () => {
     window.clearTimeout(timeout);
+    timeout = undefined;
+  };
+  /**
+   * If not already ran, will run the function immediately and remove the timeout.
+   */
+  debounced.immediate = () => {
+    if (timeout === undefined) return;
+    debounced.cancel();
+    handler?.();
   };
   return debounced;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

* Added a way to force debounced setting save to not be lost when closing a frontstage.

* ~Also fixed a logic issue in the PreviewFeatureToggle in test app.~ (Removed to facilitage backport, unrelated)

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Manual tests using #515 scenario, validated local storage consistent updates.


## Issue

Fixes #515