### PR TITLE
docs: remove frontstage links

### DIFF
--- a/common/changes/@itwin/appui-react/bdp-docs-remove-frontstage-links_2024-04-05-15-02.json
+++ b/common/changes/@itwin/appui-react/bdp-docs-remove-frontstage-links_2024-04-05-15-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "docs: remove incorrect frontstage links",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/bdp-docs-remove-frontstage-links_2024-04-05-15-02.json
+++ b/common/changes/@itwin/components-react/bdp-docs-remove-frontstage-links_2024-04-05-15-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/bdp-docs-remove-frontstage-links_2024-04-05-15-02.json
+++ b/common/changes/@itwin/core-react/bdp-docs-remove-frontstage-links_2024-04-05-15-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/bdp-docs-remove-frontstage-links_2024-04-05-15-02.json
+++ b/common/changes/@itwin/imodel-components-react/bdp-docs-remove-frontstage-links_2024-04-05-15-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -33,7 +33,7 @@ export interface FrontstageActivatedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class FrontstageActivatedEvent extends UiEvent<FrontstageActivatedEventArgs> {}
+export class FrontstageActivatedEvent extends UiEvent<FrontstageActivatedEventArgs> { }
 
 /** Frontstage Deactivated Event Args interface.
  * @public
@@ -56,7 +56,7 @@ export interface FrontstageDeactivatedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class FrontstageDeactivatedEvent extends UiEvent<FrontstageDeactivatedEventArgs> {}
+export class FrontstageDeactivatedEvent extends UiEvent<FrontstageDeactivatedEventArgs> { }
 
 /** Frontstage Ready Event Args interface.
  * @public
@@ -69,7 +69,7 @@ export interface FrontstageReadyEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class FrontstageReadyEvent extends UiEvent<FrontstageReadyEventArgs> {}
+export class FrontstageReadyEvent extends UiEvent<FrontstageReadyEventArgs> { }
 
 /** Modal Frontstage Changed Event Args interface.
  * @public
@@ -82,7 +82,7 @@ export interface ModalFrontstageChangedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ModalFrontstageChangedEvent extends UiEvent<ModalFrontstageChangedEventArgs> {}
+export class ModalFrontstageChangedEvent extends UiEvent<ModalFrontstageChangedEventArgs> { }
 
 /** Modal Frontstage Closed Event Args interface.
  * @public
@@ -107,7 +107,7 @@ export interface ModalFrontstageClosedEventArgs {
  * @alpha
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ModalFrontstageRequestedCloseEvent extends UiEvent<ModalFrontstageRequestedCloseEventArgs> {}
+export class ModalFrontstageRequestedCloseEvent extends UiEvent<ModalFrontstageRequestedCloseEventArgs> { }
 
 /** Modal Frontstage RequestedClose Event Args interface.
  * @alpha
@@ -123,7 +123,7 @@ export interface ModalFrontstageRequestedCloseEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ModalFrontstageClosedEvent extends UiEvent<ModalFrontstageClosedEventArgs> {}
+export class ModalFrontstageClosedEvent extends UiEvent<ModalFrontstageClosedEventArgs> { }
 
 /** Tool Activated Event Args interface.
  * @public
@@ -136,7 +136,7 @@ export interface ToolActivatedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ToolActivatedEvent extends UiEvent<ToolActivatedEventArgs> {}
+export class ToolActivatedEvent extends UiEvent<ToolActivatedEventArgs> { }
 
 /** Tool Icon Changed Event Args interface.
  * @public
@@ -149,7 +149,7 @@ export interface ToolIconChangedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> {}
+export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> { }
 
 /** Modal Frontstage information interface.
  * @public
@@ -268,7 +268,7 @@ export interface FrameworkFrontstages {
 
   /** Sets the active FrontstageDef give the stageId.
    * @param  frontstageId  Id of the Frontstage to set active.
-   * @returns A Promise that is fulfilled when the [[Frontstage]] is ready.
+   * @returns A Promise that is fulfilled when the Frontstage is ready.
    */
   setActiveFrontstage(frontstageId: string): Promise<void>;
 

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -33,7 +33,7 @@ export interface FrontstageActivatedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class FrontstageActivatedEvent extends UiEvent<FrontstageActivatedEventArgs> { }
+export class FrontstageActivatedEvent extends UiEvent<FrontstageActivatedEventArgs> {}
 
 /** Frontstage Deactivated Event Args interface.
  * @public
@@ -56,7 +56,7 @@ export interface FrontstageDeactivatedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class FrontstageDeactivatedEvent extends UiEvent<FrontstageDeactivatedEventArgs> { }
+export class FrontstageDeactivatedEvent extends UiEvent<FrontstageDeactivatedEventArgs> {}
 
 /** Frontstage Ready Event Args interface.
  * @public
@@ -69,7 +69,7 @@ export interface FrontstageReadyEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class FrontstageReadyEvent extends UiEvent<FrontstageReadyEventArgs> { }
+export class FrontstageReadyEvent extends UiEvent<FrontstageReadyEventArgs> {}
 
 /** Modal Frontstage Changed Event Args interface.
  * @public
@@ -82,7 +82,7 @@ export interface ModalFrontstageChangedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ModalFrontstageChangedEvent extends UiEvent<ModalFrontstageChangedEventArgs> { }
+export class ModalFrontstageChangedEvent extends UiEvent<ModalFrontstageChangedEventArgs> {}
 
 /** Modal Frontstage Closed Event Args interface.
  * @public
@@ -107,7 +107,7 @@ export interface ModalFrontstageClosedEventArgs {
  * @alpha
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ModalFrontstageRequestedCloseEvent extends UiEvent<ModalFrontstageRequestedCloseEventArgs> { }
+export class ModalFrontstageRequestedCloseEvent extends UiEvent<ModalFrontstageRequestedCloseEventArgs> {}
 
 /** Modal Frontstage RequestedClose Event Args interface.
  * @alpha
@@ -123,7 +123,7 @@ export interface ModalFrontstageRequestedCloseEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ModalFrontstageClosedEvent extends UiEvent<ModalFrontstageClosedEventArgs> { }
+export class ModalFrontstageClosedEvent extends UiEvent<ModalFrontstageClosedEventArgs> {}
 
 /** Tool Activated Event Args interface.
  * @public
@@ -136,7 +136,7 @@ export interface ToolActivatedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ToolActivatedEvent extends UiEvent<ToolActivatedEventArgs> { }
+export class ToolActivatedEvent extends UiEvent<ToolActivatedEventArgs> {}
 
 /** Tool Icon Changed Event Args interface.
  * @public
@@ -149,7 +149,7 @@ export interface ToolIconChangedEventArgs {
  * @public
  */
 // eslint-disable-next-line deprecation/deprecation
-export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> { }
+export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> {}
 
 /** Modal Frontstage information interface.
  * @public

--- a/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
+++ b/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
@@ -595,7 +595,7 @@ export class InternalFrontstageManager {
     if (InternalFrontstageManager._modalFrontstages.length > 0) {
       const topMostStageItem =
         InternalFrontstageManager._modalFrontstages[
-        InternalFrontstageManager._modalFrontstages.length - 1
+          InternalFrontstageManager._modalFrontstages.length - 1
         ];
       if (topMostStageItem.modalFrontstage.notifyCloseRequest)
         InternalFrontstageManager.onCloseModalFrontstageRequestedEvent.emit({
@@ -645,7 +645,7 @@ export class InternalFrontstageManager {
     if (InternalFrontstageManager._modalFrontstages.length > 0) {
       const frontstageItem =
         InternalFrontstageManager._modalFrontstages[
-        InternalFrontstageManager._modalFrontstages.length - 1
+          InternalFrontstageManager._modalFrontstages.length - 1
         ];
       const modalFrontstage = frontstageItem.modalFrontstage;
       return modalFrontstage;

--- a/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
+++ b/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
@@ -409,7 +409,7 @@ export class InternalFrontstageManager {
 
   /** Sets the active FrontstageDef give the stageId.
    * @param  frontstageId  Id of the Frontstage to set active.
-   * @returns A Promise that is fulfilled when the [[Frontstage]] is ready.
+   * @returns A Promise that is fulfilled when the Frontstage is ready.
    */
   public static async setActiveFrontstage(frontstageId: string): Promise<void> {
     const frontstageDef = await InternalFrontstageManager.getFrontstageDef(
@@ -595,7 +595,7 @@ export class InternalFrontstageManager {
     if (InternalFrontstageManager._modalFrontstages.length > 0) {
       const topMostStageItem =
         InternalFrontstageManager._modalFrontstages[
-          InternalFrontstageManager._modalFrontstages.length - 1
+        InternalFrontstageManager._modalFrontstages.length - 1
         ];
       if (topMostStageItem.modalFrontstage.notifyCloseRequest)
         InternalFrontstageManager.onCloseModalFrontstageRequestedEvent.emit({
@@ -645,7 +645,7 @@ export class InternalFrontstageManager {
     if (InternalFrontstageManager._modalFrontstages.length > 0) {
       const frontstageItem =
         InternalFrontstageManager._modalFrontstages[
-          InternalFrontstageManager._modalFrontstages.length - 1
+        InternalFrontstageManager._modalFrontstages.length - 1
         ];
       const modalFrontstage = frontstageItem.modalFrontstage;
       return modalFrontstage;

--- a/ui/appui-react/src/appui-react/widgets/StatusBarWidgetComposerControl.tsx
+++ b/ui/appui-react/src/appui-react/widgets/StatusBarWidgetComposerControl.tsx
@@ -12,7 +12,7 @@ import { StatusBarWidgetControl } from "../statusbar/StatusBarWidgetControl";
 import { UiFramework } from "../UiFramework";
 
 /**
- * StatusBarWidgetComposerControl provides status bar to specified [[Frontstage]] that allows status bar items to be populated
+ * StatusBarWidgetComposerControl provides status bar to specified Frontstage that allows status bar items to be populated
  * via UiItemsProviders. See [[StandardStatusbarItemsProvider]] that can be used to populate this status bar with a common
  * set of status fields.
  * @example


### PR DESCRIPTION
These are invalid links due to the `Frontstage` class being removed, but just now being flagged as invalid after some pending upgrades and fixes to the docs link resolution. 

FYI, the docs link resolution is very convoluted and almost certainly contains more bugs. It will be replaced in the next quarter or so.