### PR TITLE
Fix standard layout to prevent content overlays

### DIFF
--- a/common/changes/@itwin/appui-react/fix-tool-settings-overlay_2024-04-04-14-47.json
+++ b/common/changes/@itwin/appui-react/fix-tool-settings-overlay_2024-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix the standard layout to prevent tool settings and status bar from overlaying the content area.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -27,7 +27,7 @@ Table of contents:
 ### Fixes
 
 - Replace `process.env.NODE_ENV === "development"` check used in combination with `console.warn` by preview features with `Logger.logWarning()`. Logger APIs can be used instead to disable/enable this warning message. [#783](https://github.com/iTwin/appui/pull/783)
-- Fix the standard layout to prevent tool settings and status bar from overlaying the content area. Applications can still use `contentAlwaysMaxSize` preview feature to avoid resizing the content when i.e. tool settings is un-docked.
+- Fix the standard layout to prevent tool settings and status bar from overlaying the content area. Applications can still use `contentAlwaysMaxSize` preview feature to avoid resizing the content when i.e. tool settings is un-docked. [#793](https://github.com/iTwin/appui/pull/793)
 
 ## @itwin/core-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -27,6 +27,7 @@ Table of contents:
 ### Fixes
 
 - Replace `process.env.NODE_ENV === "development"` check used in combination with `console.warn` by preview features with `Logger.logWarning()`. Logger APIs can be used instead to disable/enable this warning message. [#783](https://github.com/iTwin/appui/pull/783)
+- Fix the standard layout to prevent tool settings and status bar from overlaying the content area. Applications can still use `contentAlwaysMaxSize` preview feature to avoid resizing the content when i.e. tool settings is un-docked.
 
 ## @itwin/core-react
 

--- a/ui/appui-react/src/appui-react/layout/StandardLayout.scss
+++ b/ui/appui-react/src/appui-react/layout/StandardLayout.scss
@@ -30,7 +30,7 @@
       "sb sb sb";
 
     > .nz-appContent {
-      grid-row: 1 / -1;
+      grid-row: ts-end / bp-end;
       grid-column: 1 / -1;
 
       // TODO: clean-up #uifw-contentlayout-div


### PR DESCRIPTION
## Changes

This PR fixes an issue where tool settings and status bar would overlay the content (i.e. viewport).
This would cause certain negative side effects like content view-overlay hiding below tool settings or imodeljs-icon hiding below status bar.

  | Before  | After |
  | ------------- | ------------- |
  | ![Screenshot 2024-04-04 at 17 56 18](https://github.com/iTwin/appui/assets/10091419/3a4e9783-330a-48ca-93ae-321bcd4312da) | ![Screenshot 2024-04-04 at 17 56 38](https://github.com/iTwin/appui/assets/10091419/9fa218d2-669f-4609-94eb-3897aeb4f4a8) |

This unintentional behavior was first introduced with #736 (released in [4.10.0](https://github.com/iTwin/appui/releases/tag/release%2F4.10.0)).

## Testing

Tested via standalone test-app.
