### PR TITLE
Keep widget content unmounted while widget state is set to `WidgetState.Unloaded`

### DIFF
--- a/common/api/appui-layout-react.api.md
+++ b/common/api/appui-layout-react.api.md
@@ -674,7 +674,7 @@ export interface NavigationAreaProps extends CommonProps, NoChildrenProps {
 export function NineZone(props: NineZoneProps): JSX.Element;
 
 // @internal (undocumented)
-export type NineZoneAction = ResizeAction | PanelToggleCollapsedAction | PanelSetCollapsedAction | PanelSetPinnedAction | PanelSetSizeAction | PanelSetSplitterPercentAction | PanelToggleSpanAction | PanelTogglePinnedAction | PanelInitializeAction | FloatingWidgetResizeAction | FloatingWidgetSetBoundsAction | FloatingWidgetBringToFrontAction | FloatingWidgetSendBackAction | FloatingWidgetClearUserSizedAction | FloatingWidgetSetUserSizedAction | PopoutWidgetSendBackAction | PanelWidgetDragStartAction | WidgetDragAction | WidgetDragEndAction | WidgetTabClickAction | WidgetTabDoubleClickAction | WidgetTabDragStartAction | WidgetTabDragAction | WidgetTabDragEndAction | WidgetTabPopoutAction | WidgetTabCloseAction | WidgetTabFloatAction | WidgetTabHideAction | WidgetTabOpenAction | WidgetTabSetLabelAction | WidgetTabSetPopoutBoundsAction | WidgetTabShowAction | WidgetTabExpandAction | ToolSettingsDragStartAction | ToolSettingsDockAction;
+export type NineZoneAction = ResizeAction | PanelToggleCollapsedAction | PanelSetCollapsedAction | PanelSetPinnedAction | PanelSetSizeAction | PanelSetSplitterPercentAction | PanelToggleSpanAction | PanelTogglePinnedAction | PanelInitializeAction | FloatingWidgetResizeAction | FloatingWidgetSetBoundsAction | FloatingWidgetBringToFrontAction | FloatingWidgetSendBackAction | FloatingWidgetClearUserSizedAction | FloatingWidgetSetUserSizedAction | PopoutWidgetSendBackAction | PanelWidgetDragStartAction | WidgetDragAction | WidgetDragEndAction | WidgetTabClickAction | WidgetTabCloseAction | WidgetTabDoubleClickAction | WidgetTabDragStartAction | WidgetTabDragAction | WidgetTabDragEndAction | WidgetTabExpandAction | WidgetTabFloatAction | WidgetTabHideAction | WidgetTabOpenAction | WidgetTabPopoutAction | WidgetTabSetLabelAction | WidgetTabSetPopoutBoundsAction | WidgetTabShowAction | WidgetTabUnloadAction | ToolSettingsDragStartAction | ToolSettingsDockAction;
 
 // @internal (undocumented)
 export type NineZoneDispatch = (action: NineZoneAction) => void;
@@ -1227,6 +1227,8 @@ export interface TabState {
     readonly preferredFloatingWidgetSize?: SizeProps;
     // (undocumented)
     readonly preferredPanelWidgetSize?: "fit-content";
+    // (undocumented)
+    readonly unloaded?: boolean;
     // (undocumented)
     readonly userSized?: boolean;
 }
@@ -2089,6 +2091,14 @@ export interface WidgetTabShowAction {
     readonly id: TabState["id"];
     // (undocumented)
     readonly type: "WIDGET_TAB_SHOW";
+}
+
+// @internal (undocumented)
+export interface WidgetTabUnloadAction {
+    // (undocumented)
+    readonly id: TabState["id"];
+    // (undocumented)
+    readonly type: "WIDGET_TAB_UNLOAD";
 }
 
 // @internal (undocumented)

--- a/common/api/summary/appui-layout-react.exports.csv
+++ b/common/api/summary/appui-layout-react.exports.csv
@@ -128,7 +128,7 @@ internal;MessageCenterTabProps
 internal;NavigationArea(props: NavigationAreaProps): JSX.Element
 internal;NavigationAreaProps 
 internal;NineZone(props: NineZoneProps): JSX.Element
-internal;NineZoneAction = ResizeAction | PanelToggleCollapsedAction | PanelSetCollapsedAction | PanelSetPinnedAction | PanelSetSizeAction | PanelSetSplitterPercentAction | PanelToggleSpanAction | PanelTogglePinnedAction | PanelInitializeAction | FloatingWidgetResizeAction | FloatingWidgetSetBoundsAction | FloatingWidgetBringToFrontAction | FloatingWidgetSendBackAction | FloatingWidgetClearUserSizedAction | FloatingWidgetSetUserSizedAction | PopoutWidgetSendBackAction | PanelWidgetDragStartAction | WidgetDragAction | WidgetDragEndAction | WidgetTabClickAction | WidgetTabDoubleClickAction | WidgetTabDragStartAction | WidgetTabDragAction | WidgetTabDragEndAction | WidgetTabPopoutAction | WidgetTabCloseAction | WidgetTabFloatAction | WidgetTabHideAction | WidgetTabOpenAction | WidgetTabSetLabelAction | WidgetTabSetPopoutBoundsAction | WidgetTabShowAction | WidgetTabExpandAction | ToolSettingsDragStartAction | ToolSettingsDockAction
+internal;NineZoneAction = ResizeAction | PanelToggleCollapsedAction | PanelSetCollapsedAction | PanelSetPinnedAction | PanelSetSizeAction | PanelSetSplitterPercentAction | PanelToggleSpanAction | PanelTogglePinnedAction | PanelInitializeAction | FloatingWidgetResizeAction | FloatingWidgetSetBoundsAction | FloatingWidgetBringToFrontAction | FloatingWidgetSendBackAction | FloatingWidgetClearUserSizedAction | FloatingWidgetSetUserSizedAction | PopoutWidgetSendBackAction | PanelWidgetDragStartAction | WidgetDragAction | WidgetDragEndAction | WidgetTabClickAction | WidgetTabCloseAction | WidgetTabDoubleClickAction | WidgetTabDragStartAction | WidgetTabDragAction | WidgetTabDragEndAction | WidgetTabExpandAction | WidgetTabFloatAction | WidgetTabHideAction | WidgetTabOpenAction | WidgetTabPopoutAction | WidgetTabSetLabelAction | WidgetTabSetPopoutBoundsAction | WidgetTabShowAction | WidgetTabUnloadAction | ToolSettingsDragStartAction | ToolSettingsDockAction
 internal;NineZoneDispatch = (action: NineZoneAction) => void
 internal;NineZoneDispatchContext: React_2.Context
 internal;NineZoneLabels
@@ -345,5 +345,6 @@ internal;WidgetTabsEntryProvider(props: WidgetTabsEntryContextProviderProps): JS
 internal;WidgetTabSetLabelAction
 internal;WidgetTabSetPopoutBoundsAction
 internal;WidgetTabShowAction
+internal;WidgetTabUnloadAction
 internal;WidgetToolSettingsState
 internal;WindowDropTargetState

--- a/common/changes/@itwin/appui-layout-react/issue-338_2023-12-05-17-54.json
+++ b/common/changes/@itwin/appui-layout-react/issue-338_2023-12-05-17-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/common/changes/@itwin/appui-react/issue-338_2023-12-05-17-54.json
+++ b/common/changes/@itwin/appui-react/issue-338_2023-12-05-17-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Keep widget content unmounted while widget state is set to WidgetState.Unloaded.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -211,6 +211,10 @@
       "allowedCategories": [ "internal" ]
     },
     {
+      "name": "@storybook/addon-actions",
+      "allowedCategories": [ "internal" ]
+    },
+    {
       "name": "@storybook/addon-essentials",
       "allowedCategories": [ "internal" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -519,6 +519,10 @@
       "allowedCategories": [ "frontend", "internal", "tools" ]
     },
     {
+      "name": "upath",
+      "allowedCategories": [ "frontend" ]
+    },
+    {
       "name": "vite",
       "allowedCategories": [ "internal" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -24,6 +24,7 @@ importers:
       '@itwin/itwinui-icons-react': ^2.1.0
       '@itwin/itwinui-react': ^2.11.11
       '@originjs/vite-plugin-commonjs': ~1.0.3
+      '@storybook/addon-actions': ^7.4.6
       '@storybook/addon-essentials': ^7.4.6
       '@storybook/addon-interactions': ^7.4.6
       '@storybook/addon-links': ^7.4.6
@@ -74,6 +75,7 @@ importers:
       react-redux: 7.2.9_react-dom@17.0.2+react@17.0.2
     devDependencies:
       '@originjs/vite-plugin-commonjs': 1.0.3
+      '@storybook/addon-actions': 7.4.6_54d6c303e86b1ed39f97a7d48627e275
       '@storybook/addon-essentials': 7.4.6_54d6c303e86b1ed39f97a7d48627e275
       '@storybook/addon-interactions': 7.4.6_54d6c303e86b1ed39f97a7d48627e275
       '@storybook/addon-links': 7.4.6_react-dom@17.0.2+react@17.0.2
@@ -1428,7 +1430,7 @@ packages:
     resolution: {integrity: sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.23.0
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
@@ -1693,7 +1695,7 @@ packages:
     resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-module-transforms/7.21.2:
@@ -1719,10 +1721,10 @@ packages:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       '@babel/template': 7.22.5
       '@babel/traverse': 7.23.2
-      '@babel/types': 7.22.5
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1824,7 +1826,7 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
@@ -1925,7 +1927,7 @@ packages:
     dependencies:
       '@babel/template': 7.22.5
       '@babel/traverse': 7.23.2
-      '@babel/types': 7.22.5
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1961,7 +1963,7 @@ packages:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
@@ -3886,8 +3888,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.22.5
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/traverse/7.23.2:
@@ -3920,7 +3922,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
 
   /@babel/types/7.23.0:
@@ -8253,8 +8255,8 @@ packages:
   /@types/babel__core/7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
@@ -8263,14 +8265,14 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.23.0
     dev: true
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
     dev: true
 
   /@types/babel__traverse/7.18.3:
@@ -12784,7 +12786,7 @@ packages:
     engines: {node: '>=8.3.0'}
     dependencies:
       '@babel/traverse': 7.23.2
-      '@babel/types': 7.22.5
+      '@babel/types': 7.23.0
       c8: 7.14.0
     transitivePeerDependencies:
       - supports-color

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -540,6 +540,7 @@ importers:
       ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ^5.0.2
+      upath: ^2.0.1
       zustand: ^4.4.1
     dependencies:
       '@itwin/itwinui-icons-react': 2.1.0_react-dom@17.0.2+react@17.0.2
@@ -591,6 +592,7 @@ importers:
       ts-node: 10.9.1_9a41dbaa370b60afede472b47d9ffeeb
       typemoq: 2.1.0
       typescript: 5.0.2
+      upath: 2.0.1
 
   ../../ui/appui-react:
     specifiers:
@@ -21034,6 +21036,11 @@ packages:
 
   /upath/1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /upath/2.0.1:
+    resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
     engines: {node: '>=4'}
     dev: true
 

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -24,6 +24,7 @@ importers:
       '@itwin/itwinui-icons-react': ^2.1.0
       '@itwin/itwinui-react': ^2.11.11
       '@originjs/vite-plugin-commonjs': ~1.0.3
+      '@storybook/addon-actions': ^7.4.6
       '@storybook/addon-essentials': ^7.4.6
       '@storybook/addon-interactions': ^7.4.6
       '@storybook/addon-links': ^7.4.6
@@ -74,6 +75,7 @@ importers:
       react-redux: 7.2.9_react-dom@17.0.2+react@17.0.2
     devDependencies:
       '@originjs/vite-plugin-commonjs': 1.0.3
+      '@storybook/addon-actions': 7.4.6_54d6c303e86b1ed39f97a7d48627e275
       '@storybook/addon-essentials': 7.4.6_54d6c303e86b1ed39f97a7d48627e275
       '@storybook/addon-interactions': 7.4.6_54d6c303e86b1ed39f97a7d48627e275
       '@storybook/addon-links': 7.4.6_react-dom@17.0.2+react@17.0.2

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -540,6 +540,7 @@ importers:
       ts-node: ^10.8.2
       typemoq: ^2.1.0
       typescript: ~5.0.2
+      upath: ^2.0.1
       zustand: ^4.4.1
     dependencies:
       '@itwin/itwinui-icons-react': 2.1.0_react-dom@17.0.2+react@17.0.2
@@ -591,6 +592,7 @@ importers:
       ts-node: 10.9.1_9a41dbaa370b60afede472b47d9ffeeb
       typemoq: 2.1.0
       typescript: 5.0.2
+      upath: 2.0.1
 
   ../../ui/appui-react:
     specifiers:
@@ -21120,6 +21122,11 @@ packages:
 
   /upath/1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
+    engines: {node: '>=4'}
+    dev: true
+
+  /upath/2.0.1:
+    resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
     engines: {node: '>=4'}
     dev: true
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -13,6 +13,7 @@ Table of contents:
 ### Changes
 
 - Promoted `FrameworkToolAdmin` to _beta_. #618
+- Correctly handle `WidgetState.Unloaded` and keep widget content unmounted when widget is unloaded. #617
 
 ## @itwin/components-react
 

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@originjs/vite-plugin-commonjs": "~1.0.3",
+    "@storybook/addon-actions": "^7.4.6",
     "@storybook/addon-essentials": "^7.4.6",
     "@storybook/addon-interactions": "^7.4.6",
     "@storybook/addon-links": "^7.4.6",

--- a/docs/storybook/src/widget/Widget.stories.tsx
+++ b/docs/storybook/src/widget/Widget.stories.tsx
@@ -7,7 +7,7 @@ import { BadgeType } from "@itwin/appui-abstract";
 import { WidgetState } from "@itwin/appui-react";
 import { AppUiDecorator } from "../AppUiDecorator";
 import { Page } from "../AppUiStory";
-import { WidgetStory } from "./Widget";
+import { StoryWidget, WidgetStory } from "./Widget";
 
 const meta = {
   title: "Widget/Widget",
@@ -22,7 +22,7 @@ const meta = {
   args: {
     id: "w1",
     label: "Widget 1",
-    content: <>Widget 1 content </>,
+    content: <StoryWidget id="w1" />,
   },
 } satisfies Meta<typeof WidgetStory>;
 
@@ -30,6 +30,12 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const Unloaded: Story = {
+  args: {
+    defaultState: WidgetState.Unloaded,
+  },
+};
 
 export const Floating: Story = {
   args: {

--- a/docs/storybook/src/widget/Widget.tsx
+++ b/docs/storybook/src/widget/Widget.tsx
@@ -2,8 +2,26 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { UiItemsProvider, Widget } from "@itwin/appui-react";
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import {
+  StagePanelState,
+  UiItemsProvider,
+  Widget,
+  WidgetState,
+} from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
+import { createFrontstageProvider } from "../Utils";
+
+export function StoryWidget({ id }: { id: string }) {
+  React.useEffect(() => {
+    action(`Widget ${id} mounted`)();
+    return () => {
+      action(`Widget ${id} unmounted`)();
+    };
+  });
+  return <>Widget {id} content </>;
+}
 
 function createProvider(props: Widget): UiItemsProvider {
   return {
@@ -12,7 +30,8 @@ function createProvider(props: Widget): UiItemsProvider {
       const widget2: Widget = {
         id: "w2",
         label: "Widget 2",
-        content: <>Widget 2 content </>,
+        content: <StoryWidget id="w2" />,
+        defaultState: WidgetState.Open,
       };
       return [props, widget2];
     },
@@ -22,5 +41,18 @@ function createProvider(props: Widget): UiItemsProvider {
 /** [Widget](https://www.itwinjs.org/reference/appui-react/widget/widget) interface allows you to configure the widget. */
 export function WidgetStory(props: Widget) {
   const provider = createProvider(props);
-  return <AppUiStory itemProviders={[provider]} {...props} />;
+  return (
+    <AppUiStory
+      frontstageProviders={[
+        createFrontstageProvider({
+          leftPanelProps: {
+            defaultState: StagePanelState.Open,
+            pinned: true,
+          },
+        }),
+      ]}
+      itemProviders={[provider]}
+      {...props}
+    />
+  );
 }

--- a/docs/storybook/src/widget/Widget.tsx
+++ b/docs/storybook/src/widget/Widget.tsx
@@ -4,12 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import {
-  StagePanelState,
-  UiItemsProvider,
-  Widget,
-  WidgetState,
-} from "@itwin/appui-react";
+import { StagePanelState, UiItemsProvider, Widget } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
 import { createFrontstageProvider } from "../Utils";
 

--- a/docs/storybook/src/widget/Widget.tsx
+++ b/docs/storybook/src/widget/Widget.tsx
@@ -31,7 +31,6 @@ function createProvider(props: Widget): UiItemsProvider {
         id: "w2",
         label: "Widget 2",
         content: <StoryWidget id="w2" />,
-        defaultState: WidgetState.Open,
       };
       return [props, widget2];
     },

--- a/full-stack-tests/ui/tests/Utils.ts
+++ b/full-stack-tests/ui/tests/Utils.ts
@@ -176,6 +176,7 @@ export enum WidgetState {
   Closed = 1,
   Hidden = 2,
   Floating = 3,
+  Unloaded = 4,
 }
 
 export async function setWidgetState(
@@ -206,4 +207,16 @@ export async function openComponentExamples(
   await page.goto(`${baseURL}?frontstage=appui-test-providers:WidgetApi`);
   await page.locator(".nz-toolbar-button-button").click();
   await page.getByRole("menuitem", { name: "Component Examples" }).click();
+}
+
+export function trackWidgetLifecycle(page: Page, widgetId: string) {
+  const lifecycle = {
+    mountCount: 0,
+    unMountCount: 0,
+  };
+  page.on("console", (msg) => {
+    if (msg.text() === `Widget ${widgetId} mount`) lifecycle.mountCount++;
+    if (msg.text() === `Widget ${widgetId} unmount`) lifecycle.unMountCount++;
+  });
+  return lifecycle;
 }

--- a/full-stack-tests/ui/tests/popout-widget.test.ts
+++ b/full-stack-tests/ui/tests/popout-widget.test.ts
@@ -11,6 +11,7 @@ import {
   openFrontstage,
   setWidgetState,
   tabLocator,
+  trackWidgetLifecycle,
   widgetLocator,
 } from "./Utils";
 
@@ -193,16 +194,11 @@ test.describe("popout widget", () => {
     context,
     page,
   }) => {
-    let mountCount = 0;
-    let unMountCount = 0;
-    page.on("console", (msg) => {
-      if (msg.text() === "Widget PopoutMountUnmountWidget mount") mountCount++;
-      if (msg.text() === "Widget PopoutMountUnmountWidget unmount")
-        unMountCount++;
-    });
+    const id = "appui-test-providers:PopoutMountUnmountWidget";
+    const widgetLifecycle = trackWidgetLifecycle(page, id);
     const widget = floatingWidgetLocator({
       page,
-      id: "appui-test-providers:PopoutMountUnmountWidget",
+      id,
     });
     const popoutButton = widget.locator('[title="Pop out active widget tab"]');
 
@@ -215,15 +211,11 @@ test.describe("popout widget", () => {
 
     popoutPage.close();
 
-    await setWidgetState(
-      page,
-      "appui-test-providers:PopoutMountUnmountWidget",
-      WidgetState.Floating
-    );
+    await setWidgetState(page, id, WidgetState.Floating);
     await expect.poll(async () => popoutPage.isClosed()).toBe(true);
     // Due to the change to Popouts where `WidgetContentContainer` is displayed instead of a React Node. The actual widget is no longer unmounted
     // and is simply sent to a different `WidgetContentContainer`. That's why the unmount count was changed to 0 here.
-    expect(mountCount).toBe(1);
-    expect(unMountCount).toBe(0);
+    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.unMountCount).toBe(0);
   });
 });

--- a/full-stack-tests/ui/tests/popout-widget.test.ts
+++ b/full-stack-tests/ui/tests/popout-widget.test.ts
@@ -196,8 +196,9 @@ test.describe("popout widget", () => {
     let mountCount = 0;
     let unMountCount = 0;
     page.on("console", (msg) => {
-      if (msg.text() === "POPOUT COMPONENT MOUNT") mountCount++;
-      if (msg.text() === "POPOUT COMPONENT UNMOUNT") unMountCount++;
+      if (msg.text() === "Widget PopoutMountUnmountWidget mount") mountCount++;
+      if (msg.text() === "Widget PopoutMountUnmountWidget unmount")
+        unMountCount++;
     });
     const widget = floatingWidgetLocator({
       page,

--- a/full-stack-tests/ui/tests/widget-state.test.ts
+++ b/full-stack-tests/ui/tests/widget-state.test.ts
@@ -14,6 +14,7 @@ import {
   panelLocator,
   setWidgetState,
   tabLocator,
+  trackWidgetLifecycle,
   widgetLocator,
   WidgetState,
 } from "./Utils";
@@ -192,7 +193,6 @@ test.describe("widget state", () => {
   }) => {
     const tab1 = tabLocator(page, "WT-A");
     const tab2 = tabLocator(page, "WT-2");
-    const body = page.locator("body");
     await expectTabInPanelSection(tab1, "top", 0);
 
     // Drag from top start to top end.
@@ -288,5 +288,39 @@ test.describe("widget state", () => {
 
     await setWidgetState(page, "FW-H1", WidgetState.Floating);
     await expect(tab).toBeVisible();
+  });
+
+  test("should not mount unloaded widget", async ({ page }) => {
+    const widgetLifecycle = trackWidgetLifecycle(page, "WL-B");
+
+    const tab = tabLocator(page, "WL-B");
+    await expect(tab).toBeHidden();
+
+    expect(widgetLifecycle.mountCount).toBe(0);
+    expect(widgetLifecycle.unMountCount).toBe(0);
+  });
+
+  test("should mount unloaded widget on open", async ({ page }) => {
+    const widgetLifecycle = trackWidgetLifecycle(page, "WL-B");
+    await setWidgetState(page, "WL-B", WidgetState.Open);
+
+    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.unMountCount).toBe(0);
+  });
+
+  test("should mount unloaded widget on close", async ({ page }) => {
+    const widgetLifecycle = trackWidgetLifecycle(page, "WL-B");
+    await setWidgetState(page, "WL-B", WidgetState.Closed);
+
+    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.unMountCount).toBe(0);
+  });
+
+  test("should mount unloaded widget on float", async ({ page }) => {
+    const widgetLifecycle = trackWidgetLifecycle(page, "WL-B");
+    await setWidgetState(page, "WL-B", WidgetState.Floating);
+
+    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.unMountCount).toBe(0);
   });
 });

--- a/full-stack-tests/ui/tests/widget-state.test.ts
+++ b/full-stack-tests/ui/tests/widget-state.test.ts
@@ -292,7 +292,6 @@ test.describe("widget state", () => {
 
   test("should not mount unloaded widget", async ({ page }) => {
     const widgetLifecycle = trackWidgetLifecycle(page, "WL-B");
-
     const tab = tabLocator(page, "WL-B");
     await expect(tab).toBeHidden();
 
@@ -322,5 +321,28 @@ test.describe("widget state", () => {
 
     expect(widgetLifecycle.mountCount).toBe(1);
     expect(widgetLifecycle.unMountCount).toBe(0);
+  });
+
+  test("should unmount and hide widget when unloading", async ({ page }) => {
+    const widgetLifecycle = trackWidgetLifecycle(page, "WL-A");
+    const tab = tabLocator(page, "WL-A");
+    await expect(tab).toBeVisible();
+    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.unMountCount).toBe(0);
+
+    await setWidgetState(page, "WL-A", WidgetState.Unloaded);
+    await expect(tab).not.toBeVisible();
+    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.unMountCount).toBe(1);
+  });
+
+  test("should mount and unmount unloaded widget", async ({ page }) => {
+    const widgetLifecycle = trackWidgetLifecycle(page, "WL-B");
+    const tab = tabLocator(page, "WL-B");
+    await setWidgetState(page, "WL-B", WidgetState.Open);
+    await setWidgetState(page, "WL-B", WidgetState.Unloaded);
+    await expect(tab).toBeHidden();
+    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.unMountCount).toBe(1);
   });
 });

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/FloatingWidgetsUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/FloatingWidgetsUiItemsProvider.tsx
@@ -12,11 +12,9 @@ import {
   Widget,
   WidgetState,
 } from "@itwin/appui-react";
-import { PopoutMountUnmountWidgetComponent } from "../widgets/PopoutMountUnmountWidget";
+import { LogLifecycleWidget } from "../widgets/LogLifecycleWidget";
 
-/**
- * Test UiItemsProvider that provide FloatingWidgets in any General usage stage.
- */
+/** Test UiItemsProvider that provide FloatingWidgets in any General usage stage. */
 export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
   public static providerId = "appui-test-providers:FloatingWidgetsUiProvider";
   public readonly id = FloatingWidgetsUiItemsProvider.providerId;
@@ -98,7 +96,7 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
           containerId: "appui-test-providers:PopoutMountUnmountWidget",
           defaultPosition: { x: 101, y: 200 },
         },
-        content: <PopoutMountUnmountWidgetComponent />,
+        content: <LogLifecycleWidget id="PopoutMountUnmountWidget" />,
         canPopout: true,
         allowedPanels: [StagePanelLocation.Left],
       });

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/FloatingWidgetsUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/FloatingWidgetsUiItemsProvider.tsx
@@ -96,7 +96,9 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
           containerId: "appui-test-providers:PopoutMountUnmountWidget",
           defaultPosition: { x: 101, y: 200 },
         },
-        content: <LogLifecycleWidget id="PopoutMountUnmountWidget" />,
+        content: (
+          <LogLifecycleWidget id="appui-test-providers:PopoutMountUnmountWidget" />
+        ),
         canPopout: true,
         allowedPanels: [StagePanelLocation.Left],
       });

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/WidgetApiStageUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/WidgetApiStageUiItemsProvider.tsx
@@ -86,7 +86,7 @@ export class WidgetApiStageUiItemsProvider implements UiItemsProvider {
         icon: "icon-app-1",
         canPopout: true,
         defaultState: WidgetState.Open,
-        content: <h2>Left WL-A</h2>,
+        content: <LogLifecycleWidget id="WL-A" />,
         canFloat: {
           hideWithUi: true,
         },

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/WidgetApiStageUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/WidgetApiStageUiItemsProvider.tsx
@@ -33,6 +33,7 @@ import {
   RegisterUiProviderTool,
   UnregisterUiProviderTool,
 } from "../../tools/RegisterUiProviderTool";
+import { LogLifecycleWidget } from "../widgets/LogLifecycleWidget";
 
 /**
  * WidgetApiStageUiItemsProvider provides widget in the bottom panel that can exercise the Widget API on Widgets in the other panels.
@@ -90,6 +91,13 @@ export class WidgetApiStageUiItemsProvider implements UiItemsProvider {
           hideWithUi: true,
         },
         allowedPanels: [StagePanelLocation.Left, StagePanelLocation.Right],
+      });
+      widgets.push({
+        id: "WL-B",
+        label: "WL-B",
+        icon: "icon-app-2",
+        defaultState: WidgetState.Unloaded,
+        content: <LogLifecycleWidget id="WL-B" />,
       });
     } else if (section === StagePanelSection.End) {
       widgets.push({

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/LogLifecycleWidget.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/LogLifecycleWidget.tsx
@@ -4,15 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 
-export function PopoutMountUnmountWidgetComponent() {
+export function LogLifecycleWidget({ id }: { id: string }) {
   React.useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log("POPOUT COMPONENT MOUNT");
+    console.log(`Widget ${id} mount`); // eslint-disable-line no-console
     return () => {
       // eslint-disable-next-line no-console
-      console.log("POPOUT COMPONENT UNMOUNT");
+      console.log(`Widget ${id} unmount`); // eslint-disable-line no-console
     };
-  }, []);
-
-  return <div>Mount Unmount Widget</div>;
+  }, [id]);
+  return <div>Widget {id} content</div>;
 }

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/LogLifecycleWidget.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/LogLifecycleWidget.tsx
@@ -8,7 +8,6 @@ export function LogLifecycleWidget({ id }: { id: string }) {
   React.useEffect(() => {
     console.log(`Widget ${id} mount`); // eslint-disable-line no-console
     return () => {
-      // eslint-disable-next-line no-console
       console.log(`Widget ${id} unmount`); // eslint-disable-line no-console
     };
   }, [id]);

--- a/ui/appui-layout-react/package.json
+++ b/ui/appui-layout-react/package.json
@@ -75,6 +75,7 @@
     "chai-jest-snapshot": "^2.0.0",
     "cpx2": "^3.0.0",
     "eslint": "^8.44.0",
+    "eslint-config-prettier": "~8.8.0",
     "ignore-styles": "^5.0.1",
     "jsdom": "^19.0.0",
     "jsdom-global": "3.0.2",
@@ -90,7 +91,7 @@
     "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
     "typescript": "~5.0.2",
-    "eslint-config-prettier": "~8.8.0"
+    "upath": "^2.0.1"
   },
   "//dependencies": [
     "NOTE: these dependencies should be only for things that DO NOT APPEAR IN THE API",

--- a/ui/appui-layout-react/src/appui-layout-react/state/NineZoneAction.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/NineZoneAction.ts
@@ -218,13 +218,6 @@ export interface WidgetTabSetLabelAction {
 }
 
 /** @internal */
-export interface WidgetTabSetLoadedAction {
-  readonly type: "WIDGET_TAB_SET_LOADED";
-  readonly id: TabState["id"];
-  readonly loaded: boolean;
-}
-
-/** @internal */
 export interface WidgetTabOpenAction {
   readonly type: "WIDGET_TAB_OPEN";
   readonly id: TabState["id"];
@@ -254,6 +247,12 @@ export interface WidgetTabShowAction {
 /** @internal */
 export interface WidgetTabExpandAction {
   readonly type: "WIDGET_TAB_EXPAND";
+  readonly id: TabState["id"];
+}
+
+/** @internal */
+export interface WidgetTabUnloadAction {
+  readonly type: "WIDGET_TAB_UNLOAD";
   readonly id: TabState["id"];
 }
 
@@ -290,19 +289,19 @@ export type NineZoneAction =
   | WidgetDragAction
   | WidgetDragEndAction
   | WidgetTabClickAction
+  | WidgetTabCloseAction
   | WidgetTabDoubleClickAction
   | WidgetTabDragStartAction
   | WidgetTabDragAction
   | WidgetTabDragEndAction
-  | WidgetTabPopoutAction
-  | WidgetTabCloseAction
+  | WidgetTabExpandAction
   | WidgetTabFloatAction
   | WidgetTabHideAction
   | WidgetTabOpenAction
+  | WidgetTabPopoutAction
   | WidgetTabSetLabelAction
-  | WidgetTabSetLoadedAction
   | WidgetTabSetPopoutBoundsAction
   | WidgetTabShowAction
-  | WidgetTabExpandAction
+  | WidgetTabUnloadAction
   | ToolSettingsDragStartAction
   | ToolSettingsDockAction;

--- a/ui/appui-layout-react/src/appui-layout-react/state/NineZoneAction.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/NineZoneAction.ts
@@ -218,6 +218,13 @@ export interface WidgetTabSetLabelAction {
 }
 
 /** @internal */
+export interface WidgetTabSetLoadedAction {
+  readonly type: "WIDGET_TAB_SET_LOADED";
+  readonly id: TabState["id"];
+  readonly loaded: boolean;
+}
+
+/** @internal */
 export interface WidgetTabOpenAction {
   readonly type: "WIDGET_TAB_OPEN";
   readonly id: TabState["id"];
@@ -293,6 +300,7 @@ export type NineZoneAction =
   | WidgetTabHideAction
   | WidgetTabOpenAction
   | WidgetTabSetLabelAction
+  | WidgetTabSetLoadedAction
   | WidgetTabSetPopoutBoundsAction
   | WidgetTabShowAction
   | WidgetTabExpandAction

--- a/ui/appui-layout-react/src/appui-layout-react/state/NineZoneStateReducer.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/NineZoneStateReducer.ts
@@ -583,16 +583,9 @@ export function NineZoneStateReducer(
     case "WIDGET_TAB_HIDE": {
       return hideTab(state, action.id);
     }
-
     case "WIDGET_TAB_SET_LABEL": {
       return updateTabState(state, action.id, {
         label: action.label,
-      });
-    }
-    case "WIDGET_TAB_SET_LOADED": {
-      state = hideTab(state, action.id);
-      return updateTabState(state, action.id, {
-        unloaded: !action.loaded,
       });
     }
     case "WIDGET_TAB_OPEN": {
@@ -699,6 +692,12 @@ export function NineZoneStateReducer(
     case "WIDGET_TAB_SHOW": {
       return showWidgetTab(state, action.id);
     }
+    case "WIDGET_TAB_UNLOAD": {
+      state = hideTab(state, action.id);
+      return updateTabState(state, action.id, {
+        unloaded: true,
+      });
+    }
     case "WIDGET_TAB_EXPAND": {
       state = showWidgetTab(state, action.id);
       const location = getTabLocation(state, action.id);
@@ -803,6 +802,9 @@ function unhideTab(state: NineZoneState, id: TabState["id"]) {
     location = getTabLocation(state, id);
     assert(!!location);
   }
+  state = updateTabState(state, id, {
+    unloaded: false,
+  });
   return [state, location] as const;
 }
 
@@ -814,6 +816,10 @@ function hideTab(state: NineZoneState, id: TabState["id"]) {
     if (isToolSettings && draft.toolSettings.type === "docked") {
       draft.toolSettings.hidden = true;
     }
+  });
+
+  state = updateTabState(state, id, {
+    unloaded: false,
   });
 
   const location = getTabLocation(state, id);

--- a/ui/appui-layout-react/src/appui-layout-react/state/NineZoneStateReducer.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/NineZoneStateReducer.ts
@@ -39,6 +39,7 @@ import {
 } from "./internal/TabStateHelpers";
 import {
   initRectangleProps,
+  initSizeProps,
   isToolSettingsFloatingWidget,
   setPointProps,
   setSizeProps,
@@ -299,9 +300,9 @@ export function NineZoneStateReducer(
       const tab = state.tabs[widget.activeTabId];
       if (tab.isFloatingWidgetResizable) {
         const size = newBounds.getSize();
-        state = updateTabState(state, widget.activeTabId, {
-          preferredFloatingWidgetSize: size,
-          userSized: true,
+        state = updateTabState(state, widget.activeTabId, (draft) => {
+          initSizeProps(draft, "preferredFloatingWidgetSize", size);
+          draft.userSized = true;
         });
       }
 
@@ -584,8 +585,8 @@ export function NineZoneStateReducer(
       return hideTab(state, action.id);
     }
     case "WIDGET_TAB_SET_LABEL": {
-      return updateTabState(state, action.id, {
-        label: action.label,
+      return updateTabState(state, action.id, (draft) => {
+        draft.label = action.label;
       });
     }
     case "WIDGET_TAB_OPEN": {
@@ -639,8 +640,8 @@ export function NineZoneStateReducer(
         const panel = state.panels[location.side];
         const widgetIndex = panel.widgets.indexOf(location.widgetId);
 
-        state = updateTabState(state, id, {
-          preferredFloatingWidgetSize: preferredSize,
+        state = updateTabState(state, id, (draft) => {
+          initSizeProps(draft, "preferredFloatingWidgetSize", preferredSize);
         });
         state = removeTabFromWidget(state, id);
         state = addFloatingWidget(state, id, [id], {
@@ -694,8 +695,8 @@ export function NineZoneStateReducer(
     }
     case "WIDGET_TAB_UNLOAD": {
       state = hideTab(state, action.id);
-      return updateTabState(state, action.id, {
-        unloaded: true,
+      return updateTabState(state, action.id, (draft) => {
+        draft.unloaded = true;
       });
     }
     case "WIDGET_TAB_EXPAND": {
@@ -802,8 +803,8 @@ function unhideTab(state: NineZoneState, id: TabState["id"]) {
     location = getTabLocation(state, id);
     assert(!!location);
   }
-  state = updateTabState(state, id, {
-    unloaded: false,
+  state = updateTabState(state, id, (draft) => {
+    draft.unloaded = false;
   });
   return [state, location] as const;
 }
@@ -818,8 +819,8 @@ function hideTab(state: NineZoneState, id: TabState["id"]) {
     }
   });
 
-  state = updateTabState(state, id, {
-    unloaded: false,
+  state = updateTabState(state, id, (draft) => {
+    draft.unloaded = false;
   });
 
   const location = getTabLocation(state, id);

--- a/ui/appui-layout-react/src/appui-layout-react/state/NineZoneStateReducer.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/NineZoneStateReducer.ts
@@ -581,49 +581,18 @@ export function NineZoneStateReducer(
       });
     }
     case "WIDGET_TAB_HIDE": {
-      const { id } = action;
-      state = produce(state, (draft) => {
-        if (!draft.toolSettings) return;
-
-        const isToolSettings = draft.toolSettings.tabId === id;
-        if (isToolSettings && draft.toolSettings.type === "docked") {
-          draft.toolSettings.hidden = true;
-        }
-      });
-
-      const location = getTabLocation(state, id);
-      if (!location) return state;
-
-      const widgetId = location.widgetId;
-      const tabIndex = state.widgets[widgetId].tabs.indexOf(id);
-      if (isFloatingTabLocation(location)) {
-        const floatingWidget = state.floatingWidgets.byId[widgetId];
-        // widgetDef.setFloatingContainerId(location.floatingWidgetId);
-        state = updateSavedTabState(state, id, (draft) => {
-          draft.home = {
-            widgetId,
-            tabIndex,
-            floatingWidget,
-          };
-        });
-      } else if (isPanelTabLocation(location)) {
-        const side = location.side;
-        const widgetIndex = state.panels[side].widgets.indexOf(widgetId);
-        state = updateSavedTabState(state, id, (draft) => {
-          draft.home = {
-            widgetId,
-            side,
-            widgetIndex,
-            tabIndex,
-          };
-        });
-      }
-
-      return removeTabFromWidget(state, id);
+      return hideTab(state, action.id);
     }
+
     case "WIDGET_TAB_SET_LABEL": {
       return updateTabState(state, action.id, {
         label: action.label,
+      });
+    }
+    case "WIDGET_TAB_SET_LOADED": {
+      state = hideTab(state, action.id);
+      return updateTabState(state, action.id, {
+        unloaded: !action.loaded,
       });
     }
     case "WIDGET_TAB_OPEN": {
@@ -835,4 +804,45 @@ function unhideTab(state: NineZoneState, id: TabState["id"]) {
     assert(!!location);
   }
   return [state, location] as const;
+}
+
+function hideTab(state: NineZoneState, id: TabState["id"]) {
+  state = produce(state, (draft) => {
+    if (!draft.toolSettings) return;
+
+    const isToolSettings = draft.toolSettings.tabId === id;
+    if (isToolSettings && draft.toolSettings.type === "docked") {
+      draft.toolSettings.hidden = true;
+    }
+  });
+
+  const location = getTabLocation(state, id);
+  if (!location) return state;
+
+  const widgetId = location.widgetId;
+  const tabIndex = state.widgets[widgetId].tabs.indexOf(id);
+  if (isFloatingTabLocation(location)) {
+    const floatingWidget = state.floatingWidgets.byId[widgetId];
+    // widgetDef.setFloatingContainerId(location.floatingWidgetId);
+    state = updateSavedTabState(state, id, (draft) => {
+      draft.home = {
+        widgetId,
+        tabIndex,
+        floatingWidget,
+      };
+    });
+  } else if (isPanelTabLocation(location)) {
+    const side = location.side;
+    const widgetIndex = state.panels[side].widgets.indexOf(widgetId);
+    state = updateSavedTabState(state, id, (draft) => {
+      draft.home = {
+        widgetId,
+        side,
+        widgetIndex,
+        tabIndex,
+      };
+    });
+  }
+
+  return removeTabFromWidget(state, id);
 }

--- a/ui/appui-layout-react/src/appui-layout-react/state/TabState.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/TabState.ts
@@ -47,6 +47,7 @@ export interface TabState {
   readonly userSized?: boolean;
   readonly isFloatingWidgetResizable?: boolean;
   readonly hideWithUiWhenFloating?: boolean;
+  readonly unloaded?: boolean;
 }
 
 /** @internal */

--- a/ui/appui-layout-react/src/appui-layout-react/state/internal/TabStateHelpers.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/internal/TabStateHelpers.ts
@@ -6,11 +6,11 @@
  * @module Base
  */
 
-import produce, { castDraft } from "immer";
+import produce from "immer";
 import { UiError } from "@itwin/appui-abstract";
 import type { NineZoneState } from "../NineZoneState";
 import type { DraggedTabState, TabState } from "../TabState";
-import { category, initSizeProps } from "./NineZoneStateHelpers";
+import { category } from "./NineZoneStateHelpers";
 import type { SavedTabState } from "../SavedTabState";
 import type { WritableDraft } from "immer/dist/internal";
 
@@ -23,6 +23,7 @@ export function createTabState(
     label: "",
     ...args,
     id,
+    unloaded: false,
   };
 }
 
@@ -47,23 +48,13 @@ export function createDraggedTabState(
 export function updateTabState(
   state: NineZoneState,
   id: TabState["id"],
-  args: Partial<TabState>
+  update: (draft: WritableDraft<TabState>) => void
 ) {
   if (!(id in state.tabs)) throw new UiError(category, "Tab does not exist");
 
   return produce(state, (draft) => {
     const tab = draft.tabs[id];
-    const { preferredFloatingWidgetSize, ...other } = args;
-    draft.tabs[id] = castDraft({
-      ...tab,
-      ...other,
-    });
-    if (preferredFloatingWidgetSize)
-      initSizeProps(
-        draft.tabs[id],
-        "preferredFloatingWidgetSize",
-        preferredFloatingWidgetSize
-      );
+    update(tab);
   });
 }
 

--- a/ui/appui-layout-react/src/appui-layout-react/state/internal/WidgetStateHelpers.ts
+++ b/ui/appui-layout-react/src/appui-layout-react/state/internal/WidgetStateHelpers.ts
@@ -27,6 +27,7 @@ import {
 } from "../WidgetLocation";
 import {
   category,
+  initSizeProps,
   setRectangleProps,
   toRectangleProps,
 } from "./NineZoneStateHelpers";
@@ -287,8 +288,12 @@ export function setWidgetActiveTabId(
     const preferredFloatingWidgetSize = Rectangle.create(
       floatingWidget.bounds
     ).getSize();
-    state = updateTabState(state, activeTab.id, {
-      preferredFloatingWidgetSize,
+    state = updateTabState(state, activeTab.id, (draft) => {
+      initSizeProps(
+        draft,
+        "preferredFloatingWidgetSize",
+        preferredFloatingWidgetSize
+      );
     });
   }
   return state;

--- a/ui/appui-layout-react/src/appui-layout-react/widget/ContentRenderer.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget/ContentRenderer.tsx
@@ -52,6 +52,7 @@ interface WidgetContentRendererProps {
 /** @internal */
 export function WidgetContentRenderer(props: WidgetContentRendererProps) {
   const renderTo = useContainersStore((state) => state.containers[props.tabId]);
+  const unloaded = useLayout((state) => !!state.tabs[props.tabId].unloaded);
   const widgetContentManager = React.useContext(WidgetContentManagerContext);
   const container = React.useRef<HTMLDivElement>(undefined!);
   if (!container.current) {
@@ -83,7 +84,7 @@ export function WidgetContentRenderer(props: WidgetContentRendererProps) {
       id={`content-container:${props.tabId}`}
     >
       <TabIdContext.Provider value={props.tabId}>
-        {props.children}
+        {unloaded ? null : props.children}
       </TabIdContext.Provider>
     </div>,
     container.current

--- a/ui/appui-layout-react/src/test/state/NineZoneStateReducer.test.ts
+++ b/ui/appui-layout-react/src/test/state/NineZoneStateReducer.test.ts
@@ -1927,6 +1927,21 @@ describe("NineZoneStateReducer", () => {
     });
   });
 
+  describe("WIDGET_TAB_UNLOAD", () => {
+    it("should hide a tab and set `unloaded` flag to `true`", () => {
+      let state = createNineZoneState();
+      state = addTab(state, "t1");
+      state = addPanelWidget(state, "left", "w1", ["t1"]);
+
+      const newState = NineZoneStateReducer(state, {
+        type: "WIDGET_TAB_UNLOAD",
+        id: "t1",
+      });
+      expect(newState.panels.left.widgets).lengthOf(0);
+      expect(newState.tabs.t1.unloaded).to.true;
+    });
+  });
+
   describe("WIDGET_TAB_EXPAND", () => {
     it("should expand a panel section", () => {
       let state = createNineZoneState();

--- a/ui/appui-layout-react/src/test/state/internal/TabStateHelpers.test.ts
+++ b/ui/appui-layout-react/src/test/state/internal/TabStateHelpers.test.ts
@@ -12,16 +12,17 @@ import { expect } from "chai";
 describe("updateTabState", () => {
   it("should throw if tab does not exist", () => {
     const state = createNineZoneState();
-    (() => updateTabState(state, "t1", { iconSpec: "test" })).should.throw(
-      "Tab does not exist"
-    );
+    (() =>
+      updateTabState(state, "t1", (draft) => {
+        draft.iconSpec = "test";
+      })).should.throw("Tab does not exist");
   });
 
   it("should update `preferredFloatingWidgetSize`", () => {
     let state = createNineZoneState();
     state = addTab(state, "t1");
-    const newState = updateTabState(state, "t1", {
-      preferredFloatingWidgetSize: { height: 100, width: 200 },
+    const newState = updateTabState(state, "t1", (draft) => {
+      draft.preferredFloatingWidgetSize = { height: 100, width: 200 };
     });
     expect(newState.tabs.t1.preferredFloatingWidgetSize).to.eql({
       height: 100,

--- a/ui/appui-layout-react/src/test/widget/ContentRenderer.test.tsx
+++ b/ui/appui-layout-react/src/test/widget/ContentRenderer.test.tsx
@@ -2,26 +2,37 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { expect } from "chai";
+import produce from "immer";
 import * as React from "react";
 import * as sinon from "sinon";
-import { BeEvent } from "@itwin/core-bentley";
 import { render } from "@testing-library/react";
+import { BeEvent } from "@itwin/core-bentley";
 import { act, renderHook } from "@testing-library/react-hooks";
 import type {
   TabState,
   WidgetContentManagerContextArgs,
 } from "../../appui-layout-react";
 import {
+  addFloatingWidget,
+  addTab,
+  createLayoutStore,
+  createNineZoneState,
   TabIdContext,
   useContainersStore,
   useTransientState,
-  WidgetContentManager,
   WidgetContentManagerContext,
   WidgetContentRenderer,
 } from "../../appui-layout-react";
+import { TestNineZoneProvider } from "../Providers";
 
 describe("WidgetContentRenderer", () => {
-  const wrapper = WidgetContentManager;
+  const wrapper = (props: React.PropsWithChildren<{}>) => (
+    <TestNineZoneProvider
+      defaultState={addTab(createNineZoneState(), "t1")}
+      {...props}
+    />
+  );
 
   it("should remove existing content nodes before restoring", () => {
     const renderTo = document.createElement("div");
@@ -30,7 +41,9 @@ describe("WidgetContentRenderer", () => {
     useContainersStore.getState().setContainer("t2", renderTo);
 
     const spy = sinon.spy(renderTo, "removeChild");
-    render(<WidgetContentRenderer tabId="t1" />, { wrapper });
+    render(<WidgetContentRenderer tabId="t1" />, {
+      wrapper,
+    });
 
     sinon.assert.callCount(spy, 1);
   });
@@ -49,6 +62,34 @@ describe("WidgetContentRenderer", () => {
     unmount();
 
     sinon.assert.callCount(spy, 1);
+  });
+
+  it("should not render when tab is unloaded", async () => {
+    const renderTo = document.createElement("div");
+    document.body.appendChild(renderTo);
+    useContainersStore.getState().setContainer("t1", renderTo);
+
+    let state = createNineZoneState();
+    state = addTab(state, "t1");
+    state = addFloatingWidget(state, "w1", ["t1"]);
+
+    const layout = createLayoutStore(state);
+    const { findByText, queryByText } = render(
+      <WidgetContentRenderer tabId="t1">Widget content</WidgetContentRenderer>,
+      {
+        wrapper: (props) => <TestNineZoneProvider layout={layout} {...props} />,
+      }
+    );
+
+    await findByText("Widget content");
+
+    layout.setState((prev) =>
+      produce(prev, (draft) => {
+        draft.tabs.t1.unloaded = true;
+      })
+    );
+    const content = queryByText("Widget content");
+    expect(content).to.null;
   });
 });
 

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -712,39 +712,41 @@ export class FrontstageDef {
    */
   public getWidgetCurrentState(widgetDef: WidgetDef): WidgetState | undefined {
     const state = this.nineZoneState;
+    if (!state) return widgetDef.defaultState;
 
-    // istanbul ignore else
-    if (state) {
-      const toolSettingsTabId = state.toolSettings?.tabId;
-      if (
-        toolSettingsTabId === widgetDef.id &&
-        state.toolSettings?.type === "docked"
-      ) {
-        return WidgetState.Open;
-      }
-
-      const location = getTabLocation(state, widgetDef.id);
-
-      // istanbul ignore next
-      if (!location) return WidgetState.Hidden;
-
-      if (isFloatingTabLocation(location)) {
-        return WidgetState.Floating;
-      }
-
-      let collapsedPanel = false;
-      // istanbul ignore else
-      if ("side" in location) {
-        const panel = state.panels[location.side];
-        collapsedPanel =
-          panel.collapsed || undefined === panel.size || 0 === panel.size;
-      }
-      const widgetContainer = state.widgets[location.widgetId];
-      if (widgetDef.id === widgetContainer.activeTabId && !collapsedPanel)
-        return WidgetState.Open;
-      else return WidgetState.Closed;
+    const tab = state.tabs[widgetDef.id];
+    if (tab && tab.unloaded) {
+      return WidgetState.Unloaded;
     }
-    return widgetDef.defaultState;
+
+    const toolSettingsTabId = state.toolSettings?.tabId;
+    if (
+      toolSettingsTabId === widgetDef.id &&
+      state.toolSettings?.type === "docked"
+    ) {
+      return WidgetState.Open;
+    }
+
+    const location = getTabLocation(state, widgetDef.id);
+
+    // istanbul ignore next
+    if (!location) return WidgetState.Hidden;
+
+    if (isFloatingTabLocation(location)) {
+      return WidgetState.Floating;
+    }
+
+    let collapsedPanel = false;
+    // istanbul ignore else
+    if ("side" in location) {
+      const panel = state.panels[location.side];
+      collapsedPanel =
+        panel.collapsed || undefined === panel.size || 0 === panel.size;
+    }
+    const widgetContainer = state.widgets[location.widgetId];
+    if (widgetDef.id === widgetContainer.activeTabId && !collapsedPanel)
+      return WidgetState.Open;
+    return WidgetState.Closed;
   }
 
   public isPopoutWidget(widgetId: string) {

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -601,6 +601,13 @@ function hideWidgets(
         id: widgetDef.id,
       });
     }
+    if (widgetDef.defaultState === WidgetState.Unloaded) {
+      state = NineZoneStateReducer(state, {
+        type: "WIDGET_TAB_SET_LOADED",
+        id: widgetDef.id,
+        loaded: false,
+      });
+    }
   }
 
   return state;

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -603,9 +603,8 @@ function hideWidgets(
     }
     if (widgetDef.defaultState === WidgetState.Unloaded) {
       state = NineZoneStateReducer(state, {
-        type: "WIDGET_TAB_SET_LOADED",
+        type: "WIDGET_TAB_UNLOAD",
         id: widgetDef.id,
-        loaded: false,
       });
     }
   }

--- a/ui/appui-react/src/appui-react/widgets/Widget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/Widget.tsx
@@ -42,7 +42,7 @@ export interface Widget {
    * It is not possible to disable the floating of a widget if `allowedPanels` is an empty array.
    */
   readonly canFloat?: boolean | CanFloatWidgetOptions;
-  /** Defaults to `Floating` if widget is not allowed to dock to any panels. */
+  /** Defaults to `Floating` if widget is not allowed to dock to any panels. Otherwise defaults to `Closed`. */
   readonly defaultState?: WidgetState;
   /** Content of the Widget. */
   readonly content?: React.ReactNode;

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -431,6 +431,13 @@ export class WidgetDef {
         });
         break;
       }
+      case WidgetState.Unloaded: {
+        frontstageDef.dispatch({
+          type: "WIDGET_TAB_UNLOAD",
+          id: this.id,
+        });
+        break;
+      }
     }
   }
 

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -74,7 +74,7 @@ export class WidgetDef {
   private _tooltip: string | ConditionalStringValue | StringGetter = "";
   private _widgetReactNode: React.ReactNode;
   private _widgetControl!: WidgetControl;
-  private _defaultState: WidgetState = WidgetState.Unloaded;
+  private _defaultState: WidgetState = WidgetState.Closed;
   private _id: string;
   private _classId: string | ConfigurableUiControlConstructor | undefined =
     undefined;
@@ -465,7 +465,9 @@ export class WidgetDef {
   }
 
   public get isVisible(): boolean {
-    return WidgetState.Hidden !== this.state;
+    return (
+      WidgetState.Hidden !== this.state && WidgetState.Unloaded !== this.state
+    );
   }
 
   public get activeState(): WidgetState {

--- a/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
@@ -82,13 +82,13 @@ describe("FrontstageDef", () => {
     Object.defineProperty(window, "localStorage", {
       get: () => localStorageMock,
     });
-    await TestUtils.initializeUiFramework();
     await NoRenderApp.startup();
+    await TestUtils.initializeUiFramework();
   });
 
   after(async () => {
-    await IModelApp.shutdown();
     TestUtils.terminateUiFramework();
+    await IModelApp.shutdown();
     Object.defineProperty(window, "localStorage", localStorageToRestore);
   });
 
@@ -370,7 +370,7 @@ describe("FrontstageDef", () => {
   });
 
   describe("getWidgetCurrentState", () => {
-    it("should show WidgetState as closed in panel size is undefined", () => {
+    it("should return `Closed` if panel size is undefined", () => {
       const frontstageDef = new FrontstageDef();
       sinon.stub(frontstageDef, "isReady").get(() => true);
 
@@ -415,7 +415,7 @@ describe("FrontstageDef", () => {
       );
     });
 
-    it("should show WidgetState as closed in panel size is 0", () => {
+    it("should return `Closed` if panel size is 0", () => {
       const frontstageDef = new FrontstageDef();
       sinon.stub(frontstageDef, "isReady").get(() => true);
 
@@ -462,7 +462,7 @@ describe("FrontstageDef", () => {
       );
     });
 
-    it("should show WidgetState as closed in panel is collapsed", () => {
+    it("should return `Closed` if panel is collapsed", () => {
       const frontstageDef = new FrontstageDef();
       sinon.stub(frontstageDef, "isReady").get(() => true);
 
@@ -491,6 +491,26 @@ describe("FrontstageDef", () => {
         .returns(widgetDef);
       expect(frontstageDef.getWidgetCurrentState(widgetDef)).to.be.eql(
         WidgetState.Closed
+      );
+    });
+
+    it("should return `Unloaded` if tab is not loaded", () => {
+      const frontstageDef = new FrontstageDef();
+
+      let nineZoneState = createNineZoneState();
+      nineZoneState = addTab(nineZoneState, "t1", { unloaded: true });
+      nineZoneState = addPanelWidget(nineZoneState, "left", "start", ["t1"]);
+      frontstageDef.nineZoneState = nineZoneState;
+      const widgetDef = WidgetDef.create({
+        id: "t1",
+      });
+
+      sinon
+        .stub(frontstageDef, "findWidgetDef")
+        .withArgs("t1")
+        .returns(widgetDef);
+      expect(frontstageDef.getWidgetCurrentState(widgetDef)).to.be.eql(
+        WidgetState.Unloaded
       );
     });
   });


### PR DESCRIPTION
## Changes

Fixes #338. Correctly handles `WidgetState.Unloaded` and keeps widget content unmounted when it is unloaded.

## Testing

Added additional e2e tests and story actions.
