### PR TITLE
`ControlledTree`: add ability to select multiple nodes using `CMD` key + mouse click

### DIFF
--- a/common/changes/@itwin/components-react/fix_tree_multi_select_on_ipad_2024-02-15-12-44.json
+++ b/common/changes/@itwin/components-react/fix_tree_multi_select_on_ipad_2024-02-15-12-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "`ControlledTree`: add ability to select multiple nodes using `CMD` key + mouse click.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -18,7 +18,7 @@ Table of contents:
 
 ### Additions
 
-- `ControlledTree`: add ability to select multiple nodes using `CMD` key + mouse click.
+- `ControlledTree`: add ability to select multiple nodes using `CMD` key + mouse click. [#734](https://github.com/iTwin/appui/pull/734)
 
 ### Fixes
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,7 +5,6 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Changes](#changes)
 - [@itwin/components-react](#itwincomponents-react)
-  - [Additions](#additions)
   - [Fixes](#fixes)
 
 ## @itwin/appui-react
@@ -16,10 +15,7 @@ Table of contents:
 
 ## @itwin/components-react
 
-### Additions
-
-- `ControlledTree`: add ability to select multiple nodes using `CMD` key + mouse click. [#734](https://github.com/iTwin/appui/pull/734)
-
 ### Fixes
 
 - Fix a potential maximum update depth error caused by useResizeObserver. #658
+- `ControlledTree`: add ability to select multiple nodes using `CMD` key + mouse click. [#734](https://github.com/iTwin/appui/pull/734)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,6 +5,7 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Changes](#changes)
 - [@itwin/components-react](#itwincomponents-react)
+  - [Additions](#additions)
   - [Fixes](#fixes)
 
 ## @itwin/appui-react
@@ -14,6 +15,10 @@ Table of contents:
 - Update styling of tool settings components. #658
 
 ## @itwin/components-react
+
+### Additions
+
+- `ControlledTree`: add ability to select multiple nodes using `CMD` key + mouse click.
 
 ### Fixes
 

--- a/ui/components-react/src/components-react/tree/controlled/internal/TreeSelectionManager.ts
+++ b/ui/components-react/src/components-react/tree/controlled/internal/TreeSelectionManager.ts
@@ -158,7 +158,7 @@ export class TreeSelectionManager
     const selectionFunc = this._selectionHandler.createSelectionFunction(
       ...this.createSelectionHandlers(nodeId)
     );
-    selectionFunc(event.shiftKey, event.ctrlKey);
+    selectionFunc(event.shiftKey, event.ctrlKey || event.metaKey);
   }
 
   public onNodeMouseDown(nodeId: string) {

--- a/ui/components-react/src/test/tree/controlled/internal/TreeSelectionManager.test.ts
+++ b/ui/components-react/src/test/tree/controlled/internal/TreeSelectionManager.test.ts
@@ -99,6 +99,7 @@ describe("TreeSelectionManager", () => {
       );
       eventMock.setup((x) => x.shiftKey).returns(() => false);
       eventMock.setup((x) => x.ctrlKey).returns(() => false);
+      eventMock.setup((x) => x.metaKey).returns(() => false);
       extendedSelectionManager.onNodeClicked(node.id, eventMock.object);
       expect(spy).to.be.calledOnce;
       expect(spy).to.be.calledWithExactly({
@@ -115,6 +116,7 @@ describe("TreeSelectionManager", () => {
       );
       eventMock.setup((x) => x.shiftKey).returns(() => false);
       eventMock.setup((x) => x.ctrlKey).returns(() => true);
+      eventMock.setup((x) => x.metaKey).returns(() => false);
       extendedSelectionManager.onNodeClicked(node.id, eventMock.object);
       expect(spy).to.be.calledOnce;
       expect(spy).to.be.calledWithExactly({
@@ -132,6 +134,7 @@ describe("TreeSelectionManager", () => {
       );
       eventMock.setup((x) => x.shiftKey).returns(() => false);
       eventMock.setup((x) => x.ctrlKey).returns(() => true);
+      eventMock.setup((x) => x.metaKey).returns(() => false);
       extendedSelectionManager.onNodeClicked(nodes[0].id, eventMock.object);
       extendedSelectionManager.onNodeClicked(nodes[1].id, eventMock.object);
       expect(spy).to.be.calledTwice;
@@ -154,6 +157,7 @@ describe("TreeSelectionManager", () => {
       );
       eventMock.setup((x) => x.shiftKey).returns(() => true);
       eventMock.setup((x) => x.ctrlKey).returns(() => false);
+      eventMock.setup((x) => x.metaKey).returns(() => false);
       extendedSelectionManager.onNodeClicked(nodes[0].id, eventMock.object);
       extendedSelectionManager.onNodeClicked(nodes[1].id, eventMock.object);
       expect(spy).to.be.calledTwice;
@@ -174,6 +178,7 @@ describe("TreeSelectionManager", () => {
       );
       eventMock.setup((x) => x.shiftKey).returns(() => true);
       eventMock.setup((x) => x.ctrlKey).returns(() => true);
+      eventMock.setup((x) => x.metaKey).returns(() => false);
       extendedSelectionManager.onNodeClicked(nodes[0].id, eventMock.object);
       extendedSelectionManager.onNodeClicked(nodes[1].id, eventMock.object);
       expect(spy).to.be.calledTwice;
@@ -183,6 +188,29 @@ describe("TreeSelectionManager", () => {
       });
       expect(spy.secondCall).to.be.calledWithExactly({
         selectedNodes: { from: nodes[0].id, to: nodes[1].id },
+        deselectedNodes: [],
+      });
+    });
+
+    it("cmd selects nodes", () => {
+      const nodes = [createTreeModelNode(), createTreeModelNode()];
+      setupModelWithNodes(nodes);
+      const spy = sinon.spy(
+        extendedSelectionManager.onSelectionChanged,
+        "emit"
+      );
+      eventMock.setup((x) => x.shiftKey).returns(() => false);
+      eventMock.setup((x) => x.ctrlKey).returns(() => false);
+      eventMock.setup((x) => x.metaKey).returns(() => true);
+      extendedSelectionManager.onNodeClicked(nodes[0].id, eventMock.object);
+      extendedSelectionManager.onNodeClicked(nodes[1].id, eventMock.object);
+      expect(spy).to.be.calledTwice;
+      expect(spy.firstCall).to.be.calledWithExactly({
+        selectedNodes: [nodes[0].id],
+        deselectedNodes: [],
+      });
+      expect(spy.secondCall).to.be.calledWithExactly({
+        selectedNodes: [nodes[1].id],
         deselectedNodes: [],
       });
     });


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
Treat `Cmd` key on Apple devices as `Ctrl` when clicking on tree nodes. `Ctrl` + mouse click on Apple devices acts as right mouse button click.

Fixes: https://github.com/iTwin/viewer-components-react/issues/770

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Tested manually.
