### PR TITLE
Fix assertion in tool settings widget

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -5156,7 +5156,7 @@ export function useFrontstageManager(frontstageDef: FrontstageDef, useToolAsTool
 export const useGroupedItems: (items: ReadonlyArray<BackstageItem>) => GroupedItems;
 
 // @internal (undocumented)
-export function useHorizontalToolSettingNodes(): ToolSettingsEntry[];
+export function useHorizontalToolSettingEntries(): ToolSettingsEntry[];
 
 // @public
 export const useIsBackstageOpen: (manager: FrameworkBackstage) => boolean;

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -562,7 +562,7 @@ deprecated;useDefaultToolbarItems: (manager: ToolbarItemsManager) => readonly To
 alpha;useFloatingViewport(args: FloatingViewportContentProps):
 internal;useFrontstageManager(frontstageDef: FrontstageDef, useToolAsToolSettingsLabel?: boolean): void
 internal;useGroupedItems: (items: ReadonlyArray
-internal;useHorizontalToolSettingNodes(): ToolSettingsEntry[]
+internal;useHorizontalToolSettingEntries(): ToolSettingsEntry[]
 public;useIsBackstageOpen: (manager: FrameworkBackstage) => boolean
 internal;useItemsManager(frontstageDef: FrontstageDef): void
 internal;useLabels(): NineZoneLabels

--- a/common/changes/@itwin/appui-react/tool-settings-fix_2024-03-15-13-12.json
+++ b/common/changes/@itwin/appui-react/tool-settings-fix_2024-03-15-13-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Render empty tool settings message in widget mode.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -59,11 +59,13 @@ Table of contents:
 - Update `WidgetDef.show()` to bring the popout widget window to the front (this behavior is not guaranteed and depends on browser and user settings). [#667](https://github.com/iTwin/appui/pull/667)
 - Removed arrow from status bar popup. [#750](https://github.com/iTwin/appui/pull/750)
 - Render AccuDraw Distance field above Angle field when in Polar mode. [#753](https://github.com/iTwin/appui/pull/753)
+- Changed tool settings to render empty tool settings message when in widget mode.
 
 ### Fixes
 
 - Fix the issue when right-click + left-click starts a widget drag interaction. [#730](https://github.com/iTwin/appui/pull/730)
 - Fix polar mode AccuDraw input focus by correctly focusing the distance field. [#753](https://github.com/iTwin/appui/pull/753)
+- Fix an assertion in `ScrollableWidgetContent` when tool settings is un-docked.
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
+++ b/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
@@ -520,9 +520,7 @@ export class InternalFrontstageManager {
   public static get activeToolSettingsProvider(): ToolUiProvider | undefined {
     const activeToolInformation =
       InternalFrontstageManager.activeToolInformation;
-    return activeToolInformation
-      ? activeToolInformation.toolUiProvider
-      : /* istanbul ignore next */ undefined;
+    return activeToolInformation?.toolUiProvider;
   }
 
   /** Sets the active layout, content group and active content.

--- a/ui/appui-react/src/appui-react/hooks/useActiveToolId.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useActiveToolId.tsx
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Hooks
+ */
+
+import * as React from "react";
+import { UiFramework } from "../UiFramework";
+
+/** @internal */
+export function useActiveToolId() {
+  const [toolId, setToolId] = React.useState(
+    UiFramework.frontstages.activeToolId
+  );
+  React.useEffect(() => {
+    return UiFramework.frontstages.onToolActivatedEvent.addListener((args) => {
+      setToolId(args.toolId);
+    });
+  }, []);
+  return toolId;
+}

--- a/ui/appui-react/src/appui-react/layout/widget/Content.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Content.tsx
@@ -6,7 +6,6 @@
  * @module Widget
  */
 
-import { assert } from "@itwin/core-bentley";
 import { Point } from "@itwin/core-react";
 import * as React from "react";
 import { useTransientState } from "../../widget-panels/useTransientState";
@@ -29,15 +28,14 @@ export function ScrollableWidgetContent(props: ScrollableWidgetContentProps) {
   const scrollPosition = React.useRef(new Point());
   const ref = React.useRef<HTMLDivElement>(null);
   const onSave = React.useCallback(() => {
-    // istanbul ignore else
-    if (!!ref.current)
-      scrollPosition.current = new Point(
-        ref.current.scrollLeft,
-        ref.current.scrollTop
-      );
+    if (!ref.current) return;
+    scrollPosition.current = new Point(
+      ref.current.scrollLeft,
+      ref.current.scrollTop
+    );
   }, []);
   const onRestore = React.useCallback(() => {
-    assert(!!ref.current);
+    if (!ref.current) return;
     ref.current.scrollLeft = scrollPosition.current.x;
     ref.current.scrollTop = scrollPosition.current.y;
   }, []);

--- a/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
@@ -179,37 +179,20 @@ export function useToolSettingsNode() {
     InternalFrontstageManager.activeToolSettingsProvider?.toolSettingsNode
   );
   React.useEffect(() => {
-    const handleToolActivatedEvent = () => {
+    return UiFramework.frontstages.onToolActivatedEvent.addListener(() => {
       const nodes =
         InternalFrontstageManager.activeToolSettingsProvider?.toolSettingsNode;
       setSettings(nodes);
-    };
-    UiFramework.frontstages.onToolActivatedEvent.addListener(
-      handleToolActivatedEvent
-    );
-    return () => {
-      UiFramework.frontstages.onToolActivatedEvent.removeListener(
-        handleToolActivatedEvent
-      );
-    };
+    });
   }, [setSettings]);
 
   React.useEffect(() => {
-    const handleToolSettingsReloadEvent = () => {
+    return UiFramework.frontstages.onToolSettingsReloadEvent.addListener(() => {
       const nodes =
         InternalFrontstageManager.activeToolSettingsProvider?.toolSettingsNode;
       setSettings(nodes);
-    };
-    UiFramework.frontstages.onToolSettingsReloadEvent.addListener(
-      handleToolSettingsReloadEvent
-    );
-    return () => {
-      UiFramework.frontstages.onToolSettingsReloadEvent.removeListener(
-        handleToolSettingsReloadEvent
-      );
-    };
+    });
   }, [setSettings]);
-
   return settings;
 }
 
@@ -229,25 +212,21 @@ export function ToolSettingsWidgetContent() {
 
   // if no tool settings hide the floating widgets tab
   React.useEffect(() => {
-    // istanbul ignore else
     if (floatingToolSettingsContainerRef.current) {
       const floatingWidgetTab =
         floatingToolSettingsContainerRef.current.closest(
           ".nz-floating-toolsettings"
         );
-      // istanbul ignore else
       if (floatingWidgetTab) {
         (floatingWidgetTab as HTMLDivElement).style.visibility = !!node
           ? "visible"
-          : /* istanbul ignore next */ "hidden";
+          : "hidden";
       }
     }
   }, [node]);
 
-  // istanbul ignore next
   const providerId =
     InternalFrontstageManager.activeToolSettingsProvider?.uniqueId ?? "none";
-
   return (
     <div
       data-toolsettings-provider={providerId}

--- a/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
@@ -211,21 +211,6 @@ export function ToolSettingsWidgetContent() {
   const activeToolId = useActiveToolId();
   const forceRefreshKey = useRefreshKey(node);
 
-  // if no tool settings hide the floating widgets tab
-  React.useEffect(() => {
-    if (floatingToolSettingsContainerRef.current) {
-      const floatingWidgetTab =
-        floatingToolSettingsContainerRef.current.closest(
-          ".nz-floating-toolsettings"
-        );
-      if (floatingWidgetTab) {
-        (floatingWidgetTab as HTMLDivElement).style.visibility = !!node
-          ? "visible"
-          : "hidden";
-      }
-    }
-  }, [node]);
-
   const providerId =
     InternalFrontstageManager.activeToolSettingsProvider?.uniqueId ?? "none";
   return (

--- a/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
@@ -208,6 +208,7 @@ export function ToolSettingsContent() {
 export function ToolSettingsWidgetContent() {
   const floatingToolSettingsContainerRef = React.useRef<HTMLDivElement>(null);
   const node = useToolSettingsNode();
+  const activeToolId = useActiveToolId();
   const forceRefreshKey = useRefreshKey(node);
 
   // if no tool settings hide the floating widgets tab
@@ -234,7 +235,9 @@ export function ToolSettingsWidgetContent() {
       ref={floatingToolSettingsContainerRef}
       key={forceRefreshKey}
     >
-      <ScrollableWidgetContent>{node}</ScrollableWidgetContent>
+      <ScrollableWidgetContent>
+        {node ?? <EmptyToolSettingsLabel toolId={activeToolId} />}
+      </ScrollableWidgetContent>
     </div>
   );
 }

--- a/ui/appui-react/src/test/widget-panels/ToolSettings.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/ToolSettings.test.tsx
@@ -17,7 +17,7 @@ import {
   ToolSettingsGrid,
   ToolUiProvider,
   UiFramework,
-  useHorizontalToolSettingNodes,
+  useHorizontalToolSettingEntries,
   useToolSettingsNode,
   WidgetDef,
   WidgetPanelsToolSettings,
@@ -189,7 +189,7 @@ describe("ToolSettingsContent", () => {
   });
 });
 
-describe("useHorizontalToolSettingNodes", () => {
+describe("useHorizontalToolSettingEntries", () => {
   it("should add tool activated event listener", () => {
     const addListenerSpy = sinon.spy(
       UiFramework.frontstages.onToolActivatedEvent,
@@ -199,7 +199,7 @@ describe("useHorizontalToolSettingNodes", () => {
       UiFramework.frontstages.onToolActivatedEvent,
       "removeListener"
     );
-    const sut = renderHook(() => useHorizontalToolSettingNodes());
+    const sut = renderHook(() => useHorizontalToolSettingEntries());
     sut.unmount();
     addListenerSpy.calledOnce.should.true;
     removeListenerSpy.calledOnce.should.true;
@@ -214,7 +214,7 @@ describe("useHorizontalToolSettingNodes", () => {
       UiFramework.frontstages.onToolSettingsReloadEvent,
       "removeListener"
     );
-    const sut = renderHook(() => useHorizontalToolSettingNodes());
+    const sut = renderHook(() => useHorizontalToolSettingEntries());
     act(() => {
       UiFramework.frontstages.onToolSettingsReloadEvent.emit();
     });
@@ -224,7 +224,7 @@ describe("useHorizontalToolSettingNodes", () => {
   });
 
   it("should not return undefined if activeToolSettingsProvider is unset", () => {
-    const { result } = renderHook(() => useHorizontalToolSettingNodes());
+    const { result } = renderHook(() => useHorizontalToolSettingEntries());
     act(() => {
       UiFramework.frontstages.onToolActivatedEvent.emit({ toolId: "t1" });
     });
@@ -258,7 +258,7 @@ describe("useHorizontalToolSettingNodes", () => {
             undefined
           )
       );
-    const sut = renderHook(() => useHorizontalToolSettingNodes());
+    const sut = renderHook(() => useHorizontalToolSettingEntries());
 
     act(() => {
       sinon


### PR DESCRIPTION
## Changes

Fixes an assertion in `ScrollableWidgetContent` when tool settings is undocked.
Changed tool settings to render empty tool settings message when in widget mode.

## Testing

Tested via standalone test-app.
