### PR TITLE
Remove preview features from redux store

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -897,8 +897,6 @@ export enum ConfigurableUiActionId {
     // (undocumented)
     SetDragInteraction = "configurableui:set-drag-interaction",
     // (undocumented)
-    SetPreviewFeatures = "configurableui:set-preview-features",
-    // (undocumented)
     SetShowWidgetIcon = "configurableui:set-show-widget-icon",
     // (undocumented)
     SetSnapMode = "configurableui:set_snapmode",
@@ -929,11 +927,6 @@ export const ConfigurableUiActions: {
     setAnimateToolSettings: (animateToolSettings: boolean) => ActionWithPayload<ConfigurableUiActionId.AnimateToolSettings, boolean>;
     setUseToolAsToolSettingsLabel: (useToolAsToolSettingsLabel: boolean) => ActionWithPayload<ConfigurableUiActionId.UseToolAsToolSettingsLabel, boolean>;
     setToolbarOpacity: (opacity: number) => ActionWithPayload<ConfigurableUiActionId.SetToolbarOpacity, number>;
-    setPreviewFeatures: (features: {
-        [featureName: string]: any;
-    }) => ActionWithPayload<ConfigurableUiActionId.SetPreviewFeatures, DeepReadonlyObject<    {
-    [featureName: string]: any;
-    }>>;
 };
 
 // @public
@@ -1002,8 +995,6 @@ export interface ConfigurableUiState {
     animateToolSettings: boolean;
     // (undocumented)
     autoCollapseUnpinnedPanels: boolean;
-    // @beta (undocumented)
-    previewFeatures?: PreviewFeatures;
     // (undocumented)
     showWidgetIcon: boolean;
     // (undocumented)
@@ -2050,9 +2041,7 @@ export interface FrameworkKeyboardShortcuts {
 export const FrameworkReducer: (state: CombinedReducerState<    {
 configurableUiState: typeof ConfigurableUiReducer;
 sessionState: typeof SessionStateReducer;
-}>, action: DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetSnapMode, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetTheme, string>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetToolPrompt, string>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetWidgetOpacity, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetDragInteraction, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetShowWidgetIcon, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.AutoCollapseUnpinnedPanels, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetViewOverlayDisplay, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.AnimateToolSettings, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.UseToolAsToolSettingsLabel, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetToolbarOpacity, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetPreviewFeatures, DeepReadonlyObject<    {
-[featureName: string]: any;
-}>>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetActiveIModelId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetAvailableSelectionScopes, DeepReadonlyArray<PresentationSelectionScope>>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultIModelViewportControlId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultViewId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultViewState, any>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetNumItemsSelected, number>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetIModelConnection, any>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetSelectionScope, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.UpdateCursorMenu, DeepReadonlyObject<CursorMenuData>>>) => CombinedReducerState<    {
+}>, action: DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetSnapMode, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetTheme, string>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetToolPrompt, string>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetWidgetOpacity, number>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetDragInteraction, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetShowWidgetIcon, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.AutoCollapseUnpinnedPanels, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetViewOverlayDisplay, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.AnimateToolSettings, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.UseToolAsToolSettingsLabel, boolean>> | DeepReadonlyObject<ActionWithPayload<import("../configurableui/state").ConfigurableUiActionId.SetToolbarOpacity, number>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetActiveIModelId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetAvailableSelectionScopes, DeepReadonlyArray<PresentationSelectionScope>>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultIModelViewportControlId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultViewId, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetDefaultViewState, any>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetNumItemsSelected, number>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetIModelConnection, any>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.SetSelectionScope, string>> | DeepReadonlyObject<ActionWithPayload<import("./SessionState").SessionStateActionId.UpdateCursorMenu, DeepReadonlyObject<CursorMenuData>>>) => CombinedReducerState<    {
 configurableUiState: typeof ConfigurableUiReducer;
 sessionState: typeof SessionStateReducer;
 }>;

--- a/common/changes/@itwin/appui-react/preview-features-out-of-redux_2023-11-24-11-00.json
+++ b/common/changes/@itwin/appui-react/preview-features-out-of-redux_2023-11-24-11-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -658,6 +658,7 @@ importers:
       ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ^5.0.2
+      zustand: ^4.4.1
     dependencies:
       '@bentley/icons-generic': 1.0.34
       '@itwin/itwinui-icons': 1.16.0
@@ -671,6 +672,7 @@ importers:
       react-error-boundary: 4.0.3_react@17.0.2
       rxjs: 7.8.1
       ts-key-enum: 2.0.12
+      zustand: 4.4.1_b4b4c799a5a2f4488606d88d938fa77d
     devDependencies:
       '@itwin/appui-abstract': 4.0.0-dev.104_be9786c2146472f5e05bafea59511dc9
       '@itwin/appui-layout-react': link:../appui-layout-react

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -658,6 +658,7 @@ importers:
       ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~5.0.2
+      zustand: ^4.4.1
     dependencies:
       '@bentley/icons-generic': 1.0.34
       '@itwin/itwinui-icons': 1.16.0
@@ -671,6 +672,7 @@ importers:
       react-error-boundary: 4.0.3_react@17.0.2
       rxjs: 7.8.1
       ts-key-enum: 2.0.12
+      zustand: 4.4.1_b4b4c799a5a2f4488606d88d938fa77d
     devDependencies:
       '@itwin/appui-abstract': 3.7.0_@itwin+core-bentley@3.7.0
       '@itwin/appui-layout-react': link:../appui-layout-react

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -30,9 +30,18 @@ type PropsWithArgs = React.ComponentProps<typeof ToolbarComposer> & {
   newToolbars: boolean;
 };
 
+function StoryComponent(props: PropsWithArgs) {
+  const { newToolbars, ...other } = props;
+  React.useEffect(() => {
+    UiFramework.setPreviewFeatures({
+      newToolbars,
+    });
+  }, [newToolbars]);
+  return <ToolbarComposer {...other} />;
+}
+
 const meta = {
   title: "Components/ToolbarComposer",
-  component: ToolbarComposer,
   tags: ["autodocs"],
   args: {
     newToolbars: false,
@@ -43,13 +52,7 @@ const meta = {
     },
   },
   render: (props) => {
-    const { newToolbars, ...other } = props;
-    React.useEffect(() => {
-      UiFramework.setPreviewFeatures({
-        newToolbars,
-      });
-    }, [newToolbars]);
-    return <ToolbarComposer {...other} />;
+    return <StoryComponent {...props} />;
   },
 } satisfies Meta<PropsWithArgs>;
 

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -2,16 +2,18 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { BadgeType } from "@itwin/appui-abstract";
 import {
   CommandItemDef,
+  ToolbarComposer,
   ToolbarHelper,
   ToolbarItemUtilities,
   ToolbarOrientation,
   ToolbarUsage,
   UiFramework,
-} from "@itwin/appui-react";
+} from "@itwin/appui-react/src/appui-react";
 import { ConditionalIconItem, IconHelper } from "@itwin/core-react";
 import {
   Svg2D,
@@ -21,15 +23,35 @@ import {
   SvgClipboard,
   SvgExport,
 } from "@itwin/itwinui-icons-react";
-import { ToolbarComposer } from "@itwin/appui-react/src/appui-react/toolbar/ToolbarComposer";
 
 UiFramework.initialize(undefined);
+
+type PropsWithArgs = React.ComponentProps<typeof ToolbarComposer> & {
+  newToolbars: boolean;
+};
 
 const meta = {
   title: "Components/ToolbarComposer",
   component: ToolbarComposer,
   tags: ["autodocs"],
-} satisfies Meta<typeof ToolbarComposer>;
+  args: {
+    newToolbars: false,
+  },
+  argTypes: {
+    newToolbars: {
+      description: "Enables `newToolbars` preview feature.",
+    },
+  },
+  render: (props) => {
+    const { newToolbars, ...other } = props;
+    React.useEffect(() => {
+      UiFramework.setPreviewFeatures({
+        newToolbars,
+      });
+    }, [newToolbars]);
+    return <ToolbarComposer {...other} />;
+  },
+} satisfies Meta<PropsWithArgs>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -139,7 +139,8 @@
     "lodash": "^4.17.10",
     "react-error-boundary": "4.0.3",
     "rxjs": "^7.8.1",
-    "ts-key-enum": "~2.0.12"
+    "ts-key-enum": "~2.0.12",
+    "zustand": "^4.4.1"
   },
   "nyc": {
     "extends": "./node_modules/@itwin/build-tools/.nycrc",

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -116,7 +116,7 @@ export * from "./appui-react/popup/PopupManager";
 export * from "./appui-react/popup/PositionPopup";
 export * from "./appui-react/popup/ToolbarPopup";
 
-export { PreviewFeatures } from "./appui-react/preview/PreviewFeatures";
+export type { PreviewFeatures } from "./appui-react/preview/PreviewFeatures";
 
 export * from "./appui-react/redux/SessionState";
 export * from "./appui-react/redux/StateManager";

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -65,7 +65,10 @@ import {
   SyncUiEventDispatcher,
   SyncUiEventId,
 } from "./syncui/SyncUiEventDispatcher";
-import type { PreviewFeatures } from "./preview/PreviewFeatures";
+import {
+  type PreviewFeatures,
+  usePreviewFeaturesStore,
+} from "./preview/PreviewFeatures";
 
 // cSpell:ignore Mobi
 
@@ -865,27 +868,20 @@ export class UiFramework {
     return contextMenu !== null && contextMenu !== undefined;
   }
 
-  /**
-   * Set which preview features are enabled. These features are not yet ready for production use nor have
+  /** Set which preview features are enabled. These features are not yet ready for production use nor have
    * a proper API defined yet.
    * The available set of features are defined in the [[PreviewFeatures]] interface.
    * @param features Set of feature to enable.
    * @beta
    */
   public static setPreviewFeatures(features: PreviewFeatures) {
-    UiFramework.dispatchActionToStore(
-      ConfigurableUiActionId.SetPreviewFeatures,
-      features
-    );
+    return usePreviewFeaturesStore.getState().setPreviewFeatures(features);
   }
 
-  /**
-   * Get which preview features are enabled. These features are not yet ready for production use.
+  /** Get which preview features are enabled. These features are not yet ready for production use.
    * @beta
    */
   public static get previewFeatures(): PreviewFeatures {
-    return (
-      UiFramework.frameworkState?.configurableUiState.previewFeatures ?? {}
-    );
+    return usePreviewFeaturesStore.getState().previewFeatures;
   }
 }

--- a/ui/appui-react/src/appui-react/configurableui/state.ts
+++ b/ui/appui-react/src/appui-react/configurableui/state.ts
@@ -15,8 +15,6 @@ import {
   TOOLBAR_OPACITY_DEFAULT,
   WIDGET_OPACITY_DEFAULT,
 } from "../theme/ThemeManager";
-import type { PreviewFeatures } from "../preview/PreviewFeatures";
-import { trimToKnownFeaturesOnly } from "../preview/PreviewFeatures";
 
 // cSpell:ignore configurableui snapmode toolprompt
 
@@ -36,7 +34,6 @@ export enum ConfigurableUiActionId {
   AnimateToolSettings = "configurableui:set-animate-tool-settings",
   UseToolAsToolSettingsLabel = "configurableui:set-use-tool-as-tool-settings-label",
   SetToolbarOpacity = "configurableui:set-toolbar-opacity",
-  SetPreviewFeatures = "configurableui:set-preview-features",
 }
 
 /** The portion of state managed by the ConfigurableUiReducer.
@@ -54,8 +51,6 @@ export interface ConfigurableUiState {
   animateToolSettings: boolean;
   useToolAsToolSettingsLabel: boolean;
   toolbarOpacity: number;
-  /** @beta */
-  previewFeatures?: PreviewFeatures;
 }
 
 /** used on first call of ConfigurableUiReducer */
@@ -71,7 +66,6 @@ const initialState: ConfigurableUiState = {
   animateToolSettings: false,
   useToolAsToolSettingsLabel: false,
   toolbarOpacity: TOOLBAR_OPACITY_DEFAULT,
-  previewFeatures: {},
 };
 
 /** An object with a function that creates each ConfigurableUiReducer that can be handled by our reducer.
@@ -120,12 +114,6 @@ export const ConfigurableUiActions = {
     ),
   setToolbarOpacity: (opacity: number) =>
     createAction(ConfigurableUiActionId.SetToolbarOpacity, opacity),
-  /**
-   * Use `UiFramework.setPreviewFeatures` instead which is conveniently typed with current available features.
-   * @param features PreviewFeatures
-   */
-  setPreviewFeatures: (features: { [featureName: string]: any }) =>
-    createAction(ConfigurableUiActionId.SetPreviewFeatures, features),
 };
 
 /** Union of ConfigurableUi Redux actions
@@ -177,12 +165,6 @@ export function ConfigurableUiReducer(
     }
     case ConfigurableUiActionId.SetToolbarOpacity: {
       return { ...state, toolbarOpacity: action.payload };
-    }
-    case ConfigurableUiActionId.SetPreviewFeatures: {
-      return {
-        ...state,
-        previewFeatures: trimToKnownFeaturesOnly(action.payload),
-      };
     }
   }
   return outState;

--- a/ui/appui-react/src/appui-react/content/IModelViewport.tsx
+++ b/ui/appui-react/src/appui-react/content/IModelViewport.tsx
@@ -70,7 +70,9 @@ export function ViewOverlayHost({
   userSuppliedOverlay,
 }: ViewOverlayHostProps) {
   const displayViewOverlay = useSelector((state: FrameworkState) => {
-    const frameworkState = (state as any)[UiFramework.frameworkStateKey];
+    const frameworkState: FrameworkState = (state as any)[
+      UiFramework.frameworkStateKey
+    ];
     return frameworkState
       ? frameworkState.configurableUiState.viewOverlayDisplay
       : true;

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
@@ -6,36 +6,28 @@
  * @module Utilities
  */
 
-import { useSelector } from "react-redux";
-import type { FrameworkRootState } from "../redux/StateManager";
-import { UiFramework } from "../UiFramework";
+import { create } from "zustand";
 
-/**
- * List of known preview features.
- */
+/** List of known preview features. */
 interface KnownPreviewFeatures {
-  /**
-   * If true, the panels and tool settings will always be rendered over the content.
+  /** If true, the panels and tool settings will always be rendered over the content.
    * The content will never change size.
    */
   contentAlwaysMaxSize: boolean;
-  /**
-   * If true, the floating widget will have a "maximize" button.
-   */
+  /** If true, the floating widget will have a "maximize" button. */
   enableMaximizedFloatingWidget: boolean;
 }
 
-/**
- * Object used trim to only known features at runtime.
+/** Object used trim to only known features at runtime.
  * @internal
  */
 const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
   contentAlwaysMaxSize: undefined,
   enableMaximizedFloatingWidget: undefined,
+  ...{ newToolbars: undefined },
 };
 
-/**
- * List of preview features that can be enabled/disabled.
+/** List of preview features that can be enabled/disabled.
  * This list is expected to change over time, the interface is made
  * so that new features can be added or removed without breaking existing code.
  * A console warning will simply appear if unknown features are passed.
@@ -45,8 +37,7 @@ export interface PreviewFeatures extends Partial<KnownPreviewFeatures> {
   [featureName: string]: any;
 }
 
-/**
- * Trim an object to only contain known feature keys.
+/** Trim an object to only contain known feature keys.
  * @param previewFeatures object potentially containing unknown features
  * @returns object containing only known features
  * @internal
@@ -79,14 +70,25 @@ export function trimToKnownFeaturesOnly(previewFeatures: PreviewFeatures) {
   return knownFeatures;
 }
 
-/**
- * Hook to access the preview features set in the Redux store.
+interface PreviewFeaturesState {
+  previewFeatures: PreviewFeatures;
+  setPreviewFeatures: (previewFeatures: PreviewFeatures) => void;
+}
+
+/** @internal */
+export const usePreviewFeaturesStore = create<PreviewFeaturesState>((set) => {
+  return {
+    previewFeatures: {},
+    setPreviewFeatures: (newPreviewFeatures: PreviewFeatures) => {
+      const previewFeatures = trimToKnownFeaturesOnly(newPreviewFeatures);
+      set({ previewFeatures });
+    },
+  };
+});
+
+/** Hook to access the preview features set in the Redux store.
  * @internal
  */
 export function usePreviewFeatures() {
-  return useSelector((state: FrameworkRootState) => {
-    const frameworkState = (state as any)[UiFramework.frameworkStateKey];
-    return frameworkState.configurableUiState
-      .previewFeatures as PreviewFeatures;
-  });
+  return usePreviewFeaturesStore((state) => state.previewFeatures);
 }

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.ts
@@ -24,7 +24,7 @@ interface KnownPreviewFeatures {
 const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
   contentAlwaysMaxSize: undefined,
   enableMaximizedFloatingWidget: undefined,
-  ...{ newToolbars: undefined },
+  ...{ newToolbars: undefined }, // Hidden feature used in storybook only (to avoid trimming).
 };
 
 /** List of preview features that can be enabled/disabled.
@@ -75,7 +75,10 @@ interface PreviewFeaturesState {
   setPreviewFeatures: (previewFeatures: PreviewFeatures) => void;
 }
 
-/** @internal */
+/** Preview features store used by `UiFramework.previewFeatures` and `UiFramework.setPreviewFeatures()` APIs to manage the preview features.
+ * Use `usePreviewFeatures` hook to access the preview features set.
+ * @internal
+ */
 export const usePreviewFeaturesStore = create<PreviewFeaturesState>((set) => {
   return {
     previewFeatures: {},
@@ -86,7 +89,7 @@ export const usePreviewFeaturesStore = create<PreviewFeaturesState>((set) => {
   };
 });
 
-/** Hook to access the preview features set in the Redux store.
+/** Hook to access the preview features set.
  * @internal
  */
 export function usePreviewFeatures() {

--- a/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
@@ -18,6 +18,7 @@ import { InternalToolbarComponent as CR_Toolbar } from "@itwin/components-react"
 import type { ToolbarItem } from "./ToolbarItem";
 import { toUIAToolbarItem } from "./toUIAToolbarItem";
 import { SyncUiEventDispatcher } from "../syncui/SyncUiEventDispatcher";
+import { usePreviewFeatures } from "../preview/PreviewFeatures";
 
 /**
  * Properties of [[Toolbar.enableOverflow]] component.
@@ -54,6 +55,18 @@ export interface ToolbarProps extends CommonProps, NoChildrenProps {
  * @beta
  */
 export function Toolbar(props: ToolbarProps) {
+  const previewFeatures = usePreviewFeatures();
+  if (previewFeatures.newToolbars) {
+    return <NewToolbar {...props} />;
+  }
+  return <OriginalToolbar {...props} />;
+}
+
+function NewToolbar(_props: ToolbarProps) {
+  return <>WIP</>;
+}
+
+function OriginalToolbar(props: ToolbarProps) {
   const { items, ...other } = props;
   const uiaItems = React.useMemo(() => {
     return items.map((item) => toUIAToolbarItem(item));

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -82,6 +82,7 @@ import { StagePanelLocation } from "../stagepanels/StagePanelLocation";
 import { UiItemsManager } from "../ui-items-provider/UiItemsManager";
 import { usePreviewFeatures } from "../preview/PreviewFeatures";
 import classNames from "classnames";
+import type { FrameworkState } from "../redux/FrameworkState";
 
 function WidgetPanelsFrontstageComponent() {
   const activeModalFrontstageInfo = useActiveModalFrontstageInfo();
@@ -214,22 +215,30 @@ export function ActiveFrontstageDefProvider({
   const labels = useLabels();
   const uiIsVisible = useUiVisibility();
   const showWidgetIcon = useSelector((state: FrameworkRootState) => {
-    const frameworkState = (state as any)[UiFramework.frameworkStateKey];
+    const frameworkState: FrameworkState = (state as any)[
+      UiFramework.frameworkStateKey
+    ];
     return !!frameworkState.configurableUiState.showWidgetIcon;
   });
   const autoCollapseUnpinnedPanels = useSelector(
     (state: FrameworkRootState) => {
-      const frameworkState = (state as any)[UiFramework.frameworkStateKey];
+      const frameworkState: FrameworkState = (state as any)[
+        UiFramework.frameworkStateKey
+      ];
       return !!frameworkState.configurableUiState.autoCollapseUnpinnedPanels;
     }
   );
   const animateToolSettings = useSelector((state: FrameworkRootState) => {
-    const frameworkState = (state as any)[UiFramework.frameworkStateKey];
+    const frameworkState: FrameworkState = (state as any)[
+      UiFramework.frameworkStateKey
+    ];
     return !!frameworkState.configurableUiState.animateToolSettings;
   });
   const useToolAsToolSettingsLabel = useSelector(
     (state: FrameworkRootState) => {
-      const frameworkState = (state as any)[UiFramework.frameworkStateKey];
+      const frameworkState: FrameworkState = (state as any)[
+        UiFramework.frameworkStateKey
+      ];
       return !!frameworkState.configurableUiState.useToolAsToolSettingsLabel;
     }
   );

--- a/ui/appui-react/src/test/UiFramework.test.ts
+++ b/ui/appui-react/src/test/UiFramework.test.ts
@@ -261,6 +261,16 @@ describe("UiFramework localStorage Wrapper", () => {
       // try again when store is not defined
       expect(UiFramework.useDragInteraction).to.eql(false);
     });
+
+    it("should set known preview features only", () => {
+      UiFramework.setPreviewFeatures({
+        contentAlwaysMaxSize: true,
+        randomFeature: "random",
+      });
+      expect(UiFramework.previewFeatures).to.be.eql({
+        contentAlwaysMaxSize: true,
+      });
+    });
   });
 
   // before we can test setting scope to a valid scope id we must make sure Presentation Manager is initialized.

--- a/ui/appui-react/src/test/redux/StateManager.test.ts
+++ b/ui/appui-react/src/test/redux/StateManager.test.ts
@@ -297,16 +297,5 @@ describe("ConfigurableUiReducer", () => {
       ConfigurableUiActions.setToolbarOpacity(0.9)
     );
     expect(outState.toolbarOpacity).to.be.eql(0.9);
-
-    outState = ConfigurableUiReducer(
-      initialState,
-      ConfigurableUiActions.setPreviewFeatures({
-        contentAlwaysMaxSize: true,
-        randomFeature: "random",
-      })
-    );
-    expect(outState.previewFeatures).to.be.eql({
-      contentAlwaysMaxSize: true,
-    });
   });
 });

--- a/ui/appui-react/src/test/setup.test.ts
+++ b/ui/appui-react/src/test/setup.test.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { toaster } from "@itwin/itwinui-react";
+import { usePreviewFeaturesStore } from "../appui-react/preview/PreviewFeatures";
 
 afterEach(() => {
   // Undo DOM manipulations made by iTwinUI-React components
@@ -13,4 +14,9 @@ afterEach(() => {
   // it looses reference of container ot render in
   // eslint-disable-next-line @typescript-eslint/dot-notation
   toaster["isInitialized"] = false;
+});
+
+const initialPreviewFeaturesState = usePreviewFeaturesStore.getState();
+afterEach(() => {
+  usePreviewFeaturesStore.setState(initialPreviewFeaturesState, true);
 });


### PR DESCRIPTION
## Changes

Remove `previewFeatures` from the redux store to avoid having a requirement of a Provider.

## Testing

Added a hidden `newToolbars` preview feature which can be enabled in `ToolbarComposer` story.