### PR TITLE
Fix RestoreLayout tool

### DIFF
--- a/common/changes/@itwin/appui-react/raplemie-restoreLayout_2023-12-12-20-31.json
+++ b/common/changes/@itwin/appui-react/raplemie-restoreLayout_2023-12-12-20-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `RestoreLayout` tool.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -3,39 +3,36 @@
 Table of contents:
 
 - [@itwin/appui-react](#itwinappui-react)
-  - [Fixes](#fixes)
   - [Changes](#changes)
   - [Fixes](#fixes)
 - [@itwin/components-react](#itwincomponents-react)
-  - [Fixes](#fixes)
-  - [Improvements](#improvements)
   - [Additions](#additions)
+  - [Changes](#changes-1)
+  - [Fixes](#fixes-1)
 
 ## @itwin/appui-react
 
-### Fixes
-
-- Localize popout error message text.
-
 ### Changes
 
-- Promoted `FrameworkToolAdmin` to _beta_. #618
-- Correctly handle `WidgetState.Unloaded` and keep widget content unmounted when widget is unloaded. #617
+- Promoted `FrameworkToolAdmin` to _beta_. [#618](https://github.com/iTwin/appui/pull/618)
+- Correctly handle `WidgetState.Unloaded` and keep widget content unmounted when widget is unloaded. [#617](https://github.com/iTwin/appui/pull/617)
 
 ### Fixes
 
-- Fixed popout widgets getting incrementally smaller or larger each time popped out. [#563](https://github.com/iTwin/appui/issues/563)
+- Localize popout error message text. [#628](https://github.com/iTwin/appui/pull/628)
+- Fixed popout widgets getting incrementally smaller or larger each time popped out. [#622](https://github.com/iTwin/appui/pull/622)
+- Fixed "RestoreAllFrontstagesTool" missing "pinned" state. [#633](https://github.com/iTwin/appui/pull/633)
 
 ## @itwin/components-react
 
-### Fixes
-
-- Fixed data filterers to work with uppercase letters after using the constructor.
-
-### Improvements
-
-- Reset to default operator when property of a rule item is changed in `FilterBuilderState`.
-
 ### Additions
 
-- Add `removeAllItems` function which will clear all items in the filter state.
+- Add `removeAllItems` function which will clear all items in the filter state. [#629](https://github.com/iTwin/appui/pull/629)
+
+### Changes
+
+- Reset to default operator when property of a rule item is changed in `FilterBuilderState`. [#619](https://github.com/iTwin/appui/pull/619)
+
+### Fixes
+
+- Fixed data filterers to work with uppercase letters after using the constructor. [#620](https://github.com/iTwin/appui/pull/620)

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -699,6 +699,7 @@ export class FrontstageDef {
     for (const panelDef of this.panelDefs) {
       panelDef.size = panelDef.defaultSize;
       panelDef.panelState = panelDef.defaultState;
+      panelDef.pinned = panelDef.initialConfig?.pinned ?? true;
     }
     for (const widgetDef of this.widgetDefs) {
       widgetDef.setWidgetState(widgetDef.defaultState);

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -118,6 +118,7 @@ export interface PreviewFeaturesProviderProps {
  *    [/...]
  *   </Provider>
  * </PreviewFeaturesProvider>
+ * ```
  * @beta
  */
 export function PreviewFeaturesProvider({

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -398,7 +398,7 @@ export class WidgetDef {
   public setWidgetState(newState: WidgetState): void {
     const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
     const state = frontstageDef?.nineZoneState;
-    if (!state) return;
+    if (!state || this.isStatusBar) return;
     if (!frontstageDef.findWidgetDef(this.id)) return;
 
     switch (newState) {


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
* Adding "pinned" state restore to panels
* `setWidgetState` will now explicitly skip calls for `isStatusBar` since this is not handled and caused a crash with recent changes to handle "Unloaded" state.
* Updated NextVersion.md to follow new suggested structure.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Validated that calling the "Restore Layout" tool no longer caused a crash, and reset the "pinned" state.

## Issue
Fixes #254