### PR TITLE
Add `widgetActionDropdown` preview feature

### DIFF
--- a/common/changes/@itwin/appui-react/preview-widget-buttons_2024-02-05-13-59.json
+++ b/common/changes/@itwin/appui-react/preview-widget-buttons_2024-02-05-13-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add `widgetActionDropdown` preview feature to render drop down menu in the widget title bar.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -18,7 +18,8 @@ Table of contents:
 
 - `activateDroppedTab` preview feature to activate a dragged widget tab whenever it is dropped in the receiving container. #601
 - `useWidget` hook to convey widget state and location. #655
-- `horizontalPanelAlignment` preview feature: Horizontal panels will now have "align" button that allow the panel to be aligned to the left, center or right of the view, along with original justify behavior where the panel take the full width of the view. #705
+- `horizontalPanelAlignment` preview feature to add an "align" button to horizontal panels that allow the panel to be aligned to the left, center or right of the view, along with original justify behavior where the panel might take the full width of the view. #705
+- `widgetActionDropdown` preview feature to add a dropdown menu to the widget title bar when specified threshold of buttons is exceeded.
 
 ### Changes
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -19,7 +19,7 @@ Table of contents:
 - `activateDroppedTab` preview feature to activate a dragged widget tab whenever it is dropped in the receiving container. #601
 - `useWidget` hook to convey widget state and location. #655
 - `horizontalPanelAlignment` preview feature to add an "align" button to horizontal panels that allow the panel to be aligned to the left, center or right of the view, along with original justify behavior where the panel might take the full width of the view. #705
-- `widgetActionDropdown` preview feature to add a dropdown menu to the widget title bar when specified threshold of buttons is exceeded.
+- `widgetActionDropdown` preview feature to add a dropdown menu to the widget title bar when specified threshold of buttons is exceeded. #721
 
 ### Changes
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -19,7 +19,7 @@ Table of contents:
 - `activateDroppedTab` preview feature to activate a dragged widget tab whenever it is dropped in the receiving container. #601
 - `useWidget` hook to convey widget state and location. #655
 - `horizontalPanelAlignment` preview feature to add an "align" button to horizontal panels that allow the panel to be aligned to the left, center or right of the view, along with original justify behavior where the panel might take the full width of the view. #705
-- `widgetActionDropdown` preview feature to add a dropdown menu to the widget title bar when specified threshold of buttons is exceeded. #721
+- `widgetActionDropdown` preview feature to render the widget title bar buttons in a dropdown menu when specified threshold is exceeded. #721
 
 ### Changes
 

--- a/docs/storybook/.storybook/preview.ts
+++ b/docs/storybook/.storybook/preview.ts
@@ -14,6 +14,17 @@ const preview: Preview = {
         date: /Date$/,
       },
     },
+    options: {
+      storySort: {
+        order: [
+          "Components",
+          "Frontstage",
+          "Widget",
+          "Hooks",
+          "Preview Features",
+        ],
+      },
+    },
   },
   globalTypes: {
     iModel: demoIModelGlobalType,

--- a/docs/storybook/src/preview/WidgetActionDropdown.stories.tsx
+++ b/docs/storybook/src/preview/WidgetActionDropdown.stories.tsx
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { Meta, StoryObj } from "@storybook/react";
+import { AppUiDecorator } from "../AppUiDecorator";
+import { Page } from "../AppUiStory";
+import { PreviewStory } from "./WidgetActionDropdown";
+
+const meta = {
+  title: "preview features/WidgetActionDropdown",
+  component: PreviewStory,
+  tags: ["autodocs"],
+  decorators: [AppUiDecorator],
+  parameters: {
+    docs: {
+      page: () => <Page />,
+    },
+  },
+  args: {
+    threshold: 2,
+  },
+} satisfies Meta<typeof PreviewStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/docs/storybook/src/preview/WidgetActionDropdown.tsx
+++ b/docs/storybook/src/preview/WidgetActionDropdown.tsx
@@ -1,0 +1,75 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import {
+  PreviewFeatures,
+  PreviewFeaturesProvider,
+  StagePanelLocation,
+  StagePanelSection,
+  StagePanelState,
+  UiItemsProvider,
+  WidgetState,
+} from "@itwin/appui-react";
+import { AppUiStory } from "../AppUiStory";
+import { createFrontstageProvider } from "../Utils";
+
+function createProvider(): UiItemsProvider {
+  return {
+    id: "widgets",
+    getWidgets: () => {
+      return [
+        {
+          id: "w1",
+          label: "Widget 1",
+          canPopout: true,
+          layouts: {
+            standard: {
+              location: StagePanelLocation.Bottom,
+              section: StagePanelSection.Start,
+            },
+          },
+        },
+        {
+          id: "w2",
+          label: "Widget 2",
+          defaultState: WidgetState.Floating,
+          layouts: {
+            standard: {
+              location: StagePanelLocation.Left,
+              section: StagePanelSection.Start,
+            },
+          },
+        },
+      ];
+    },
+  };
+}
+
+type PreviewStoryProps = Required<PreviewFeatures>["widgetActionDropdown"];
+
+/** `widgetActionDropdown` preview feature. When widget title bar buttons exceed the specified threshold a drop down menu is rendered instead. */
+export function PreviewStory(props: PreviewStoryProps) {
+  const provider = createProvider();
+  return (
+    <PreviewFeaturesProvider
+      features={{
+        enableMaximizedFloatingWidget: true,
+        horizontalPanelAlignment: true,
+        widgetActionDropdown: { threshold: props.threshold },
+      }}
+    >
+      <AppUiStory
+        itemProviders={[provider]}
+        frontstageProviders={[
+          createFrontstageProvider({
+            leftPanelProps: {
+              defaultState: StagePanelState.Open,
+              pinned: true,
+            },
+          }),
+        ]}
+      />
+    </PreviewFeaturesProvider>
+  );
+}

--- a/full-stack-tests/ui/tests/Utils.ts
+++ b/full-stack-tests/ui/tests/Utils.ts
@@ -224,7 +224,7 @@ export async function dragWidget(
 ) {
   const page = widget.page();
   const titleBarHandle = titleBarHandleLocator(widget);
-  const titleBarButtons = widget.locator(".nz-widget-tabBarButtons");
+  const titleBarButtons = widget.locator(".nz-widget-buttons");
   const frontstage = frontstageLocator(page);
 
   // Widget tabs or title bar buttons overlay the handle. Make sure we drag the handle.

--- a/full-stack-tests/ui/tests/floating-widget.test.ts
+++ b/full-stack-tests/ui/tests/floating-widget.test.ts
@@ -217,7 +217,7 @@ test.describe("floating widget send back outline", () => {
   test("should show a widget (with tab) outline", async ({ page }) => {
     const tab = tabLocator(page, "FW-1");
     const floatingWidget = floatingWidgetLocator({ tab });
-    const sendBackButton = floatingWidget.locator(".nz-widget-sendBack");
+    const sendBackButton = floatingWidget.getByTitle("Send to panel");
 
     const destTab = tabLocator(page, "WL-A");
     const [widgetOutline, tabOutline] = outlineLocator({ tab: destTab });
@@ -240,7 +240,7 @@ test.describe("floating widget send back outline", () => {
 
     const tab = tabLocator(page, "FW-1");
     const floatingWidget = floatingWidgetLocator({ tab });
-    const sendBackButton = floatingWidget.locator(".nz-widget-sendBack");
+    const sendBackButton = floatingWidget.getByTitle("Send to panel");
 
     const outline = outlineLocator({ page, side: "left" });
 
@@ -256,7 +256,7 @@ test.describe("floating widget send back outline", () => {
 
     const tab = tabLocator(page, "FW-1");
     const floatingWidget = floatingWidgetLocator({ tab });
-    const sendBackButton = floatingWidget.locator(".nz-widget-sendBack");
+    const sendBackButton = floatingWidget.getByTitle("Send to panel");
 
     const panel = panelLocator({ page, side: "left" });
     const outline = outlineLocator({ panel, sectionId: 0 });
@@ -280,7 +280,7 @@ test.describe("floating widget send back outline", () => {
     });
 
     const floatingWidget = floatingWidgetLocator({ tab });
-    const sendBackButton = floatingWidget.locator(".nz-widget-sendBack");
+    const sendBackButton = floatingWidget.getByTitle("Send to panel");
 
     await setWidgetState(page, "WL-2", WidgetState.Hidden);
     await setWidgetState(page, "WL-3", WidgetState.Hidden);

--- a/full-stack-tests/ui/tests/stage-panel.test.ts
+++ b/full-stack-tests/ui/tests/stage-panel.test.ts
@@ -19,7 +19,7 @@ test.describe("WidgetApi", () => {
 
   test("should toggle pin state", async ({ page }) => {
     const panel = panelLocator({ page, side: "right" });
-    const pinToggle = panel.locator(".nz-widget-pinToggle");
+    const pinToggle = panel.getByTitle("Unpin widget panel");
 
     const layoutInfoTab = tabLocator(page, "Layout Info");
     await layoutInfoTab.click();

--- a/full-stack-tests/ui/tests/stage-panel.test.ts
+++ b/full-stack-tests/ui/tests/stage-panel.test.ts
@@ -19,7 +19,6 @@ test.describe("WidgetApi", () => {
 
   test("should toggle pin state", async ({ page }) => {
     const panel = panelLocator({ page, side: "right" });
-    const pinToggle = panel.getByTitle("Unpin widget panel");
 
     const layoutInfoTab = tabLocator(page, "Layout Info");
     await layoutInfoTab.click();
@@ -27,10 +26,12 @@ test.describe("WidgetApi", () => {
     const pinned = layoutInfoWidget.getByText("pinned=");
     await expect(pinned).toHaveText("pinned=true");
 
-    await pinToggle.click();
+    const unpinButton = panel.getByTitle("Unpin widget panel");
+    await unpinButton.click();
     await expect(pinned).toHaveText("pinned=false");
 
-    await pinToggle.click();
+    const pinButton = panel.getByTitle("Pin widget panel");
+    await pinButton.click();
     await expect(pinned).toHaveText("pinned=true");
   });
 

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
@@ -2,65 +2,74 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
+import * as React from "react";
 import {
   PreviewFeatures,
   PreviewFeaturesProvider,
-  StatusBarItem,
   StatusBarSection,
   UiItemsProvider,
 } from "@itwin/appui-react";
 import { BetaBadge } from "@itwin/core-react";
 import { Checkbox, DropdownButton, MenuItem } from "@itwin/itwinui-react";
-import * as React from "react";
 
-const PreviewFeatureListContext = React.createContext<
-  [string[], React.Dispatch<React.SetStateAction<string[]>>] | undefined
+const PreviewFeaturesContext = React.createContext<
+  | [PreviewFeatures, React.Dispatch<React.SetStateAction<PreviewFeatures>>]
+  | undefined
 >(undefined);
 
-const featureList = [
-  { id: "contentAlwaysMaxSize", label: "Content is always maximum size" },
-  {
-    id: "enableMaximizedFloatingWidget",
+type AvailableFeatures = {
+  [K in keyof PreviewFeatures]: { label: string; value?: PreviewFeatures[K] };
+};
+
+const availableFeatures: AvailableFeatures = {
+  contentAlwaysMaxSize: {
+    label: "Content is always maximum size",
+  },
+  enableMaximizedFloatingWidget: {
     label: "Enable maximized floating widgets",
   },
-  {
-    id: "activateDroppedTab",
+  activateDroppedTab: {
     label: "Change active tab after drag & drop",
   },
-  {
-    id: "horizontalPanelAlignment",
+  horizontalPanelAlignment: {
     label: "Horizontal panel alignment",
   },
-];
-function PreviewFeatureList() {
-  const [activeFeatureList, setActiveFeatureList] =
-    React.useContext(PreviewFeatureListContext) ?? [];
+  widgetActionDropdown: {
+    label: "Render dropdown menu when widget title bar has more than 2 buttons",
+    value: { threshold: 2 },
+  },
+};
 
-  if (!activeFeatureList || !setActiveFeatureList) {
+function PreviewFeatureList() {
+  const context = React.useContext(PreviewFeaturesContext);
+
+  if (!context) {
     return null;
   }
 
+  const [features, setFeatures] = context;
+  const availableFeatureEntries = Object.entries(availableFeatures);
   return (
     <DropdownButton
       size="small"
       menuItems={() =>
-        featureList.map(({ id: feature, label }) => (
+        availableFeatureEntries.map(([feature, { label, value }]) => (
           <MenuItem
             key={feature}
             sublabel={feature}
-            badge={
-              <Checkbox
-                checked={activeFeatureList.includes(feature)}
-                readOnly
-              />
-            }
+            badge={<Checkbox checked={feature in features} readOnly />}
             onClick={() => {
-              setActiveFeatureList((prev) =>
-                prev.includes(feature)
-                  ? prev.filter((item) => item !== feature)
-                  : [...prev, feature]
-              );
+              setFeatures((prev) => {
+                if (Object.keys(prev).includes(feature)) {
+                  const { [feature]: _, ...rest } = prev;
+                  return rest;
+                }
+
+                return {
+                  ...prev,
+                  [feature]: value === undefined ? true : value,
+                };
+              });
             }}
           >
             {label}
@@ -73,36 +82,25 @@ function PreviewFeatureList() {
   );
 }
 
-/**
- */
-export class PreviewFeaturesToggleProvider implements UiItemsProvider {
-  public readonly id = "appui-test-providers:PreviewFeaturesToggleProvider";
+export const previewFeaturesToggleProvider: UiItemsProvider = {
+  id: "appui-test-providers:PreviewFeaturesToggleProvider",
+  getStatusBarItems: () => [
+    {
+      content: <PreviewFeatureList />,
+      section: StatusBarSection.Right,
+      id: `${previewFeaturesToggleProvider.id}:StatusBarItem`,
+      itemPriority: Infinity,
+    },
+  ],
+};
 
-  public getStatusBarItems(): readonly StatusBarItem[] {
-    return [
-      {
-        content: <PreviewFeatureList />,
-        section: StatusBarSection.Right,
-        id: `${this.id}:StatusBarItem`,
-        itemPriority: Infinity,
-      },
-    ];
-  }
-
-  public static ReactProvider = (props: { children?: React.ReactNode }) => {
-    const activeFeatureList = React.useState<string[]>([]);
-
-    return (
-      <PreviewFeatureListContext.Provider value={activeFeatureList}>
-        <PreviewFeaturesProvider
-          features={featureList.reduce<PreviewFeatures>((features, { id }) => {
-            features[id] = activeFeatureList[0].includes(id);
-            return features;
-          }, {})}
-        >
-          {props.children}
-        </PreviewFeaturesProvider>
-      </PreviewFeatureListContext.Provider>
-    );
-  };
+export function AppPreviewFeatures(props: React.PropsWithChildren<{}>) {
+  const [features, setFeatures] = React.useState<PreviewFeatures>({});
+  return (
+    <PreviewFeaturesContext.Provider value={[features, setFeatures]}>
+      <PreviewFeaturesProvider features={features}>
+        {props.children}
+      </PreviewFeaturesProvider>
+    </PreviewFeaturesContext.Provider>
+  );
 }

--- a/test-apps/appui-test-app/connected/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/index.tsx
@@ -102,13 +102,14 @@ import { IModelOpenFrontstage } from "./appui/frontstages/IModelOpenFrontstage";
 import { SignInFrontstage } from "./appui/frontstages/SignInFrontstage";
 import {
   AbstractUiItemsProvider,
+  AppPreviewFeatures,
   AppUiTestProviders,
   ContentLayoutStage,
   CustomContentFrontstage,
   FloatingWidgetsUiItemsProvider,
   InspectUiItemInfoToolProvider,
   PopoutWindowsFrontstage,
-  PreviewFeaturesToggleProvider,
+  previewFeaturesToggleProvider,
   SynchronizedFloatingViewportStage,
   WidgetApiStage,
 } from "@itwin/appui-test-providers";
@@ -386,7 +387,7 @@ export class SampleAppIModelApp {
         AppUiTestProviders.localizationNamespace
       )
     );
-    UiItemsManager.register(new PreviewFeaturesToggleProvider());
+    UiItemsManager.register(previewFeaturesToggleProvider);
     CustomContentFrontstage.register(AppUiTestProviders.localizationNamespace); // Frontstage and item providers
     WidgetApiStage.register(AppUiTestProviders.localizationNamespace); // Frontstage and item providers
     ContentLayoutStage.register(AppUiTestProviders.localizationNamespace); // Frontstage and item providers
@@ -824,7 +825,7 @@ const SampleAppViewer2 = () => {
   }, []);
 
   return (
-    <PreviewFeaturesToggleProvider.ReactProvider>
+    <AppPreviewFeatures>
       <Provider store={SampleAppIModelApp.store}>
         <ThemeManager>
           <SafeAreaContext.Provider value={SafeAreaInsets.All}>
@@ -836,7 +837,7 @@ const SampleAppViewer2 = () => {
           </SafeAreaContext.Provider>
         </ThemeManager>
       </Provider>
-    </PreviewFeaturesToggleProvider.ReactProvider>
+    </AppPreviewFeatures>
   );
 };
 

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -90,6 +90,7 @@ import { AppSettingsTabsProvider } from "./appui/settingsproviders/AppSettingsTa
 // import { ECSchemaRpcLocater } from "@itwin/ecschema-rpcinterface-common";
 import {
   AbstractUiItemsProvider,
+  AppPreviewFeatures,
   AppUiTestProviders,
   ContentLayoutStage,
   CustomContentFrontstage,
@@ -98,7 +99,7 @@ import {
   InspectUiItemInfoToolProvider,
   MessageUiItemsProvider,
   PopoutWindowsFrontstage,
-  PreviewFeaturesToggleProvider,
+  previewFeaturesToggleProvider,
   registerCustomFrontstage,
   SynchronizedFloatingViewportStage,
   TestFrontstageProvider,
@@ -347,7 +348,7 @@ export class SampleAppIModelApp {
         AppUiTestProviders.localizationNamespace
       )
     );
-    UiItemsManager.register(new PreviewFeaturesToggleProvider());
+    UiItemsManager.register(previewFeaturesToggleProvider);
     UiItemsManager.register(new CustomStageUiItemsProvider());
 
     // Register frontstages
@@ -583,7 +584,7 @@ const SampleAppViewer = () => {
   useHandleURLParams();
 
   return (
-    <PreviewFeaturesToggleProvider.ReactProvider>
+    <AppPreviewFeatures>
       <Provider store={SampleAppIModelApp.store}>
         <ThemeManager>
           <SafeAreaContext.Provider value={SafeAreaInsets.All}>
@@ -595,7 +596,7 @@ const SampleAppViewer = () => {
           </SafeAreaContext.Provider>
         </ThemeManager>
       </Provider>
-    </PreviewFeaturesToggleProvider.ReactProvider>
+    </AppPreviewFeatures>
   );
 };
 

--- a/ui/appui-react/src/appui-react/layout/widget/Button.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Button.tsx
@@ -7,12 +7,14 @@
  */
 
 import * as React from "react";
-import { Button } from "@itwin/itwinui-react";
+import { IconButton } from "@itwin/itwinui-react";
 
 /** @internal */
 export const TabBarButton = React.forwardRef<
   HTMLButtonElement,
-  React.ComponentProps<typeof Button>
+  React.ComponentProps<typeof IconButton>
 >(function TabBarButton(props, ref) {
-  return <Button ref={ref} styleType="borderless" size="small" {...props} />;
+  return (
+    <IconButton ref={ref} styleType="borderless" size="small" {...props} />
+  );
 });

--- a/ui/appui-react/src/appui-react/layout/widget/Button.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Button.tsx
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import * as React from "react";
+import { Button } from "@itwin/itwinui-react";
+
+/** @internal */
+export const TabBarButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(function TabBarButton(props, ref) {
+  return <Button ref={ref} styleType="borderless" size="small" {...props} />;
+});

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.scss
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+.nz-widget-buttons {
+  display: flex;
+  align-items: center;
+  align-content: center;
+  height: 100%;
+}

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
@@ -6,8 +6,8 @@
  * @module Widget
  */
 
-import { assert } from "@itwin/core-bentley";
 import * as React from "react";
+import { assert } from "@itwin/core-bentley";
 import { useLayout } from "../base/LayoutStore";
 import {
   isHorizontalPanelSide,
@@ -29,6 +29,7 @@ import { WidgetIdContext } from "./Widget";
 import { usePreviewFeatures } from "../../preview/PreviewFeatures";
 import { MoreButton } from "../../preview/widget-action-dropdown/MoreButton";
 import { useIsToolSettingsTab } from "./useIsToolSettingsTab";
+import "./Buttons.scss";
 
 /** @internal */
 export function TabBarButtons() {
@@ -55,10 +56,12 @@ export function TabBarButtons() {
 
   const { widgetActionDropdown } = usePreviewFeatures();
   const threshold = widgetActionDropdown?.threshold ?? Infinity;
-  if (buttons.length > threshold) {
-    return <MoreButton>{buttons.reverse()}</MoreButton>;
-  }
-  return <div className="nz-widget-tabBarButtons">{buttons}</div>;
+  const isDropdown = buttons.length > threshold;
+  return (
+    <div className="nz-widget-buttons">
+      {isDropdown ? <MoreButton>{buttons.reverse()}</MoreButton> : buttons}
+    </div>
+  );
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
@@ -14,57 +14,51 @@ import {
   PanelSideContext,
 } from "../widget-panels/Panel";
 import { Dock } from "./Dock";
-import { useFloatingWidgetId, useWidgetAllowedToDock } from "./FloatingWidget";
 import { PinToggle } from "./PinToggle";
-import { PopoutToggle } from "./PopoutToggle";
-import { PreviewHorizontalPanelAlignButton } from "./PreviewHorizontalPanelAlign";
+import { PopoutToggle, usePopoutToggle } from "./PopoutToggle";
+import {
+  PreviewHorizontalPanelAlignButton,
+  useHorizontalPanelAlignButton,
+} from "./PreviewHorizontalPanelAlign";
 import {
   PreviewMaximizeToggle,
-  usePreviewMaximizedWidget,
+  useMaximizeToggle,
 } from "./PreviewMaximizeToggle";
-import { SendBack } from "./SendBack";
-import { useActiveTabId, WidgetIdContext } from "./Widget";
+import { SendBack, useSendBack } from "./SendBack";
+import { WidgetIdContext } from "./Widget";
+import { usePreviewFeatures } from "../../preview/PreviewFeatures";
+import { MoreButton } from "../../preview/widget-action-dropdown/MoreButton";
+import { useIsToolSettingsTab } from "./useIsToolSettingsTab";
+
 /** @internal */
 export function TabBarButtons() {
-  const { enabled: previewEnableMaximizedFloatingWidget, maximizedWidget } =
-    usePreviewMaximizedWidget();
   const isToolSettings = useIsToolSettingsTab();
-  const floatingWidgetId = useFloatingWidgetId();
-  const canBeDocked = useWidgetAllowedToDock();
-
   const isMainPanelWidget = useIsMainPanelWidget();
-  const tabId = useActiveTabId();
-  const canPopout = useLayout((state) => {
-    const tab = state.tabs[tabId];
-    return tab.canPopout;
-  });
-  // istanbul ignore next (preview)
-  const isMaximized =
-    maximizedWidget === floatingWidgetId &&
-    previewEnableMaximizedFloatingWidget;
-  return (
-    <div className="nz-widget-tabBarButtons">
-      {canPopout && <PopoutToggle />}
-      {
-        // istanbul ignore next (preview)
-        previewEnableMaximizedFloatingWidget &&
-          !isToolSettings &&
-          floatingWidgetId && <PreviewMaximizeToggle />
-      }
-      {!isMaximized && floatingWidgetId && !isToolSettings && canBeDocked && (
-        <SendBack />
-      )}
-      {isToolSettings && <Dock />}
-      {isMainPanelWidget && <PreviewHorizontalPanelAlignButton />}
-      {isMainPanelWidget && <PinToggle />}
-    </div>
-  );
-}
 
-function useIsToolSettingsTab() {
-  const activeTabId = useActiveTabId();
-  const toolSettingsTabId = useLayout((state) => state.toolSettings?.tabId);
-  return activeTabId === toolSettingsTabId;
+  const popoutToggle = usePopoutToggle();
+  const maximizeToggle = useMaximizeToggle();
+  const sendBack = useSendBack();
+  const dock = isToolSettings;
+  const horizontalPanelAlignButton = useHorizontalPanelAlignButton();
+  const pinToggle = isMainPanelWidget;
+
+  const buttons = [
+    ...(popoutToggle ? [<PopoutToggle key="popout" />] : []),
+    ...(maximizeToggle ? [<PreviewMaximizeToggle key="maximize" />] : []),
+    ...(sendBack ? [<SendBack key="sendBack" />] : []),
+    ...(dock ? [<Dock key="dock" />] : []),
+    ...(horizontalPanelAlignButton
+      ? [<PreviewHorizontalPanelAlignButton key="horizontalAlign" />]
+      : []),
+    ...(pinToggle ? [<PinToggle key="pin" />] : []),
+  ];
+
+  const { widgetActionDropdown } = usePreviewFeatures();
+  const threshold = widgetActionDropdown?.threshold ?? Infinity;
+  if (buttons.length > threshold) {
+    return <MoreButton>{buttons}</MoreButton>;
+  }
+  return <div className="nz-widget-tabBarButtons">{buttons}</div>;
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
@@ -56,7 +56,7 @@ export function TabBarButtons() {
   const { widgetActionDropdown } = usePreviewFeatures();
   const threshold = widgetActionDropdown?.threshold ?? Infinity;
   if (buttons.length > threshold) {
-    return <MoreButton>{buttons}</MoreButton>;
+    return <MoreButton>{buttons.reverse()}</MoreButton>;
   }
   return <div className="nz-widget-tabBarButtons">{buttons}</div>;
 }

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
@@ -26,13 +26,45 @@ import {
 } from "./PreviewMaximizeToggle";
 import { SendBack, useSendBack } from "./SendBack";
 import { WidgetIdContext } from "./Widget";
-import { usePreviewFeatures } from "../../preview/PreviewFeatures";
-import { MoreButton } from "../../preview/widget-action-dropdown/MoreButton";
+import {
+  MoreButton,
+  useDropdownFeatures,
+} from "../../preview/widget-action-dropdown/MoreButton";
 import { useIsToolSettingsTab } from "./useIsToolSettingsTab";
 import "./Buttons.scss";
 
 /** @internal */
 export function TabBarButtons() {
+  const features = useWidgetFeatures();
+  const [sortedFeatures, isDropdown] = useDropdownFeatures(features);
+
+  const buttons = sortedFeatures.map((feature) => {
+    switch (feature) {
+      case "popout":
+        return <PopoutToggle key="popout" />;
+      case "maximize":
+        return <PreviewMaximizeToggle key="maximize" />;
+      case "sendBack":
+        return <SendBack key="sendBack" />;
+      case "dock":
+        return <Dock key="dock" />;
+      case "horizontalAlign":
+        return <PreviewHorizontalPanelAlignButton key="horizontalAlign" />;
+      case "pin":
+        return <PinToggle key="pin" />;
+    }
+    return undefined;
+  });
+
+  return (
+    <div className="nz-widget-buttons">
+      {isDropdown ? <MoreButton>{buttons}</MoreButton> : buttons}
+    </div>
+  );
+}
+
+/** @internal */
+export function useWidgetFeatures() {
   const isToolSettings = useIsToolSettingsTab();
   const isMainPanelWidget = useIsMainPanelWidget();
 
@@ -43,25 +75,14 @@ export function TabBarButtons() {
   const horizontalPanelAlignButton = useHorizontalPanelAlignButton();
   const pinToggle = isMainPanelWidget;
 
-  const buttons = [
-    ...(popoutToggle ? [<PopoutToggle key="popout" />] : []),
-    ...(maximizeToggle ? [<PreviewMaximizeToggle key="maximize" />] : []),
-    ...(sendBack ? [<SendBack key="sendBack" />] : []),
-    ...(dock ? [<Dock key="dock" />] : []),
-    ...(horizontalPanelAlignButton
-      ? [<PreviewHorizontalPanelAlignButton key="horizontalAlign" />]
-      : []),
-    ...(pinToggle ? [<PinToggle key="pin" />] : []),
+  return [
+    ...(popoutToggle ? (["popout"] as const) : []),
+    ...(maximizeToggle ? (["maximize"] as const) : []),
+    ...(sendBack ? (["sendBack"] as const) : []),
+    ...(dock ? (["dock"] as const) : []),
+    ...(horizontalPanelAlignButton ? (["horizontalAlign"] as const) : []),
+    ...(pinToggle ? (["pin"] as const) : []),
   ];
-
-  const { widgetActionDropdown } = usePreviewFeatures();
-  const threshold = widgetActionDropdown?.threshold ?? Infinity;
-  const isDropdown = buttons.length > threshold;
-  return (
-    <div className="nz-widget-buttons">
-      {isDropdown ? <MoreButton>{buttons.reverse()}</MoreButton> : buttons}
-    </div>
-  );
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/layout/widget/Dock.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Dock.tsx
@@ -7,27 +7,23 @@
  */
 
 import * as React from "react";
-import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
-import { Button } from "@itwin/itwinui-react";
 import { SvgDockTop } from "@itwin/itwinui-icons-react";
+import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
+import { ActionButton } from "../../preview/widget-action-dropdown/Button";
 
 /** @internal */
 export function Dock() {
   const dispatch = React.useContext(NineZoneDispatchContext);
   const title = useLabel("dockToolSettingsTitle");
   return (
-    <Button
-      className="nz-widget-dock"
-      styleType="borderless"
-      size="small"
+    <ActionButton
+      icon={<SvgDockTop />}
+      title={title}
       onClick={() => {
         dispatch({
           type: "TOOL_SETTINGS_DOCK",
         });
       }}
-      title={title}
-    >
-      <SvgDockTop />
-    </Button>
+    />
   );
 }

--- a/ui/appui-react/src/appui-react/layout/widget/PinToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PinToggle.tsx
@@ -7,13 +7,12 @@
  */
 
 import * as React from "react";
-import classnames from "classnames";
 import { assert } from "@itwin/core-bentley";
+import { SvgPin, SvgPinHollow } from "@itwin/itwinui-icons-react";
 import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
 import { PanelSideContext } from "../widget-panels/Panel";
 import { useLayout } from "../base/LayoutStore";
-import { Button } from "@itwin/itwinui-react";
-import { SvgPin, SvgPinHollow } from "@itwin/itwinui-icons-react";
+import { ActionButton } from "../../preview/widget-action-dropdown/Button";
 
 /** @internal */
 export function PinToggle() {
@@ -24,25 +23,16 @@ export function PinToggle() {
   const unpinPanelTitle = useLabel("unpinPanelTitle");
   const pinned = useLayout((state) => state.panels[side].pinned);
 
-  const className = classnames(
-    "nz-widget-pinToggle",
-    pinned ? "nz-is-pinned" : "nz-is-unpinned"
-  );
-
   return (
-    <Button
-      className={className}
-      styleType="borderless"
-      size="small"
+    <ActionButton
+      icon={pinned ? <SvgPin /> : <SvgPinHollow />}
+      title={pinned ? unpinPanelTitle : pinPanelTitle}
       onClick={() => {
         dispatch({
           side,
           type: "PANEL_TOGGLE_PINNED",
         });
       }}
-      title={pinned ? unpinPanelTitle : pinPanelTitle}
-    >
-      {pinned ? <SvgPin /> : <SvgPinHollow />}
-    </Button>
+    />
   );
 }

--- a/ui/appui-react/src/appui-react/layout/widget/PopoutToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PopoutToggle.tsx
@@ -7,11 +7,11 @@
  */
 
 import * as React from "react";
+import { SvgWindowPopout } from "@itwin/itwinui-icons-react";
 import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
 import { useActiveTabId } from "./Widget";
-import { Button } from "@itwin/itwinui-react";
-import { SvgWindowPopout } from "@itwin/itwinui-icons-react";
 import { useLayout } from "../base/LayoutStore";
+import { ActionButton } from "../../preview/widget-action-dropdown/Button";
 
 /** @internal */
 export function PopoutToggle() {
@@ -20,20 +20,16 @@ export function PopoutToggle() {
   const popoutTitle = useLabel("popoutActiveTab");
 
   return (
-    <Button
-      className="nz-widget-popoutToggle"
-      styleType="borderless"
-      size="small"
+    <ActionButton
+      icon={<SvgWindowPopout />}
+      title={popoutTitle}
       onClick={() => {
         dispatch({
           id: activeTabId,
           type: "WIDGET_TAB_POPOUT",
         });
       }}
-      title={popoutTitle}
-    >
-      <SvgWindowPopout />
-    </Button>
+    />
   );
 }
 

--- a/ui/appui-react/src/appui-react/layout/widget/PopoutToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PopoutToggle.tsx
@@ -6,13 +6,12 @@
  * @module Widget
  */
 
-// cSpell:ignore popout
-
 import * as React from "react";
 import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
 import { useActiveTabId } from "./Widget";
 import { Button } from "@itwin/itwinui-react";
 import { SvgWindowPopout } from "@itwin/itwinui-icons-react";
+import { useLayout } from "../base/LayoutStore";
 
 /** @internal */
 export function PopoutToggle() {
@@ -36,4 +35,13 @@ export function PopoutToggle() {
       <SvgWindowPopout />
     </Button>
   );
+}
+
+/** @internal */
+export function usePopoutToggle() {
+  const tabId = useActiveTabId();
+  return useLayout((state) => {
+    const tab = state.tabs[tabId];
+    return !!tab.canPopout;
+  });
 }

--- a/ui/appui-react/src/appui-react/layout/widget/PreviewHorizontalPanelAlign.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PreviewHorizontalPanelAlign.tsx
@@ -156,7 +156,7 @@ export function PreviewHorizontalPanelAlignButton() {
   const { alignments, setAlignment } = usePreviewHorizontalPanelAlign();
   const title = "Align panel";
 
-  const getMenuItems = (onClose: () => void) =>
+  const getMenuItems = (onClose?: () => void) =>
     [
       HorizontalAlignment.Justify,
       HorizontalAlignment.Center,
@@ -182,7 +182,7 @@ export function PreviewHorizontalPanelAlignButton() {
     return (
       <MenuItem
         icon={getIcon(side, alignments[side])}
-        subMenuItems={getMenuItems(dropdownContext.onClose)}
+        subMenuItems={getMenuItems()}
       >
         {title}
       </MenuItem>

--- a/ui/appui-react/src/appui-react/layout/widget/PreviewHorizontalPanelAlign.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PreviewHorizontalPanelAlign.tsx
@@ -18,6 +18,7 @@ import type {
   HorizontalPanelSide,
   PanelSide,
 } from "../widget-panels/PanelTypes";
+import { useIsMainPanelWidget } from "./Buttons";
 
 /** default value used when not provided or disabled */
 const defaultAlignments = {
@@ -149,10 +150,9 @@ function capitalize(s: string) {
 export function PreviewHorizontalPanelAlignButton() {
   const side = React.useContext(PanelSideContext);
   assert(!!side);
-  const { enabled, alignments, setAlignment } =
-    usePreviewHorizontalPanelAlign();
+  assert(isHorizontalPanelSide(side));
+  const { alignments, setAlignment } = usePreviewHorizontalPanelAlign();
 
-  if (!enabled || !isHorizontalPanelSide(side)) return null;
   return (
     <DropdownMenu
       menuItems={(close) =>
@@ -182,5 +182,19 @@ export function PreviewHorizontalPanelAlignButton() {
         {getIcon(side, alignments[side])}
       </Button>
     </DropdownMenu>
+  );
+}
+
+/** @internal */
+export function useHorizontalPanelAlignButton() {
+  const side = React.useContext(PanelSideContext);
+  const { enabled } = usePreviewHorizontalPanelAlign();
+  const isMainPanelWidget = useIsMainPanelWidget();
+
+  return !!(
+    enabled &&
+    side &&
+    isHorizontalPanelSide(side) &&
+    isMainPanelWidget
   );
 }

--- a/ui/appui-react/src/appui-react/layout/widget/PreviewHorizontalPanelAlign.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PreviewHorizontalPanelAlign.tsx
@@ -6,10 +6,10 @@
  * @module Widget
  */
 
+import * as React from "react";
 import { assert } from "@itwin/core-bentley";
 import { HorizontalAlignment } from "@itwin/core-react";
-import { Button, DropdownMenu, MenuItem } from "@itwin/itwinui-react";
-import * as React from "react";
+import { DropdownMenu, MenuItem } from "@itwin/itwinui-react";
 import {
   isHorizontalPanelSide,
   PanelSideContext,
@@ -19,8 +19,10 @@ import type {
   PanelSide,
 } from "../widget-panels/PanelTypes";
 import { useIsMainPanelWidget } from "./Buttons";
+import { WidgetActionDropdownContext } from "../../preview/widget-action-dropdown/MoreButton";
+import { TabBarButton } from "./Button";
 
-/** default value used when not provided or disabled */
+/** Default value used when not provided or disabled. */
 const defaultAlignments = {
   top: HorizontalAlignment.Justify,
   bottom: HorizontalAlignment.Justify,
@@ -152,35 +154,45 @@ export function PreviewHorizontalPanelAlignButton() {
   assert(!!side);
   assert(isHorizontalPanelSide(side));
   const { alignments, setAlignment } = usePreviewHorizontalPanelAlign();
+  const title = "Align panel";
 
+  const getMenuItems = (onClose: () => void) =>
+    [
+      HorizontalAlignment.Justify,
+      HorizontalAlignment.Center,
+      HorizontalAlignment.Left,
+      HorizontalAlignment.Right,
+    ].map((align) => {
+      return (
+        <MenuItem
+          key={align}
+          onClick={() => {
+            setAlignment(side, align);
+            onClose?.();
+          }}
+          icon={getIcon(side, align)}
+          isSelected={alignments[side] === align}
+        >
+          {capitalize(align)}
+        </MenuItem>
+      );
+    });
+  const dropdownContext = React.useContext(WidgetActionDropdownContext);
+  if (dropdownContext !== undefined) {
+    return (
+      <MenuItem
+        icon={getIcon(side, alignments[side])}
+        subMenuItems={getMenuItems(dropdownContext.onClose)}
+      >
+        {title}
+      </MenuItem>
+    );
+  }
   return (
-    <DropdownMenu
-      menuItems={(close) =>
-        [
-          HorizontalAlignment.Justify,
-          HorizontalAlignment.Center,
-          HorizontalAlignment.Left,
-          HorizontalAlignment.Right,
-        ].map((align) => {
-          return (
-            <MenuItem
-              key={align}
-              onClick={() => {
-                setAlignment(side, align);
-                close();
-              }}
-              icon={getIcon(side, align)}
-              isSelected={alignments[side] === align}
-            >
-              {capitalize(align)}
-            </MenuItem>
-          );
-        })
-      }
-    >
-      <Button size="small" styleType="borderless" title={"Align panel"}>
+    <DropdownMenu menuItems={(close) => getMenuItems(close)}>
+      <TabBarButton title={title}>
         {getIcon(side, alignments[side])}
-      </Button>
+      </TabBarButton>
     </DropdownMenu>
   );
 }

--- a/ui/appui-react/src/appui-react/layout/widget/PreviewMaximizeToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PreviewMaximizeToggle.tsx
@@ -12,8 +12,8 @@ import {
   SvgWindowMinimize,
 } from "@itwin/itwinui-icons-react";
 import { useFloatingWidgetId } from "./FloatingWidget";
-import { Button } from "@itwin/itwinui-react";
 import { useIsToolSettingsTab } from "./useIsToolSettingsTab";
+import { ActionButton } from "../../preview/widget-action-dropdown/Button";
 
 /** Maximized widget preview feature state.
  * @internal
@@ -81,16 +81,13 @@ export function PreviewMaximizeToggle() {
         };
 
   return (
-    <Button
-      styleType="borderless"
-      size="small"
+    <ActionButton
+      icon={iconSpec}
+      title={title}
       onClick={() => {
         setMaximizedWidget(id);
       }}
-      title={title}
-    >
-      {iconSpec}
-    </Button>
+    />
   );
 }
 

--- a/ui/appui-react/src/appui-react/layout/widget/PreviewMaximizeToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PreviewMaximizeToggle.tsx
@@ -13,10 +13,11 @@ import {
 } from "@itwin/itwinui-icons-react";
 import { useFloatingWidgetId } from "./FloatingWidget";
 import { Button } from "@itwin/itwinui-react";
+import { useIsToolSettingsTab } from "./useIsToolSettingsTab";
 
 /** Maximized widget preview feature state.
- * @internal */
-// istanbul ignore next (preview)
+ * @internal
+ */
 export function usePreviewMaximizedWidget() {
   return React.useContext(MaximizedWidgetContext);
 }
@@ -36,7 +37,6 @@ interface MaximizedWidgetState {
 }
 
 /** Context containing configuration and state for preview maximized widget feature. */
-// istanbul ignore next (preview)
 const MaximizedWidgetContext = React.createContext<MaximizedWidgetState>({
   enabled: false,
   maximizedWidget: undefined,
@@ -46,7 +46,6 @@ const MaximizedWidgetContext = React.createContext<MaximizedWidgetState>({
 /** Preview maximized widget feature provider.
  * @internal
  */
-// istanbul ignore next (preview)
 export function PreviewMaximizedWidgetFeatureProvider({
   enabled,
   children,
@@ -64,10 +63,8 @@ export function PreviewMaximizedWidgetFeatureProvider({
 }
 
 /** @internal */
-// istanbul ignore next (preview)
 export function PreviewMaximizeToggle() {
   const { maximizedWidget, setMaximizedWidget } = usePreviewMaximizedWidget();
-
   const floatingWidgetId = useFloatingWidgetId();
 
   const { id, title, iconSpec } =
@@ -95,4 +92,13 @@ export function PreviewMaximizeToggle() {
       {iconSpec}
     </Button>
   );
+}
+
+/** @internal */
+export function useMaximizeToggle() {
+  const { enabled } = usePreviewMaximizedWidget();
+  const isToolSettings = useIsToolSettingsTab();
+  const floatingWidgetId = useFloatingWidgetId();
+
+  return !!(enabled && !isToolSettings && floatingWidgetId);
 }

--- a/ui/appui-react/src/appui-react/layout/widget/SendBack.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/SendBack.tsx
@@ -9,22 +9,21 @@
 import * as React from "react";
 import { create } from "zustand";
 import { assert } from "@itwin/core-bentley";
-import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
-import { useLayout } from "../base/LayoutStore";
-import { useFloatingWidgetId, useWidgetAllowedToDock } from "./FloatingWidget";
-import type { WidgetState } from "../state/WidgetState";
-import { getWidgetPanelSectionId } from "../state/PanelState";
-import type { NineZoneState } from "../state/NineZoneState";
-import { Button } from "@itwin/itwinui-react";
 import {
   SvgDockBottom,
   SvgDockLeft,
   SvgDockRight,
   SvgDockTop,
 } from "@itwin/itwinui-icons-react";
-import type { PanelWidgetRestoreState } from "../state/WidgetRestoreState";
+import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
+import { useLayout } from "../base/LayoutStore";
+import { useFloatingWidgetId, useWidgetAllowedToDock } from "./FloatingWidget";
+import type { WidgetState } from "../state/WidgetState";
+import { getWidgetPanelSectionId } from "../state/PanelState";
+import type { NineZoneState } from "../state/NineZoneState";
 import { useIsToolSettingsTab } from "./useIsToolSettingsTab";
 import { usePreviewMaximizedWidget } from "./PreviewMaximizeToggle";
+import { ActionButton } from "../../preview/widget-action-dropdown/Button";
 
 /** @internal */
 export const useActiveSendBackWidgetIdStore = create<
@@ -80,7 +79,10 @@ export function useSendBackHomeState() {
   );
 }
 
-function getHomeIcon(home: PanelWidgetRestoreState) {
+function Icon() {
+  const id = useFloatingWidgetId();
+  assert(!!id);
+  const home = useLayout((state) => state.floatingWidgets.byId[id].home);
   return home.side === "left" ? (
     <SvgDockLeft />
   ) : home.side === "right" ? (
@@ -96,47 +98,40 @@ function getHomeIcon(home: PanelWidgetRestoreState) {
 export function SendBack() {
   const id = useFloatingWidgetId();
   assert(!!id);
-  const home = useLayout((state) => state.floatingWidgets.byId[id].home);
-  const homeIcon = getHomeIcon(home);
   const dispatch = React.useContext(NineZoneDispatchContext);
   const title = useLabel("sendWidgetHomeTitle");
   const setActiveWidgetId = (newId: WidgetState["id"] | undefined) =>
     useActiveSendBackWidgetIdStore.setState(newId);
 
+  const onClick = () => {
+    setActiveWidgetId(undefined);
+    dispatch({
+      type: "FLOATING_WIDGET_SEND_BACK",
+      id,
+    });
+  };
+  const onMouseOver = () => {
+    setActiveWidgetId(id);
+  };
+  const onFocus = () => {
+    setActiveWidgetId(id);
+  };
+  const onMouseOut = () => {
+    setActiveWidgetId(undefined);
+  };
+  const onBlur = () => {
+    setActiveWidgetId(undefined);
+  };
+  const eventHandlers = { onMouseOver, onFocus, onMouseOut, onBlur };
   return (
-    <Button
-      className="nz-widget-sendBack"
-      styleType="borderless"
-      size="small"
-      onClick={() => {
-        setActiveWidgetId(undefined);
-        dispatch({
-          type: "FLOATING_WIDGET_SEND_BACK",
-          id,
-        });
-      }}
-      onMouseOver={() => {
-        setActiveWidgetId(id);
-      }}
-      onFocus={
-        // istanbul ignore next
-        () => {
-          setActiveWidgetId(id);
-        }
-      }
-      onMouseOut={() => {
-        setActiveWidgetId(undefined);
-      }}
-      onBlur={
-        // istanbul ignore next
-        () => {
-          setActiveWidgetId(undefined);
-        }
-      }
+    <ActionButton
+      icon={<Icon />}
       title={title}
-    >
-      {homeIcon}
-    </Button>
+      onClick={onClick}
+      buttonProps={eventHandlers}
+      // TODO: can not pass down event handlers due to iTwinUI type issues.
+      menuProps={eventHandlers as any}
+    />
   );
 }
 

--- a/ui/appui-react/src/appui-react/layout/widget/SendBack.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/SendBack.tsx
@@ -11,7 +11,7 @@ import { create } from "zustand";
 import { assert } from "@itwin/core-bentley";
 import { NineZoneDispatchContext, useLabel } from "../base/NineZone";
 import { useLayout } from "../base/LayoutStore";
-import { useFloatingWidgetId } from "./FloatingWidget";
+import { useFloatingWidgetId, useWidgetAllowedToDock } from "./FloatingWidget";
 import type { WidgetState } from "../state/WidgetState";
 import { getWidgetPanelSectionId } from "../state/PanelState";
 import type { NineZoneState } from "../state/NineZoneState";
@@ -23,6 +23,8 @@ import {
   SvgDockTop,
 } from "@itwin/itwinui-icons-react";
 import type { PanelWidgetRestoreState } from "../state/WidgetRestoreState";
+import { useIsToolSettingsTab } from "./useIsToolSettingsTab";
+import { usePreviewMaximizedWidget } from "./PreviewMaximizeToggle";
 
 /** @internal */
 export const useActiveSendBackWidgetIdStore = create<
@@ -136,4 +138,15 @@ export function SendBack() {
       {homeIcon}
     </Button>
   );
+}
+
+/** @internal */
+export function useSendBack() {
+  const { enabled, maximizedWidget } = usePreviewMaximizedWidget();
+  const isToolSettings = useIsToolSettingsTab();
+  const floatingWidgetId = useFloatingWidgetId();
+  const canBeDocked = useWidgetAllowedToDock();
+
+  const isMaximized = maximizedWidget === floatingWidgetId && enabled;
+  return !!(!isMaximized && floatingWidgetId && !isToolSettings && canBeDocked);
 }

--- a/ui/appui-react/src/appui-react/layout/widget/TabBar.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/TabBar.scss
@@ -27,11 +27,4 @@
       pointer-events: none;
     }
   }
-
-  > .nz-widget-tabBarButtons {
-    display: flex;
-    align-items: center;
-    align-content: center;
-    height: 100%;
-  }
 }

--- a/ui/appui-react/src/appui-react/layout/widget/useIsToolSettingsTab.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/useIsToolSettingsTab.tsx
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import { useLayout } from "../base/LayoutStore";
+import { useActiveTabId } from "./Widget";
+
+/** @internal */
+export function useIsToolSettingsTab() {
+  const activeTabId = useActiveTabId();
+  const toolSettingsTabId = useLayout((state) => state.toolSettings?.tabId);
+  return activeTabId === toolSettingsTabId;
+}

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -10,7 +10,6 @@ import * as React from "react";
 import { create } from "zustand";
 
 /** List of known preview features. */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface KnownPreviewFeatures {
   /** If true, the panels and tool settings will always be rendered over the content.
    * The content will never change size.
@@ -33,6 +32,8 @@ interface KnownPreviewFeatures {
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/706
    */
   horizontalPanelAlignment: boolean;
+  /** If enabled, a dropdown menu will be rendered for widgets that exceed the specified threshold of title bar buttons. */
+  widgetActionDropdown: { threshold: number };
 }
 
 /** Object used trim to only known features at runtime.
@@ -43,6 +44,7 @@ const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
   contentAlwaysMaxSize: undefined,
   enableMaximizedFloatingWidget: undefined,
   horizontalPanelAlignment: undefined,
+  widgetActionDropdown: undefined,
   ...{ newToolbars: undefined }, // Hidden feature used in storybook only (to avoid trimming).
 };
 

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -32,7 +32,10 @@ interface KnownPreviewFeatures {
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/706
    */
   horizontalPanelAlignment: boolean;
-  /** If enabled, a dropdown menu will be rendered for widgets that exceed the specified threshold of title bar buttons. */
+  /** If enabled, a dropdown menu will be rendered for widgets that exceed the specified threshold of title bar buttons.
+   *
+   * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/723
+   */
   widgetActionDropdown: { threshold: number };
 }
 

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/Button.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/Button.tsx
@@ -13,7 +13,7 @@ import { TabBarButton } from "../../layout/widget/Button";
 
 interface ActionButtonProps {
   title?: string;
-  icon: React.ReactNode;
+  icon: React.JSX.Element;
   onClick?: () => void;
   menuProps?: React.ComponentProps<typeof MenuItem>;
   buttonProps?: React.ComponentProps<typeof TabBarButton>;
@@ -24,11 +24,7 @@ export function ActionButton(props: ActionButtonProps) {
   const dropdownContext = React.useContext(WidgetActionDropdownContext);
   if (dropdownContext !== undefined) {
     return (
-      <MenuItem
-        icon={<>{props.icon}</>}
-        onClick={props.onClick}
-        {...props.menuProps}
-      >
+      <MenuItem icon={props.icon} onClick={props.onClick} {...props.menuProps}>
         {props.title}
       </MenuItem>
     );

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/Button.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/Button.tsx
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Utilities
+ */
+
+import * as React from "react";
+import { MenuItem } from "@itwin/itwinui-react";
+import { WidgetActionDropdownContext } from "./MoreButton";
+import { TabBarButton } from "../../layout/widget/Button";
+
+interface ActionButtonProps {
+  title?: string;
+  icon: React.ReactNode;
+  onClick?: () => void;
+  menuProps?: React.ComponentProps<typeof MenuItem>;
+  buttonProps?: React.ComponentProps<typeof TabBarButton>;
+}
+
+/** @internal */
+export function ActionButton(props: ActionButtonProps) {
+  const dropdownContext = React.useContext(WidgetActionDropdownContext);
+  if (dropdownContext !== undefined) {
+    return (
+      <MenuItem
+        icon={<>{props.icon}</>}
+        onClick={props.onClick}
+        {...props.menuProps}
+      >
+        {props.title}
+      </MenuItem>
+    );
+  }
+  return (
+    <TabBarButton
+      onClick={props.onClick}
+      title={props.title}
+      {...props.buttonProps}
+    >
+      {props.icon}
+    </TabBarButton>
+  );
+}

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
@@ -8,19 +8,18 @@
 
 import * as React from "react";
 import { SvgMoreVertical } from "@itwin/itwinui-icons-react";
-import { DropdownMenu, IconButton, MenuItem } from "@itwin/itwinui-react";
+import { DropdownMenu, IconButton } from "@itwin/itwinui-react";
 
 /** @internal */
 export function MoreButton(props: React.PropsWithChildren<{}>) {
   return (
     <DropdownMenu
       placement="bottom-end"
-      menuItems={(_close) => {
-        const children = React.Children.toArray(props.children);
-        return children.map((child, index) => {
-          return <MenuItem key={index}>{child}</MenuItem>;
-        });
-      }}
+      menuItems={(onClose) => [
+        <WidgetActionDropdownContext.Provider key={0} value={{ onClose }}>
+          {props.children}
+        </WidgetActionDropdownContext.Provider>,
+      ]}
     >
       <IconButton size="small" styleType="borderless" aria-label="More actions">
         <SvgMoreVertical />
@@ -28,3 +27,11 @@ export function MoreButton(props: React.PropsWithChildren<{}>) {
     </DropdownMenu>
   );
 }
+
+/** @internal */
+export const WidgetActionDropdownContext = React.createContext<
+  | undefined
+  | {
+      onClose: () => void;
+    }
+>(undefined);

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
@@ -8,7 +8,8 @@
 
 import * as React from "react";
 import { SvgMoreVertical } from "@itwin/itwinui-icons-react";
-import { DropdownMenu, IconButton } from "@itwin/itwinui-react";
+import { DropdownMenu } from "@itwin/itwinui-react";
+import { TabBarButton } from "../../layout/widget/Button";
 
 /** @internal */
 export function MoreButton(props: React.PropsWithChildren<{}>) {
@@ -20,10 +21,11 @@ export function MoreButton(props: React.PropsWithChildren<{}>) {
           {props.children}
         </WidgetActionDropdownContext.Provider>,
       ]}
+      offset={[0, 2]}
     >
-      <IconButton size="small" styleType="borderless" aria-label="More actions">
+      <TabBarButton label="More actions" style={{ marginInline: "0.25em" }}>
         <SvgMoreVertical />
-      </IconButton>
+      </TabBarButton>
     </DropdownMenu>
   );
 }

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
@@ -7,10 +7,13 @@
  */
 
 import * as React from "react";
+import { assert } from "@itwin/core-bentley";
 import { SvgMoreVertical } from "@itwin/itwinui-icons-react";
 import { DropdownMenu } from "@itwin/itwinui-react";
 import { TabBarButton } from "../../layout/widget/Button";
 import { usePreviewFeatures } from "../PreviewFeatures";
+import { useLayout } from "../../layout/base/LayoutStore";
+import { PanelSideContext } from "../../layout/widget-panels/Panel";
 
 /** @internal */
 export function MoreButton(props: React.PropsWithChildren<{}>) {
@@ -19,6 +22,7 @@ export function MoreButton(props: React.PropsWithChildren<{}>) {
       placement="bottom-end"
       menuItems={(onClose) => [
         <WidgetActionDropdownContext.Provider key={0} value={{ onClose }}>
+          <CloseOnPanelCollapse />
           {props.children}
         </WidgetActionDropdownContext.Provider>,
       ]}
@@ -39,6 +43,22 @@ export const WidgetActionDropdownContext = React.createContext<
     }
 >(undefined);
 
+function CloseOnPanelCollapse() {
+  const context = React.useContext(WidgetActionDropdownContext);
+  assert(!!context);
+  const side = React.useContext(PanelSideContext);
+
+  const { onClose } = context;
+  const collapsed = useLayout((state) => {
+    if (!side) return false;
+    return state.panels[side].collapsed;
+  });
+  React.useEffect(() => {
+    if (collapsed) onClose();
+  }, [collapsed, onClose]);
+  return null;
+}
+
 const order = [
   "pin",
   "maximize",
@@ -57,5 +77,5 @@ export function useDropdownFeatures(buttons: string[]) {
   const sorted = [...buttons].sort(
     (a, b) => order.indexOf(a) - order.indexOf(b)
   );
-  return [sorted, isDropdown] as const;
+  return [sorted, true] as const;
 }

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Utilities
+ */
+
+import * as React from "react";
+import { SvgMoreVertical } from "@itwin/itwinui-icons-react";
+import { DropdownMenu, IconButton, MenuItem } from "@itwin/itwinui-react";
+
+/** @internal */
+export function MoreButton(props: React.PropsWithChildren<{}>) {
+  return (
+    <DropdownMenu
+      placement="bottom-end"
+      menuItems={(_close) => {
+        const children = React.Children.toArray(props.children);
+        return children.map((child, index) => {
+          return <MenuItem key={index}>{child}</MenuItem>;
+        });
+      }}
+    >
+      <IconButton size="small" styleType="borderless" aria-label="More actions">
+        <SvgMoreVertical />
+      </IconButton>
+    </DropdownMenu>
+  );
+}

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import { SvgMoreVertical } from "@itwin/itwinui-icons-react";
 import { DropdownMenu } from "@itwin/itwinui-react";
 import { TabBarButton } from "../../layout/widget/Button";
+import { usePreviewFeatures } from "../PreviewFeatures";
 
 /** @internal */
 export function MoreButton(props: React.PropsWithChildren<{}>) {
@@ -37,3 +38,24 @@ export const WidgetActionDropdownContext = React.createContext<
       onClose: () => void;
     }
 >(undefined);
+
+const order = [
+  "pin",
+  "maximize",
+  "popout",
+  "horizontalAlign",
+  "dock",
+  "sendBack",
+];
+
+/** @internal */
+export function useDropdownFeatures(buttons: string[]) {
+  const { widgetActionDropdown } = usePreviewFeatures();
+  const threshold = widgetActionDropdown?.threshold ?? Infinity;
+  const isDropdown = buttons.length > threshold;
+  if (!isDropdown) return [buttons, false] as const;
+  const sorted = [...buttons].sort(
+    (a, b) => order.indexOf(a) - order.indexOf(b)
+  );
+  return [sorted, isDropdown] as const;
+}

--- a/ui/appui-react/src/test/layout/widget-panels/Panel.test.snap
+++ b/ui/appui-react/src/test/layout/widget-panels/Panel.test.snap
@@ -62,15 +62,18 @@ exports[`WidgetPanelProvider should render captured 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           >
             <button
-              class="iui-button nz-widget-pinToggle nz-is-pinned"
+              class="iui-button"
               data-iui-size="small"
               data-iui-variant="borderless"
               type="button"
             >
-              <span>
+              <span
+                aria-hidden="true"
+                class="iui-button-icon"
+              >
                 <svg
                   fill="var(--iui-color-icon-muted, currentColor)"
                   height="1rem"
@@ -217,15 +220,18 @@ exports[`WidgetPanelProvider should render collapsed 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           >
             <button
-              class="iui-button nz-widget-pinToggle nz-is-pinned"
+              class="iui-button"
               data-iui-size="small"
               data-iui-variant="borderless"
               type="button"
             >
-              <span>
+              <span
+                aria-hidden="true"
+                class="iui-button-icon"
+              >
                 <svg
                   fill="var(--iui-color-icon-muted, currentColor)"
                   height="1rem"
@@ -339,15 +345,18 @@ exports[`WidgetPanelProvider should render horizontal 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           >
             <button
-              class="iui-button nz-widget-pinToggle nz-is-pinned"
+              class="iui-button"
               data-iui-size="small"
               data-iui-variant="borderless"
               type="button"
             >
-              <span>
+              <span
+                aria-hidden="true"
+                class="iui-button-icon"
+              >
                 <svg
                   fill="var(--iui-color-icon-muted, currentColor)"
                   height="1rem"
@@ -492,15 +501,18 @@ exports[`WidgetPanelProvider should render multiple widgets 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           >
             <button
-              class="iui-button nz-widget-pinToggle nz-is-pinned"
+              class="iui-button"
               data-iui-size="small"
               data-iui-variant="borderless"
               type="button"
             >
-              <span>
+              <span
+                aria-hidden="true"
+                class="iui-button-icon"
+              >
                 <svg
                   fill="var(--iui-color-icon-muted, currentColor)"
                   height="1rem"
@@ -588,7 +600,7 @@ exports[`WidgetPanelProvider should render multiple widgets 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           />
         </div>
         <div
@@ -694,15 +706,18 @@ exports[`WidgetPanelProvider should render spanned 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           >
             <button
-              class="iui-button nz-widget-pinToggle nz-is-pinned"
+              class="iui-button"
               data-iui-size="small"
               data-iui-variant="borderless"
               type="button"
             >
-              <span>
+              <span
+                aria-hidden="true"
+                class="iui-button-icon"
+              >
                 <svg
                   fill="var(--iui-color-icon-muted, currentColor)"
                   height="1rem"
@@ -849,15 +864,18 @@ exports[`WidgetPanelProvider should render vertical 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           >
             <button
-              class="iui-button nz-widget-pinToggle nz-is-pinned"
+              class="iui-button"
               data-iui-size="small"
               data-iui-variant="borderless"
               type="button"
             >
-              <span>
+              <span
+                aria-hidden="true"
+                class="iui-button-icon"
+              >
                 <svg
                   fill="var(--iui-color-icon-muted, currentColor)"
                   height="1rem"
@@ -1004,15 +1022,18 @@ exports[`WidgetPanelProvider should render with span bottom 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           >
             <button
-              class="iui-button nz-widget-pinToggle nz-is-pinned"
+              class="iui-button"
               data-iui-size="small"
               data-iui-variant="borderless"
               type="button"
             >
-              <span>
+              <span
+                aria-hidden="true"
+                class="iui-button-icon"
+              >
                 <svg
                   fill="var(--iui-color-icon-muted, currentColor)"
                   height="1rem"
@@ -1159,15 +1180,18 @@ exports[`WidgetPanelProvider should render with top spanned 1`] = `
             </div>
           </div>
           <div
-            class="nz-widget-tabBarButtons"
+            class="nz-widget-buttons"
           >
             <button
-              class="iui-button nz-widget-pinToggle nz-is-pinned"
+              class="iui-button"
               data-iui-size="small"
               data-iui-variant="borderless"
               type="button"
             >
-              <span>
+              <span
+                aria-hidden="true"
+                class="iui-button-icon"
+              >
                 <svg
                   fill="var(--iui-color-icon-muted, currentColor)"
                   height="1rem"

--- a/ui/appui-react/src/test/layout/widget/Buttons.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/Buttons.test.tsx
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { render } from "@testing-library/react";
-import { expect } from "chai";
 import * as React from "react";
 import { createNineZoneState } from "../../../appui-react/layout/state/NineZoneState";
 import { addPanelWidget } from "../../../appui-react/layout/state/internal/PanelStateHelpers";
@@ -21,31 +20,33 @@ describe("TabBarButtons", () => {
     state = addTab(state, "t1", { label: "t1-label" });
     state = addFloatingWidget(state, "fw1", ["t1"]);
     const wrapper = render(
-      <TestNineZoneProvider defaultState={state}>
+      <TestNineZoneProvider
+        defaultState={state}
+        labels={{ sendWidgetHomeTitle: "Send back" }}
+      >
         <WidgetIdContext.Provider value="fw1">
           <TabBarButtons />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    expect(wrapper.container.querySelector("button.nz-widget-sendBack")).to.not
-      .be.null;
+    wrapper.getByTitle("Send back");
   });
 
-  it("should render Popout button in a floating widget that canPopout ", () => {
+  it("should render PopoutToggle in a floating widget that canPopout ", () => {
     let state = createNineZoneState();
     state = addTab(state, "t1", { label: "t1-label", canPopout: true });
     state = addFloatingWidget(state, "fw1", ["t1"]);
     const wrapper = render(
-      <TestNineZoneProvider defaultState={state}>
+      <TestNineZoneProvider
+        defaultState={state}
+        labels={{ popoutActiveTab: "Popout" }}
+      >
         <WidgetIdContext.Provider value="fw1">
           <TabBarButtons />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    expect(wrapper.container.querySelector("button.nz-widget-sendBack")).to.not
-      .be.null;
-    expect(wrapper.container.querySelector("button.nz-widget-popoutToggle")).to
-      .not.be.null;
+    wrapper.getByTitle("Popout");
   });
 
   it("should render Dock button in floating ToolSettings", () => {
@@ -54,22 +55,29 @@ describe("TabBarButtons", () => {
     state = addFloatingWidget(state, "fw1", ["ts"]);
     state = addWidgetToolSettings(state, "ts");
     const wrapper = render(
-      <TestNineZoneProvider defaultState={state}>
+      <TestNineZoneProvider
+        defaultState={state}
+        labels={{
+          dockToolSettingsTitle: "Dock",
+        }}
+      >
         <WidgetIdContext.Provider value="fw1">
           <TabBarButtons />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    expect(wrapper.container.querySelector("button.nz-widget-dock")).to.not.be
-      .null;
+    wrapper.getByTitle("Dock");
   });
 
-  it("should render Pin button in main panel widget", () => {
+  it("should render PinToggle in main panel widget", () => {
     let state = createNineZoneState();
     state = addTab(state, "t1", { label: "t1-label", canPopout: false });
     state = addPanelWidget(state, "left", "w1", ["t1"], { activeTabId: "t1" });
     const wrapper = render(
-      <TestNineZoneProvider defaultState={state}>
+      <TestNineZoneProvider
+        defaultState={state}
+        labels={{ unpinPanelTitle: "Unpin panel" }}
+      >
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
             <TabBarButtons />
@@ -77,16 +85,18 @@ describe("TabBarButtons", () => {
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    expect(wrapper.container.querySelector("button.nz-widget-pinToggle")).to.not
-      .be.null;
+    wrapper.getByTitle("Unpin panel");
   });
 
-  it("should render Popout and Pin buttons in main panel widget that canPopout ", () => {
+  it("should render PopoutToggle in main panel widget that canPopout", () => {
     let state = createNineZoneState();
     state = addTab(state, "t1", { label: "t1-label", canPopout: true });
     state = addPanelWidget(state, "left", "w1", ["t1"], { activeTabId: "t1" });
     const wrapper = render(
-      <TestNineZoneProvider defaultState={state}>
+      <TestNineZoneProvider
+        defaultState={state}
+        labels={{ popoutActiveTab: "Popout widget" }}
+      >
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
             <TabBarButtons />
@@ -94,10 +104,7 @@ describe("TabBarButtons", () => {
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    expect(wrapper.container.querySelector("button.nz-widget-popoutToggle")).to
-      .not.be.null;
-    expect(wrapper.container.querySelector("button.nz-widget-pinToggle")).to.not
-      .be.null;
+    wrapper.getByTitle("Popout widget");
   });
 
   it("should render popout button", () => {
@@ -105,7 +112,10 @@ describe("TabBarButtons", () => {
     state = addTab(state, "t1", { label: "t1-label", canPopout: true });
     state = addPanelWidget(state, "left", "w1", ["t1"], { activeTabId: "t1" });
     const wrapper = render(
-      <TestNineZoneProvider defaultState={state}>
+      <TestNineZoneProvider
+        defaultState={state}
+        labels={{ popoutActiveTab: "Popout" }}
+      >
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
             <TabBarButtons />
@@ -113,7 +123,6 @@ describe("TabBarButtons", () => {
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    expect(wrapper.container.querySelector("button.nz-widget-popoutToggle")).to
-      .not.be.null;
+    wrapper.getByTitle("Popout");
   });
 });

--- a/ui/appui-react/src/test/layout/widget/Dock.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/Dock.test.tsx
@@ -6,22 +6,29 @@ import { fireEvent, render } from "@testing-library/react";
 import * as React from "react";
 import * as sinon from "sinon";
 import type { NineZoneDispatch } from "../../../appui-react/layout/base/NineZone";
-import { NineZoneDispatchContext } from "../../../appui-react/layout/base/NineZone";
+import {
+  NineZoneDispatchContext,
+  NineZoneLabelsContext,
+} from "../../../appui-react/layout/base/NineZone";
 import { Dock } from "../../../appui-react/layout/widget/Dock";
 
 describe("Dock", () => {
   it("should dispatch TOOL_SETTINGS_DOCK", () => {
     const dispatch = sinon.stub<NineZoneDispatch>();
-    const { container } = render(
+    const component = render(
       <NineZoneDispatchContext.Provider value={dispatch}>
-        <Dock />
+        <NineZoneLabelsContext.Provider
+          value={{ dockToolSettingsTitle: "Dock" }}
+        >
+          <Dock />
+        </NineZoneLabelsContext.Provider>
       </NineZoneDispatchContext.Provider>
     );
-    const button = container.getElementsByClassName("nz-widget-dock")[0];
+    const button = component.getByTitle("Dock");
     fireEvent.click(button);
 
-    dispatch.calledOnceWithExactly({
+    sinon.assert.calledOnceWithExactly(dispatch, {
       type: "TOOL_SETTINGS_DOCK",
-    }).should.true;
+    });
   });
 });

--- a/ui/appui-react/src/test/layout/widget/FloatingWidget.test.snap
+++ b/ui/appui-react/src/test/layout/widget/FloatingWidget.test.snap
@@ -51,15 +51,18 @@ exports[`FloatingWidget should render 1`] = `
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     >
       <button
-        class="iui-button nz-widget-sendBack"
+        class="iui-button"
         data-iui-size="small"
         data-iui-variant="borderless"
         type="button"
       >
-        <span>
+        <span
+          aria-hidden="true"
+          class="iui-button-icon"
+        >
           <svg
             fill="var(--iui-color-icon-muted, currentColor)"
             height="1rem"
@@ -145,15 +148,18 @@ exports[`FloatingWidget should render dragged 1`] = `
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     >
       <button
-        class="iui-button nz-widget-sendBack"
+        class="iui-button"
         data-iui-size="small"
         data-iui-variant="borderless"
         type="button"
       >
-        <span>
+        <span
+          aria-hidden="true"
+          class="iui-button-icon"
+        >
           <svg
             fill="var(--iui-color-icon-muted, currentColor)"
             height="1rem"
@@ -239,15 +245,18 @@ exports[`FloatingWidget should render hidden when hideWithUiWhenFloating is true
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     >
       <button
-        class="iui-button nz-widget-sendBack"
+        class="iui-button"
         data-iui-size="small"
         data-iui-variant="borderless"
         type="button"
       >
-        <span>
+        <span
+          aria-hidden="true"
+          class="iui-button-icon"
+        >
           <svg
             fill="var(--iui-color-icon-muted, currentColor)"
             height="1rem"
@@ -333,15 +342,18 @@ exports[`FloatingWidget should render minimized 1`] = `
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     >
       <button
-        class="iui-button nz-widget-sendBack"
+        class="iui-button"
         data-iui-size="small"
         data-iui-variant="borderless"
         type="button"
       >
-        <span>
+        <span
+          aria-hidden="true"
+          class="iui-button-icon"
+        >
           <svg
             fill="var(--iui-color-icon-muted, currentColor)"
             height="1rem"

--- a/ui/appui-react/src/test/layout/widget/FloatingWidgets.test.snap
+++ b/ui/appui-react/src/test/layout/widget/FloatingWidgets.test.snap
@@ -51,15 +51,18 @@ exports[`FloatingWidgets should render 1`] = `
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     >
       <button
-        class="iui-button nz-widget-sendBack"
+        class="iui-button"
         data-iui-size="small"
         data-iui-variant="borderless"
         type="button"
       >
-        <span>
+        <span
+          aria-hidden="true"
+          class="iui-button-icon"
+        >
           <svg
             fill="var(--iui-color-icon-muted, currentColor)"
             height="1rem"

--- a/ui/appui-react/src/test/layout/widget/PanelWidget.test.snap
+++ b/ui/appui-react/src/test/layout/widget/PanelWidget.test.snap
@@ -49,15 +49,18 @@ exports[`PanelWidget should render 1`] = `
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     >
       <button
-        class="iui-button nz-widget-pinToggle nz-is-pinned"
+        class="iui-button"
         data-iui-size="small"
         data-iui-variant="borderless"
         type="button"
       >
-        <span>
+        <span
+          aria-hidden="true"
+          class="iui-button-icon"
+        >
           <svg
             fill="var(--iui-color-icon-muted, currentColor)"
             height="1rem"
@@ -134,7 +137,7 @@ exports[`PanelWidget should render horizontal with fit-content 1`] = `
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     />
   </div>
   <div
@@ -206,15 +209,18 @@ exports[`PanelWidget should render minimized 1`] = `
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     >
       <button
-        class="iui-button nz-widget-pinToggle nz-is-pinned"
+        class="iui-button"
         data-iui-size="small"
         data-iui-variant="borderless"
         type="button"
       >
-        <span>
+        <span
+          aria-hidden="true"
+          class="iui-button-icon"
+        >
           <svg
             fill="var(--iui-color-icon-muted, currentColor)"
             height="1rem"
@@ -291,15 +297,18 @@ exports[`PanelWidget should render with fit-content 1`] = `
       </div>
     </div>
     <div
-      class="nz-widget-tabBarButtons"
+      class="nz-widget-buttons"
     >
       <button
-        class="iui-button nz-widget-pinToggle nz-is-pinned"
+        class="iui-button"
         data-iui-size="small"
         data-iui-variant="borderless"
         type="button"
       >
-        <span>
+        <span
+          aria-hidden="true"
+          class="iui-button-icon"
+        >
           <svg
             fill="var(--iui-color-icon-muted, currentColor)"
             height="1rem"

--- a/ui/appui-react/src/test/layout/widget/PinToggle.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PinToggle.test.tsx
@@ -13,7 +13,22 @@ import { PinToggle } from "../../../appui-react/layout/widget/PinToggle";
 import { TestNineZoneProvider } from "../Providers";
 
 describe("PinToggle", () => {
-  it("should render with `pin panel` title", () => {
+  it("should render in pinned panel", () => {
+    const component = render(
+      <TestNineZoneProvider
+        labels={{
+          unpinPanelTitle: "Unpin panel",
+        }}
+      >
+        <PanelSideContext.Provider value="bottom">
+          <PinToggle />
+        </PanelSideContext.Provider>
+      </TestNineZoneProvider>
+    );
+    component.getByTitle("Unpin panel");
+  });
+
+  it("should render in unpinned panel", () => {
     let state = createNineZoneState();
     state = updatePanelState(state, "left", (draft) => {
       draft.pinned = false;
@@ -33,29 +48,24 @@ describe("PinToggle", () => {
     getByTitle("Pin panel");
   });
 
-  it("should render `icon-chevron-down` for bottom pinned panel", () => {
-    const { container } = render(
-      <TestNineZoneProvider>
-        <PanelSideContext.Provider value="bottom">
-          <PinToggle />
-        </PanelSideContext.Provider>
-      </TestNineZoneProvider>
-    );
-    const toggle = container.getElementsByClassName("nz-widget-pinToggle")[0];
-    Array.from(toggle.classList.values()).should.contain("nz-is-pinned");
-  });
-
   it("should dispatch PANEL_TOGGLE_PINNED", () => {
     const dispatch = sinon.stub<NineZoneDispatch>();
     const state = createNineZoneState();
-    const { container } = render(
-      <TestNineZoneProvider defaultState={state} dispatch={dispatch}>
+    const component = render(
+      <TestNineZoneProvider
+        defaultState={state}
+        labels={{
+          unpinPanelTitle: "Unpin panel",
+        }}
+        dispatch={dispatch}
+      >
         <PanelSideContext.Provider value="left">
           <PinToggle />
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    const button = container.getElementsByClassName("nz-widget-pinToggle")[0];
+
+    const button = component.getByTitle("Unpin panel");
     fireEvent.click(button);
 
     sinon.assert.calledOnceWithExactly(dispatch, {

--- a/ui/appui-react/src/test/layout/widget/PopoutToggle.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PopoutToggle.test.tsx
@@ -19,16 +19,20 @@ describe("PopoutToggle", () => {
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
-    const { container } = render(
-      <TestNineZoneProvider defaultState={state} dispatch={dispatch}>
+    const component = render(
+      <TestNineZoneProvider
+        defaultState={state}
+        dispatch={dispatch}
+        labels={{
+          popoutActiveTab: "Popout",
+        }}
+      >
         <WidgetIdContext.Provider value="w1">
           <PopoutToggle />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    const button = container.getElementsByClassName(
-      "nz-widget-popoutToggle"
-    )[0];
+    const button = component.getByTitle("Popout");
     fireEvent.click(button);
 
     sinon.assert.calledOnceWithExactly(dispatch, {

--- a/ui/appui-react/src/test/layout/widget/SendBack.test.snap
+++ b/ui/appui-react/src/test/layout/widget/SendBack.test.snap
@@ -2,12 +2,15 @@
 
 exports[`SendBack should render 1`] = `
 <button
-  class="iui-button nz-widget-sendBack"
+  class="iui-button"
   data-iui-size="small"
   data-iui-variant="borderless"
   type="button"
 >
-  <span>
+  <span
+    aria-hidden="true"
+    class="iui-button-icon"
+  >
     <svg
       fill="var(--iui-color-icon-muted, currentColor)"
       height="1rem"

--- a/ui/appui-react/src/test/layout/widget/SendBack.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/SendBack.test.tsx
@@ -37,14 +37,18 @@ describe("SendBack", () => {
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
-    const { container } = render(
-      <TestNineZoneProvider defaultState={state} dispatch={dispatch}>
+    const component = render(
+      <TestNineZoneProvider
+        defaultState={state}
+        dispatch={dispatch}
+        labels={{ sendWidgetHomeTitle: "Send back" }}
+      >
         <WidgetIdContext.Provider value="w1">
           <SendBack />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    const button = container.getElementsByClassName("nz-widget-sendBack")[0];
+    const button = component.getByTitle("Send back");
     fireEvent.click(button);
 
     sinon.assert.calledOnceWithExactly(dispatch, {
@@ -57,14 +61,17 @@ describe("SendBack", () => {
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
-    const { container } = render(
-      <TestNineZoneProvider defaultState={state}>
+    const component = render(
+      <TestNineZoneProvider
+        defaultState={state}
+        labels={{ sendWidgetHomeTitle: "Send back" }}
+      >
         <WidgetIdContext.Provider value="w1">
           <SendBack />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    const button = container.getElementsByClassName("nz-widget-sendBack")[0];
+    const button = component.getByTitle("Send back");
 
     fireEvent.mouseOver(button);
     expect(useActiveSendBackWidgetIdStore.getState()).equal("w1");


### PR DESCRIPTION
## Changes

This PR adds the `widgetActionDropdown` preview feature to display widget title bar buttons in a drop-down menu when a specified threshold value is exceeded.

![image](https://github.com/iTwin/appui/assets/10091419/3420a446-9453-45e4-8abb-2475e5df604a)

## Testing

Added additional story and tested via the standalone test app.
