### PR TITLE
Add capability to open a blank iModel connection from storybook

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@types/react-dom':
         specifier: ^17.0.0
         version: 17.0.25
+      '@types/react-redux':
+        specifier: ^7.1.18
+        version: 7.1.33
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.0
         version: 5.62.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.0.4)
@@ -17596,7 +17599,7 @@ packages:
     dependencies:
       object-assign: 4.1.1
       react: 17.0.2
-      react-is: 17.0.2
+      react-is: 18.2.0
     dev: true
 
   /react-style-singleton@2.2.1(@types/react@17.0.75)(react@17.0.2):

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -214,7 +214,7 @@ importers:
         version: 4.0.0-dev.104
       '@reduxjs/toolkit':
         specifier: ^1.5.0
-        version: 1.9.7(react@17.0.2)
+        version: 1.9.7(react-redux@7.2.9)(react@17.0.2)
       classnames:
         specifier: 2.3.1
         version: 2.3.1
@@ -224,6 +224,9 @@ importers:
       react-dom:
         specifier: ^17.0.0
         version: 17.0.2(react@17.0.2)
+      react-redux:
+        specifier: ^7.2.2
+        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
       ts-key-enum:
         specifier: ~2.0.12
         version: 2.0.12
@@ -5673,7 +5676,7 @@ packages:
       '@babel/runtime': 7.23.8
     dev: true
 
-  /@reduxjs/toolkit@1.9.7(react@17.0.2):
+  /@reduxjs/toolkit@1.9.7(react-redux@7.2.9)(react@17.0.2):
     resolution: {integrity: sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==}
     peerDependencies:
       react: ^16.9.0 || ^17.0.0 || ^18
@@ -5686,6 +5689,7 @@ packages:
     dependencies:
       immer: 9.0.21
       react: 17.0.2
+      react-redux: 7.2.9(react-dom@17.0.2)(react@17.0.2)
       redux: 4.2.1
       redux-thunk: 2.4.2(redux@4.2.1)
       reselect: 4.1.8

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -214,7 +214,7 @@ importers:
         version: 3.8.0
       '@reduxjs/toolkit':
         specifier: ^1.5.0
-        version: 1.9.7(react@17.0.2)
+        version: 1.9.7(react-redux@7.2.9)(react@17.0.2)
       classnames:
         specifier: 2.3.1
         version: 2.3.1
@@ -224,6 +224,9 @@ importers:
       react-dom:
         specifier: ^17.0.0
         version: 17.0.2(react@17.0.2)
+      react-redux:
+        specifier: ^7.2.2
+        version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
       ts-key-enum:
         specifier: ~2.0.12
         version: 2.0.12
@@ -5751,7 +5754,7 @@ packages:
       '@babel/runtime': 7.23.8
     dev: true
 
-  /@reduxjs/toolkit@1.9.7(react@17.0.2):
+  /@reduxjs/toolkit@1.9.7(react-redux@7.2.9)(react@17.0.2):
     resolution: {integrity: sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==}
     peerDependencies:
       react: ^16.9.0 || ^17.0.0 || ^18
@@ -5764,6 +5767,7 @@ packages:
     dependencies:
       immer: 9.0.21
       react: 17.0.2
+      react-redux: 7.2.9(react-dom@17.0.2)(react@17.0.2)
       redux: 4.2.1
       redux-thunk: 2.4.2(redux@4.2.1)
       reselect: 4.1.8
@@ -17680,7 +17684,7 @@ packages:
     dependencies:
       object-assign: 4.1.1
       react: 17.0.2
-      react-is: 17.0.2
+      react-is: 18.2.0
     dev: true
 
   /react-style-singleton@2.2.1(@types/react@17.0.75)(react@17.0.2):

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@types/react-dom':
         specifier: ^17.0.0
         version: 17.0.25
+      '@types/react-redux':
+        specifier: ^7.1.18
+        version: 7.1.33
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.0
         version: 5.62.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.0.4)

--- a/docs/storybook/.storybook/addons/DemoIModel.tsx
+++ b/docs/storybook/.storybook/addons/DemoIModel.tsx
@@ -15,8 +15,11 @@ export namespace Storybook {
   }
 }
 
-const getDemoIModel = (name: string) => {
-  const model = demoIModels.find((model) => model.name === name);
+const getDemoIModel = (name: string): DemoIModel | undefined => {
+  if (name === "blank") {
+    return "blank";
+  }
+  const model = remoteIModels.find((model) => model.name === name);
   return model;
 };
 
@@ -37,14 +40,16 @@ export function useDemoIModel() {
   return React.useContext(DemoIModelContext);
 }
 
-export interface DemoIModel {
+export interface RemoteIModel {
   name: string;
   label: string;
   iTwinId: string;
   iModelId: string;
 }
 
-export const demoIModels: DemoIModel[] = [
+export type DemoIModel = RemoteIModel | "blank";
+
+export const remoteIModels: RemoteIModel[] = [
   {
     name: "metrostation",
     label: "Metrostation",
@@ -114,8 +119,15 @@ export const demoIModelGlobalType = {
     title: "Demo iModel",
     icon: "doclist",
     items: [
-      { title: "No iModel", value: "no" },
-      ...demoIModels.map<Storybook.MenuItem>((model) => ({
+      {
+        title: "Reset",
+        type: "reset",
+      },
+      {
+        title: "Blank iModel",
+        value: "blank",
+      },
+      ...remoteIModels.map<Storybook.MenuItem>((model) => ({
         title: model.label,
         value: model.name,
       })),

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -49,6 +49,7 @@
     "@storybook/theming": "^7.4.6",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.0",
+    "@types/react-redux": "^7.1.18",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^6.1.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/docs/storybook/src/frontstage/ToolSettings.tsx
+++ b/docs/storybook/src/frontstage/ToolSettings.tsx
@@ -8,5 +8,11 @@ import { AppUiStory, AppUiStoryProps } from "../AppUiStory";
 export function ToolSettingsStory(
   props: Pick<AppUiStoryProps, "frontstageProviders" | "onFrontstageActivated">
 ) {
-  return <AppUiStory layout="fullscreen" demoIModel={true} {...props} />;
+  return (
+    <AppUiStory
+      layout="fullscreen"
+      demoIModel={{ default: "blank" }}
+      {...props}
+    />
+  );
 }

--- a/docs/storybook/src/openDemoIModel.ts
+++ b/docs/storybook/src/openDemoIModel.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { UiFramework } from "@itwin/appui-react";
+import {
+  createBlankConnection,
+  createBlankViewState,
+} from "@itwin/appui-test-providers";
+import { CheckpointConnection, ViewCreator3d } from "@itwin/core-frontend";
+import { DemoIModel } from "../.storybook/addons/DemoIModel";
+
+export async function openDemoIModel(demoIModel: DemoIModel) {
+  let iModelConnection;
+  let viewState;
+  if (demoIModel === "blank") {
+    iModelConnection = createBlankConnection();
+    viewState = createBlankViewState(iModelConnection);
+  } else {
+    iModelConnection = await CheckpointConnection.openRemote(
+      demoIModel.iTwinId,
+      demoIModel.iModelId
+    );
+    const viewCreator = new ViewCreator3d(iModelConnection);
+    viewState = await viewCreator.createDefaultView();
+  }
+  UiFramework.setIModelConnection(iModelConnection, true);
+  UiFramework.setDefaultViewState(viewState, true);
+}

--- a/test-apps/appui-test-app/appui-test-providers/package.json
+++ b/test-apps/appui-test-app/appui-test-providers/package.json
@@ -64,6 +64,7 @@
     "classnames": "2.3.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
+    "react-redux": "^7.2.2",
     "@reduxjs/toolkit": "^1.5.0",
     "ts-key-enum": "~2.0.12"
   },

--- a/test-apps/appui-test-app/appui-test-providers/src/appui-test-providers.ts
+++ b/test-apps/appui-test-app/appui-test-providers/src/appui-test-providers.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 export * from "./AppUiTestProviders";
+export * from "./createBlankConnection";
 
 export * from "./ui/providers/AbstractUiItemsProvider";
 export * from "./ui/providers/CustomStageUiItemsProvider";

--- a/test-apps/appui-test-app/appui-test-providers/src/createBlankConnection.ts
+++ b/test-apps/appui-test-app/appui-test-providers/src/createBlankConnection.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { Cartographic, ColorDef, RenderMode } from "@itwin/core-common";
+import {
+  BlankConnection,
+  IModelApp,
+  IModelConnection,
+  SpatialViewState,
+} from "@itwin/core-frontend";
+import { Range3d } from "@itwin/core-geometry";
+
+export function createBlankConnection() {
+  return BlankConnection.create({
+    name: "Exton PA",
+    location: Cartographic.fromDegrees({
+      longitude: -75.686694,
+      latitude: 40.065757,
+      height: 0,
+    }),
+    extents: new Range3d(-1000, -1000, -100, 1000, 1000, 100),
+  });
+}
+
+export function createBlankViewState(iModel: IModelConnection) {
+  const ext = iModel.projectExtents;
+  const viewState = SpatialViewState.createBlank(
+    iModel,
+    ext.low,
+    ext.high.minus(ext.low)
+  );
+
+  viewState.setAllow3dManipulations(true);
+
+  viewState.displayStyle.backgroundColor = ColorDef.white;
+  const flags = viewState.viewFlags.copy({
+    grid: false,
+    renderMode: RenderMode.SmoothShade,
+    backgroundMap: false,
+  });
+  viewState.displayStyle.viewFlags = flags;
+
+  IModelApp.viewManager.onViewOpen.addOnce((vp) => {
+    if (vp.view.hasSameCoordinates(viewState)) {
+      vp.applyViewState(viewState);
+    }
+  });
+
+  return viewState;
+}

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/ComponentExamplesProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/ComponentExamplesProvider.tsx
@@ -101,7 +101,7 @@ import {
   StandardContentLayouts,
   StandardTypeNames,
 } from "@itwin/appui-abstract";
-import { ComponentGenerator } from "@itwin/appui-react/lib/cjs/appui-react/uiprovider/ComponentGenerator";
+import { ComponentGenerator } from "@itwin/appui-react/lib/esm/appui-react/uiprovider/ComponentGenerator";
 import { UnitSystemKey } from "@itwin/core-quantity";
 import { Button, DropdownMenu, MenuItem } from "@itwin/itwinui-react";
 import { TreeWidgetComponent } from "../widgets/TreeWidget";
@@ -1453,7 +1453,7 @@ export class ComponentExamplesProvider {
 
   private static get uiProviderSample(): ComponentExampleCategory {
     const testUiLayoutDataProvider = new TestUiDataProvider();
-    const componentGenerator = new ComponentGenerator(testUiLayoutDataProvider);
+    const componentGenerator = new ComponentGenerator(testUiLayoutDataProvider); // TODO: internal types should not be used in public types
 
     return {
       title: "UiProvider",
@@ -1461,7 +1461,9 @@ export class ComponentExamplesProvider {
         createComponentExample(
           "Tool Settings Grid Container",
           undefined,
-          <ToolSettingsGridContainer componentGenerator={componentGenerator} />
+          <ToolSettingsGridContainer
+            componentGenerator={componentGenerator as any}
+          />
         ),
       ],
     };

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/BlankConnection.ts
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/BlankConnection.ts
@@ -4,14 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 import { UiFramework } from "@itwin/appui-react";
 import { Logger } from "@itwin/core-bentley";
-import { Cartographic, ColorDef, RenderMode } from "@itwin/core-common";
 import {
-  BlankConnection,
-  IModelApp,
-  IModelConnection,
-  SpatialViewState,
-} from "@itwin/core-frontend";
-import { Range3d } from "@itwin/core-geometry";
+  createBlankConnection,
+  createBlankViewState,
+} from "@itwin/appui-test-providers";
 import { SampleAppIModelApp } from "..";
 
 export async function openBlankConnection() {
@@ -26,50 +22,11 @@ export async function openBlankConnection() {
   const connection = createBlankConnection();
 
   SampleAppIModelApp.setIsIModelLocal(true, true);
-  const viewState = await createBlankViewState(connection);
+  const viewState = createBlankViewState(connection);
   UiFramework.setDefaultViewState(viewState, true);
 
   UiFramework.frontstages.closeModalFrontstage();
   await SampleAppIModelApp.setViewIdAndOpenMainStage(connection, [
     viewState.id,
   ]);
-}
-
-function createBlankConnection() {
-  return BlankConnection.create({
-    name: "Exton PA",
-    location: Cartographic.fromDegrees({
-      longitude: -75.686694,
-      latitude: 40.065757,
-      height: 0,
-    }),
-    extents: new Range3d(-1000, -1000, -100, 1000, 1000, 100),
-  });
-}
-
-async function createBlankViewState(iModel: IModelConnection) {
-  const ext = iModel.projectExtents;
-  const viewState = SpatialViewState.createBlank(
-    iModel,
-    ext.low,
-    ext.high.minus(ext.low)
-  );
-
-  viewState.setAllow3dManipulations(true);
-
-  viewState.displayStyle.backgroundColor = ColorDef.white;
-  const flags = viewState.viewFlags.copy({
-    grid: false,
-    renderMode: RenderMode.SmoothShade,
-    backgroundMap: false,
-  });
-  viewState.displayStyle.viewFlags = flags;
-
-  IModelApp.viewManager.onViewOpen.addOnce((vp) => {
-    if (vp.view.hasSameCoordinates(viewState)) {
-      vp.applyViewState(viewState);
-    }
-  });
-
-  return viewState;
 }


### PR DESCRIPTION
## Changes

Add the capability to open a blank iModel connection from storybook. It is needed since opening a checkpoint is slower and requires a network connection, while iModel connection is required for some stories.

## Testing

Ran storybook to verify
