### PR TITLE
Fix popouts opening and saving as incorrect size

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -2266,7 +2266,7 @@ export class FrontstageDef {
     // (undocumented)
     get rightPanel(): StagePanelDef | undefined;
     // @internal (undocumented)
-    saveChildWindowSizeAndPosition(childWindowId: string, childWindow: Window): void;
+    saveChildWindowSizeAndPosition(childWindowId: string, childWindow: ChildWindow): void;
     setActiveContent(): Promise<boolean>;
     setActiveView(newContent: ContentControl, oldContent?: ContentControl): void;
     setActiveViewFromViewport(viewport: ScreenViewport): boolean;

--- a/common/changes/@itwin/appui-react/joeh-popoutSmallerOrLarger_2023-12-07-17-24.json
+++ b/common/changes/@itwin/appui-react/joeh-popoutSmallerOrLarger_2023-12-07-17-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fixed bug where popouts would get incrementally smaller or larger each time opened",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -4,6 +4,7 @@ Table of contents:
 
 - [@itwin/appui-react](#itwinappui-react)
   - [Changes](#changes)
+  - [Fixes](#fixes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Fixes](#fixes)
   - [Improvements](#improvements)
@@ -14,6 +15,10 @@ Table of contents:
 
 - Promoted `FrameworkToolAdmin` to _beta_. #618
 - Correctly handle `WidgetState.Unloaded` and keep widget content unmounted when widget is unloaded. #617
+
+### Fixes
+
+- Fixed popout widgets getting incrementally smaller or larger each time popped out. [#563](https://github.com/iTwin/appui/issues/563)
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/childwindow/ChildWindowConfig.ts
+++ b/ui/appui-react/src/appui-react/childwindow/ChildWindowConfig.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/**
+ * An extension of a Window to be used for Popout Widgets.
+ * @internal
+ */
+export interface ChildWindow extends Window {
+  /** Width that child window wants to open to */
+  expectedWidth?: number;
+  /** Height that child window wants to open to */
+  expectedHeight?: number;
+  /** Difference between width child window actually opened to as compared to expected */
+  deltaWidth?: number;
+  /** Difference between height child window actually opened to as compared to expected */
+  deltaHeight?: number;
+  /** Current browser being used */
+  currentBrowser?: string;
+}

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -47,7 +47,7 @@ import type { FrontstageProvider } from "./FrontstageProvider";
 import { TimeTracker } from "../configurableui/TimeTracker";
 import type { ChildWindowLocationProps } from "../framework/FrameworkChildWindows";
 import { PopoutWidget } from "../childwindow/PopoutWidget";
-import { BentleyStatus, ProcessDetector } from "@itwin/core-bentley";
+import { BentleyStatus } from "@itwin/core-bentley";
 import type { FrontstageConfig } from "./FrontstageConfig";
 import type { StagePanelConfig } from "../stagepanels/StagePanelConfig";
 import type { WidgetConfig } from "../widgets/WidgetConfig";
@@ -57,6 +57,7 @@ import { WidgetState } from "../widgets/WidgetState";
 import { InternalFrontstageManager } from "./InternalFrontstageManager";
 import { InternalContentDialogManager } from "../dialog/InternalContentDialogManager";
 import type { XAndY } from "@itwin/core-geometry";
+import type { ChildWindow } from "../childwindow/ChildWindowConfig";
 
 /** @internal */
 export interface FrontstageEventArgs {
@@ -898,7 +899,7 @@ export class FrontstageDef {
   /** @internal */
   public saveChildWindowSizeAndPosition(
     childWindowId: string,
-    childWindow: Window
+    childWindow: ChildWindow
   ) {
     const state = this.nineZoneState;
     if (!state) return;
@@ -911,11 +912,21 @@ export class FrontstageDef {
     const widgetDef = this.findWidgetDef(tabId);
     if (!widgetDef) return;
 
-    const adjustmentWidth = ProcessDetector.isElectronAppFrontend ? 16 : 0;
-    const adjustmentHeight = ProcessDetector.isElectronAppFrontend ? 39 : 0;
+    let width =
+      childWindow.currentBrowser === "chromium based edge"
+        ? childWindow.outerWidth
+        : childWindow.innerWidth;
+    let height =
+      childWindow.currentBrowser === "chromium based edge"
+        ? childWindow.outerHeight
+        : childWindow.innerHeight;
+    if (childWindow.deltaHeight && childWindow.deltaWidth) {
+      height = height + childWindow.deltaHeight;
+      width = width + childWindow.deltaWidth;
+      if (height < 1) height = 100;
+      if (width < 1) width = 100;
+    }
 
-    const width = childWindow.innerWidth + adjustmentWidth;
-    const height = childWindow.innerHeight + adjustmentHeight;
     const bounds = Rectangle.createFromSize({ width, height }).offset({
       x: childWindow.screenX,
       y: childWindow.screenY,


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes
There was a bug where each time you opened and closed a popout widget it would get smaller or larger than you had left it. This was due to how window.open() works with browser zoom. We were expecting the child window to open to certain specified dimensions but the browsers would open them to varying dimensions depending on zoom and browser type. This snowballed in our code to cause the graphical issues shown in the bug. Being that this is a long time issue with window.open, we had to find a way to work around it on our end. So the expected size of the popout is saved when opened so we now how much to offset the final save of the dimensions by. More changes may be needed later if users are using different browsers then mentioned below and issues are noticed.
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing
Test popout widget stays same size as expected when opened and closed on Chrome, Edge, Firefox, and Electron.
<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
