### PR TITLE
Add "os" type to ColorTheme for type-safe setting of theme

### DIFF
--- a/common/changes/@itwin/appui-react/os-typing_2024-03-22-09-28.json
+++ b/common/changes/@itwin/appui-react/os-typing_2024-03-22-09-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add \"os\" type to ColorTheme for type-safe setting of theme",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/theme/ThemeManager.tsx
+++ b/ui/appui-react/src/appui-react/theme/ThemeManager.tsx
@@ -36,6 +36,8 @@ export enum ColorTheme {
   HighContrastLight = "high-contrast-light",
   /** Will use iTwinUI `dark` theme with `highContrast` set to `true` */
   HighContrastDark = "high-contrast-dark",
+  /** Will use iTwinUI `os` theme. Needed for type-safe backwards compatibility */
+  OS = "os",
 }
 
 /**
@@ -54,7 +56,7 @@ const colorThemeToThemeTypeMap: { [x: string]: ThemeType } = {
   [ColorTheme.Dark]: "dark",
   [ColorTheme.HighContrastDark]: "dark",
   [ColorTheme.System]: "os",
-  os: "os", // handle "os" for backwards compatibility
+  [ColorTheme.OS]: "os", // handle "os" for backwards compatibility
 };
 
 /**


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Add "os" type to ColorTheme for type-safe setting of theme. With this change, you can use type-safe themes like so:

```
type Theme = `${ColorTheme}`;

const setColorTheme = (colorTheme: Theme) => {
    UiFramework.setColorTheme(colorTheme);
};
```
