### PR TITLE
Add a frontstage to test AccuDraw

### DIFF
--- a/common/changes/@itwin/appui-react/test-accudraw_2024-02-29-15-27.json
+++ b/common/changes/@itwin/appui-react/test-accudraw_2024-02-29-15-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -107,6 +107,14 @@
       "allowedCategories": [ "internal" ]
     },
     {
+      "name": "@itwin/editor-common",
+      "allowedCategories": [ "internal" ]
+    },
+    {
+      "name": "@itwin/editor-frontend",
+      "allowedCategories": [ "internal" ]
+    },
+    {
       "name": "@itwin/electron-authorization",
       "allowedCategories": [ "internal" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -532,6 +532,12 @@ importers:
       '@itwin/editor-backend':
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0(@itwin/core-backend@4.4.0)(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0)
+      '@itwin/editor-common':
+        specifier: ^3.7.0 || ^4.0.0
+        version: 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0)
+      '@itwin/editor-frontend':
+        specifier: ^3.7.0 || ^4.0.0
+        version: 4.4.3(@itwin/appui-abstract@4.4.0)(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-frontend@4.4.0)(@itwin/core-geometry@4.4.0)
       '@itwin/express-server':
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0(@itwin/core-backend@4.4.0)
@@ -4285,6 +4291,35 @@ packages:
       '@itwin/core-bentley': 4.4.0
       '@itwin/core-common': 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-geometry@4.4.0)
       '@itwin/core-geometry': 4.4.0
+    dev: false
+
+  /@itwin/editor-common@4.4.3(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0):
+    resolution: {integrity: sha512-grnvZEK4xBTravtu0s5l7psLM7tyrQwFgI/IRVNTMbb8IVFO4CLeuj95UfvnttIQN7bah2SwHtbn90qicWGutg==}
+    peerDependencies:
+      '@itwin/core-bentley': ^4.4.3
+      '@itwin/core-common': ^4.4.3
+      '@itwin/core-geometry': ^4.4.3
+    dependencies:
+      '@itwin/core-bentley': 4.4.0
+      '@itwin/core-common': 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-geometry@4.4.0)
+      '@itwin/core-geometry': 4.4.0
+    dev: false
+
+  /@itwin/editor-frontend@4.4.3(@itwin/appui-abstract@4.4.0)(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-frontend@4.4.0)(@itwin/core-geometry@4.4.0):
+    resolution: {integrity: sha512-WkRBDAm/ETrziKqUeE3LE0/wj3W3t0pxccvSllMhOcAZ4RV/dxK5sRmB3/RWLQ6dirzRGiAaf14pwPkdSt5E+A==}
+    peerDependencies:
+      '@itwin/appui-abstract': ^4.4.3
+      '@itwin/core-bentley': ^4.4.3
+      '@itwin/core-common': ^4.4.3
+      '@itwin/core-frontend': ^4.4.3
+      '@itwin/core-geometry': ^4.4.3
+    dependencies:
+      '@itwin/appui-abstract': 4.4.0(@itwin/core-bentley@4.4.0)
+      '@itwin/core-bentley': 4.4.0
+      '@itwin/core-common': 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-geometry@4.4.0)
+      '@itwin/core-frontend': 4.4.0(@itwin/appui-abstract@4.4.0)(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0)(@itwin/core-orbitgt@4.4.0)(@itwin/core-quantity@4.4.0)
+      '@itwin/core-geometry': 4.4.0
+      '@itwin/editor-common': 4.4.3(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-geometry@4.4.0)
     dev: false
 
   /@itwin/electron-authorization@0.11.0(@itwin/core-bentley@4.4.0)(electron@22.3.27):

--- a/common/config/rush/variants/core-3x/pnpm-lock.yaml
+++ b/common/config/rush/variants/core-3x/pnpm-lock.yaml
@@ -532,6 +532,12 @@ importers:
       '@itwin/editor-backend':
         specifier: ^3.7.0 || ^4.0.0
         version: 3.8.0(@itwin/core-backend@3.8.0)(@itwin/core-bentley@3.8.0)(@itwin/core-common@3.8.0)(@itwin/core-geometry@3.8.0)
+      '@itwin/editor-common':
+        specifier: ^3.7.0 || ^4.0.0
+        version: 3.8.0(@itwin/core-bentley@3.8.0)(@itwin/core-common@3.8.0)(@itwin/core-geometry@3.8.0)
+      '@itwin/editor-frontend':
+        specifier: ^3.7.0 || ^4.0.0
+        version: 4.4.3(@itwin/appui-abstract@3.8.0)(@itwin/core-bentley@3.8.0)(@itwin/core-common@3.8.0)(@itwin/core-frontend@3.8.0)(@itwin/core-geometry@3.8.0)
       '@itwin/express-server':
         specifier: ^3.7.0 || ^4.0.0
         version: 3.8.0(@itwin/core-backend@3.8.0)
@@ -4297,6 +4303,35 @@ packages:
       '@itwin/core-bentley': 3.8.0
       '@itwin/core-common': 3.8.0(@itwin/core-bentley@3.8.0)(@itwin/core-geometry@3.8.0)
       '@itwin/core-geometry': 3.8.0
+    dev: false
+
+  /@itwin/editor-common@4.4.3(@itwin/core-bentley@3.8.0)(@itwin/core-common@3.8.0)(@itwin/core-geometry@3.8.0):
+    resolution: {integrity: sha512-grnvZEK4xBTravtu0s5l7psLM7tyrQwFgI/IRVNTMbb8IVFO4CLeuj95UfvnttIQN7bah2SwHtbn90qicWGutg==}
+    peerDependencies:
+      '@itwin/core-bentley': ^4.4.3
+      '@itwin/core-common': ^4.4.3
+      '@itwin/core-geometry': ^4.4.3
+    dependencies:
+      '@itwin/core-bentley': 3.8.0
+      '@itwin/core-common': 3.8.0(@itwin/core-bentley@3.8.0)(@itwin/core-geometry@3.8.0)
+      '@itwin/core-geometry': 3.8.0
+    dev: false
+
+  /@itwin/editor-frontend@4.4.3(@itwin/appui-abstract@3.8.0)(@itwin/core-bentley@3.8.0)(@itwin/core-common@3.8.0)(@itwin/core-frontend@3.8.0)(@itwin/core-geometry@3.8.0):
+    resolution: {integrity: sha512-WkRBDAm/ETrziKqUeE3LE0/wj3W3t0pxccvSllMhOcAZ4RV/dxK5sRmB3/RWLQ6dirzRGiAaf14pwPkdSt5E+A==}
+    peerDependencies:
+      '@itwin/appui-abstract': ^4.4.3
+      '@itwin/core-bentley': ^4.4.3
+      '@itwin/core-common': ^4.4.3
+      '@itwin/core-frontend': ^4.4.3
+      '@itwin/core-geometry': ^4.4.3
+    dependencies:
+      '@itwin/appui-abstract': 3.8.0(@itwin/core-bentley@3.8.0)
+      '@itwin/core-bentley': 3.8.0
+      '@itwin/core-common': 3.8.0(@itwin/core-bentley@3.8.0)(@itwin/core-geometry@3.8.0)
+      '@itwin/core-frontend': 3.8.0(@itwin/appui-abstract@3.8.0)(@itwin/core-bentley@3.8.0)(@itwin/core-common@3.8.0)(@itwin/core-geometry@3.8.0)(@itwin/core-orbitgt@3.8.0)(@itwin/core-quantity@3.8.0)(@itwin/webgl-compatibility@3.8.0)
+      '@itwin/core-geometry': 3.8.0
+      '@itwin/editor-common': 4.4.3(@itwin/core-bentley@3.8.0)(@itwin/core-common@3.8.0)(@itwin/core-geometry@3.8.0)
     dev: false
 
   /@itwin/electron-authorization@0.11.0(@itwin/core-bentley@3.8.0)(electron@22.3.27):

--- a/test-apps/appui-test-app/standalone/README.md
+++ b/test-apps/appui-test-app/standalone/README.md
@@ -61,6 +61,8 @@ To set the environment variables, either set them directly within the terminal y
 
 - IMJS_NO_DEV_TOOLS
   - If defined, do not open the electron dev tools on startup
+- IMJS_READ_WRITE
+  - If defined, the `OpenMode.ReadWrite` mode is used while opening the briefcase.
 
 ### Browser-only
 

--- a/test-apps/appui-test-app/standalone/package.json
+++ b/test-apps/appui-test-app/standalone/package.json
@@ -84,6 +84,8 @@
     "@itwin/ecschema-rpcinterface-common": "^3.7.0 || ^4.0.0",
     "@itwin/ecschema-rpcinterface-impl": "^3.7.0 || ^4.0.0",
     "@itwin/editor-backend": "^3.7.0 || ^4.0.0",
+    "@itwin/editor-common": "^3.7.0 || ^4.0.0",
+    "@itwin/editor-frontend": "^3.7.0 || ^4.0.0",
     "@itwin/express-server": "^3.7.0 || ^4.0.0",
     "@itwin/frontend-devtools": "^3.7.0 || ^4.0.0",
     "@itwin/hypermodeling-frontend": "^3.7.0 || ^4.0.0",

--- a/test-apps/appui-test-app/standalone/src/common/TestAppConfiguration.ts
+++ b/test-apps/appui-test-app/standalone/src/common/TestAppConfiguration.ts
@@ -10,6 +10,7 @@ export interface TestAppConfiguration {
   bingMapsKey?: string;
   mapBoxKey?: string;
   cesiumIonKey?: string;
+  readWrite?: boolean;
 }
 
 export const loggerCategory = "appui-test-app";

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/LocalFileSupport.ts
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/LocalFileSupport.ts
@@ -54,7 +54,9 @@ export class LocalFileSupport {
       try {
         iModelConnection = await BriefcaseConnection.openStandalone(
           filePath,
-          OpenMode.Readonly,
+          SampleAppIModelApp.testAppConfiguration?.readWrite
+            ? OpenMode.ReadWrite
+            : OpenMode.Readonly,
           { key: filePath }
         );
       } catch (err: any) {

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 import {
   AccuDrawWidget,
+  BackstageAppButton,
   BackstageItemUtilities,
   StagePanelLocation,
   StagePanelSection,
@@ -50,6 +51,7 @@ export const editorFrontstageProvider = new StandardFrontstageProvider({
   id: frontstageId,
   contentGroupProps: new InitialIModelContentStageProvider(),
   usage: StageUsage.General,
+  cornerButton: <BackstageAppButton />,
 });
 
 export const editorUiItemsProvider = createUiItemsProvider();

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import {
+  BackstageItemUtilities,
+  StageUsage,
+  StandardFrontstageProvider,
+  ToolbarActionItem,
+  ToolbarItemUtilities,
+  ToolbarOrientation,
+  ToolbarUsage,
+  UiItemsProvider,
+} from "@itwin/appui-react";
+import {
+  CreateArcTool,
+  CreateLineStringTool,
+  EditTools,
+} from "@itwin/editor-frontend";
+import { SvgEdit } from "@itwin/itwinui-icons-react";
+import { InitialIModelContentStageProvider } from "./MainFrontstage";
+import { IModelApp, ToolType } from "@itwin/core-frontend";
+
+function createToolbarItem( // TODO: add to imodel-components-react?
+  tool: ToolType,
+  overrides?: Partial<ToolbarActionItem>
+) {
+  return ToolbarItemUtilities.createActionItem(
+    tool.toolId,
+    10,
+    tool.iconSpec,
+    tool.flyover,
+    async () => {
+      await IModelApp.tools.run(tool.toolId);
+    },
+    overrides
+  );
+}
+
+export async function initializeEditor() {
+  await EditTools.initialize();
+}
+
+export const editorFrontstageProvider = new StandardFrontstageProvider({
+  id: "standalone:editor-frontstage",
+  contentGroupProps: new InitialIModelContentStageProvider(),
+  usage: StageUsage.General,
+});
+
+const toolbarItemOverrides = {
+  layouts: {
+    standard: {
+      orientation: ToolbarOrientation.Horizontal,
+      usage: ToolbarUsage.ContentManipulation,
+    },
+  },
+};
+
+export const editorUiItemsProvider: UiItemsProvider = {
+  id: "standalone:editor-items",
+  getBackstageItems: () => [
+    BackstageItemUtilities.createStageLauncher(
+      "standalone:editor-frontstage",
+      400,
+      0,
+      "Editor",
+      undefined,
+      <SvgEdit />
+    ),
+  ],
+  getToolbarItems: () => [
+    createToolbarItem(CreateLineStringTool, toolbarItemOverrides),
+    createToolbarItem(CreateArcTool, toolbarItemOverrides),
+  ],
+};

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
@@ -4,7 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import {
+  AccuDrawWidget,
   BackstageItemUtilities,
+  StagePanelLocation,
+  StagePanelSection,
   StageUsage,
   StandardFrontstageProvider,
   ToolbarActionItem,
@@ -18,7 +21,7 @@ import {
   CreateLineStringTool,
   EditTools,
 } from "@itwin/editor-frontend";
-import { SvgEdit } from "@itwin/itwinui-icons-react";
+import { SvgDraw, SvgEdit } from "@itwin/itwinui-icons-react";
 import { InitialIModelContentStageProvider } from "./MainFrontstage";
 import { IModelApp, ToolType } from "@itwin/core-frontend";
 
@@ -42,35 +45,59 @@ export async function initializeEditor() {
   await EditTools.initialize();
 }
 
+const frontstageId = "standalone:editor-frontstage";
 export const editorFrontstageProvider = new StandardFrontstageProvider({
-  id: "standalone:editor-frontstage",
+  id: frontstageId,
   contentGroupProps: new InitialIModelContentStageProvider(),
   usage: StageUsage.General,
 });
 
-const toolbarItemOverrides = {
-  layouts: {
-    standard: {
-      orientation: ToolbarOrientation.Horizontal,
-      usage: ToolbarUsage.ContentManipulation,
-    },
-  },
-};
+export const editorUiItemsProvider = createUiItemsProvider();
 
-export const editorUiItemsProvider: UiItemsProvider = {
-  id: "standalone:editor-items",
-  getBackstageItems: () => [
-    BackstageItemUtilities.createStageLauncher(
-      "standalone:editor-frontstage",
-      400,
-      0,
-      "Editor",
-      undefined,
-      <SvgEdit />
-    ),
-  ],
-  getToolbarItems: () => [
-    createToolbarItem(CreateLineStringTool, toolbarItemOverrides),
-    createToolbarItem(CreateArcTool, toolbarItemOverrides),
-  ],
-};
+function createUiItemsProvider(): UiItemsProvider {
+  const id = "standalone:editor-items";
+  return {
+    id,
+    getBackstageItems: () => [
+      BackstageItemUtilities.createStageLauncher(
+        frontstageId,
+        400,
+        0,
+        "Editor",
+        undefined,
+        <SvgEdit />
+      ),
+    ],
+    getToolbarItems: () => {
+      const overrides = {
+        layouts: {
+          standard: {
+            orientation: ToolbarOrientation.Horizontal,
+            usage: ToolbarUsage.ContentManipulation,
+          },
+        },
+      };
+      return [
+        createToolbarItem(CreateLineStringTool, overrides),
+        createToolbarItem(CreateArcTool, overrides),
+      ];
+    },
+    getWidgets: () => {
+      const layouts = {
+        standard: {
+          location: StagePanelLocation.Right,
+          section: StagePanelSection.Start,
+        },
+      };
+      return [
+        {
+          id: `${id}:accudraw-widget`,
+          label: "AccuDraw",
+          icon: <SvgDraw />,
+          content: <AccuDrawWidget />,
+          layouts,
+        },
+      ];
+    },
+  };
+}

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/useEditorToolSettings.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/useEditorToolSettings.tsx
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import {
+  BriefcaseConnection,
+  IModelApp,
+  Viewport,
+  ViewState,
+} from "@itwin/core-frontend";
+
+function updateEditorToolSettingsForIModelInViewport(viewport: Viewport) {
+  const view = viewport.view;
+  const iModel = view.iModel;
+
+  if (!iModel.isBriefcaseConnection()) return;
+
+  // Select first category if no category is selected.
+  if (!iModel.editorToolSettings.category) {
+    for (const catId of view.categorySelector.categories) {
+      iModel.editorToolSettings.category = catId;
+      break;
+    }
+  }
+
+  // Select first or base model if no model is selected.
+  if (!iModel.editorToolSettings.model) setDefaultModelAsActive(view, iModel);
+}
+
+function setDefaultModelAsActive(view: ViewState, iModel: BriefcaseConnection) {
+  if (view.is2d()) {
+    iModel.editorToolSettings.model = view.baseModelId;
+    return;
+  }
+
+  if (view.isSpatialView()) {
+    for (const modId of view.modelSelector.models) {
+      iModel.editorToolSettings.model = modId;
+      return;
+    }
+  }
+}
+
+/** @internal */
+export function useEditorToolSettings() {
+  React.useEffect(() => {
+    return IModelApp.viewManager.onSelectedViewportChanged.addListener(
+      (args) => {
+        const viewport = args.current;
+        viewport && updateEditorToolSettingsForIModelInViewport(viewport);
+      }
+    );
+  }, []);
+}

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -35,6 +35,7 @@ import {
   SafeAreaContext,
   SafeAreaInsets,
   SessionStateActionId,
+  StandardContentToolsUiItemsProvider,
   StateManager,
   SyncUiEventDispatcher,
   SYSTEM_PREFERRED_COLOR_THEME,
@@ -372,6 +373,9 @@ export class SampleAppIModelApp {
       UiItemsManager.register(editorUiItemsProvider, {
         stageIds: [editorFrontstageProvider.id],
       });
+      UiItemsManager.register(new StandardContentToolsUiItemsProvider(), {
+        stageIds: [editorFrontstageProvider.id],
+      });
     }
 
     // TODO: should not be required. Start event loop to open key-in palette.
@@ -422,7 +426,11 @@ export class SampleAppIModelApp {
 
     if (this.iModelParams && this.iModelParams.stageId)
       stageId = this.iModelParams.stageId;
-    else stageId = defaultFrontstage;
+    else if (SampleAppIModelApp.testAppConfiguration?.readWrite) {
+      stageId = editorFrontstageProvider.id;
+    } else {
+      stageId = defaultFrontstage;
+    }
 
     if (stageId === defaultFrontstage) {
       if (stageId === MainFrontstage.stageId) {
@@ -700,8 +708,10 @@ async function main() {
     process.env.IMJS_CESIUM_ION_KEY;
   SampleAppIModelApp.testAppConfiguration.reactAxeConsole =
     SampleAppIModelApp.isEnvVarOn("IMJS_TESTAPP_REACT_AXE_CONSOLE");
-  SampleAppIModelApp.testAppConfiguration.readWrite =
-    SampleAppIModelApp.isEnvVarOn("IMJS_READ_WRITE");
+  if (ProcessDetector.isElectronAppFrontend) {
+    SampleAppIModelApp.testAppConfiguration.readWrite =
+      SampleAppIModelApp.isEnvVarOn("IMJS_READ_WRITE");
+  }
   Logger.logInfo(
     "Configuration",
     JSON.stringify(SampleAppIModelApp.testAppConfiguration)

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -738,7 +738,8 @@ async function main() {
     /** API Url. Used to select environment. Defaults to "https://api.bentley.com/realitydata" */
     baseUrl: `https://${process.env.IMJS_URL_PREFIX}api.bentley.com/realitydata`,
   };
-  const opts: NativeAppOpts = {
+  // Start the app.
+  await SampleAppIModelApp.startup({
     iModelApp: {
       accuSnap: new SampleAppAccuSnap(),
       toolAdmin: new FrameworkToolAdmin(),
@@ -753,10 +754,7 @@ async function main() {
         cesiumIonKey: SampleAppIModelApp.testAppConfiguration.cesiumIonKey,
       },
     },
-  };
-
-  // Start the app.
-  await SampleAppIModelApp.startup(opts);
+  });
   await SampleAppIModelApp.initialize();
 
   ReactDOM.render(

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -108,6 +108,12 @@ import {
   addExampleFrontstagesToBackstage,
   registerExampleFrontstages,
 } from "./appui/frontstages/example-stages/ExampleStagesBackstageProvider";
+import {
+  editorFrontstageProvider,
+  editorUiItemsProvider,
+  initializeEditor,
+} from "./appui/frontstages/EditorFrontstageProvider";
+import { useEditorToolSettings } from "./appui/useEditorToolSettings";
 
 // Initialize my application gateway configuration for the frontend
 RpcConfiguration.developmentMode = true;
@@ -360,6 +366,14 @@ export class SampleAppIModelApp {
     );
     PopoutWindowsFrontstage.register(AppUiTestProviders.localizationNamespace);
 
+    if (ProcessDetector.isElectronAppFrontend) {
+      await initializeEditor();
+      UiFramework.frontstages.addFrontstageProvider(editorFrontstageProvider);
+      UiItemsManager.register(editorUiItemsProvider, {
+        stageIds: [editorFrontstageProvider.id],
+      });
+    }
+
     // TODO: should not be required. Start event loop to open key-in palette.
     IModelApp.startEventLoop();
   }
@@ -536,6 +550,8 @@ const AppDragInteraction = connect(mapDragInteractionStateToProps)(
 );
 
 const SampleAppViewer = () => {
+  useEditorToolSettings();
+
   React.useEffect(() => {
     AppUi.initialize();
   }, []);
@@ -684,6 +700,8 @@ async function main() {
     process.env.IMJS_CESIUM_ION_KEY;
   SampleAppIModelApp.testAppConfiguration.reactAxeConsole =
     SampleAppIModelApp.isEnvVarOn("IMJS_TESTAPP_REACT_AXE_CONSOLE");
+  SampleAppIModelApp.testAppConfiguration.readWrite =
+    SampleAppIModelApp.isEnvVarOn("IMJS_READ_WRITE");
   Logger.logInfo(
     "Configuration",
     JSON.stringify(SampleAppIModelApp.testAppConfiguration)

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawFieldContainer.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawFieldContainer.tsx
@@ -10,10 +10,7 @@ import "./AccuDrawFieldContainer.scss";
 import classnames from "classnames";
 import * as React from "react";
 import type { ColorDef } from "@itwin/core-common";
-import type {
-  ScreenViewport,
-  SelectedViewportChangedArgs,
-} from "@itwin/core-frontend";
+import type { ScreenViewport } from "@itwin/core-frontend";
 import { CompassMode, IModelApp, ItemField } from "@itwin/core-frontend";
 import type { CommonProps, IconSpec, UiStateStorage } from "@itwin/core-react";
 import { Orientation } from "@itwin/core-react";
@@ -214,15 +211,10 @@ export function AccuDrawFieldContainer(props: AccuDrawFieldContainerProps) {
       showZOverride || determineShowZ(IModelApp.viewManager.selectedView)
     );
 
-    // istanbul ignore next
-    const handleSelectedViewportChanged = (
-      args: SelectedViewportChangedArgs
-    ) => {
-      setShowZ(determineShowZ(args.current));
-    };
-
     return IModelApp.viewManager.onSelectedViewportChanged.addListener(
-      handleSelectedViewportChanged
+      (args) => {
+        setShowZ(determineShowZ(args.current));
+      }
     );
   }, [showZOverride]);
 
@@ -351,13 +343,10 @@ export function AccuDrawFieldContainer(props: AccuDrawFieldContainerProps) {
     if (FrameworkAccuDraw.uiStateStorage)
       processAccuDrawUiSettings(FrameworkAccuDraw.uiStateStorage);
 
-    // istanbul ignore next
-    const handleAccuDrawUiSettingsChanged = () => {
-      processAccuDrawUiSettings(FrameworkAccuDraw.uiStateStorage);
-    };
-
     return FrameworkAccuDraw.onAccuDrawUiSettingsChangedEvent.addListener(
-      handleAccuDrawUiSettingsChanged
+      () => {
+        processAccuDrawUiSettings(FrameworkAccuDraw.uiStateStorage);
+      }
     );
   }, []);
 

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.tsx
@@ -14,10 +14,6 @@ import type { ItemField } from "@itwin/core-frontend";
 import type { CommonProps, IconSpec } from "@itwin/core-react";
 import { Icon, useRefs } from "@itwin/core-react";
 import { Input } from "@itwin/itwinui-react";
-import type {
-  AccuDrawSetFieldFocusEventArgs,
-  AccuDrawSetFieldValueToUiEventArgs,
-} from "./FrameworkAccuDraw";
 import { FrameworkAccuDraw } from "./FrameworkAccuDraw";
 import { UiFramework } from "../UiFramework";
 import { SvgLock } from "@itwin/itwinui-icons-react";
@@ -158,17 +154,14 @@ const ForwardRefAccuDrawInput = React.forwardRef<
   );
 
   React.useEffect(() => {
-    const handleSetFieldValueToUi = (
-      args: AccuDrawSetFieldValueToUiEventArgs
-    ) => {
-      if (args.field === field && stringValue !== args.formattedValue) {
-        setStringValue(args.formattedValue);
-        // istanbul ignore else
-        if (isFocusField) setNeedSelection(true);
-      }
-    };
     return FrameworkAccuDraw.onAccuDrawSetFieldValueToUiEvent.addListener(
-      handleSetFieldValueToUi
+      (args) => {
+        if (args.field === field && stringValue !== args.formattedValue) {
+          setStringValue(args.formattedValue);
+          // istanbul ignore else
+          if (isFocusField) setNeedSelection(true);
+        }
+      }
     );
   }, [field, isFocusField, stringValue]);
 
@@ -181,11 +174,10 @@ const ForwardRefAccuDrawInput = React.forwardRef<
   }, [needSelection]);
 
   React.useEffect(() => {
-    const handleSetFieldFocus = (args: AccuDrawSetFieldFocusEventArgs) => {
-      setIsFocusField(args.field === field);
-    };
     return FrameworkAccuDraw.onAccuDrawSetFieldFocusEvent.addListener(
-      handleSetFieldFocus
+      (args) => {
+        setIsFocusField(args.field === field);
+      }
     );
   }, [field]);
 
@@ -221,7 +213,7 @@ const ForwardRefAccuDrawInput = React.forwardRef<
   );
 });
 
-/** Input field for AccuDraw Ui
+/** Input field for AccuDraw UI.
  * @beta
  */
 export const AccuDrawInputField: (


### PR DESCRIPTION
## Changes

Add a frontstage to test AccuDraw to the standalone test-app. iTwin/itwinjs-core#6478
Maintenance: cleaned up AccuDraw event listeners.

## Testing

Tested manually in a standalone test-app.
