### PR TITLE
Fix constructors of data filterers

### DIFF
--- a/common/changes/@itwin/components-react/filterer-edit-filtering-constructors_2023-12-07-13-35.json
+++ b/common/changes/@itwin/components-react/filterer-edit-filtering-constructors_2023-12-07-13-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Set filterText to lowercase in constructors of filterers.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/components-react](#itwincomponents-react)
+  - [Fixes](#fixes)
+
+## @itwin/components-react
+
+### Fixes
+
+- Fixed data filterers to work with uppercase letters after using the constructor.

--- a/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/DisplayValuePropertyDataFilterer.ts
+++ b/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/DisplayValuePropertyDataFilterer.ts
@@ -24,12 +24,13 @@ export class DisplayValuePropertyDataFilterer extends PropertyRecordDataFilterer
 
   public constructor(filterText: string = "") {
     super();
-    this._filterText = filterText;
+    this._filterText = filterText.toLowerCase().trim();
   }
 
   public get filterText(): string {
     return this._filterText;
   }
+
   public set filterText(value: string) {
     const lowerValue = value.toLowerCase().trim();
     if (lowerValue !== this.filterText) {

--- a/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/LabelPropertyDataFilterer.ts
+++ b/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/LabelPropertyDataFilterer.ts
@@ -29,6 +29,7 @@ export class LabelPropertyDataFilterer extends PropertyRecordDataFiltererBase {
   public get filterText(): string {
     return this._filterText;
   }
+
   public set filterText(value: string) {
     const lowerValue = value.toLowerCase().trim();
     if (lowerValue !== this.filterText) {

--- a/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/LabelPropertyDataFilterer.ts
+++ b/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/LabelPropertyDataFilterer.ts
@@ -23,7 +23,7 @@ export class LabelPropertyDataFilterer extends PropertyRecordDataFiltererBase {
 
   public constructor(filterText: string = "") {
     super();
-    this._filterText = filterText;
+    this._filterText = filterText.toLowerCase().trim();
   }
 
   public get filterText(): string {

--- a/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/PropertyCategoryLabelFilterer.ts
+++ b/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/PropertyCategoryLabelFilterer.ts
@@ -23,7 +23,7 @@ export class PropertyCategoryLabelFilterer extends PropertyCategoryDataFiltererB
 
   public constructor(filterText: string = "") {
     super();
-    this._filterText = filterText;
+    this._filterText = filterText.toLowerCase().trim();
   }
 
   public get filterText(): string {

--- a/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/PropertyCategoryLabelFilterer.ts
+++ b/ui/components-react/src/components-react/propertygrid/dataproviders/filterers/PropertyCategoryLabelFilterer.ts
@@ -29,6 +29,7 @@ export class PropertyCategoryLabelFilterer extends PropertyCategoryDataFiltererB
   public get filterText(): string {
     return this._filterText;
   }
+
   public set filterText(value: string) {
     const lowerValue = value.toLowerCase().trim();
     if (lowerValue !== this.filterText) {

--- a/ui/components-react/src/test/propertygrid/dataproviders/filterers/DisplayValuePropertyDataFilterer.test.ts
+++ b/ui/components-react/src/test/propertygrid/dataproviders/filterers/DisplayValuePropertyDataFilterer.test.ts
@@ -198,6 +198,23 @@ describe("DisplayValuePropertyDataFilterer", () => {
         filteredTypes: [FilteredType.Value],
       });
     });
+
+    it("Should match if case of letters does not match", async () => {
+      const filterer = new DisplayValuePropertyDataFilterer("sOmE");
+      const record = TestUtils.createPrimitiveStringProperty(
+        "Property",
+        "Value",
+        "DisplaySomeFilteredName"
+      );
+
+      const matchResult = await filterer.recordMatchesFilter(record);
+      expect(matchResult).to.deep.eq({
+        matchesFilter: true,
+        shouldExpandNodeParents: true,
+        matchesCount: 1,
+        filteredTypes: [FilteredType.Value],
+      });
+    });
   });
 
   describe("raising `onFilterChanged` event", () => {

--- a/ui/components-react/src/test/propertygrid/dataproviders/filterers/LabelPropertyDataFilterer.test.ts
+++ b/ui/components-react/src/test/propertygrid/dataproviders/filterers/LabelPropertyDataFilterer.test.ts
@@ -216,6 +216,20 @@ describe("LabelPropertyDataFilterer", () => {
         filteredTypes: [FilteredType.Label],
       });
     });
+
+    it("Should match if case of letters does not match", async () => {
+      const filterer = new LabelPropertyDataFilterer("sTrUcT");
+      const record = TestUtils.createStructProperty("StructsTSt");
+
+      const matchResult = await filterer.recordMatchesFilter(record);
+      expect(matchResult).to.deep.eq({
+        matchesFilter: true,
+        shouldForceIncludeDescendants: true,
+        shouldExpandNodeParents: true,
+        matchesCount: 1,
+        filteredTypes: [FilteredType.Label],
+      });
+    });
   });
 
   describe("raising `onFilterChanged` event", () => {

--- a/ui/components-react/src/test/propertygrid/dataproviders/filterers/PropertyCategoryLabelFilterer.test.ts
+++ b/ui/components-react/src/test/propertygrid/dataproviders/filterers/PropertyCategoryLabelFilterer.test.ts
@@ -174,6 +174,25 @@ describe("PropertyCategoryLabelFilterer", () => {
         filteredTypes: [FilteredType.Category],
       });
     });
+
+    it("Should match if case of letters does not match", async () => {
+      const filterer = new PropertyCategoryLabelFilterer("DiSpLaY");
+      const category = {
+        name: "Cat",
+        label: "displaySomefilteredNaMe",
+        expand: true,
+        childCategories: [],
+      };
+
+      const matchResult = await filterer.categoryMatchesFilter(category);
+      expect(matchResult).to.deep.eq({
+        matchesFilter: true,
+        shouldForceIncludeDescendants: true,
+        shouldExpandNodeParents: true,
+        matchesCount: 1,
+        filteredTypes: [FilteredType.Category],
+      });
+    });
   });
 
   describe("raising `onFilterChanged` event", () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Change the constructor implementation of data filterers to automatically convert filterText to lowercase, as it prevents bugs from happening if user would forget to manually set the filterer text after constructing.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Tested all filterers with a case where filterText isn't set with the setter, but rather with the constructor.
