### PR TITLE
Fix `ThemeManager` to correctly handle `os` theme

### DIFF
--- a/common/changes/@itwin/appui-react/fix-770_2024-03-19-12-51.json
+++ b/common/changes/@itwin/appui-react/fix-770_2024-03-19-12-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `ThemeManager` to correctly handle `os` theme for backwards compatibility.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -67,7 +67,7 @@ Table of contents:
 - Fix polar mode AccuDraw input focus by correctly focusing the distance field. [#753](https://github.com/iTwin/appui/pull/753)
 - Fix `UiFramework.frontstages.onWidgetStateChangedEvent` event to correctly emit state changes and match `WidgetState` returned by `WidgetDef.state`. [#768](https://github.com/iTwin/appui/pull/768)
 - Fix an assertion in `ScrollableWidgetContent` when tool settings is un-docked. [#769](https://github.com/iTwin/appui/pull/769)
-- Fix `ThemeManager` to correctly handle `os` theme for backwards compatibility.
+- Fix `ThemeManager` to correctly handle `os` theme for backwards compatibility. [#774](https://github.com/iTwin/appui/pull/774)
 
 ## @itwin/components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -67,6 +67,7 @@ Table of contents:
 - Fix polar mode AccuDraw input focus by correctly focusing the distance field. [#753](https://github.com/iTwin/appui/pull/753)
 - Fix `UiFramework.frontstages.onWidgetStateChangedEvent` event to correctly emit state changes and match `WidgetState` returned by `WidgetDef.state`. [#768](https://github.com/iTwin/appui/pull/768)
 - Fix an assertion in `ScrollableWidgetContent` when tool settings is un-docked. [#769](https://github.com/iTwin/appui/pull/769)
+- Fix `ThemeManager` to correctly handle `os` theme for backwards compatibility.
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/theme/ThemeManager.tsx
+++ b/ui/appui-react/src/appui-react/theme/ThemeManager.tsx
@@ -54,6 +54,7 @@ const colorThemeToThemeTypeMap: { [x: string]: ThemeType } = {
   [ColorTheme.Dark]: "dark",
   [ColorTheme.HighContrastDark]: "dark",
   [ColorTheme.System]: "os",
+  os: "os", // handle "os" for backwards compatibility
 };
 
 /**


### PR DESCRIPTION
## Changes

Fixes #770 by correctly handling `os` theme in `ThemeManager` for backwards compatibility.

## Testing

N/A
