### PR TITLE
Add story for split viewport

### DIFF
--- a/docs/storybook/src/frontstage/SplitViewport.stories.tsx
+++ b/docs/storybook/src/frontstage/SplitViewport.stories.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import type { Meta, StoryObj } from "@storybook/react";
 import {
+  ConditionalBooleanValue,
   ConditionalStringValue,
   StandardContentLayouts,
 } from "@itwin/appui-abstract";
@@ -21,6 +22,8 @@ import { SplitViewportStory } from "./SplitViewport";
 import {
   Svg2D,
   Svg3D,
+  SvgAirplane,
+  SvgClipboard,
   SvgWindow,
   SvgWindowSplitVertical,
 } from "@itwin/itwinui-icons-react";
@@ -63,6 +66,9 @@ const testIcon1 = () => {
 const testIcon2 = () => {
   return leftViewportActive ? <Svg2D /> : <Svg3D />;
 };
+const testIcon3 = () => {
+  return leftViewportActive ? <SvgClipboard /> : <SvgAirplane />;
+};
 
 UiFramework.content.onActiveContentChangedEvent.addListener(() => {
   leftViewportActive = !leftViewportActive;
@@ -97,7 +103,7 @@ export const Default: Story = {
           ),
           ToolbarItemUtilities.createActionItem(
             `Test3and4`,
-            0,
+            1,
             new ConditionalIconItem(testIcon2, [
               SyncUiEventId.ActiveContentChanged,
             ]),
@@ -105,7 +111,31 @@ export const Default: Story = {
               () => (leftViewportActive ? "Test 3" : "Test 4"),
               [SyncUiEventId.ActiveContentChanged]
             ),
-            () => undefined
+            () => undefined,
+            {
+              isDisabled: new ConditionalBooleanValue(
+                () => (leftViewportActive ? true : false),
+                [SyncUiEventId.ActiveContentChanged]
+              ),
+            }
+          ),
+          ToolbarItemUtilities.createActionItem(
+            `Test5and6`,
+            2,
+            new ConditionalIconItem(testIcon3, [
+              SyncUiEventId.ActiveContentChanged,
+            ]),
+            new ConditionalStringValue(
+              () => (leftViewportActive ? "Test 5" : "Test 6"),
+              [SyncUiEventId.ActiveContentChanged]
+            ),
+            () => undefined,
+            {
+              isHidden: new ConditionalBooleanValue(
+                () => (leftViewportActive ? true : false),
+                [SyncUiEventId.ActiveContentChanged]
+              ),
+            }
           ),
         ],
       },

--- a/docs/storybook/src/frontstage/SplitViewport.stories.tsx
+++ b/docs/storybook/src/frontstage/SplitViewport.stories.tsx
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  ConditionalStringValue,
+  StandardContentLayouts,
+} from "@itwin/appui-abstract";
+import {
+  ContentProps,
+  IModelViewportControl,
+  SyncUiEventId,
+  ToolbarItemUtilities,
+  UiFramework,
+} from "@itwin/appui-react";
+import { AppUiDecorator } from "../AppUiDecorator";
+import { Page } from "../AppUiStory";
+import { createFrontstageProvider, removeProperty } from "../Utils";
+import { SplitViewportStory } from "./SplitViewport";
+import {
+  Svg2D,
+  Svg3D,
+  SvgWindow,
+  SvgWindowSplitVertical,
+} from "@itwin/itwinui-icons-react";
+import { ConditionalIconItem } from "@itwin/core-react";
+
+const meta = {
+  title: "Frontstage/SplitViewport",
+  component: SplitViewportStory,
+  tags: ["autodocs"],
+  decorators: [AppUiDecorator],
+  parameters: {
+    docs: {
+      page: () => <Page />,
+    },
+    layout: "fullscreen",
+  },
+  argTypes: {
+    frontstageProviders: removeProperty(),
+    itemProviders: removeProperty(),
+  },
+} satisfies Meta<typeof SplitViewportStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const contentPropsArray: ContentProps[] = [];
+contentPropsArray.push({
+  id: "imodel-view-0",
+  classId: IModelViewportControl.id,
+});
+contentPropsArray.push({
+  id: "imodel-view-1",
+  classId: IModelViewportControl.id,
+});
+
+let leftViewportActive = false;
+const testIcon1 = () => {
+  return leftViewportActive ? <SvgWindowSplitVertical /> : <SvgWindow />;
+};
+const testIcon2 = () => {
+  return leftViewportActive ? <Svg2D /> : <Svg3D />;
+};
+
+UiFramework.content.onActiveContentChangedEvent.addListener(() => {
+  leftViewportActive = !leftViewportActive;
+});
+
+export const Default: Story = {
+  args: {
+    frontstageProviders: [
+      createFrontstageProvider({
+        contentGroupProps: {
+          id: "split-vertical-group",
+          layout: StandardContentLayouts.twoVerticalSplit,
+          contents: contentPropsArray,
+        },
+      }),
+    ],
+    itemProviders: [
+      {
+        id: "toolbar",
+        provideToolbarItems: () => [
+          ToolbarItemUtilities.createActionItem(
+            `Test1and2`,
+            0,
+            new ConditionalIconItem(testIcon1, [
+              SyncUiEventId.ActiveContentChanged,
+            ]),
+            new ConditionalStringValue(
+              () => (leftViewportActive ? "Test 1" : "Test 2"),
+              [SyncUiEventId.ActiveContentChanged]
+            ),
+            () => undefined
+          ),
+          ToolbarItemUtilities.createActionItem(
+            `Test3and4`,
+            0,
+            new ConditionalIconItem(testIcon2, [
+              SyncUiEventId.ActiveContentChanged,
+            ]),
+            new ConditionalStringValue(
+              () => (leftViewportActive ? "Test 3" : "Test 4"),
+              [SyncUiEventId.ActiveContentChanged]
+            ),
+            () => undefined
+          ),
+        ],
+      },
+    ],
+  },
+};

--- a/docs/storybook/src/frontstage/SplitViewport.tsx
+++ b/docs/storybook/src/frontstage/SplitViewport.tsx
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { AppUiStory, AppUiStoryProps } from "../AppUiStory";
+
+/** This story shows two separate views. Depending on which view is active, the tools in the toolbars will change*/
+export function SplitViewportStory(
+  props: Pick<AppUiStoryProps, "frontstageProviders" | "itemProviders">
+) {
+  return <AppUiStory layout="fullscreen" {...props} />;
+}

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/MessageUiItemsProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/MessageUiItemsProvider.tsx
@@ -30,12 +30,12 @@ export class MessageUiItemsProvider implements UiItemsProvider {
     _stageId: string,
     stageUsage: string,
     usage: ToolbarUsage,
-    orientatipn: ToolbarOrientation
+    orientation: ToolbarOrientation
   ): ToolbarItem[] {
     if (
       stageUsage === StageUsage.General &&
       usage === ToolbarUsage.ContentManipulation &&
-      orientatipn === ToolbarOrientation.Vertical
+      orientation === ToolbarOrientation.Vertical
     ) {
       return [
         ToolbarItemUtilities.createGroupItem(


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes
- Added a split viewport story to the storybook. The tools in toolbars change based on which view is active

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing
- Check out the storybook
<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
