### PR TITLE
Fix event listener disposal to address viewport memory leak.

### DIFF
--- a/common/changes/@itwin/imodel-components-react/nam-listener-fix_2024-03-19-15-13.json
+++ b/common/changes/@itwin/imodel-components-react/nam-listener-fix_2024-03-19-15-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Fix disposal of handleWindowUnload() event listener to address a memory leak.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/common/changes/@itwin/imodel-components-react/nam-listener-fix_2024-03-19-15-13.json
+++ b/common/changes/@itwin/imodel-components-react/nam-listener-fix_2024-03-19-15-13.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Fix disposal of handleWindowUnload() event listener to address a memory leak.",
+      "comment": "Fix disposal of `unload` event listener in `ViewportComponent` to address a memory leak.",
       "type": "none"
     }
   ],

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -12,6 +12,7 @@ Table of contents:
 - [@itwin/core-react](#itwincore-react)
   - [Additions](#additions-1)
 - [@itwin/imodel-components-react](#itwinimodel-components-react)
+  - [Fixes](#fixes-1)
   - [Deprecations](#deprecations-2)
   - [Additions](#additions-2)
   - [Changes](#changes-1)
@@ -82,6 +83,10 @@ Table of contents:
 - `BadgeType` has been moved from `@itwin/appui-abstract`. [#729](https://github.com/iTwin/appui/pull/729)
 
 ## @itwin/imodel-components-react
+
+### Fixes
+
+- Fix disposal of handleWindowUnload() event listener to address a memory leak. [#773](https://github.com/iTwin/appui/pull/773)
 
 ### Deprecations
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -12,10 +12,10 @@ Table of contents:
 - [@itwin/core-react](#itwincore-react)
   - [Additions](#additions-1)
 - [@itwin/imodel-components-react](#itwinimodel-components-react)
-  - [Fixes](#fixes-1)
   - [Deprecations](#deprecations-2)
   - [Additions](#additions-2)
   - [Changes](#changes-1)
+  - [Fixes](#fixes-1)
 
 ## @itwin/appui-react
 
@@ -84,10 +84,6 @@ Table of contents:
 
 ## @itwin/imodel-components-react
 
-### Fixes
-
-- Fix disposal of handleWindowUnload() event listener to address a memory leak. [#773](https://github.com/iTwin/appui/pull/773)
-
 ### Deprecations
 
 - `TimelineComponentProps.componentId` was used only when listening for events on `UiAdmin.onGenericUiEvent.addListener`. As `UiAdmin` will be deprecated, please use the `TimelineComponentProps.isPlaying` prop to control the timeline play state. [#729](https://github.com/iTwin/appui/pull/729)
@@ -100,3 +96,7 @@ Table of contents:
 ### Changes
 
 - Updated visual styling of `SolarTimeline` and `TimelineComponent` components. [#733](https://github.com/iTwin/appui/pull/733), [#763](https://github.com/iTwin/appui/pull/763)
+
+### Fixes
+
+- Fix disposal of `unload` event listener in `ViewportComponent` to address a memory leak. [#773](https://github.com/iTwin/appui/pull/773)

--- a/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
@@ -255,7 +255,7 @@ export function ViewportComponent(props: ViewportProps) {
       ? screenViewportOverride
       : ScreenViewport;
     const parentWindow = parentDiv.ownerDocument.defaultView as Window;
-    parentWindow.addEventListener("unload", handleWindowUnload, true); // listener clear after being called
+    parentWindow.addEventListener("unload", handleWindowUnload, {once: true, capture: true}); // by specifying 'once', listener clears after being called
     ViewportComponentEvents.initialize();
     ViewportComponentEvents.onDrawingViewportChangeEvent.addListener(
       handleDrawingViewportChangeEvent

--- a/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponent.tsx
@@ -255,7 +255,10 @@ export function ViewportComponent(props: ViewportProps) {
       ? screenViewportOverride
       : ScreenViewport;
     const parentWindow = parentDiv.ownerDocument.defaultView as Window;
-    parentWindow.addEventListener("unload", handleWindowUnload, {once: true, capture: true}); // by specifying 'once', listener clears after being called
+    parentWindow.addEventListener("unload", handleWindowUnload, {
+      once: true,
+      capture: true,
+    }); // by specifying 'once', listener clears after being called
     ViewportComponentEvents.initialize();
     ViewportComponentEvents.onDrawingViewportChangeEvent.addListener(
       handleDrawingViewportChangeEvent


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Link to issue in backlog: https://github.com/iTwin/itwinjs-backlog/issues/1065
As part of a memory leak investigation, I'm looking at places that may have references (pointers) to viewports and whether those places have been properly disposed. One case is with event listeners and javascript closures. The handleWindowUnload() event listener is a closure, that has a reference to a screenViewport object. If the event listener is never removed, the javascript garbage collector can't dispose of variables that event listener / closure uses, including the parent object of the event listener. This leads to a memory leak, because we can't dispose of any references that the ViewportComponent uses (like the screenViewportRef as an example)

Attached is an example of a memory snapshot on chrome devtools, which shows the handleWindowUnload() still existing after multiple page refreshes (a page refresh counts as a window.unload event), and causes the viewportRef to still exist.
![image](https://github.com/iTwin/appui/assets/50554904/a6214c3b-8f3d-4936-b9e2-19ea0a705f1f)


Line 258 was not removing the event listener properly - the third argument to the addEventListener, when its type is boolean
, is used to tell the event dispatcher to [prioritize](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#usecapture) this event handler before any others on unload. We can remove the event listener by changing the third argument to an object, and add the `once` opt.
## Testing
N/A, tests already exist to make sure the event listener triggers (found in FrontStage.test.tsx), but it's very unlikely we can verify that an event listener was **removed** without access to chrome DevTools within unit tests.
<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
