### PR TITLE
Deprecate non-snap toolbar opacity setting

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -2166,6 +2166,7 @@ export interface FrameworkVisibility {
     showUiAndCancelTimer(): void;
     showUiAndResetTimer(): void;
     snapWidgetOpacity: boolean;
+    // @deprecated
     useProximityOpacity: boolean;
 }
 

--- a/common/changes/@itwin/appui-react/deprecate-non-snap-toolbar-opacity-setting_2024-03-12-12-56.json
+++ b/common/changes/@itwin/appui-react/deprecate-non-snap-toolbar-opacity-setting_2024-03-12-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Deprecate useProximityOpacity visibility setting.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/deprecate-non-snap-toolbar-opacity-setting_2024-03-12-12-56.json
+++ b/common/changes/@itwin/components-react/deprecate-non-snap-toolbar-opacity-setting_2024-03-12-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Deprecate useProximityOpacity visibility setting.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -47,6 +47,8 @@ Table of contents:
 
 - `MenuItemProps` in favor of `CursorMenuItemProps`. [#729](https://github.com/iTwin/appui/pull/729)
 
+- `useProximityOpacity` setting of `FrameworkVisibility` is deprecated. The preferred mode is to change opacity immediately when the mouse gets close (use `FrameworkVisibility.snapWidgetOpacity`). [#765](https://github.com/iTwin/appui/pull/765)
+
 ### Additions
 
 - `UiFramework` methods detailed above which replace FrameworkUiAdmin methods. [#729](https://github.com/iTwin/appui/pull/729)

--- a/ui/appui-react/src/appui-react/framework/FrameworkVisibility.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkVisibility.ts
@@ -28,7 +28,7 @@ export interface FrameworkVisibility {
   inactivityTime: number;
 
   /** Determines whether the proximity of the mouse should alter the opacity of a toolbar. Defaults to `true`.
-   * @deprecated in 4.11.x. The preferred mode is to change opacity in a snappy way (use {@link snapWidgetOpacity}).
+   * @deprecated in 4.11.x. The preferred mode is to change opacity in a snappy way (use {@link FrameworkVisibility.snapWidgetOpacity}).
    */
   useProximityOpacity: boolean;
 

--- a/ui/appui-react/src/appui-react/framework/FrameworkVisibility.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkVisibility.ts
@@ -27,10 +27,12 @@ export interface FrameworkVisibility {
   /** Determines the amount of inactivity time before the Ui is hidden. Defaults to 3.5 seconds. */
   inactivityTime: number;
 
-  /** Determines whether the proximity of the mouse should alter the opacity of a toolbar. Defaults to true. */
+  /** Determines whether the proximity of the mouse should alter the opacity of a toolbar. Defaults to `true`.
+   * @deprecated in 4.11.x. The preferred mode is to change opacity in a snappy way (use {@link snapWidgetOpacity}).
+   */
   useProximityOpacity: boolean;
 
-  /** Determines whether the opacity of a toolbar should snap. Defaults to false. */
+  /** Determines whether the opacity of a toolbar should change immediately when the mouse gets close. Defaults to `false`. */
   snapWidgetOpacity: boolean;
 
   /** Handler for when a Frontstage is ready */

--- a/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.tsx
+++ b/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.tsx
@@ -159,6 +159,7 @@ export function UiSettingsPage() {
     () => UiFramework.visibility.autoHideUi
   );
   const [useProximityOpacity, setUseProximityOpacity] = React.useState(
+    // eslint-disable-next-line deprecation/deprecation
     () => UiFramework.visibility.useProximityOpacity
   );
   const [snapWidgetOpacity, setSnapWidgetOpacity] = React.useState(
@@ -204,7 +205,9 @@ export function UiSettingsPage() {
           setWidgetOpacity(UiFramework.getWidgetOpacity());
         if (UiFramework.visibility.autoHideUi !== autoHideUi)
           setAutoHideUi(UiFramework.visibility.autoHideUi);
+        // eslint-disable-next-line deprecation/deprecation
         if (UiFramework.visibility.useProximityOpacity !== useProximityOpacity)
+          // eslint-disable-next-line deprecation/deprecation
           setUseProximityOpacity(UiFramework.visibility.useProximityOpacity);
         if (UiFramework.visibility.snapWidgetOpacity !== snapWidgetOpacity)
           setSnapWidgetOpacity(UiFramework.visibility.snapWidgetOpacity);
@@ -255,6 +258,7 @@ export function UiSettingsPage() {
   }, [autoHideUi]);
 
   const onUseProximityOpacityChange = React.useCallback(async () => {
+    // eslint-disable-next-line deprecation/deprecation
     UiFramework.visibility.useProximityOpacity = !useProximityOpacity;
   }, [useProximityOpacity]);
 

--- a/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
@@ -72,7 +72,7 @@ function OriginalToolbar(props: ToolbarProps) {
     return items.map((item) => toUIAToolbarItem(item));
   }, [items]);
   return (
-    <CR_Toolbar // eslint-disable-line deprecation/deprecation
+    <CR_Toolbar
       items={uiaItems}
       syncUiEvent={SyncUiEventDispatcher.onSyncUiEvent}
       {...other}

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
@@ -167,17 +167,9 @@ const useProximityOpacitySetting = () => {
   );
 
   React.useEffect(() => {
-    // istanbul ignore next
-    const handleUiVisibilityChanged = () => {
-      // eslint-disable-next-line deprecation/deprecation
-      setProximityOpacity(UiFramework.visibility.useProximityOpacity);
-    };
-    UiFramework.onUiVisibilityChanged.addListener(handleUiVisibilityChanged);
-    return () => {
-      UiFramework.onUiVisibilityChanged.removeListener(
-        handleUiVisibilityChanged
-      );
-    };
+    UiFramework.onUiVisibilityChanged.addListener(
+      () => setProximityOpacity(UiFramework.visibility.useProximityOpacity) // eslint-disable-line deprecation/deprecation
+    );
   }, []);
 
   return proximityOpacity;
@@ -189,16 +181,9 @@ const useSnapWidgetOpacitySetting = () => {
   );
 
   React.useEffect(() => {
-    // istanbul ignore next
-    const handleUiVisibilityChanged = () => {
-      setSnapWidgetOpacity(UiFramework.visibility.snapWidgetOpacity);
-    };
-    UiFramework.onUiVisibilityChanged.addListener(handleUiVisibilityChanged);
-    return () => {
-      UiFramework.onUiVisibilityChanged.removeListener(
-        handleUiVisibilityChanged
-      );
-    };
+    UiFramework.onUiVisibilityChanged.addListener(() =>
+      setSnapWidgetOpacity(UiFramework.visibility.snapWidgetOpacity)
+    );
   }, []);
 
   return snapWidgetOpacity;

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
@@ -163,11 +163,13 @@ function combineItems(
 
 const useProximityOpacitySetting = () => {
   const [proximityOpacity, setProximityOpacity] = React.useState(
-    UiFramework.visibility.useProximityOpacity
+    UiFramework.visibility.useProximityOpacity // eslint-disable-line deprecation/deprecation
   );
+
   React.useEffect(() => {
     // istanbul ignore next
     const handleUiVisibilityChanged = () => {
+      // eslint-disable-next-line deprecation/deprecation
       setProximityOpacity(UiFramework.visibility.useProximityOpacity);
     };
     UiFramework.onUiVisibilityChanged.addListener(handleUiVisibilityChanged);
@@ -177,7 +179,29 @@ const useProximityOpacitySetting = () => {
       );
     };
   }, []);
+
   return proximityOpacity;
+};
+
+const useSnapWidgetOpacitySetting = () => {
+  const [snapWidgetOpacity, setSnapWidgetOpacity] = React.useState(
+    UiFramework.visibility.snapWidgetOpacity
+  );
+
+  React.useEffect(() => {
+    // istanbul ignore next
+    const handleUiVisibilityChanged = () => {
+      setSnapWidgetOpacity(UiFramework.visibility.snapWidgetOpacity);
+    };
+    UiFramework.onUiVisibilityChanged.addListener(handleUiVisibilityChanged);
+    return () => {
+      UiFramework.onUiVisibilityChanged.removeListener(
+        handleUiVisibilityChanged
+      );
+    };
+  }, []);
+
+  return snapWidgetOpacity;
 };
 
 /** Properties for the [[ToolbarComposer]] React components
@@ -224,6 +248,7 @@ export function ToolbarComposer(props: ExtensibleToolbarProps) {
       : ToolbarPanelAlignment.Start;
   const isDragEnabled = React.useContext(ToolbarDragInteractionContext);
   const useProximityOpacity = useProximityOpacitySetting();
+  const snapWidgetOpacity = useSnapWidgetOpacitySetting();
 
   return (
     <Toolbar
@@ -233,7 +258,7 @@ export function ToolbarComposer(props: ExtensibleToolbarProps) {
       items={items}
       useDragInteraction={isDragEnabled}
       toolbarOpacitySetting={
-        useProximityOpacity && !UiFramework.isMobile()
+        (useProximityOpacity || snapWidgetOpacity) && !UiFramework.isMobile()
           ? ToolbarOpacitySetting.Proximity
           : /* istanbul ignore next */ ToolbarOpacitySetting.Defaults
       }

--- a/ui/appui-react/src/appui-react/widgets/BackstageAppButton.tsx
+++ b/ui/appui-react/src/appui-react/widgets/BackstageAppButton.tsx
@@ -63,7 +63,11 @@ export function BackstageAppButton(props: BackstageAppButtonProps) {
 
   let buttonProximityScale: number | undefined;
 
-  if (UiFramework.visibility.useProximityOpacity && !UiFramework.isMobile()) {
+  if (
+    (UiFramework.visibility.useProximityOpacity || // eslint-disable-line deprecation/deprecation
+      UiFramework.visibility.snapWidgetOpacity) &&
+    !UiFramework.isMobile()
+  ) {
     buttonProximityScale = proximityScale;
   }
 

--- a/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
@@ -156,7 +156,11 @@ export function NavigationAidHost(props: NavigationAidHostProps) {
   };
 
   // istanbul ignore else
-  if (UiFramework.visibility.useProximityOpacity && !UiFramework.isMobile()) {
+  if (
+    (UiFramework.visibility.useProximityOpacity || // eslint-disable-line deprecation/deprecation
+      UiFramework.visibility.snapWidgetOpacity) &&
+    !UiFramework.isMobile()
+  ) {
     const navigationAidOpacity = 0.3 * proximityScale + 0.7;
     divStyle.opacity = `${navigationAidOpacity}`;
   }

--- a/ui/components-react/src/components-react/toolbar/InternalToolbarComponent.tsx
+++ b/ui/components-react/src/components-react/toolbar/InternalToolbarComponent.tsx
@@ -601,9 +601,7 @@ export function InternalToolbarComponent(props: InternalToolbarComponentProps) {
         panelAlignment,
         useDragInteraction,
         toolbarOpacitySetting:
-          undefined !== props.toolbarOpacitySetting
-            ? props.toolbarOpacitySetting
-            : ToolbarOpacitySetting.Proximity,
+          props.toolbarOpacitySetting ?? ToolbarOpacitySetting.Proximity,
         overflowDirection:
           direction === OrthogonalDirection.Horizontal
             ? OrthogonalDirection.Vertical


### PR DESCRIPTION
## Changes
Deprecated `FrameworkVisibility.useProximityOpacity`. Modified some toolbar components so `FrameworkVisibility.snapyWidghetOpacity` is now independent from `useProximityOpacity` (before the snap opacity would not work without the turning on the proximity opacity setting).

## Testing
Tested in standalone test-app.
