### PR TITLE
Add note to PropertyFilterRuleOperator

### DIFF
--- a/common/changes/@itwin/components-react/like-operator-note_2024-04-02-07-32.json
+++ b/common/changes/@itwin/components-react/like-operator-note_2024-04-02-07-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Added note to `PropertyFilterRuleOperator` that `Like` operator should be handled as a contains operator.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/filter-builder/Operators.ts
+++ b/ui/components-react/src/components-react/filter-builder/Operators.ts
@@ -20,6 +20,7 @@ export enum PropertyFilterRuleGroupOperator {
 
 /**
  * Operators for comparing property value in [[PropertyFilterRule]].
+ * @note `Like` operator should be handled as a contains operator - it matches all strings that contain a given string.
  * @beta
  */
 export enum PropertyFilterRuleOperator {


### PR DESCRIPTION
## Changes
Added note to `PropertyFilterRuleOperator` that like operator should be handled as a contains operator as discussed in [496](https://github.com/iTwin/presentation/pull/496).

## Testing
No testing required.
