### PR TITLE
Delay viewport creation to non 0x0 div.

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-0x0ViewportHandling_2023-12-04-21-46.json
+++ b/common/changes/@itwin/appui-react/raplemie-0x0ViewportHandling_2023-12-04-21-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Now support `null` Content (allow delay rendering on specific cases)",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/imodel-components-react/raplemie-0x0ViewportHandling_2023-12-04-21-46.json
+++ b/common/changes/@itwin/imodel-components-react/raplemie-0x0ViewportHandling_2023-12-04-21-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "`ViewportComponent` will now wait to have positive space before creating iTwin.js viewport.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
+++ b/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
@@ -79,7 +79,7 @@ export class InternalContentViewManager {
       }
       floatingControls.forEach((contentControl: ContentControl) => {
         const node = contentControl.reactNode;
-        const key = (node as React.ReactElement<any>).key as string;
+        const key = (node as React.ReactElement<any>)?.key as string;
         const nodeId = key && key.split("::", 1)[0];
         if (nodeId === controlId) control = contentControl;
       });

--- a/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
@@ -26,7 +26,10 @@ import {
   ToolSettings,
 } from "@itwin/core-frontend";
 
-import type { CommonProps } from "@itwin/core-react";
+import {
+  type CommonProps,
+  ResizableContainerObserver,
+} from "@itwin/core-react";
 import type {
   CubeRotationChangeEventArgs,
   DrawingViewportChangeEventArgs,
@@ -96,6 +99,8 @@ export function ViewportComponent(props: ViewportProps) {
   const isMounted = React.useRef(false);
   const viewClassFullName = React.useRef("");
   const viewId = React.useRef("0");
+  const [isLargeEnoughForInitialRender, setIsLargeEnoughForInitialRender] =
+    React.useState(false);
 
   // istanbul ignore next
   const handleViewChanged = (vp: Viewport) => {
@@ -340,6 +345,7 @@ export function ViewportComponent(props: ViewportProps) {
     const viewManager = viewManagerRef.current;
     // istanbul ignore next
     if (
+      isLargeEnoughForInitialRender &&
       parentDiv &&
       initialViewState &&
       (initialViewState?.iModel.isOpen || initialViewState?.iModel.isBlank)
@@ -364,7 +370,7 @@ export function ViewportComponent(props: ViewportProps) {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [controlId, initialViewState, viewportRef]);
+  }, [controlId, initialViewState, viewportRef, isLargeEnoughForInitialRender]);
 
   const handleContextMenu = React.useCallback(
     (e: React.MouseEvent) => {
@@ -388,16 +394,21 @@ export function ViewportComponent(props: ViewportProps) {
 
   return (
     <div style={parentDivStyle} data-item-id={controlId}>
-      <>
-        <div
-          ref={viewportDiv}
-          data-testid="viewport-component"
-          className={className}
-          style={viewportDivStyle}
-          onContextMenu={handleContextMenu}
+      {!isLargeEnoughForInitialRender && (
+        <ResizableContainerObserver
+          onResize={(w, h) =>
+            setIsLargeEnoughForInitialRender(![w, h].includes(0))
+          }
         />
-        {viewOverlay}
-      </>
+      )}
+      <div
+        ref={viewportDiv}
+        data-testid="viewport-component"
+        className={className}
+        style={viewportDivStyle}
+        onContextMenu={handleContextMenu}
+      />
+      {viewOverlay}
     </div>
   );
 }

--- a/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
@@ -26,10 +26,8 @@ import {
   ToolSettings,
 } from "@itwin/core-frontend";
 
-import {
-  type CommonProps,
-  ResizableContainerObserver,
-} from "@itwin/core-react";
+import type { CommonProps } from "@itwin/core-react";
+import { ResizableContainerObserver } from "@itwin/core-react";
 import type {
   CubeRotationChangeEventArgs,
   DrawingViewportChangeEventArgs,

--- a/ui/imodel-components-react/src/test/viewport/ViewportComponent.test.tsx
+++ b/ui/imodel-components-react/src/test/viewport/ViewportComponent.test.tsx
@@ -197,6 +197,9 @@ describe("ViewportComponent", () => {
     worldToViewPoint = Point3d.create(50, 50);
     nearestVisibleGeometryPoint = Point3d.create(30, 30);
     viewRect = new ViewRect(0, 0, 100, 100);
+    sinon.replace(Element.prototype, "getBoundingClientRect", () =>
+      DOMRect.fromRect({ x: 0, y: 0, height: 100, width: 100 })
+    );
   });
 
   it("should render with viewState", async () => {
@@ -652,5 +655,56 @@ describe("ViewportComponent", () => {
       await TestUtils.flushAsyncOperations();
       onViewChanged.raiseEvent(viewportMock2.object);
     });
+  });
+
+  it("should only set viewportRef once size is at least 1x1", async () => {
+    sinon.restore();
+    sinon.replace(Element.prototype, "getBoundingClientRect", () =>
+      DOMRect.fromRect({ x: 0, y: 0, height: 0, width: 0 })
+    );
+    const viewportRef = sinon.spy();
+    const { rerender } = render(
+      <ViewportComponent
+        imodel={imodelMock.object}
+        viewportRef={viewportRef}
+        viewState={viewState}
+        viewManagerOverride={viewManager.object}
+        screenViewportOverride={ScreenViewportMock}
+      />
+    );
+    await TestUtils.flushAsyncOperations();
+    expect(viewportRef).to.not.be.called;
+
+    sinon.restore();
+    sinon.replace(Element.prototype, "getBoundingClientRect", () =>
+      DOMRect.fromRect({ x: 0, y: 0, height: 1, width: 0 })
+    );
+    rerender(
+      <ViewportComponent
+        imodel={imodelMock.object}
+        viewportRef={viewportRef}
+        viewState={viewState}
+        viewManagerOverride={viewManager.object}
+        screenViewportOverride={ScreenViewportMock}
+      />
+    );
+    await TestUtils.flushAsyncOperations();
+    expect(viewportRef).to.not.be.called;
+
+    sinon.restore();
+    sinon.replace(Element.prototype, "getBoundingClientRect", () =>
+      DOMRect.fromRect({ x: 0, y: 0, height: 1, width: 1 })
+    );
+    rerender(
+      <ViewportComponent
+        imodel={imodelMock.object}
+        viewportRef={viewportRef}
+        viewState={viewState}
+        viewManagerOverride={viewManager.object}
+        screenViewportOverride={ScreenViewportMock}
+      />
+    );
+    await TestUtils.flushAsyncOperations();
+    expect(viewportRef).to.be.calledWith(viewportMock.object);
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
Include a `ResizeObserver` to validate that the `div` targeted for iTwin.js `viewport` actually have non 0 height and width (otherwise it crashes anyway and the fix was needed by user devs)
`viewportRef` will not be set until the `div` is large enough, and resize observer is completely removed after initial render, to have same result as before.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Updated tests to have a size, and added a tests for 0x0 sizes.

## Issue
Resolves #608
