### PR TITLE
Fix logic of default orientation of PropertyGrid elements.

### DIFF
--- a/common/changes/@itwin/components-react/property-grid-fix-default-orientation_2023-12-18-10-51.json
+++ b/common/changes/@itwin/components-react/property-grid-fix-default-orientation_2023-12-18-10-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Ensure correct initial property orientation in `PropertyGrid`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,12 +5,11 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Changes](#changes)
   - [Fixes](#fixes)
+  - [Fixes](#fixes-1)
 - [@itwin/components-react](#itwincomponents-react)
   - [Additions](#additions)
   - [Changes](#changes-1)
-  - [Fixes](#fixes-1)
-
-## @itwin/appui-react
+  - [Fixes](#fixes-2)
 
 ## @itwin/appui-react
 
@@ -43,3 +42,4 @@ Table of contents:
 ### Fixes
 
 - Fixed data filterers to work with uppercase letters after using the constructor. [#620](https://github.com/iTwin/appui/pull/620)
+- Ensure correct initial property orientation in `VirtualizedPropertyGrid`.

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -167,7 +167,14 @@ export class VirtualizedPropertyGrid extends React.Component<
     super(props);
     this.state = {
       gridItems: [],
-      orientation: props.orientation ?? Orientation.Horizontal,
+      orientation:
+        props.orientation ??
+        PropertyGridCommons.getCurrentOrientation(
+          props.width,
+          undefined,
+          props.isOrientationFixed,
+          props.horizontalOrientationMinWidth
+        ),
       dynamicNodeHeights: new Map(),
       resetIndex: 0,
     };

--- a/ui/components-react/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
+++ b/ui/components-react/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
@@ -589,6 +589,25 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
         .to.be.not.null;
     });
 
+    it("chooses correct orientation on first render if undefined", async () => {
+      const { container } = render(
+        <VirtualizedPropertyGridWithDataProvider
+          {...defaultProps}
+          horizontalOrientationMinWidth={500}
+          orientation={undefined}
+          isOrientationFixed={false}
+          width={499}
+        />
+      );
+
+      await waitFor(
+        () =>
+          expect(
+            container.querySelector(".components-property-record--vertical")
+          ).to.be.not.null
+      );
+    });
+
     describe("custom category renderers", () => {
       interface SetupDataProviderArgs {
         expandCustomCategory: boolean;


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

There was an issue with orientation of `PropertyGrid` items being set incorrectly when it is first shown. ([See issue](https://github.com/orgs/iTwin/projects/20/views/19?pane=issue&itemId=47330041))
This was fixed by not waiting for a component to be updated to find out what is the correct orientation for the item and instead, determine the correct orientation in the constructor.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Added a test case to ensure that when orientation is undefined - appropriate one is assigned.