### PR TITLE
Fix `UiFramework.frontstages.onWidgetStateChangedEvent` event to correctly emit widget state changes

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -2397,7 +2397,7 @@ export function getSelectionContextSyncEventIds(): string[];
 export function getUiSettingsManagerEntry(itemPriority: number): SettingsTabEntry;
 
 // @internal (undocumented)
-export function getWidgetState(widgetDef: WidgetDef, state: NineZoneState): WidgetState;
+export function getWidgetState(widgetDef: WidgetDef, nineZone: NineZoneState): WidgetState;
 
 // @internal (undocumented)
 export type GroupedItems = ReadonlyArray<ReadonlyArray<BackstageItem>>;

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -2257,8 +2257,6 @@ export class FrontstageDef {
     getFloatingWidgetContainerIds(): string[];
     // @beta
     getStagePanelDef(location: StagePanelLocation): StagePanelDef | undefined;
-    // @internal
-    getWidgetCurrentState(widgetDef: WidgetDef): WidgetState | undefined;
     // (undocumented)
     get id(): string;
     // @internal
@@ -2397,6 +2395,9 @@ export function getSelectionContextSyncEventIds(): string[];
 
 // @beta
 export function getUiSettingsManagerEntry(itemPriority: number): SettingsTabEntry;
+
+// @internal (undocumented)
+export function getWidgetState(widgetDef: WidgetDef, state: NineZoneState): WidgetState;
 
 // @internal (undocumented)
 export type GroupedItems = ReadonlyArray<ReadonlyArray<BackstageItem>>;

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -235,6 +235,7 @@ internal;getPanelState(state: NineZoneState, side: PanelSide): StagePanelState.M
 beta;getQuantityFormatsSettingsManagerEntry(itemPriority: number, opts?: Partial
 beta;getSelectionContextSyncEventIds(): string[]
 beta;getUiSettingsManagerEntry(itemPriority: number): SettingsTabEntry
+internal;getWidgetState(widgetDef: WidgetDef, state: NineZoneState): WidgetState
 internal;GroupedItems = ReadonlyArray
 public;GroupItemDef 
 public;GroupItemProps 

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -235,7 +235,7 @@ internal;getPanelState(state: NineZoneState, side: PanelSide): StagePanelState.M
 beta;getQuantityFormatsSettingsManagerEntry(itemPriority: number, opts?: Partial
 beta;getSelectionContextSyncEventIds(): string[]
 beta;getUiSettingsManagerEntry(itemPriority: number): SettingsTabEntry
-internal;getWidgetState(widgetDef: WidgetDef, state: NineZoneState): WidgetState
+internal;getWidgetState(widgetDef: WidgetDef, nineZone: NineZoneState): WidgetState
 internal;GroupedItems = ReadonlyArray
 public;GroupItemDef 
 public;GroupItemProps 

--- a/common/changes/@itwin/appui-react/fix-757_2024-03-15-09-09.json
+++ b/common/changes/@itwin/appui-react/fix-757_2024-03-15-09-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `UiFramework.frontstages.onWidgetStateChangedEvent` event to correctly emit widget state changes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -64,6 +64,7 @@ Table of contents:
 
 - Fix the issue when right-click + left-click starts a widget drag interaction. [#730](https://github.com/iTwin/appui/pull/730)
 - Fix polar mode AccuDraw input focus by correctly focusing the distance field. [#753](https://github.com/iTwin/appui/pull/753)
+- Fix `UiFramework.frontstages.onWidgetStateChangedEvent` event to correctly emit state changes and match `WidgetState` returned by `WidgetDef.state`.
 
 ## @itwin/components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -64,7 +64,7 @@ Table of contents:
 
 - Fix the issue when right-click + left-click starts a widget drag interaction. [#730](https://github.com/iTwin/appui/pull/730)
 - Fix polar mode AccuDraw input focus by correctly focusing the distance field. [#753](https://github.com/iTwin/appui/pull/753)
-- Fix `UiFramework.frontstages.onWidgetStateChangedEvent` event to correctly emit state changes and match `WidgetState` returned by `WidgetDef.state`.
+- Fix `UiFramework.frontstages.onWidgetStateChangedEvent` event to correctly emit state changes and match `WidgetState` returned by `WidgetDef.state`. [#768](https://github.com/iTwin/appui/pull/768)
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -53,7 +53,7 @@ import { StagePanelLocation } from "../stagepanels/StagePanelLocation";
 import { StagePanelState } from "../stagepanels/StagePanelState";
 import type { WidgetConfig } from "../widgets/WidgetConfig";
 import type { WidgetControl } from "../widgets/WidgetControl";
-import { WidgetDef, WidgetType } from "../widgets/WidgetDef";
+import { getWidgetState, WidgetDef, WidgetType } from "../widgets/WidgetDef";
 import { WidgetState } from "../widgets/WidgetState";
 import type { FrontstageConfig } from "./FrontstageConfig";
 import type { FrontstageProvider } from "./FrontstageProvider";
@@ -182,32 +182,7 @@ export class FrontstageDef {
     }
 
     for (const widgetDef of this.widgetDefs) {
-      const widgetId = widgetDef.id;
-      if (widgetDef === this.toolSettings) {
-        if (!nineZone.toolSettings) {
-          widgetMap.set(widgetDef, WidgetState.Hidden);
-          continue;
-        } else if (nineZone.toolSettings.type === "docked") {
-          widgetMap.set(widgetDef, WidgetState.Open);
-          continue;
-        }
-      }
-
-      if (nineZone.draggedTab?.tabId === widgetId) {
-        widgetMap.set(widgetDef, WidgetState.Closed);
-        continue;
-      }
-
-      const tabLocation = getTabLocation(nineZone, widgetId);
-      if (!tabLocation) {
-        widgetMap.set(widgetDef, WidgetState.Hidden);
-        continue;
-      }
-
-      const widget = nineZone.widgets[tabLocation.widgetId];
-      let widgetState = WidgetState.Open;
-      if (widget.minimized || widgetId !== widget.activeTabId)
-        widgetState = WidgetState.Closed;
+      const widgetState = getWidgetState(widgetDef, nineZone);
       widgetMap.set(widgetDef, widgetState);
     }
     return { panelMap, widgetMap };

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -722,48 +722,6 @@ export class FrontstageDef {
     });
   }
 
-  /** Used to determine WidgetState from NinezoneState
-   *  @internal
-   */
-  public getWidgetCurrentState(widgetDef: WidgetDef): WidgetState | undefined {
-    const state = this.nineZoneState;
-    if (!state) return widgetDef.defaultState;
-
-    const tab = state.tabs[widgetDef.id];
-    if (tab && tab.unloaded) {
-      return WidgetState.Unloaded;
-    }
-
-    const toolSettingsTabId = state.toolSettings?.tabId;
-    if (
-      toolSettingsTabId === widgetDef.id &&
-      state.toolSettings?.type === "docked"
-    ) {
-      return WidgetState.Open;
-    }
-
-    const location = getTabLocation(state, widgetDef.id);
-
-    // istanbul ignore next
-    if (!location) return WidgetState.Hidden;
-
-    if (isFloatingTabLocation(location)) {
-      return WidgetState.Floating;
-    }
-
-    let collapsedPanel = false;
-    // istanbul ignore else
-    if ("side" in location) {
-      const panel = state.panels[location.side];
-      collapsedPanel =
-        panel.collapsed || undefined === panel.size || 0 === panel.size;
-    }
-    const widgetContainer = state.widgets[location.widgetId];
-    if (widgetDef.id === widgetContainer.activeTabId && !collapsedPanel)
-      return WidgetState.Open;
-    return WidgetState.Closed;
-  }
-
   public isPopoutWidget(widgetId: string) {
     // istanbul ignore else
     if (this.nineZoneState) {

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -581,25 +581,25 @@ export class WidgetDef {
 }
 
 /** @internal */
-export function getWidgetState(widgetDef: WidgetDef, state: NineZoneState) {
-  const tab = state.tabs[widgetDef.id];
+export function getWidgetState(widgetDef: WidgetDef, nineZone: NineZoneState) {
+  const tab = nineZone.tabs[widgetDef.id];
   if (tab && tab.unloaded) {
     return WidgetState.Unloaded;
   }
 
-  if (state.draggedTab?.tabId === widgetDef.id) {
+  if (nineZone.draggedTab?.tabId === widgetDef.id) {
     return WidgetState.Closed;
   }
 
-  const toolSettingsTabId = state.toolSettings?.tabId;
+  const toolSettingsTabId = nineZone.toolSettings?.tabId;
   if (
     toolSettingsTabId === widgetDef.id &&
-    state.toolSettings?.type === "docked"
+    nineZone.toolSettings?.type === "docked"
   ) {
-    return state.toolSettings.hidden ? WidgetState.Hidden : WidgetState.Open;
+    return nineZone.toolSettings.hidden ? WidgetState.Hidden : WidgetState.Open;
   }
 
-  const location = getTabLocation(state, widgetDef.id);
+  const location = getTabLocation(nineZone, widgetDef.id);
   if (!location) {
     return WidgetState.Hidden;
   }
@@ -609,12 +609,12 @@ export function getWidgetState(widgetDef: WidgetDef, state: NineZoneState) {
   }
 
   if (isPanelTabLocation(location)) {
-    const panel = state.panels[location.side];
+    const panel = nineZone.panels[location.side];
     if (panel.collapsed || undefined === panel.size || 0 === panel.size)
       return WidgetState.Closed;
   }
 
-  const widget = state.widgets[location.widgetId];
+  const widget = nineZone.widgets[location.widgetId];
   if (widget.minimized || widgetDef.id !== widget.activeTabId)
     return WidgetState.Closed;
 

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -582,14 +582,6 @@ export class WidgetDef {
 
 /** @internal */
 export function getWidgetState(widgetDef: WidgetDef, state: NineZoneState) {
-  // if (widgetDef === this.toolSettings) {
-  //   if (!state.toolSettings) {
-  //     return WidgetState.Hidden;
-  //   } else if (state.toolSettings.type === "docked") {
-  //     return WidgetState.Open;
-  //   }
-  // }
-
   const tab = state.tabs[widgetDef.id];
   if (tab && tab.unloaded) {
     return WidgetState.Unloaded;
@@ -604,7 +596,7 @@ export function getWidgetState(widgetDef: WidgetDef, state: NineZoneState) {
     toolSettingsTabId === widgetDef.id &&
     state.toolSettings?.type === "docked"
   ) {
-    return WidgetState.Open;
+    return state.toolSettings.hidden ? WidgetState.Hidden : WidgetState.Open;
   }
 
   const location = getTabLocation(state, widgetDef.id);

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -106,10 +106,10 @@ export class WidgetDef {
 
   public get state(): WidgetState {
     const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
-    const state = frontstageDef?.nineZoneState;
-    if (!state) return this.defaultState;
+    const nineZone = frontstageDef?.nineZoneState;
+    if (!nineZone) return this.defaultState;
     if (!frontstageDef.findWidgetDef(this.id)) return this.defaultState;
-    return getWidgetState(this, state);
+    return getWidgetState(this, nineZone);
   }
 
   public get id(): string {
@@ -403,8 +403,8 @@ export class WidgetDef {
 
   public setWidgetState(newState: WidgetState): void {
     const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
-    const state = frontstageDef?.nineZoneState;
-    if (!state || this.isStatusBar) return;
+    const nineZone = frontstageDef?.nineZoneState;
+    if (!nineZone || this.isStatusBar) return;
     if (!frontstageDef.findWidgetDef(this.id)) return;
 
     switch (newState) {
@@ -545,11 +545,11 @@ export class WidgetDef {
    */
   public show() {
     const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
-    const state = frontstageDef?.nineZoneState;
-    if (!state) return;
+    const nineZone = frontstageDef?.nineZoneState;
+    if (!nineZone) return;
     if (!frontstageDef.findWidgetDef(this.id)) return;
 
-    const tabLocation = getTabLocation(state, this.id);
+    const tabLocation = getTabLocation(nineZone, this.id);
     if (tabLocation && isPopoutTabLocation(tabLocation)) {
       const testWindow = UiFramework.childWindows.find(
         tabLocation.popoutWidgetId
@@ -569,8 +569,8 @@ export class WidgetDef {
    */
   public expand() {
     const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
-    const state = frontstageDef?.nineZoneState;
-    if (!state) return;
+    const nineZone = frontstageDef?.nineZoneState;
+    if (!nineZone) return;
     if (!frontstageDef.findWidgetDef(this.id)) return;
 
     frontstageDef.dispatch({

--- a/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
@@ -5,7 +5,6 @@
 import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
 import { act, renderHook } from "@testing-library/react-hooks";
 import { expect } from "chai";
-import produce from "immer";
 import * as sinon from "sinon";
 import type {
   FrontstageConfig,
@@ -148,9 +147,6 @@ describe("FrontstageDef", () => {
     expect(frontstageDef.isWidgetDisplayed("t1")).to.be.true;
     expect(frontstageDef.isWidgetDisplayed("t2")).to.be.false;
     expect(frontstageDef.isWidgetDisplayed("t3")).to.be.true;
-    expect(frontstageDef.getWidgetCurrentState(t3)).to.eql(
-      WidgetState.Floating
-    );
   });
 
   it("should not save size and position if ninezone state is not available", () => {
@@ -187,35 +183,96 @@ describe("FrontstageDef", () => {
     expect(spy).to.be.calledOnceWithExactly("t1");
   });
 
-  it("should activate a widget def", async () => {
-    const def = new FrontstageDef();
-    await def.initializeFromConfig({
-      ...defaultFrontstageConfig,
-      rightPanel: {
-        sections: {
-          start: [
-            {
-              id: "test-widget",
-              defaultState: WidgetState.Hidden,
-            },
-          ],
+  describe("onWidgetStateChangedEvent", () => {
+    it("should open a hidden widget", async () => {
+      const def = new FrontstageDef();
+      await def.initializeFromConfig({
+        ...defaultFrontstageConfig,
+        rightPanel: {
+          sections: {
+            start: [
+              {
+                id: "test-widget",
+                defaultState: WidgetState.Hidden,
+              },
+            ],
+          },
         },
-      },
+      });
+      initializeNineZoneState(def);
+      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
+
+      const spy = sinon.spy();
+      UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
+
+      // __PUBLISH_EXTRACT_START__ AppUI.WidgetDef.setWidgetState
+      const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
+      if (!frontstageDef) throw new Error("Active frontstage not found");
+      const widgetDef = frontstageDef.findWidgetDef("test-widget");
+      widgetDef?.setWidgetState(WidgetState.Open);
+      // __PUBLISH_EXTRACT_END__
+
+      expect(spy).to.calledOnceWith({
+        widgetDef,
+        widgetState: WidgetState.Open,
+      });
+      expect(widgetDef?.state).to.eq(WidgetState.Open);
     });
-    initializeNineZoneState(def);
-    sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
 
-    const spy = sinon.spy();
-    UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
+    it("should float a panel widget", async () => {
+      const def = new FrontstageDef();
+      await def.initializeFromConfig({
+        ...defaultFrontstageConfig,
+        rightPanel: {
+          sections: {
+            start: [
+              {
+                id: "test-widget",
+                defaultState: WidgetState.Open,
+              },
+            ],
+          },
+        },
+      });
+      initializeNineZoneState(def);
+      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
 
-    // __PUBLISH_EXTRACT_START__ AppUI.WidgetDef.setWidgetState
-    const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
-    if (!frontstageDef) throw new Error("Active frontstage not found");
-    const widgetDef = frontstageDef.findWidgetDef("test-widget");
-    widgetDef?.setWidgetState(WidgetState.Open);
-    // __PUBLISH_EXTRACT_END__
+      const spy = sinon.spy();
+      UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
 
-    expect(spy).to.calledOnceWith();
+      const widgetDef = def.findWidgetDef("test-widget");
+      widgetDef?.setWidgetState(WidgetState.Floating);
+
+      expect(spy).to.calledOnceWith({
+        widgetDef,
+        widgetState: WidgetState.Floating,
+      });
+      expect(widgetDef?.state).to.eq(WidgetState.Floating);
+    });
+
+    it("should hide tool settings", async () => {
+      const def = new FrontstageDef();
+      await def.initializeFromConfig({
+        ...defaultFrontstageConfig,
+        toolSettings: {
+          id: "ts",
+        },
+      });
+      initializeNineZoneState(def);
+      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
+
+      const spy = sinon.spy();
+      UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
+
+      const widgetDef = def.findWidgetDef("ts");
+      widgetDef?.setWidgetState(WidgetState.Hidden);
+
+      expect(spy).to.calledOnceWith({
+        widgetDef,
+        widgetState: WidgetState.Hidden,
+      });
+      expect(widgetDef?.state).to.eq(WidgetState.Hidden);
+    });
   });
 
   describe("findWidgetDef", () => {
@@ -364,152 +421,6 @@ describe("FrontstageDef", () => {
         .leftPanel!.getPanelSectionDef(StagePanelSection.Start)
         .widgetDefs.map((w) => w.id)
         .should.eql(["WidgetsProviderW1"]);
-    });
-  });
-
-  describe("getWidgetCurrentState", () => {
-    it("should return `Closed` if panel size is undefined", () => {
-      const frontstageDef = new FrontstageDef();
-      sinon.stub(frontstageDef, "isReady").get(() => true);
-
-      let nineZoneState = createNineZoneState();
-      nineZoneState = addTab(nineZoneState, "t1");
-      nineZoneState = addTab(nineZoneState, "t2");
-      nineZoneState = addPanelWidget(
-        nineZoneState,
-        "left",
-        "start",
-        ["t1", "t2"],
-        { activeTabId: "t1" }
-      );
-      frontstageDef.nineZoneState = nineZoneState;
-      const widgetDef = WidgetDef.create({
-        id: "t1",
-        defaultState: WidgetState.Hidden,
-      });
-
-      const leftPanel = StagePanelDef.create(
-        {
-          resizable: true,
-          sections: {
-            start: [{ id: "start" }],
-          },
-        },
-        StagePanelLocation.Left
-      );
-      sinon.stub(frontstageDef, "leftPanel").get(() => leftPanel);
-
-      sinon
-        .stub(frontstageDef, "getStagePanelDef")
-        .withArgs(StagePanelLocation.Left)
-        .returns(leftPanel);
-      sinon
-        .stub(frontstageDef, "findWidgetDef")
-        .withArgs("t1")
-        .returns(widgetDef);
-
-      expect(frontstageDef.getWidgetCurrentState(widgetDef)).to.be.eql(
-        WidgetState.Closed
-      );
-    });
-
-    it("should return `Closed` if panel size is 0", () => {
-      const frontstageDef = new FrontstageDef();
-      sinon.stub(frontstageDef, "isReady").get(() => true);
-
-      let nineZoneState = createNineZoneState();
-      nineZoneState = addTab(nineZoneState, "t1");
-      nineZoneState = addTab(nineZoneState, "t2");
-      nineZoneState = addPanelWidget(
-        nineZoneState,
-        "left",
-        "start",
-        ["t1", "t2"],
-        { activeTabId: "t1" }
-      );
-      frontstageDef.nineZoneState = nineZoneState;
-      const widgetDef = WidgetDef.create({
-        id: "t1",
-        defaultState: WidgetState.Hidden,
-      });
-
-      const leftPanel = StagePanelDef.create(
-        {
-          resizable: true,
-          size: 0,
-          sections: {
-            start: [{ id: "start" }],
-          },
-        },
-        StagePanelLocation.Left
-      );
-      sinon.stub(frontstageDef, "leftPanel").get(() => leftPanel);
-
-      sinon
-        .stub(frontstageDef, "getStagePanelDef")
-        .withArgs(StagePanelLocation.Left)
-        .returns(leftPanel);
-      sinon
-        .stub(frontstageDef, "findWidgetDef")
-        .withArgs("t1")
-        .returns(widgetDef);
-
-      // const panel = frontstageDef.nineZoneState.panels.left;
-      expect(frontstageDef.getWidgetCurrentState(widgetDef)).to.be.eql(
-        WidgetState.Closed
-      );
-    });
-
-    it("should return `Closed` if panel is collapsed", () => {
-      const frontstageDef = new FrontstageDef();
-      sinon.stub(frontstageDef, "isReady").get(() => true);
-
-      let nineZoneState = createNineZoneState();
-      nineZoneState = addTab(nineZoneState, "t1");
-      nineZoneState = addTab(nineZoneState, "t2");
-      nineZoneState = addPanelWidget(
-        nineZoneState,
-        "left",
-        "start",
-        ["t1", "t2"],
-        { activeTabId: "t1" }
-      );
-      nineZoneState = produce(nineZoneState, (draft) => {
-        draft.panels.left.collapsed = true;
-      });
-      frontstageDef.nineZoneState = nineZoneState;
-      const widgetDef = WidgetDef.create({
-        id: "t1",
-        defaultState: WidgetState.Open,
-      });
-
-      sinon
-        .stub(frontstageDef, "findWidgetDef")
-        .withArgs("t1")
-        .returns(widgetDef);
-      expect(frontstageDef.getWidgetCurrentState(widgetDef)).to.be.eql(
-        WidgetState.Closed
-      );
-    });
-
-    it("should return `Unloaded` if tab is not loaded", () => {
-      const frontstageDef = new FrontstageDef();
-
-      let nineZoneState = createNineZoneState();
-      nineZoneState = addTab(nineZoneState, "t1", { unloaded: true });
-      nineZoneState = addPanelWidget(nineZoneState, "left", "start", ["t1"]);
-      frontstageDef.nineZoneState = nineZoneState;
-      const widgetDef = WidgetDef.create({
-        id: "t1",
-      });
-
-      sinon
-        .stub(frontstageDef, "findWidgetDef")
-        .withArgs("t1")
-        .returns(widgetDef);
-      expect(frontstageDef.getWidgetCurrentState(widgetDef)).to.be.eql(
-        WidgetState.Unloaded
-      );
     });
   });
 

--- a/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
@@ -185,8 +185,8 @@ describe("FrontstageDef", () => {
 
   describe("onWidgetStateChangedEvent", () => {
     it("should open a hidden widget", async () => {
-      const def = new FrontstageDef();
-      await def.initializeFromConfig({
+      const activeFrontstageDef = new FrontstageDef();
+      await activeFrontstageDef.initializeFromConfig({
         ...defaultFrontstageConfig,
         rightPanel: {
           sections: {
@@ -199,8 +199,10 @@ describe("FrontstageDef", () => {
           },
         },
       });
-      initializeNineZoneState(def);
-      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
+      initializeNineZoneState(activeFrontstageDef);
+      sinon
+        .stub(UiFramework.frontstages, "activeFrontstageDef")
+        .get(() => activeFrontstageDef);
 
       const spy = sinon.spy();
       UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
@@ -219,9 +221,39 @@ describe("FrontstageDef", () => {
       expect(widgetDef?.state).to.eq(WidgetState.Open);
     });
 
+    it("should hide a panel widget", async () => {
+      const frontstageDef = new FrontstageDef();
+      await frontstageDef.initializeFromConfig({
+        ...defaultFrontstageConfig,
+        rightPanel: {
+          sections: {
+            start: [
+              {
+                id: "w1",
+              },
+            ],
+          },
+        },
+      });
+      initializeNineZoneState(frontstageDef);
+      sinon
+        .stub(UiFramework.frontstages, "activeFrontstageDef")
+        .get(() => frontstageDef);
+
+      const spy = sinon.spy();
+      UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
+
+      const widgetDef = frontstageDef.findWidgetDef("w1")!;
+      widgetDef.setWidgetState(WidgetState.Hidden);
+      expect(spy).to.calledOnceWithExactly({
+        widgetDef,
+        widgetState: WidgetState.Hidden,
+      });
+    });
+
     it("should float a panel widget", async () => {
-      const def = new FrontstageDef();
-      await def.initializeFromConfig({
+      const frontstageDef = new FrontstageDef();
+      await frontstageDef.initializeFromConfig({
         ...defaultFrontstageConfig,
         rightPanel: {
           sections: {
@@ -234,13 +266,15 @@ describe("FrontstageDef", () => {
           },
         },
       });
-      initializeNineZoneState(def);
-      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
+      initializeNineZoneState(frontstageDef);
+      sinon
+        .stub(UiFramework.frontstages, "activeFrontstageDef")
+        .get(() => frontstageDef);
 
       const spy = sinon.spy();
       UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
 
-      const widgetDef = def.findWidgetDef("test-widget");
+      const widgetDef = frontstageDef.findWidgetDef("test-widget");
       widgetDef?.setWidgetState(WidgetState.Floating);
 
       expect(spy).to.calledOnceWith({
@@ -251,20 +285,22 @@ describe("FrontstageDef", () => {
     });
 
     it("should hide tool settings", async () => {
-      const def = new FrontstageDef();
-      await def.initializeFromConfig({
+      const frontstageDef = new FrontstageDef();
+      await frontstageDef.initializeFromConfig({
         ...defaultFrontstageConfig,
         toolSettings: {
           id: "ts",
         },
       });
-      initializeNineZoneState(def);
-      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
+      initializeNineZoneState(frontstageDef);
+      sinon
+        .stub(UiFramework.frontstages, "activeFrontstageDef")
+        .get(() => frontstageDef);
 
       const spy = sinon.spy();
       UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
 
-      const widgetDef = def.findWidgetDef("ts");
+      const widgetDef = frontstageDef.findWidgetDef("ts");
       widgetDef?.setWidgetState(WidgetState.Hidden);
 
       expect(spy).to.calledOnceWith({
@@ -426,8 +462,8 @@ describe("FrontstageDef", () => {
 
   describe("floatWidget", () => {
     it("should dispatch WIDGET_TAB_FLOAT action", async () => {
-      const def = new FrontstageDef();
-      await def.initializeFromConfig({
+      const frontstageDef = new FrontstageDef();
+      await frontstageDef.initializeFromConfig({
         ...defaultFrontstageConfig,
         leftPanel: {
           sections: {
@@ -439,11 +475,11 @@ describe("FrontstageDef", () => {
           },
         },
       });
-      initializeNineZoneState(def);
+      initializeNineZoneState(frontstageDef);
 
       const dispatch = sinon.stub();
-      sinon.stub(def, "dispatch").get(() => dispatch);
-      def.floatWidget("t1");
+      sinon.stub(frontstageDef, "dispatch").get(() => dispatch);
+      frontstageDef.floatWidget("t1");
       sinon.assert.calledOnceWithMatch(dispatch, {
         type: "WIDGET_TAB_FLOAT",
         id: "t1",
@@ -453,8 +489,8 @@ describe("FrontstageDef", () => {
 
   describe("popoutWidget", () => {
     it("should dispatch WIDGET_TAB_POPOUT action", async () => {
-      const def = new FrontstageDef();
-      await def.initializeFromConfig({
+      const frontstageDef = new FrontstageDef();
+      await frontstageDef.initializeFromConfig({
         ...defaultFrontstageConfig,
         leftPanel: {
           sections: {
@@ -466,11 +502,11 @@ describe("FrontstageDef", () => {
           },
         },
       });
-      initializeNineZoneState(def);
+      initializeNineZoneState(frontstageDef);
 
       const dispatch = sinon.stub();
-      sinon.stub(def, "dispatch").get(() => dispatch);
-      def.popoutWidget("t1");
+      sinon.stub(frontstageDef, "dispatch").get(() => dispatch);
+      frontstageDef.popoutWidget("t1");
       sinon.assert.calledOnceWithMatch(dispatch, {
         type: "WIDGET_TAB_POPOUT",
         id: "t1",

--- a/ui/appui-react/src/test/widgets/WidgetDef.test.tsx
+++ b/ui/appui-react/src/test/widgets/WidgetDef.test.tsx
@@ -129,60 +129,40 @@ describe("WidgetDef", () => {
   });
 
   describe("setWidgetState", () => {
-    it("should update widget state", () => {
-      const widgetDef = WidgetDef.create({
-        id: "w1",
-        badge: BadgeType.None,
-      });
-      widgetDef.handleWidgetStateChanged(WidgetState.Open);
-
-      expect(widgetDef.stateChanged).to.eq(true);
-      expect(widgetDef.isVisible).to.eq(true);
-    });
-
-    it("should emit UiFramework.frontstages.onWidgetStateChangedEvent", () => {
-      const widgetDef = WidgetDef.create({
-        id: "t1",
-        defaultState: WidgetState.Closed,
-      });
-      const spy = sinon.spy();
-      UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
-      widgetDef.handleWidgetStateChanged(WidgetState.Hidden);
-
-      sinon.assert.calledOnce(spy);
-    });
-
-    it("should emit onWidgetStateChangedEvent for a hidden widget", async () => {
-      const def = new FrontstageDef();
-      await def.initializeFromConfig({
+    it("should update widget state", async () => {
+      const activeFrontstageDef = new FrontstageDef();
+      await activeFrontstageDef.initializeFromConfig({
         ...defaultFrontstageConfig,
         rightPanel: {
           sections: {
             start: [
               {
-                id: "w1",
+                id: "test-widget",
+                defaultState: WidgetState.Hidden,
               },
             ],
           },
         },
       });
-      initializeNineZoneState(def);
-      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
+      initializeNineZoneState(activeFrontstageDef);
+      sinon
+        .stub(UiFramework.frontstages, "activeFrontstageDef")
+        .get(() => activeFrontstageDef);
 
-      const spy = sinon.spy();
-      UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
+      // __PUBLISH_EXTRACT_START__ AppUI.WidgetDef.setWidgetState
+      const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
+      if (!frontstageDef) throw new Error("Active frontstage not found");
+      const widgetDef = frontstageDef.findWidgetDef("test-widget");
+      widgetDef?.setWidgetState(WidgetState.Open);
+      // __PUBLISH_EXTRACT_END__
 
-      const widgetDef = def.findWidgetDef("w1")!;
-      widgetDef.setWidgetState(WidgetState.Hidden);
-      expect(spy).to.calledOnceWithExactly({
-        widgetDef,
-        widgetState: WidgetState.Hidden,
-      });
+      expect(widgetDef?.state).to.eq(WidgetState.Open);
+      expect(widgetDef?.stateChanged).to.eq(true);
     });
 
-    it("should emit onWidgetStateChangedEvent for an opened widget", async () => {
-      const def = new FrontstageDef();
-      await def.initializeFromConfig({
+    it("should emit `UiFramework.frontstages.onWidgetStateChangedEvent`", async () => {
+      const frontstageDef = new FrontstageDef();
+      await frontstageDef.initializeFromConfig({
         ...defaultFrontstageConfig,
         rightPanel: {
           sections: {
@@ -195,15 +175,18 @@ describe("WidgetDef", () => {
           },
         },
       });
-      initializeNineZoneState(def);
-      sinon.stub(UiFramework.frontstages, "activeFrontstageDef").get(() => def);
+      initializeNineZoneState(frontstageDef);
+      sinon
+        .stub(UiFramework.frontstages, "activeFrontstageDef")
+        .get(() => frontstageDef);
 
       const spy = sinon.spy();
       UiFramework.frontstages.onWidgetStateChangedEvent.addListener(spy);
 
-      const widgetDef = def.findWidgetDef("w1")!;
+      const widgetDef = frontstageDef.findWidgetDef("w1")!;
       widgetDef.setWidgetState(WidgetState.Open);
-      expect(spy).to.calledOnceWithExactly({
+
+      sinon.assert.calledOnceWithExactly(spy, {
         widgetDef,
         widgetState: WidgetState.Open,
       });


### PR DESCRIPTION
## Changes

Fixes #757 
`UiFramework.frontstages.onWidgetStateChangedEvent` event will now correctly emit widget state changes.
Values emitted by the event will match `WidgetState` returned by `WidgetDef.state`.

## Testing

Added additional unit tests.

Tested via standalone test-app:
- Open <http://localhost:3000/?frontstage=appui-test-providers:WidgetApi>
- Open `Layout Info` widget
- Select a widget to inspect i.e. `FW-1`
- Interact with `FW-1` widget, note how `state={WidgetState}` output changes