### PR TITLE
Remove unneeded UiFramework complexity

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4842,8 +4842,6 @@ export class UiFramework {
     static get hideIsolateEmphasizeActionHandler(): HideIsolateEmphasizeActionHandler;
     static initialize(store: Store<any> | undefined, frameworkStateKey?: string): Promise<void>;
     static get initialized(): boolean;
-    // @internal
-    static initializeEx(store: Store<any> | undefined, frameworkStateKey?: string): Promise<void>;
     static initializeStateFromUserSettingsProviders(immediateSync?: boolean): Promise<void>;
     // @alpha
     static get isContextMenuOpen(): boolean;

--- a/common/changes/@itwin/appui-react/raplemie-unneededComplexity_2023-11-29-17-16.json
+++ b/common/changes/@itwin/appui-react/raplemie-unneededComplexity_2023-11-29-17-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -231,20 +231,6 @@ export class UiFramework {
     store: Store<any> | undefined,
     frameworkStateKey?: string
   ): Promise<void> {
-    return this.initializeEx(store, frameworkStateKey);
-  }
-
-  /**
-   * Called by the application to initialize the UiFramework. Also initializes UIIModelComponents, UiComponents, UiCore.
-   * @param store The single Redux store created by the host application. If this is `undefined` then it is assumed that the [[StateManager]] is being used to provide the Redux store.
-   * @param frameworkStateKey The name of the key used by the app when adding the UiFramework state into the Redux store. If not defined "frameworkState" is assumed. This value is ignored if [[StateManager]] is being used. The StateManager use "frameworkState".
-   *
-   * @internal
-   */
-  public static async initializeEx(
-    store: Store<any> | undefined,
-    frameworkStateKey?: string
-  ): Promise<void> {
     if (UiFramework._initialized) {
       Logger.logInfo(
         UiFramework.loggerCategory(UiFramework),


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Removed `initializeEx` internal function from `UiFramework`. This method was created back when UiFramework was managing different services (IModelServices, ProjectServices, LoginServices...) to enable providing mocks of those services in tests. The services are long gone and there really is no need to have the internal version which had been a 1:1 match for years now...

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
N/A (`initializeEx` is internal and not called anywhere except in the method above it)