### PR TITLE
Panel stage percentage size

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4048,12 +4048,18 @@ export interface StageContentLayoutProps {
 // @public
 export interface StagePanelConfig {
     readonly defaultState?: StagePanelState;
+    // @deprecated
     readonly maxSize?: StagePanelMaxSizeSpec;
+    readonly maxSizeSpec?: StagePanelSizeSpec;
+    // @deprecated
     readonly minSize?: number;
+    readonly minSizeSpec?: StagePanelSizeSpec;
     readonly pinned?: boolean;
     readonly resizable?: boolean;
     readonly sections?: StagePanelSectionsConfig;
+    // @deprecated
     readonly size?: number;
+    readonly sizeSpec?: StagePanelSizeSpec;
 }
 
 // @public
@@ -4065,8 +4071,6 @@ export class StagePanelDef extends WidgetHost {
     get defaultPinned(): boolean;
     // @internal (undocumented)
     get defaultResizable(): boolean;
-    // @internal (undocumented)
-    get defaultSize(): number | undefined;
     // @internal (undocumented)
     get defaultState(): StagePanelState;
     // @internal (undocumented)
@@ -4087,8 +4091,11 @@ export class StagePanelDef extends WidgetHost {
     get pinned(): boolean;
     set pinned(pinned: boolean);
     get resizable(): boolean;
+    // @deprecated
     get size(): number | undefined;
     set size(size: number | undefined);
+    get sizeSpec(): StagePanelSizeSpec | undefined;
+    set sizeSpec(size: StagePanelSizeSpec | undefined);
     // @internal (undocumented)
     updateDynamicWidgetDefs(stageId: string, stageUsage: string, location: StagePanelLocation, _section: StagePanelSection | undefined, allStageWidgetDefs: WidgetDef[]): void;
     get widgetDefs(): ReadonlyArray<WidgetDef>;
@@ -4106,7 +4113,7 @@ export enum StagePanelLocation {
     Top = 101
 }
 
-// @public
+// @public @deprecated
 export type StagePanelMaxSizeSpec = number | {
     percentage: number;
 };
@@ -4133,6 +4140,11 @@ export interface StagePanelSectionsConfig {
     readonly end?: StagePanelSectionConfig;
     readonly start?: StagePanelSectionConfig;
 }
+
+// @public
+export type StagePanelSizeSpec = number | {
+    percentage: number;
+};
 
 // @public
 export enum StagePanelState {

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -423,10 +423,12 @@ public;StagePanelConfig
 public;StagePanelDef 
 public;StagePanelLocation
 public;StagePanelMaxSizeSpec = number |
+deprecated;StagePanelMaxSizeSpec = number |
 public;StagePanelSection
 public;StagePanelSectionConfig = ReadonlyArray
 internal;StagePanelSectionDef 
 public;StagePanelSectionsConfig
+public;StagePanelSizeSpec = number |
 public;StagePanelState
 public;StageUsage
 public;StandardContentToolsProvider 

--- a/common/changes/@itwin/appui-react/panel-stage-percentage-size_2024-03-26-12-36.json
+++ b/common/changes/@itwin/appui-react/panel-stage-percentage-size_2024-03-26-12-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Added ability to set stage panel size as percentage value.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -3,22 +3,22 @@
 Table of contents:
 
 - [@itwin/appui-react](#itwinappui-react)
-  - [Additions](#additions)
   - [Deprecations](#deprecations)
+  - [Additions](#additions)
   - [Fixes](#fixes)
 
 ## @itwin/appui-react
-
-### Additions
-
-- `StagePanelDef.sizeSpec` allows specifying stage panel size as pixels or a percentage value. [#784](https://github.com/iTwin/appui/pull/784)
-- `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` allow specifying stage panel size as pixels or a percentage value. [#784](https://github.com/iTwin/appui/pull/784)
 
 ### Deprecations
 
 - Deprecated `StagePanelDef.size`. Please use `StagePanelDef.sizeSpec` instead. [#784](https://github.com/iTwin/appui/pull/784)
 - Deprecated `StagePanelConfig.maxSize`, `StagePanelConfig.minSize` and `StagePanelConfig.size`. Please use `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` instead. [#784](https://github.com/iTwin/appui/pull/784)
 - Deprecated `StagePanelMaxSizeSpec`. Please use `StagePanelSizeSpec` instead. [#784](https://github.com/iTwin/appui/pull/784)
+
+### Additions
+
+- `StagePanelDef.sizeSpec` allows specifying stage panel size as pixels or a percentage value. [#784](https://github.com/iTwin/appui/pull/784)
+- `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` allow specifying stage panel size as pixels or a percentage value. [#784](https://github.com/iTwin/appui/pull/784)
 
 ### Fixes
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -11,14 +11,14 @@ Table of contents:
 
 ### Additions
 
-- `StagePanelDef.sizeSpec` allows specifying stage panel size as pixels or a percentage value.
-- `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` allow specifying stage panel size as pixels or a percentage value.
+- `StagePanelDef.sizeSpec` allows specifying stage panel size as pixels or a percentage value. [#784](https://github.com/iTwin/appui/pull/784)
+- `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` allow specifying stage panel size as pixels or a percentage value. [#784](https://github.com/iTwin/appui/pull/784)
 
 ### Deprecations
 
-- Deprecated `StagePanelDef.size`. Please use `StagePanelDef.sizeSpec` instead.
-- Deprecated `StagePanelConfig.maxSize`, `StagePanelConfig.minSize` and `StagePanelConfig.size`. Please use `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` instead.
-- Deprecated `StagePanelMaxSizeSpec`. Please use `StagePanelSizeSpec` instead.
+- Deprecated `StagePanelDef.size`. Please use `StagePanelDef.sizeSpec` instead. [#784](https://github.com/iTwin/appui/pull/784)
+- Deprecated `StagePanelConfig.maxSize`, `StagePanelConfig.minSize` and `StagePanelConfig.size`. Please use `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` instead. [#784](https://github.com/iTwin/appui/pull/784)
+- Deprecated `StagePanelMaxSizeSpec`. Please use `StagePanelSizeSpec` instead. [#784](https://github.com/iTwin/appui/pull/784)
 
 ### Fixes
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -3,9 +3,22 @@
 Table of contents:
 
 - [@itwin/appui-react](#itwinappui-react)
+  - [Additions](#additions)
+  - [Deprecations](#deprecations)
   - [Fixes](#fixes)
 
 ## @itwin/appui-react
+
+### Additions
+
+- `StagePanelDef.sizeSpec` allows specifying stage panel size as pixels or a percentage value.
+- `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` allow specifying stage panel size as pixels or a percentage value.
+
+### Deprecations
+
+- Deprecated `StagePanelDef.size`. Please use `StagePanelDef.sizeSpec` instead.
+- Deprecated `StagePanelConfig.maxSize`, `StagePanelConfig.minSize` and `StagePanelConfig.size`. Please use `StagePanelConfig.maxSizeSpec`, `StagePanelConfig.minSizeSpec` and `StagePanelConfig.sizeSpec` instead.
+- Deprecated `StagePanelMaxSizeSpec`. Please use `StagePanelSizeSpec` instead.
 
 ### Fixes
 

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/TestFrontstageProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/TestFrontstageProvider.tsx
@@ -56,7 +56,7 @@ export class TestFrontstageProvider extends FrontstageProvider {
       version: Math.random(),
       contentGroup,
       leftPanel: {
-        size: size ? Number(size) : undefined,
+        sizeSpec: size ? Number(size) : undefined,
         defaultState: defaultState ? Number(defaultState) : undefined,
         resizable: resizable ? Boolean(Number(resizable)) : undefined,
         sections: {

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/LayoutWidget.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/widgets/LayoutWidget.tsx
@@ -29,9 +29,9 @@ function usePanelDef(location: StagePanelLocation) {
 
 function usePanelSize(location: StagePanelLocation) {
   const panelDef = usePanelDef(location);
-  const [size, setSize] = React.useState(panelDef?.size);
+  const [size, setSize] = React.useState(panelDef?.sizeSpec);
   React.useEffect(() => {
-    setSize(panelDef?.size);
+    setSize(panelDef?.sizeSpec);
   }, [panelDef]);
   React.useEffect(() => {
     const remove =
@@ -425,7 +425,7 @@ function PanelControls({ location }: { location: StagePanelLocation }) {
     const panelDef = frontstageDef?.getStagePanelDef(location);
     if (!panelDef) return;
     if (sizeValue === "") return;
-    panelDef.size = Number(sizeValue);
+    panelDef.sizeSpec = Number(sizeValue);
   };
   return (
     <>
@@ -462,7 +462,7 @@ function PanelControls({ location }: { location: StagePanelLocation }) {
           const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
           const panelDef = frontstageDef?.getStagePanelDef(location);
           if (!panelDef) return;
-          panelDef.size = undefined;
+          panelDef.sizeSpec = undefined;
         }}
       >
         setSize(undefined)

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -685,7 +685,9 @@ export class FrontstageDef {
    */
   public restoreLayout() {
     for (const panelDef of this.panelDefs) {
-      panelDef.size = panelDef.defaultSize;
+      // eslint-disable-next-line deprecation/deprecation
+      panelDef.size = panelDef.initialConfig?.size;
+      panelDef.sizeSpec = panelDef.initialConfig?.sizeSpec;
       panelDef.panelState = panelDef.defaultState;
       panelDef.pinned = panelDef.initialConfig?.pinned ?? true;
     }

--- a/ui/appui-react/src/appui-react/frontstage/StandardFrontstageProvider.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/StandardFrontstageProvider.tsx
@@ -63,16 +63,16 @@ export interface StandardFrontstageProps {
   /** Set to true if no status bar is needed in stage */
   hideStatusBar?: boolean;
   /** Props used to set initial size and state of panel. Defaults to:
-   *  {size: 300, pinned=false, defaultState:StagePanelState.Minimized} */
+   *  {sizeSpec: 300, pinned=false, defaultState:StagePanelState.Minimized} */
   leftPanelProps?: WidgetPanelProps;
   /** Props used to set initial size and state of panel. Defaults to:
-   *  {size: 90, pinned=false, defaultState:StagePanelState.Minimized} */
+   *  {sizeSpec: 90, pinned=false, defaultState:StagePanelState.Minimized} */
   topPanelProps?: WidgetPanelProps;
   /** Props used to set initial size and state of panel. Defaults to:
-   *  {size: 200, pinned=true, defaultState:StagePanelState.Open} */
+   *  {sizeSpec: 200, pinned=true, defaultState:StagePanelState.Open} */
   rightPanelProps?: WidgetPanelProps;
   /** Props used to set initial size and state of panel. Defaults to:
-   *  {size: 180, pinned=true, defaultState:StagePanelState.Open} */
+   *  {sizeSpec: 180, pinned=true, defaultState:StagePanelState.Open} */
   bottomPanelProps?: WidgetPanelProps;
 }
 
@@ -127,13 +127,13 @@ export class StandardFrontstageProvider extends FrontstageProvider {
             content: <StatusBarComposer items={[]} />,
           },
       leftPanel: {
-        size: 300,
+        sizeSpec: 300,
         pinned: false,
         defaultState: StagePanelState.Minimized,
         ...this.props.leftPanelProps,
       },
       topPanel: {
-        size: 90,
+        sizeSpec: 90,
         pinned: false,
         defaultState: StagePanelState.Minimized,
         ...this.props.topPanelProps,
@@ -143,7 +143,7 @@ export class StandardFrontstageProvider extends FrontstageProvider {
         ...this.props.rightPanelProps,
       },
       bottomPanel: {
-        size: 180,
+        sizeSpec: 180,
         defaultState: StagePanelState.Open,
         ...this.props.bottomPanelProps,
       },

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
@@ -23,6 +23,7 @@ import type {
 } from "./DropTargetState";
 import type { PanelState } from "./PanelState";
 import type { XAndY } from "./internal/NineZoneStateHelpers";
+import type { StagePanelSizeSpec } from "../../stagepanels/StagePanelConfig";
 
 /** @internal */
 export interface ResizeAction {
@@ -54,14 +55,14 @@ export interface PanelSetPinnedAction {
 export interface PanelSetSizeAction {
   readonly type: "PANEL_SET_SIZE";
   readonly side: PanelSide;
-  readonly size: PanelState["size"];
+  readonly size: StagePanelSizeSpec | undefined;
 }
 
 /** @internal */
 export interface PanelSetMinSizeAction {
   readonly type: "PANEL_SET_MIN_SIZE";
   readonly side: PanelSide;
-  readonly minSize: PanelState["minSize"];
+  readonly minSize: StagePanelSizeSpec;
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
@@ -24,6 +24,7 @@ import type { NineZoneState } from "./NineZoneState";
 import type { PopoutWidgetState, WidgetState } from "./WidgetState";
 import {
   addPanelWidget,
+  getPanelPixelSizeFromSpec,
   getPanelSize,
   insertPanelWidget,
   updatePanelState,
@@ -143,7 +144,12 @@ export function NineZoneStateReducer(
           state.size
         );
 
-        draft.minSize = action.minSize;
+        const minSizeInPixels = getPanelPixelSizeFromSpec(
+          draft.side,
+          state.size,
+          action.minSize
+        );
+        draft.minSize = minSizeInPixels;
         draft.size = size;
       });
     }

--- a/ui/appui-react/src/appui-react/layout/state/PanelState.ts
+++ b/ui/appui-react/src/appui-react/layout/state/PanelState.ts
@@ -13,15 +13,13 @@ import type {
 } from "../widget-panels/PanelTypes";
 import { isHorizontalPanelSide } from "../widget-panels/Panel";
 import type { WidgetState } from "./WidgetState";
-
-/** @internal */
-export type PanelMaxSizeState = number | { readonly percentage: number };
+import type { StagePanelSizeSpec } from "../../stagepanels/StagePanelConfig";
 
 /** @internal */
 export interface PanelState {
   readonly collapseOffset: number;
   readonly collapsed: boolean;
-  readonly maxSize: PanelMaxSizeState;
+  readonly maxSize: StagePanelSizeSpec;
   readonly minSize: number;
   readonly pinned: boolean;
   readonly resizable: boolean;

--- a/ui/appui-react/src/appui-react/layout/state/internal/PanelStateHelpers.ts
+++ b/ui/appui-react/src/appui-react/layout/state/internal/PanelStateHelpers.ts
@@ -20,7 +20,6 @@ import type { NineZoneState } from "../NineZoneState";
 import type {
   HorizontalPanelState,
   PanelsState,
-  PanelState,
   VerticalPanelState,
 } from "../PanelState";
 import type { WidgetState } from "../WidgetState";
@@ -112,7 +111,7 @@ export function getPanelSize(
   preferredSizeSpec: StagePanelSizeSpec | undefined,
   side: PanelSide,
   minSizeSpec: StagePanelSizeSpec,
-  maxSizeSpec: PanelState["maxSize"],
+  maxSizeSpec: StagePanelSizeSpec,
   appSize: SizeProps
 ) {
   if (preferredSizeSpec === undefined) return undefined;

--- a/ui/appui-react/src/appui-react/layout/state/internal/PanelStateHelpers.ts
+++ b/ui/appui-react/src/appui-react/layout/state/internal/PanelStateHelpers.ts
@@ -19,7 +19,6 @@ import type {
 import type { NineZoneState } from "../NineZoneState";
 import type {
   HorizontalPanelState,
-  PanelMaxSizeState,
   PanelsState,
   PanelState,
   VerticalPanelState,
@@ -27,6 +26,7 @@ import type {
 import type { WidgetState } from "../WidgetState";
 import { category } from "./NineZoneStateHelpers";
 import { addWidgetState } from "./WidgetStateHelpers";
+import type { StagePanelSizeSpec } from "../../../stagepanels/StagePanelConfig";
 
 function createPanelState(side: PanelSide) {
   return {
@@ -94,29 +94,37 @@ export function updatePanelState<K extends keyof PanelsState>(
 }
 
 /** @internal */
-export function getPanelMaxSize(
+export function getPanelPixelSizeFromSpec(
   side: PanelSide,
   appSize: SizeProps,
-  maxSize: PanelMaxSizeState
+  panelSize: StagePanelSizeSpec
 ) {
-  if (typeof maxSize === "number") {
-    return maxSize;
+  if (typeof panelSize === "number") {
+    return panelSize;
   }
-  const size = isHorizontalPanelSide(side) ? appSize.height : appSize.width;
-  return (maxSize.percentage / 100) * size;
+
+  const fullSize = isHorizontalPanelSide(side) ? appSize.height : appSize.width;
+  return (panelSize.percentage / 100) * fullSize;
 }
 
 /** @internal */
 export function getPanelSize(
-  preferredSize: number | undefined,
+  preferredSizeSpec: StagePanelSizeSpec | undefined,
   side: PanelSide,
-  minSize: PanelState["minSize"],
+  minSizeSpec: StagePanelSizeSpec,
   maxSizeSpec: PanelState["maxSize"],
   appSize: SizeProps
 ) {
-  if (preferredSize === undefined) return undefined;
+  if (preferredSizeSpec === undefined) return undefined;
 
-  const maxSize = getPanelMaxSize(side, appSize, maxSizeSpec);
+  const maxSize = getPanelPixelSizeFromSpec(side, appSize, maxSizeSpec);
+  const minSize = getPanelPixelSizeFromSpec(side, appSize, minSizeSpec);
+  const preferredSize = getPanelPixelSizeFromSpec(
+    side,
+    appSize,
+    preferredSizeSpec
+  );
+
   return Math.min(Math.max(preferredSize, minSize), maxSize);
 }
 

--- a/ui/appui-react/src/appui-react/stagepanels/StagePanelConfig.ts
+++ b/ui/appui-react/src/appui-react/stagepanels/StagePanelConfig.ts
@@ -15,16 +15,28 @@ import type { StagePanelState } from "./StagePanelState";
 export interface StagePanelConfig {
   /** Default Panel state. Controls how the panel is initially displayed. Defaults to StagePanelState.Open. */
   readonly defaultState?: StagePanelState;
+  /** Maximum size of the panel.
+   * @deprecated in 4.12.x. Please use {@link StagePanelConfig.maxSizeSpec}.
+   */
+  readonly maxSize?: StagePanelMaxSizeSpec; // eslint-disable-line deprecation/deprecation
   /** Maximum size of the panel. */
-  readonly maxSize?: StagePanelMaxSizeSpec;
-  /** Minimum size of the panel. */
+  readonly maxSizeSpec?: StagePanelSizeSpec;
+  /** Minimum size of the panel.
+   *  @deprecated in 4.12.x. Please use {@link StagePanelConfig.minSizeSpec}.
+   */
   readonly minSize?: number;
+  /** Minimum size of the panel. */
+  readonly minSizeSpec?: StagePanelSizeSpec;
   /** Indicates whether the panel is pinned. Defaults to true. */
   readonly pinned?: boolean;
   /** Indicates whether the panel is resizable. Defaults to true. */
   readonly resizable?: boolean;
-  /** Default size of the panel. */
+  /** Default size of the panel.
+   * @deprecated in 4.12.x. Please use {@link StagePanelConfig.sizeSpec}.
+   */
   readonly size?: number;
+  /** Default size of the panel. */
+  readonly sizeSpec?: StagePanelSizeSpec;
   /** Configuration of the panel sections. */
   readonly sections?: StagePanelSectionsConfig;
 }
@@ -47,5 +59,12 @@ export interface StagePanelSectionsConfig {
 /** Available units of panel max size. Pixels or percentage of App size.
  * @note Percentage of App `height` is used for top/bottom panel and percentage of App `width` is used for left/right panel.
  * @public
+ * @deprecated in 4.12.x. Please use {@link StagePanelSizeSpec}.
  */
 export type StagePanelMaxSizeSpec = number | { percentage: number };
+
+/** Available units of panel size - pixels or percentage of app size.
+ * @note Percentage of App `height` is used for top/bottom panel and percentage of app `width` is used for left/right panel.
+ * @public
+ */
+export type StagePanelSizeSpec = number | { percentage: number };

--- a/ui/appui-react/src/appui-react/stagepanels/StagePanelDef.tsx
+++ b/ui/appui-react/src/appui-react/stagepanels/StagePanelDef.tsx
@@ -108,9 +108,6 @@ export class StagePanelDef extends WidgetHost {
     return panel.size;
   }
 
-  /**
-   * @deprecated in 4.12.x. Use {@link StagePanelDef.sizeSpec} instead.
-   */
   public set size(size) {
     const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
     if (!frontstageDef) return;

--- a/ui/appui-react/src/appui-react/stagepanels/StagePanelDef.tsx
+++ b/ui/appui-react/src/appui-react/stagepanels/StagePanelDef.tsx
@@ -18,6 +18,7 @@ import { WidgetHost } from "../widgets/WidgetHost";
 import type {
   StagePanelConfig,
   StagePanelSectionConfig,
+  StagePanelSizeSpec,
 } from "./StagePanelConfig";
 import { StagePanelLocation } from "./StagePanelLocation";
 import { StagePanelSection } from "./StagePanelSection";
@@ -83,7 +84,6 @@ export class StagePanelDef extends WidgetHost {
     location: StagePanelLocation
   ) {
     this._location = location;
-
     this._initialConfig = config;
     this._start.initializeFromConfig(config?.sections?.start);
     this._end.initializeFromConfig(config?.sections?.end);
@@ -94,18 +94,47 @@ export class StagePanelDef extends WidgetHost {
     return this._initialConfig;
   }
 
-  /** Current size of the panel */
+  /** Current size of the panel.
+   * @deprecated in 4.12.x. Use {@link StagePanelDef.sizeSpec} instead.
+   */
   public get size(): number | undefined {
     const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
     const state = frontstageDef?.nineZoneState;
-    if (!state) return this.defaultSize;
+    // eslint-disable-next-line deprecation/deprecation
+    if (!state) return this.initialConfig?.size;
 
     const side = toPanelSide(this.location);
     const panel = state.panels[side];
     return panel.size;
   }
 
+  /**
+   * @deprecated in 4.12.x. Use {@link StagePanelDef.sizeSpec} instead.
+   */
   public set size(size) {
+    const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
+    if (!frontstageDef) return;
+
+    const side = toPanelSide(this.location);
+    frontstageDef.dispatch({
+      type: "PANEL_SET_SIZE",
+      side,
+      size,
+    });
+  }
+
+  /** Current size of the panel */
+  public get sizeSpec(): StagePanelSizeSpec | undefined {
+    const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
+    const state = frontstageDef?.nineZoneState;
+    if (!state) return this.initialConfig?.sizeSpec;
+
+    const side = toPanelSide(this.location);
+    const panel = state.panels[side];
+    return panel.size;
+  }
+
+  public set sizeSpec(size) {
     const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
     if (!frontstageDef) return;
 
@@ -200,11 +229,6 @@ export class StagePanelDef extends WidgetHost {
   public get defaultState() {
     const defaultState = this._initialConfig?.defaultState;
     return defaultState ?? StagePanelState.Open;
-  }
-
-  /** @internal */
-  public get defaultSize() {
-    return this._initialConfig?.size;
   }
 
   /** @internal */

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -509,7 +509,8 @@ export function initializePanel(
   const panelDef = frontstageDef.getStagePanelDef(location);
   if (!panelDef) return;
 
-  const size = panelDef.defaultSize;
+  // eslint-disable-next-line deprecation/deprecation
+  const size = panelDef.initialConfig?.sizeSpec ?? panelDef.initialConfig?.size;
   size !== undefined &&
     frontstageDef.dispatch({
       type: "PANEL_SET_SIZE",
@@ -529,7 +530,8 @@ export function initializePanel(
     resizable: panelDef.defaultResizable,
   });
 
-  const minSize = panelDef.initialConfig?.minSize;
+  const minSize =
+    panelDef.initialConfig?.minSizeSpec ?? panelDef.initialConfig?.minSize; // eslint-disable-line deprecation/deprecation
   minSize !== undefined &&
     frontstageDef.dispatch({
       type: "PANEL_SET_MIN_SIZE",
@@ -537,7 +539,8 @@ export function initializePanel(
       minSize,
     });
 
-  const maxSize = panelDef.initialConfig?.maxSize;
+  const maxSize =
+    panelDef.initialConfig?.maxSizeSpec ?? panelDef.initialConfig?.maxSize; // eslint-disable-line deprecation/deprecation
   maxSize !== undefined &&
     frontstageDef.dispatch({
       type: "PANEL_SET_MAX_SIZE",

--- a/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
@@ -8,6 +8,7 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import type {
   FrontstageConfig,
+  StagePanelConfig,
   UiItemsProvider,
   Widget,
 } from "../../appui-react";
@@ -370,9 +371,10 @@ describe("FrontstageDef", () => {
     it("should restore panel size to default size", () => {
       const frontstageDef = new FrontstageDef();
       const rightPanel = new StagePanelDef();
-      sinon.stub(rightPanel, "defaultSize").get(() => 300);
+      const stagePanelConfig: StagePanelConfig = { sizeSpec: 300 };
+      sinon.stub(rightPanel, "initialConfig").get(() => stagePanelConfig);
       sinon.stub(frontstageDef, "rightPanel").get(() => rightPanel);
-      const spy = sinon.spy(rightPanel, "size", ["set"]);
+      const spy = sinon.spy(rightPanel, "sizeSpec", ["set"]);
 
       frontstageDef.restoreLayout();
       sinon.assert.calledOnceWithExactly(spy.set, 300);

--- a/ui/appui-react/src/test/layout/state/internal/PanelStateHelpers.test.ts
+++ b/ui/appui-react/src/test/layout/state/internal/PanelStateHelpers.test.ts
@@ -5,29 +5,87 @@
 import { expect } from "chai";
 import { createNineZoneState } from "../../../../appui-react/layout/state/NineZoneState";
 import {
-  getPanelMaxSize,
+  getPanelPixelSizeFromSpec,
+  getPanelSize,
   insertPanelWidget,
 } from "../../../../appui-react/layout/state/internal/PanelStateHelpers";
 import { addTabs, handleMetaData } from "../../Utils";
 
-describe("getPanelMaxSize", () => {
+describe("getPanelPixelSizeFromSpec", () => {
+  it("should return pixel value", () => {
+    const size = getPanelPixelSizeFromSpec(
+      "top",
+      { height: 1000, width: 2000 },
+      150
+    );
+    expect(size).to.eq(150);
+  });
+
   it("should use percentage for vertical panel", () => {
-    const sut = getPanelMaxSize(
+    const size = getPanelPixelSizeFromSpec(
       "left",
       { height: 1000, width: 2000 },
       { percentage: 80 }
     );
-    expect(sut).to.eq(1600);
+    expect(size).to.eq(1600);
   });
 
   it("should use percentage for horizontal panel", () => {
-    const sut = getPanelMaxSize(
+    const size = getPanelPixelSizeFromSpec(
       "top",
       { height: 1000, width: 2000 },
       { percentage: 80 }
     );
-    expect(sut).to.eq(800);
+    expect(size).to.eq(800);
   });
+});
+
+describe("getPanelSize", () => {
+  [
+    {
+      testName:
+        "should return preferred value when it is between min and max sizes",
+      preferredSize: 250,
+      expectedResult: 250,
+    },
+    {
+      testName: "should return min size value when preferred size is smaller",
+      preferredSize: 180,
+      expectedResult: 200,
+    },
+    {
+      testName: "should return max size value when preferred size is bigger",
+      preferredSize: 600,
+      expectedResult: 500,
+    },
+    {
+      testName:
+        "should return preferred size when it is a percentage value and is between min and max sizes",
+      preferredSize: { percentage: 20 }, // 400px
+      expectedResult: 400,
+    },
+    {
+      testName:
+        "should return min size when preferred size is a percentage value and is smaller",
+      preferredSize: { percentage: 5 }, // 100px
+      expectedResult: 200,
+    },
+    {
+      testName:
+        "should return max size when preferred size is a percentage value and is bigger",
+      preferredSize: { percentage: 40 }, // 800px
+      expectedResult: 500,
+    },
+  ].forEach((testCase) =>
+    it(testCase.testName, () => {
+      const size = getPanelSize(testCase.preferredSize, "left", 200, 500, {
+        height: 1000,
+        width: 2000,
+      });
+
+      expect(size).to.eq(testCase.expectedResult);
+    })
+  );
 });
 
 describe("insertPanelWidget", () => {

--- a/ui/appui-react/src/test/stagepanels/StagePanelDef.test.tsx
+++ b/ui/appui-react/src/test/stagepanels/StagePanelDef.test.tsx
@@ -84,8 +84,8 @@ describe("StagePanelDef", () => {
       .stub(UiFramework.frontstages, "activeFrontstageDef")
       .get(() => frontstageDef);
     const panelDef = new StagePanelDef();
-    panelDef.size = 150;
-    panelDef.size.should.eq(200);
+    panelDef.sizeSpec = 150;
+    panelDef.sizeSpec.should.eq(200);
   });
 
   it("should not invoke onPanelSizeChangedEvent", () => {
@@ -96,15 +96,15 @@ describe("StagePanelDef", () => {
       .stub(UiFramework.frontstages, "activeFrontstageDef")
       .get(() => frontstageDef);
     const panelDef = new StagePanelDef();
-    panelDef.size = 200;
-    panelDef.size.should.eq(200);
+    panelDef.sizeSpec = 200;
+    panelDef.sizeSpec.should.eq(200);
 
     const spy = sinon.spy(
       InternalFrontstageManager.onPanelSizeChangedEvent,
       "emit"
     );
-    panelDef.size = 150;
-    panelDef.size.should.eq(200);
+    panelDef.sizeSpec = 150;
+    panelDef.sizeSpec.should.eq(200);
     sinon.assert.notCalled(spy);
   });
 


### PR DESCRIPTION
## Changes
Added ability to set `StagePanel` size as percentage value. This involves deprecating old `size` and `minSize` getters/setters and introducing new `sizeSpec` and `minSizeSpec` getters/setters. The same was done for `StagePanelConfig` as well.

## Testing
Tested in standalone test-app. Tried with old `size`, `minSize` and `maxSize` properties, then with new properties, various combinations etc.
