### PR TITLE
Localize popout error text

### DIFF
--- a/common/changes/@itwin/appui-react/joeh-localizePopoutText_2023-12-08-17-19.json
+++ b/common/changes/@itwin/appui-react/joeh-localizePopoutText_2023-12-08-17-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Localize popout error text",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -3,12 +3,17 @@
 Table of contents:
 
 - [@itwin/appui-react](#itwinappui-react)
+  - [Fixes](#fixes)
   - [Changes](#changes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Fixes](#fixes)
   - [Improvements](#improvements)
 
 ## @itwin/appui-react
+
+### Fixes
+
+- Localize popout error message text.
 
 ### Changes
 

--- a/ui/appui-react/public/locales/en/UiFramework.json
+++ b/ui/appui-react/public/locales/en/UiFramework.json
@@ -279,7 +279,8 @@
       "popoutActiveTab": "Pop out active widget tab"
     },
     "errorMessage": {
-      "unknownError": "Something went wrong..."
+      "unknownError": "Something went wrong...",
+      "widgetPopoutFail": "Widget Failed To Popout"
     }
   },
   "statusBar": {

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -296,7 +296,7 @@ export class FrontstageDef {
       IModelApp.notifications.outputMessage(
         new NotifyMessageDetails(
           OutputMessagePriority.Error,
-          "Widget Failed To Popout",
+          UiFramework.translate("widget.errorMessage.widgetPopoutFail"),
           undefined,
           OutputMessageType.Toast
         )


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes
- Did not localize text that appears when a widget fails to popout. It is now localized.
<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing
- Forced window.open to fail and made sure error message looked good.
<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
