### PR TITLE
Improve e2e tests

### DIFF
--- a/full-stack-tests/ui/tests/Utils.ts
+++ b/full-stack-tests/ui/tests/Utils.ts
@@ -132,6 +132,16 @@ export interface SavedFrontstageState {
     };
     savedTabs: {
       allIds: string[];
+      byId: {
+        [id in string]: {
+          popoutBounds: {
+            bottom: number;
+            left: number;
+            right: number;
+            top: number;
+          };
+        };
+      };
     };
   };
 }
@@ -205,8 +215,8 @@ export async function dragTab(tab: Locator, target: Locator) {
   await tab.dispatchEvent("mousemove", { clientX: 20, clientY: 20 });
   const bounds = (await target.boundingBox())!;
   await body.dispatchEvent("mousemove", {
-    clientX: bounds.x,
-    clientY: bounds.y,
+    clientX: bounds.x + bounds.width / 2,
+    clientY: bounds.y + bounds.height / 2,
   });
   await body.dispatchEvent("mouseup");
 }

--- a/full-stack-tests/ui/tests/popout-widget.test.ts
+++ b/full-stack-tests/ui/tests/popout-widget.test.ts
@@ -141,7 +141,10 @@ test.describe("popout widget", () => {
     await expectSavedFrontstageState(context, (state) => {
       return (
         state.nineZone.widgets["appui-test-providers:ViewAttributesWidget"]
-          ?.activeTabId === "appui-test-providers:ViewAttributesWidget"
+          ?.activeTabId === "appui-test-providers:ViewAttributesWidget" &&
+        !!state.nineZone.savedTabs.byId[
+          "appui-test-providers:ViewAttributesWidget"
+        ]
       );
     });
 
@@ -180,18 +183,18 @@ test.describe("popout widget", () => {
     page,
   }) => {
     const id = "appui-test-providers:PopoutMountUnmountWidget";
-    const widgetLifecycle = trackWidgetLifecycle(page, id);
     const widget = floatingWidgetLocator({
       page,
       id,
     });
-
+    await expect(widget).toBeVisible();
+    const widgetLifecycle = trackWidgetLifecycle(page, id);
     const popoutPage = await popoutWidget(context, widget);
     expect(popoutPage.isClosed()).toBe(false);
 
     await popoutPage.close();
 
-    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.mountCount).toBe(0);
     expect(widgetLifecycle.unMountCount).toBe(0);
   });
 });

--- a/full-stack-tests/ui/tests/widget-state.test.ts
+++ b/full-stack-tests/ui/tests/widget-state.test.ts
@@ -324,15 +324,15 @@ test.describe("widget state", () => {
   });
 
   test("should unmount and hide widget when unloading", async ({ page }) => {
-    const widgetLifecycle = trackWidgetLifecycle(page, "WL-A");
     const tab = tabLocator(page, "WL-A");
-    await expect(tab).toBeVisible();
-    expect(widgetLifecycle.mountCount).toBe(1);
+    await expect(tab).toBeVisible({ timeout: 10000 });
+    const widgetLifecycle = trackWidgetLifecycle(page, "WL-A");
+    expect(widgetLifecycle.mountCount).toBe(0);
     expect(widgetLifecycle.unMountCount).toBe(0);
 
     await setWidgetState(page, "WL-A", WidgetState.Unloaded);
     await expect(tab).not.toBeVisible();
-    expect(widgetLifecycle.mountCount).toBe(1);
+    expect(widgetLifecycle.mountCount).toBe(0);
     expect(widgetLifecycle.unMountCount).toBe(1);
   });
 


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
Minor fixes on tests.

Spent hours trying to figure what's going on, seems that the more you run these tests, either in VSCode or in playwright ui `npm test -- --ui`, at some point everything get so slow that the tests may take up to a minute to run (and we bail out at 30 seconds, and 5 seconds for each excepts)

Not sure what to do next, seems a bit less flacky now, at least for these specific tests.

Trace show that at some point it takes up to 20 seconds before the page open in the browser window, in which case the tests no longer have enough time to run... Confusion all over the place :(

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
A Lot, tried a bunch of things, thought I had improvement, then end up in a stray of failures...