### PR TITLE
Deprecate date and color pickers

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -1146,7 +1146,7 @@ export interface InternalToolbarComponentProps extends CommonProps, NoChildrenPr
     useDragInteraction?: boolean;
 }
 
-// @alpha
+// @alpha @deprecated
 export class IntlFormatter implements DateFormatter {
     constructor(_intlFormatter?: Intl.DateTimeFormat | undefined);
     // (undocumented)

--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -439,13 +439,13 @@ export interface DateFormatOptions {
     options?: Intl.DateTimeFormatOptions | undefined;
 }
 
-// @alpha
+// @alpha @deprecated
 export function DatePicker(props: DatePickerProps): React_3.JSX.Element;
 
-// @alpha
+// @alpha @deprecated
 export function DatePickerPopupButton({ displayEditField, timeDisplay, selected, onDateChange, dateFormatter, buttonToolTip, fieldStyle, fieldClassName, style, }: DatePickerPopupButtonProps): React_3.JSX.Element;
 
-// @alpha
+// @alpha @deprecated
 export interface DatePickerPopupButtonProps extends CommonProps {
     buttonToolTip?: string;
     // (undocumented)
@@ -459,7 +459,7 @@ export interface DatePickerPopupButtonProps extends CommonProps {
     timeDisplay?: TimeDisplay;
 }
 
-// @alpha
+// @alpha @deprecated
 export interface DatePickerProps {
     onDateChange?: (day: Date) => void;
     selected: Date;

--- a/common/api/imodel-components-react.api.md
+++ b/common/api/imodel-components-react.api.md
@@ -36,7 +36,7 @@ import type { ViewManager } from '@itwin/core-frontend';
 import type { Viewport } from '@itwin/core-frontend';
 import type { ViewState } from '@itwin/core-frontend';
 
-// @public
+// @public @deprecated
 export class AlphaSlider extends React_2.PureComponent<AlphaSliderProps> {
     // @internal
     constructor(props: AlphaSliderProps);
@@ -46,7 +46,7 @@ export class AlphaSlider extends React_2.PureComponent<AlphaSliderProps> {
     render(): React_2.ReactNode;
 }
 
-// @public
+// @public @deprecated
 export interface AlphaSliderProps extends React_2.HTMLAttributes<HTMLDivElement>, CommonProps {
     alpha: number;
     isHorizontal?: boolean;
@@ -165,13 +165,13 @@ export class ColorEditor extends React_2.PureComponent<PropertyEditorProps, Colo
     readonly state: Readonly<ColorEditorState>;
 }
 
-// @beta
+// @beta @deprecated
 export const ColorPickerButton: (props: ColorPickerProps) => React_2.ReactElement | null;
 
-// @beta
+// @beta @deprecated
 export function ColorPickerDialog({ dialogTitle, color, onOkResult, onCancelResult, colorPresets, colorInputType, }: ColorPickerDialogProps): React_2.JSX.Element;
 
-// @beta
+// @beta @deprecated
 export interface ColorPickerDialogProps {
     // (undocumented)
     color: ColorDef;
@@ -185,10 +185,10 @@ export interface ColorPickerDialogProps {
     onOkResult: (selectedColor: ColorDef) => void;
 }
 
-// @public
+// @public @deprecated
 export const ColorPickerPopup: (props: ColorPickerPopupProps) => React_2.ReactElement | null;
 
-// @public
+// @public @deprecated
 export interface ColorPickerPopupProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement>, CommonProps {
     captureClicks?: boolean;
     colorDefs?: ColorDef[];
@@ -204,7 +204,7 @@ export interface ColorPickerPopupProps extends React_2.ButtonHTMLAttributes<HTML
     showCaret?: boolean;
 }
 
-// @beta
+// @beta @deprecated
 export interface ColorPickerProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement>, CommonProps {
     colorDefs?: ColorDef[];
     disabled?: boolean;
@@ -224,10 +224,10 @@ export class ColorPropertyEditor extends PropertyEditorBase {
     get reactNode(): React_2.ReactNode;
 }
 
-// @beta
+// @beta @deprecated
 export function ColorSwatch(props: ColorSwatchProps): React_2.JSX.Element;
 
-// @beta
+// @beta @deprecated
 export interface ColorSwatchProps extends React_2.ButtonHTMLAttributes<HTMLButtonElement>, CommonProps {
     colorDef: ColorDef;
     onColorPick?: ((color: ColorDef, e: React_2.MouseEvent) => void) | undefined;
@@ -576,10 +576,10 @@ export function getCSSColorFromDef(colorDef: ColorDef): string;
 // @internal (undocumented)
 export function getPercentageOfRectangle(rect: DOMRect, pointer: number): number;
 
-// @beta
+// @beta @deprecated
 export function HueSlider({ isHorizontal, onHueChange, hsv, className, style, }: HueSliderProps): React_2.JSX.Element;
 
-// @beta
+// @beta @deprecated
 export interface HueSliderProps extends React_2.HTMLAttributes<HTMLDivElement>, CommonProps {
     hsv: HSVColor;
     isHorizontal?: boolean;
@@ -733,10 +733,10 @@ export function RailMarkers({ showToolTip, percent, tooltipText, markDate, }: {
     markDate?: DateMarkerProps;
 }): React_2.JSX.Element;
 
-// @beta
+// @beta @deprecated
 export function SaturationPicker({ onSaturationChange, hsv, className, style, }: SaturationPickerProps): React_2.JSX.Element;
 
-// @beta
+// @beta @deprecated
 export interface SaturationPickerProps extends React_2.HTMLAttributes<HTMLDivElement>, CommonProps {
     hsv: HSVColor;
     onSaturationChange?: ((saturation: HSVColor) => void) | undefined;

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -47,9 +47,13 @@ internal;DateField({ initialDate, onDateChange, readOnly, dateFormatter, timeDis
 internal;DateFieldProps 
 public;DateFormatOptions
 alpha;DatePicker(props: DatePickerProps): React_3.JSX.Element
+deprecated;DatePicker(props: DatePickerProps): React_3.JSX.Element
 alpha;DatePickerPopupButton({ displayEditField, timeDisplay, selected, onDateChange, dateFormatter, buttonToolTip, fieldStyle, fieldClassName, style, }: DatePickerPopupButtonProps): React_3.JSX.Element
+deprecated;DatePickerPopupButton({ displayEditField, timeDisplay, selected, onDateChange, dateFormatter, buttonToolTip, fieldStyle, fieldClassName, style, }: DatePickerPopupButtonProps): React_3.JSX.Element
 alpha;DatePickerPopupButtonProps 
+deprecated;DatePickerPopupButtonProps 
 alpha;DatePickerProps
+deprecated;DatePickerProps
 internal;DateTimeEditor 
 internal;DateTimePropertyEditor 
 public;DateTimeTypeConverter 

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -128,6 +128,7 @@ public;IMutablePropertyGridModel
 internal;InternalToolbarComponent(props: InternalToolbarComponentProps): React_3.JSX.Element
 internal;InternalToolbarComponentProps 
 alpha;IntlFormatter 
+deprecated;IntlFormatter 
 public;IntTypeConverter 
 public;IPropertyDataFilterer
 public;IPropertyDataProvider

--- a/common/api/summary/imodel-components-react.exports.csv
+++ b/common/api/summary/imodel-components-react.exports.csv
@@ -1,20 +1,30 @@
 sep=;
 Release Tag;API Item
 public;AlphaSlider 
+deprecated;AlphaSlider 
 public;AlphaSliderProps 
+deprecated;AlphaSliderProps 
 public;AnimationFractionChangeHandler = (animationFraction: number) => void
 alpha;BaseSolarDataProvider 
 alpha;BaseTimelineDataProvider 
 beta;ColorEditor 
 beta;ColorPickerButton: (props: ColorPickerProps) => React_2.ReactElement | null
+deprecated;ColorPickerButton: (props: ColorPickerProps) => React_2.ReactElement | null
 beta;ColorPickerDialog({ dialogTitle, color, onOkResult, onCancelResult, colorPresets, colorInputType, }: ColorPickerDialogProps): React_2.JSX.Element
+deprecated;ColorPickerDialog({ dialogTitle, color, onOkResult, onCancelResult, colorPresets, colorInputType, }: ColorPickerDialogProps): React_2.JSX.Element
 beta;ColorPickerDialogProps
+deprecated;ColorPickerDialogProps
 public;ColorPickerPopup: (props: ColorPickerPopupProps) => React_2.ReactElement | null
+deprecated;ColorPickerPopup: (props: ColorPickerPopupProps) => React_2.ReactElement | null
 public;ColorPickerPopupProps 
+deprecated;ColorPickerPopupProps 
 beta;ColorPickerProps 
+deprecated;ColorPickerProps 
 beta;ColorPropertyEditor 
 beta;ColorSwatch(props: ColorSwatchProps): React_2.JSX.Element
+deprecated;ColorSwatch(props: ColorSwatchProps): React_2.JSX.Element
 beta;ColorSwatchProps 
+deprecated;ColorSwatchProps 
 public;Cube 
 internal;CubeFace 
 internal;CubeFaceProps 
@@ -52,7 +62,9 @@ alpha;FormatUnitsProps
 internal;getCSSColorFromDef(colorDef: ColorDef): string
 internal;getPercentageOfRectangle(rect: DOMRect, pointer: number): number
 beta;HueSlider({ isHorizontal, onHueChange, hsv, className, style, }: HueSliderProps): React_2.JSX.Element
+deprecated;HueSlider({ isHorizontal, onHueChange, hsv, className, style, }: HueSliderProps): React_2.JSX.Element
 beta;HueSliderProps 
+deprecated;HueSliderProps 
 internal;InlineEdit 
 public;LineWeightSwatch 
 public;LineWeightSwatchProps 
@@ -71,7 +83,9 @@ beta;QuantityNumberInputProps
 beta;QuantityProps 
 internal;RailMarkers({ showToolTip, percent, tooltipText, markDate, }:
 beta;SaturationPicker({ onSaturationChange, hsv, className, style, }: SaturationPickerProps): React_2.JSX.Element
+deprecated;SaturationPicker({ onSaturationChange, hsv, className, style, }: SaturationPickerProps): React_2.JSX.Element
 beta;SaturationPickerProps 
+deprecated;SaturationPickerProps 
 internal;Scrubber(props: ScrubberProps): React_2.JSX.Element
 internal;ScrubberProps 
 alpha;SolarDataProvider

--- a/common/changes/@itwin/components-react/deprecate-pickers_2024-03-05-19-52.json
+++ b/common/changes/@itwin/components-react/deprecate-pickers_2024-03-05-19-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Depreate date picker components.",
+      "comment": "Deprecate date picker components.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/deprecate-pickers_2024-03-05-19-52.json
+++ b/common/changes/@itwin/components-react/deprecate-pickers_2024-03-05-19-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Depreate date picker components.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/imodel-components-react/deprecate-pickers_2024-03-05-19-52.json
+++ b/common/changes/@itwin/imodel-components-react/deprecate-pickers_2024-03-05-19-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Deprecate color picker components.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,6 +5,10 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Changes](#changes)
   - [Fixes](#fixes)
+- [@itwin/components-react](#itwincomponents-react)
+  - [Deprecations](#deprecations)
+- [@itwin/imodel-components-react](#itwinimodel-components-react)
+  - [Deprecations](#deprecations-1)
 
 ## @itwin/appui-react
 
@@ -18,3 +22,15 @@ Table of contents:
 
 - Fix the issue when right-click + left-click starts a widget drag interaction. [#730](https://github.com/iTwin/appui/pull/730)
 - Fix polar mode AccuDraw input focus by correctly focusing the distance field. [#753](https://github.com/iTwin/appui/pull/753)
+
+## @itwin/components-react
+
+### Deprecations
+
+- `DatePicker`, `DatePickerPopupButton` are deprecated in favor of [iTwinUI date picker](https://itwinui.bentley.com/docs/datepicker). [#755](https://github.com/iTwin/appui/pull/755)
+
+## @itwin/imodel-components-react
+
+### Deprecations
+
+- `AlphaSlider`, `ColorPickerButton`, `ColorPickerDialog`, `ColorPickerPopup`, `ColorSwatch`, `HueSlider`, `SaturationPicker` are deprecated in favor of [iTwinUI color picker](https://itwinui.bentley.com/docs/colorpicker). [#755](https://github.com/iTwin/appui/pull/755)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -27,7 +27,7 @@ Table of contents:
 
 ### Deprecations
 
-- `DatePicker`, `DatePickerPopupButton` are deprecated in favor of [iTwinUI date picker](https://itwinui.bentley.com/docs/datepicker). [#755](https://github.com/iTwin/appui/pull/755)
+- `DatePicker`, `DatePickerPopupButton`, `IntlFormatter` are deprecated in favor of [iTwinUI date picker](https://itwinui.bentley.com/docs/datepicker). [#755](https://github.com/iTwin/appui/pull/755)
 
 ## @itwin/imodel-components-react
 

--- a/e2e-tests/tests/accudraw/accudraw-dialog.test.ts
+++ b/e2e-tests/tests/accudraw/accudraw-dialog.test.ts
@@ -13,5 +13,11 @@ test("accudraw dialog test", async ({ page, baseURL }) => {
   await page.getByRole("button", { name: "Open Accudraw Dialog" }).click();
 
   const accudrawDialog = page.getByTestId("core-dialog-container");
+  await expect(
+    accudrawDialog.getByRole("img", { name: "distance" })
+  ).toBeVisible();
+  await expect(
+    accudrawDialog.getByRole("img", { name: "angle" })
+  ).toBeVisible();
   await expect(accudrawDialog).toHaveScreenshot();
 });

--- a/ui/components-react/src/components-react/datepicker/DatePicker.tsx
+++ b/ui/components-react/src/components-react/datepicker/DatePicker.tsx
@@ -42,6 +42,7 @@ export interface DatePickerProps {
  * @alpha
  * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/datepicker iTwinUI date picker} instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function DatePicker(props: DatePickerProps) {
   const previousMonthLabel = React.useRef(
     UiComponents.localization.getLocalizedString(

--- a/ui/components-react/src/components-react/datepicker/DatePicker.tsx
+++ b/ui/components-react/src/components-react/datepicker/DatePicker.tsx
@@ -27,6 +27,7 @@ function isSameDay(a: Date, b: Date) {
 /**
  * Props for [[DatePicker]] component.
  * @alpha
+ * @deprecated in 4.11.x. Props of deprecated component {@link DatePicker}.
  */
 export interface DatePickerProps {
   /** defines both date and time */
@@ -39,6 +40,7 @@ export interface DatePickerProps {
 
 /** DatePicker component. Show a month selector and a day calendar to select a specific date.
  * @alpha
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/datepicker iTwinUI date picker} instead.
  */
 export function DatePicker(props: DatePickerProps) {
   const previousMonthLabel = React.useRef(

--- a/ui/components-react/src/components-react/datepicker/DatePickerPopupButton.tsx
+++ b/ui/components-react/src/components-react/datepicker/DatePickerPopupButton.tsx
@@ -20,7 +20,9 @@ import { TimeField } from "./TimeField";
 import "./DatePickerPopupButton.scss";
 
 /** Props used by [[DatePickerPopupButton]] component.
- * @alpha */
+ * @alpha
+ * @deprecated in 4.11.x. Props of deprecated component {@link DatePickerPopupButton}.
+ */
 export interface DatePickerPopupButtonProps extends CommonProps {
   /** Date to be shown as the selected date. */
   selected: Date;
@@ -43,7 +45,8 @@ export interface DatePickerPopupButtonProps extends CommonProps {
 
 /** Component that displays a button used to pick a date and optionally a time.
  * @alpha
- * */
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/datepicker iTwinUI date picker} instead.
+ */
 export function DatePickerPopupButton({
   displayEditField,
   timeDisplay,

--- a/ui/components-react/src/components-react/datepicker/DatePickerPopupButton.tsx
+++ b/ui/components-react/src/components-react/datepicker/DatePickerPopupButton.tsx
@@ -57,7 +57,8 @@ export function DatePickerPopupButton({
   fieldStyle,
   fieldClassName,
   style,
-}: DatePickerPopupButtonProps) {
+}: // eslint-disable-next-line deprecation/deprecation
+DatePickerPopupButtonProps) {
   const [workingDate, setWorkingDate] = React.useState(
     new Date(selected.getTime())
   );
@@ -158,7 +159,7 @@ export function DatePickerPopupButton({
           className="components-date-picker-calendar-popup-panel"
           data-testid="components-date-picker-calendar-popup-panel"
         >
-          <DatePicker
+          <DatePicker // eslint-disable-line deprecation/deprecation
             selected={workingDate}
             onDateChange={handleOnDateChanged}
             showFocusOutline={showFocusOutline}

--- a/ui/components-react/src/components-react/datepicker/IntlFormatter.ts
+++ b/ui/components-react/src/components-react/datepicker/IntlFormatter.ts
@@ -15,6 +15,7 @@ import type { DateFormatter } from "@itwin/appui-abstract";
  * support parsing, so when used by [[DatePickerPopup]] the edit field will be readonly. If
  * a parseData function is implemented then the edit field will be editable.
  * @alpha
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/datepicker iTwinUI date picker} instead.
  */
 export class IntlFormatter implements DateFormatter {
   constructor(private _intlFormatter?: Intl.DateTimeFormat) {}

--- a/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
+++ b/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
@@ -333,7 +333,7 @@ export class DateTimeEditor
                 className="components-date-picker-calendar-popup-panel"
                 data-testid="components-date-picker-calendar-popup-panel"
               >
-                <DatePicker
+                <DatePicker // eslint-disable-line deprecation/deprecation
                   selected={date}
                   onDateChange={this._handleChange}
                   showFocusOutline={false}

--- a/ui/components-react/src/test/datepicker/DateField.test.tsx
+++ b/ui/components-react/src/test/datepicker/DateField.test.tsx
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 import { expect } from "chai";
 import React from "react";
 import sinon from "sinon";
@@ -14,6 +13,8 @@ import { TimeDisplay } from "@itwin/appui-abstract";
 import { DateField } from "../../components-react/datepicker/DateField";
 import TestUtils from "../TestUtils";
 import { IntlFormatter } from "../../components-react/datepicker/IntlFormatter";
+
+/* eslint-disable deprecation/deprecation */
 
 // Note many test do not test exact time because it may yield different results depending on time zone of machine running test.
 

--- a/ui/components-react/src/test/datepicker/DatePicker.test.tsx
+++ b/ui/components-react/src/test/datepicker/DatePicker.test.tsx
@@ -12,6 +12,8 @@ import TestUtils from "../TestUtils";
 import { DatePicker } from "../../components-react/datepicker/DatePicker";
 import { adjustDateToTimezone } from "../../components-react/common/DateUtils";
 
+/* eslint-disable deprecation/deprecation */
+
 describe("<DatePicker />", () => {
   let renderSpy: sinon.SinonSpy;
 

--- a/ui/components-react/src/test/datepicker/DatePickerPopupButton.test.tsx
+++ b/ui/components-react/src/test/datepicker/DatePickerPopupButton.test.tsx
@@ -12,6 +12,8 @@ import { DatePickerPopupButton } from "../../components-react/datepicker/DatePic
 import { TimeDisplay } from "@itwin/appui-abstract";
 import { Key } from "ts-key-enum";
 
+/* eslint-disable deprecation/deprecation */
+
 describe("<DatePickerPopupButton />", () => {
   let renderSpy: sinon.SinonSpy;
 

--- a/ui/imodel-components-react/src/imodel-components-react/color/AlphaSlider.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/AlphaSlider.tsx
@@ -32,12 +32,14 @@ export interface AlphaSliderProps
  * @public
  * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class AlphaSlider extends React.PureComponent<AlphaSliderProps> {
   private _container: HTMLDivElement | null = null;
   private _transparencyLabel =
     UiIModelComponents.translate("color.transparency");
 
   /** @internal */
+  // eslint-disable-next-line deprecation/deprecation
   constructor(props: AlphaSliderProps) {
     super(props);
   }

--- a/ui/imodel-components-react/src/imodel-components-react/color/AlphaSlider.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/AlphaSlider.tsx
@@ -15,6 +15,7 @@ import { UiIModelComponents } from "../UiIModelComponents";
 
 /** Properties for the [[AlphaSlider]] React component
  * @public
+ * @deprecated in 4.11.x. Props of deprecated component {@link AlphaSlider}.
  */
 export interface AlphaSliderProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -29,6 +30,7 @@ export interface AlphaSliderProps
 
 /** AlphaSlider component used to set the alpha value.
  * @public
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export class AlphaSlider extends React.PureComponent<AlphaSliderProps> {
   private _container: HTMLDivElement | null = null;

--- a/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerButton.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerButton.tsx
@@ -59,6 +59,7 @@ function ColorOptions({
 
 /** Properties for the [[ColorPickerButton]] React component
  * @beta
+ * @deprecated in 4.11.x. Props of deprecated component {@link ColorPickerButton}.
  */
 export interface ColorPickerProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -217,6 +218,7 @@ const ForwardRefColorPickerButton = React.forwardRef<
 /** ColorPickerButton component
  * @note Using forwardRef so the ColorEditor (Type Editor) can access the ref of the button element inside this component.
  * @beta
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export const ColorPickerButton: (
   props: ColorPickerProps

--- a/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerButton.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerButton.tsx
@@ -44,6 +44,7 @@ function ColorOptions({
         style={containerStyle}
       >
         {options.map((color, index) => (
+          // eslint-disable-next-line deprecation/deprecation
           <ColorSwatch
             className="components-colorpicker-swatch"
             key={index}
@@ -89,6 +90,7 @@ export interface ColorPickerProps
 // Defined using following pattern (const ColorPickerButton at bottom) to ensure useful API documentation is extracted
 const ForwardRefColorPickerButton = React.forwardRef<
   HTMLButtonElement,
+  // eslint-disable-next-line deprecation/deprecation
   ColorPickerProps
 >(function ForwardRefColorPickerButton(
   {
@@ -221,5 +223,6 @@ const ForwardRefColorPickerButton = React.forwardRef<
  * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export const ColorPickerButton: (
+  // eslint-disable-next-line deprecation/deprecation
   props: ColorPickerProps
 ) => React.ReactElement | null = ForwardRefColorPickerButton;

--- a/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerDialog.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerDialog.tsx
@@ -45,7 +45,8 @@ export function ColorPickerDialog({
   onCancelResult,
   colorPresets,
   colorInputType,
-}: ColorPickerDialogProps) {
+}: // eslint-disable-next-line deprecation/deprecation
+ColorPickerDialogProps) {
   const [activeColor, setActiveColor] = React.useState(color);
   const dialogContainer = React.useRef<HTMLDivElement>(null);
 

--- a/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerDialog.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerDialog.tsx
@@ -6,8 +6,6 @@
  * @module Color
  */
 
-// cSpell:ignore colorpicker
-
 import * as React from "react";
 import { DialogButtonType } from "@itwin/appui-abstract";
 import { Dialog } from "@itwin/core-react";
@@ -22,6 +20,7 @@ import {
 
 /** Properties for the [[ColorPickerDialog]] React component
  * @beta
+ * @deprecated in 4.11.x. Props of deprecated component {@link ColorPickerDialog}.
  */
 export interface ColorPickerDialogProps {
   dialogTitle: string;
@@ -37,6 +36,7 @@ export interface ColorPickerDialogProps {
 /**
  * Color Picker Dialog to use as modal dialog.
  * @beta
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export function ColorPickerDialog({
   dialogTitle,

--- a/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerPopup.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerPopup.tsx
@@ -6,15 +6,12 @@
  * @module Color
  */
 
-// cSpell:ignore colorpicker
-
 import * as React from "react";
 import classnames from "classnames";
 import { ColorByName, ColorDef } from "@itwin/core-common";
 import { RelativePosition } from "@itwin/appui-abstract";
 import type { CommonProps } from "@itwin/core-react";
 import { Icon, Popup, useRefs } from "@itwin/core-react";
-// import { ColorPickerPanel } from "./ColorPickerPanel";
 import {
   ColorBuilder,
   ColorInputPanel,
@@ -33,6 +30,7 @@ import {
 
 /** Properties for the [[ColorPickerPopup]] React component
  * @public
+ * @deprecated in 4.11.x. Props of deprecated component {@link ColorPickerPopup}.
  */
 export interface ColorPickerPopupProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -229,6 +227,7 @@ const ForwardRefColorPickerPopup = React.forwardRef<
  * ColorPickerButton component that allows user to select a color from a set of color swatches or to define a new color.
  * @note Using forwardRef so the ColorEditor (Type Editor) can access the ref of the button element inside this component.
  * @public
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export const ColorPickerPopup: (
   props: ColorPickerPopupProps

--- a/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerPopup.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerPopup.tsx
@@ -66,6 +66,7 @@ export interface ColorPickerPopupProps
 
 const ForwardRefColorPickerPopup = React.forwardRef<
   HTMLButtonElement,
+  // eslint-disable-next-line deprecation/deprecation
   ColorPickerPopupProps
 >(function ForwardRefColorPickerPopup(props, ref) {
   const target = React.useRef<HTMLButtonElement>(null);
@@ -230,5 +231,6 @@ const ForwardRefColorPickerPopup = React.forwardRef<
  * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export const ColorPickerPopup: (
+  // eslint-disable-next-line deprecation/deprecation
   props: ColorPickerPopupProps
 ) => React.ReactElement | null = ForwardRefColorPickerPopup;

--- a/ui/imodel-components-react/src/imodel-components-react/color/HueSlider.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/HueSlider.tsx
@@ -77,6 +77,7 @@ function calculateChange(
 
 /** Properties for the [[HueSlider]] React component
  * @beta
+ * @deprecated in 4.11.x. Props of deprecated component {@link HueSlider}.
  */
 export interface HueSliderProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -91,6 +92,7 @@ export interface HueSliderProps
 
 /** HueSlider component used to set the hue value.
  * @beta
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export function HueSlider({
   isHorizontal,

--- a/ui/imodel-components-react/src/imodel-components-react/color/HueSlider.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/HueSlider.tsx
@@ -100,7 +100,8 @@ export function HueSlider({
   hsv,
   className,
   style,
-}: HueSliderProps) {
+}: // eslint-disable-next-line deprecation/deprecation
+HueSliderProps) {
   const container = React.useRef<HTMLDivElement>(null);
   const [hueLabel] = React.useState(() =>
     UiIModelComponents.translate("color.hue")

--- a/ui/imodel-components-react/src/imodel-components-react/color/SaturationPicker.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/SaturationPicker.tsx
@@ -77,6 +77,7 @@ function calculateChange(
 
 /** Properties for the [[SaturationPicker]] React component
  * @beta
+ * @deprecated in 4.11.x. Props of deprecated component {@link SaturationPicker}.
  */
 export interface SaturationPickerProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -89,6 +90,7 @@ export interface SaturationPickerProps
 
 /** SaturationPicker component used to set the saturation value.
  * @beta
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export function SaturationPicker({
   onSaturationChange,

--- a/ui/imodel-components-react/src/imodel-components-react/color/SaturationPicker.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/SaturationPicker.tsx
@@ -97,7 +97,8 @@ export function SaturationPicker({
   hsv,
   className,
   style,
-}: SaturationPickerProps) {
+}: // eslint-disable-next-line deprecation/deprecation
+SaturationPickerProps) {
   const container = React.useRef<HTMLDivElement>(null);
   const [saturationLabel] = React.useState(() =>
     UiIModelComponents.translate("color.saturation")

--- a/ui/imodel-components-react/src/imodel-components-react/color/Swatch.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/Swatch.tsx
@@ -15,6 +15,7 @@ import { getCSSColorFromDef } from "./getCSSColorFromDef";
 
 /** Properties for the [[ColorSwatch]] React component
  * @beta
+ * @deprecated in 4.11.x. Props of deprecated component {@link ColorSwatch}.
  */
 export interface ColorSwatchProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -29,6 +30,7 @@ export interface ColorSwatchProps
 
 /** ColorSwatch Functional component displays a color swatch in a button
  * @beta
+ * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
 export function ColorSwatch(props: ColorSwatchProps) {
   const rgbaString = getCSSColorFromDef(props.colorDef);

--- a/ui/imodel-components-react/src/imodel-components-react/color/Swatch.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/Swatch.tsx
@@ -32,6 +32,7 @@ export interface ColorSwatchProps
  * @beta
  * @deprecated in 4.11.x. Use {@link https://itwinui.bentley.com/docs/colorpicker iTwinUI color picker} instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function ColorSwatch(props: ColorSwatchProps) {
   const rgbaString = getCSSColorFromDef(props.colorDef);
   const colorStyle: React.CSSProperties = {

--- a/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.tsx
@@ -172,7 +172,7 @@ export class ColorEditor
         className={classnames("components-color-editor", this.props.className)}
         style={this.props.style}
       >
-        <ColorPickerButton
+        <ColorPickerButton // eslint-disable-line deprecation/deprecation
           ref={this._buttonElement}
           initialColor={colorDef}
           colorDefs={

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/SolarTimeline.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/SolarTimeline.tsx
@@ -41,6 +41,8 @@ import {
 import { UiIModelComponents } from "../UiIModelComponents";
 import { SvgCalendar, SvgLoop, SvgSettings } from "@itwin/itwinui-icons-react";
 
+/* eslint-disable deprecation/deprecation */
+
 // cSpell:ignore millisec solarsettings showticks shadowcolor solartimeline datepicker millisecs
 
 const millisecPerMinute = 1000 * 60;

--- a/ui/imodel-components-react/src/test/color/AlphaSlider.test.tsx
+++ b/ui/imodel-components-react/src/test/color/AlphaSlider.test.tsx
@@ -6,8 +6,10 @@
 import { expect } from "chai";
 import React from "react";
 import sinon from "sinon";
-import { fireEvent, render } from "@testing-library/react"; // , waitForElement
+import { fireEvent, render } from "@testing-library/react";
 import { AlphaSlider } from "../../imodel-components-react/color/AlphaSlider";
+
+/* eslint-disable deprecation/deprecation */
 
 describe("<AlphaSlider />", () => {
   const alpha = 0.5;

--- a/ui/imodel-components-react/src/test/color/ColorPickerButton.test.tsx
+++ b/ui/imodel-components-react/src/test/color/ColorPickerButton.test.tsx
@@ -10,7 +10,7 @@ import { ColorByName, ColorDef } from "@itwin/core-common";
 import { fireEvent, render } from "@testing-library/react";
 import { ColorPickerButton } from "../../imodel-components-react/color/ColorPickerButton";
 
-// cSpell:ignore colorpicker
+/* eslint-disable deprecation/deprecation */
 
 describe("<ColorPickerButton/>", () => {
   const colorDef = ColorDef.create(ColorByName.blue);

--- a/ui/imodel-components-react/src/test/color/ColorPickerDialog.test.tsx
+++ b/ui/imodel-components-react/src/test/color/ColorPickerDialog.test.tsx
@@ -11,7 +11,7 @@ import { TestUtils } from "../TestUtils";
 import { ColorPickerDialog } from "../../imodel-components-react/color/ColorPickerDialog";
 import { ColorValue } from "@itwin/itwinui-react";
 
-// cSpell:ignore colorpicker
+/* eslint-disable deprecation/deprecation */
 
 describe("ColorPickerDialog", () => {
   before(async () => {

--- a/ui/imodel-components-react/src/test/color/ColorPickerPopup.test.tsx
+++ b/ui/imodel-components-react/src/test/color/ColorPickerPopup.test.tsx
@@ -14,6 +14,8 @@ import { ColorValue } from "@itwin/itwinui-react";
 import { TestUtils } from "../TestUtils";
 import { ColorPickerPopup } from "../../imodel-components-react/color/ColorPickerPopup";
 
+/* eslint-disable deprecation/deprecation */
+
 describe("<ColorPickerPopup/>", () => {
   const colorDef = ColorDef.create(ColorByName.blue);
 

--- a/ui/imodel-components-react/src/test/color/HueSlider.test.tsx
+++ b/ui/imodel-components-react/src/test/color/HueSlider.test.tsx
@@ -2,14 +2,15 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 import { expect } from "chai";
 import React from "react";
 import sinon from "sinon";
 import { HSVColor } from "@itwin/core-common";
-import { fireEvent, render } from "@testing-library/react"; // , waitForElement
+import { fireEvent, render } from "@testing-library/react";
 import { TestUtils } from "../TestUtils";
 import { HueSlider } from "../../imodel-components-react/color/HueSlider";
+
+/* eslint-disable deprecation/deprecation */
 
 describe("<HueSlider />", () => {
   const hsv = new HSVColor(60, 100, 50);

--- a/ui/imodel-components-react/src/test/color/SaturationPicker.test.tsx
+++ b/ui/imodel-components-react/src/test/color/SaturationPicker.test.tsx
@@ -11,6 +11,8 @@ import { fireEvent, render } from "@testing-library/react";
 import { TestUtils } from "../TestUtils";
 import { SaturationPicker } from "../../imodel-components-react/color/SaturationPicker";
 
+/* eslint-disable deprecation/deprecation */
+
 describe("<SaturationPicker />", () => {
   const hsv = new HSVColor(30, 30, 30);
 

--- a/ui/imodel-components-react/src/test/color/Swatch.test.tsx
+++ b/ui/imodel-components-react/src/test/color/Swatch.test.tsx
@@ -7,9 +7,11 @@ import { expect } from "chai";
 import React from "react";
 import sinon from "sinon";
 import { ColorDef } from "@itwin/core-common";
-import { fireEvent, render } from "@testing-library/react"; // , waitForElement
+import { fireEvent, render } from "@testing-library/react";
 import { ColorSwatch } from "../../imodel-components-react/color/Swatch";
 import { TestUtils } from "../TestUtils";
+
+/* eslint-disable deprecation/deprecation */
 
 describe("<ColorSwatch />", () => {
   const colorDef = ColorDef.from(255, 0, 0, 255);


### PR DESCRIPTION
## Changes

This PR deprecates date and color pickers in favor of iTwinUI components.

## Testing

N/A
