### PR TITLE
Fix panel resize issue

### DIFF
--- a/common/changes/@itwin/appui-layout-react/fix-panel-resize_2024-01-10-17-56.json
+++ b/common/changes/@itwin/appui-layout-react/fix-panel-resize_2024-01-10-17-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-layout-react",
+      "comment": "Fix an issue that caused a panel to become unresizable.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-layout-react"
+}

--- a/full-stack-tests/ui/tests/stage-panel.test.ts
+++ b/full-stack-tests/ui/tests/stage-panel.test.ts
@@ -2,17 +2,17 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { expect, test } from "@playwright/test";
+import { Locator, expect, test } from "@playwright/test";
 import assert from "assert";
 import { panelLocator, tabLocator, widgetLocator } from "./Utils";
 
-test.describe("stage panel def", () => {
+test.describe("stage panel", () => {
   test.beforeEach(async ({ page, baseURL }) => {
     assert(baseURL);
     await page.goto(`${baseURL}?frontstage=appui-test-providers:WidgetApi`);
   });
 
-  test("should toggle pin state of stage panel", async ({ page }) => {
+  test("should toggle pin state", async ({ page }) => {
     const panel = panelLocator({ page, side: "right" });
     const pinToggle = panel.locator(".nz-widget-pinToggle");
 
@@ -29,28 +29,70 @@ test.describe("stage panel def", () => {
     await expect(pinned).toHaveText("pinned=true");
   });
 
-  test("should change stage panel size", async ({ page }) => {
+  test("should resize", async ({ baseURL, page }) => {
+    assert(baseURL);
+    await page.goto(`${baseURL}?frontstage=appui-test-providers:WidgetApi`);
+
     const panel = panelLocator({ page, side: "right" });
-    const handlePos = (await panel
-      .locator(".nz-grip-container")
-      .locator(".nz-handle")
-      .boundingBox()) ?? { x: 0, y: 0, width: 0, height: 0 };
-    handlePos.x += handlePos.width / 2 + 3;
-    handlePos.y += handlePos.height / 2;
+    const handle = handleLocator(panel);
 
-    const layoutInfoTab = tabLocator(page, "Layout Info");
-    await layoutInfoTab.click();
-    const layoutInfoWidget = widgetLocator({ tab: layoutInfoTab });
-    const size = layoutInfoWidget.getByText("size=");
-    await expect(size).toHaveText("size=200px");
+    expect(await getPanelSize(panel)).toBe(200);
 
-    await page.mouse.move(handlePos.x, handlePos.y);
-    await page.mouse.down();
+    const panelBounds = (await panel.boundingBox())!;
+    const clientX = panelBounds.x;
+    const clientY = panelBounds.y + 20;
+    await handle.dispatchEvent("mousedown", { clientX, clientY });
 
-    await page.mouse.move(handlePos.x - 50, handlePos.y);
-    await expect(size).toHaveText("size=250px");
+    await handle.dispatchEvent("mousemove", {
+      clientX: clientX - 50,
+      clientY,
+    });
+    expect(await getPanelSize(panel)).toBe(250);
 
-    await page.mouse.move(handlePos.x - 40, handlePos.y);
-    await expect(size).toHaveText("size=240px");
+    await handle.dispatchEvent("mousemove", {
+      clientX: clientX - 40,
+      clientY,
+    });
+    expect(await getPanelSize(panel)).toBe(240);
+    await handle.dispatchEvent("mouseup");
   });
 });
+
+test("should resize (single panel)", async ({ baseURL, page }) => {
+  assert(baseURL);
+  await page.goto(
+    `${baseURL}?frontstage=appui-test-providers:CustomFrontstage`
+  );
+
+  const panel = panelLocator({ page, side: "left" });
+  const handle = handleLocator(panel);
+
+  expect(await getPanelSize(panel)).toBe(200);
+
+  const panelBounds = (await panel.boundingBox())!;
+  const clientX = panelBounds.x + panelBounds.width;
+  const clientY = panelBounds.y + 20;
+  await handle.dispatchEvent("mousedown", { clientX, clientY });
+
+  await handle.dispatchEvent("mousemove", {
+    clientX: clientX + 50,
+    clientY,
+  });
+  expect(await getPanelSize(panel)).toBe(250);
+
+  await handle.dispatchEvent("mousemove", {
+    clientX: clientX + 40,
+    clientY,
+  });
+  expect(await getPanelSize(panel)).toBe(240);
+  await handle.dispatchEvent("mouseup");
+});
+
+async function getPanelSize(panel: Locator) {
+  const panelBounds = (await panel.boundingBox())!;
+  return panelBounds.width;
+}
+
+function handleLocator(panel: Locator) {
+  return panel.locator(".nz-grip-container").locator(".nz-handle");
+}

--- a/full-stack-tests/ui/tests/stage-panel.test.ts
+++ b/full-stack-tests/ui/tests/stage-panel.test.ts
@@ -89,6 +89,7 @@ test("should resize (single panel)", async ({ baseURL, page }) => {
 });
 
 async function getPanelSize(panel: Locator) {
+  await panel.scrollIntoViewIfNeeded(); // wait for https://playwright.dev/docs/actionability#stable
   const panelBounds = (await panel.boundingBox())!;
   return panelBounds.width;
 }

--- a/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.tsx
+++ b/ui/appui-layout-react/src/appui-layout-react/widget-panels/Grip.tsx
@@ -89,7 +89,7 @@ export const useResizeGrip = <T extends HTMLElement>(): [
   const relativePosition = React.useRef(new Point());
   const layoutStore = useLayoutStore();
   const panelStateRef = React.useRef(layoutStore.getState().panels[side]);
-  React.useEffect(
+  React.useLayoutEffect(
     () =>
       layoutStore.subscribe((state) => {
         panelStateRef.current = state.panels[side];


### PR DESCRIPTION
## Changes

This PR fixes an issue that caused the panel to become unresizable due to a [transient update](https://github.com/pmndrs/zustand?tab=readme-ov-file#transient-updates-for-often-occurring-state-changes) handler added after the [PANEL_INITIALIZE](https://github.com/iTwin/appui/blob/e3e44fd0c8f276fefecc30baa0f454438eb6429b/ui/appui-layout-react/src/appui-layout-react/widget-panels/useAnimatePanel.tsx#L108) action was dispatched.

## Testing

Tested via standalone test-app with a single right panel in a frontstage.
