### PR TITLE
Deprecate UiEvent subclasses

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -176,7 +176,7 @@ export interface AccuDrawDialogProps extends CommonProps {
     orientation?: Orientation;
 }
 
-// @beta
+// @beta @deprecated
 export class AccuDrawGrabInputFocusEvent extends BeUiEvent<{}> {
 }
 
@@ -205,7 +205,7 @@ export class AccuDrawPopupManager {
     static showMenuButton(id: string, el: HTMLElement, pt: XAndY, menuItemsProps: CursorMenuItemProps[]): boolean;
 }
 
-// @beta
+// @beta @deprecated
 export class AccuDrawSetCompassModeEvent extends BeUiEvent<AccuDrawSetCompassModeEventArgs> {
 }
 
@@ -215,7 +215,7 @@ export interface AccuDrawSetCompassModeEventArgs {
     mode: CompassMode;
 }
 
-// @beta
+// @beta @deprecated
 export class AccuDrawSetFieldFocusEvent extends BeUiEvent<AccuDrawSetFieldFocusEventArgs> {
 }
 
@@ -225,7 +225,7 @@ export interface AccuDrawSetFieldFocusEventArgs {
     field: ItemField;
 }
 
-// @beta
+// @beta @deprecated
 export class AccuDrawSetFieldLockEvent extends BeUiEvent<AccuDrawSetFieldLockEventArgs> {
 }
 
@@ -237,7 +237,7 @@ export interface AccuDrawSetFieldLockEventArgs {
     lock: boolean;
 }
 
-// @beta
+// @beta @deprecated
 export class AccuDrawSetFieldValueFromUiEvent extends BeUiEvent<AccuDrawSetFieldValueFromUiEventArgs> {
 }
 
@@ -249,7 +249,7 @@ export interface AccuDrawSetFieldValueFromUiEventArgs {
     stringValue: string;
 }
 
-// @beta
+// @beta @deprecated
 export class AccuDrawSetFieldValueToUiEvent extends BeUiEvent<AccuDrawSetFieldValueToUiEventArgs> {
 }
 
@@ -292,7 +292,7 @@ export interface AccuDrawUiSettings {
     zStyle?: React.CSSProperties;
 }
 
-// @beta
+// @beta @deprecated
 export class AccuDrawUiSettingsChangedEvent extends BeUiEvent<{}> {
 }
 
@@ -343,7 +343,7 @@ export interface ActionWithPayload<T extends string, P> extends Action<T> {
     payload: P;
 }
 
-// @public
+// @public @deprecated
 export class ActiveContentChangedEvent extends UiEvent<ActiveContentChangedEventArgs> {
 }
 
@@ -359,7 +359,7 @@ export function ActiveFrontstageDefProvider({ frontstageDef, }: ActiveFrontstage
 // @public
 export function ActivityCenterField(props: CommonProps): React_2.JSX.Element | null;
 
-// @public
+// @public @deprecated
 export class ActivityMessageCancelledEvent extends UiEvent<{}> {
 }
 
@@ -371,7 +371,7 @@ export interface ActivityMessageEventArgs {
     restored?: boolean;
 }
 
-// @public
+// @public @deprecated
 export class ActivityMessageUpdatedEvent extends UiEvent<ActivityMessageEventArgs> {
 }
 
@@ -756,7 +756,7 @@ export interface CardInfo {
     viewId: any;
 }
 
-// @alpha
+// @alpha @deprecated
 export class CardSelectedEvent extends UiEvent<CardSelectedEventArgs> {
 }
 
@@ -1045,7 +1045,7 @@ export class ContentControl extends ConfigurableUiControl {
     get viewport(): ScreenViewport | undefined;
 }
 
-// @public
+// @public @deprecated
 export class ContentControlActivatedEvent extends UiEvent<ContentControlActivatedEventArgs> {
 }
 
@@ -1060,7 +1060,7 @@ export interface ContentControlActivatedEventArgs {
 // @public
 export function ContentDialog(props: ContentDialogProps): React_2.JSX.Element;
 
-// @public
+// @public @deprecated
 export class ContentDialogChangedEvent extends DialogChangedEvent {
 }
 
@@ -1146,7 +1146,7 @@ export class ContentLayout extends React_2.Component<ContentLayoutComponentProps
     readonly state: Readonly<ContentLayoutState>;
 }
 
-// @public
+// @public @deprecated
 export class ContentLayoutActivatedEvent extends UiEvent<ContentLayoutActivatedEventArgs> {
 }
 
@@ -1364,10 +1364,6 @@ export class CursorPopup extends React_2.Component<CursorPopupProps, CursorPopup
 export function CursorPopupContent(props: CommonDivProps): React_2.JSX.Element;
 
 // @internal
-export class CursorPopupFadeOutEvent extends UiEvent<CursorPopupFadeOutEventArgs> {
-}
-
-// @internal
 export interface CursorPopupFadeOutEventArgs {
     // (undocumented)
     id: string;
@@ -1379,11 +1375,11 @@ export class CursorPopupManager {
     static clearPopups(): void;
     static close(id: string, apply: boolean, fadeOut?: boolean): void;
     // @internal (undocumented)
-    static readonly onCursorPopupFadeOutEvent: CursorPopupFadeOutEvent;
+    static readonly onCursorPopupFadeOutEvent: BeUiEvent<CursorPopupFadeOutEventArgs>;
     // @internal (undocumented)
-    static readonly onCursorPopupsChangedEvent: CursorPopupsChangedEvent;
+    static readonly onCursorPopupsChangedEvent: BeUiEvent<{}>;
     // @internal (undocumented)
-    static readonly onCursorPopupUpdatePositionEvent: CursorPopupUpdatePositionEvent;
+    static readonly onCursorPopupUpdatePositionEvent: BeUiEvent<CursorPopupUpdatePositionEventArgs>;
     static open(id: string, content: React_2.ReactNode, pt: XAndY, offset: XAndY, relativePosition: RelativePosition, priority?: number, options?: CursorPopupOptions): void;
     // (undocumented)
     static get popupCount(): number;
@@ -1447,10 +1443,6 @@ export enum CursorPopupShow {
 }
 
 // @internal
-export class CursorPopupUpdatePositionEvent extends UiEvent<CursorPopupUpdatePositionEventArgs> {
-}
-
-// @internal
 export interface CursorPopupUpdatePositionEventArgs {
     // (undocumented)
     pt: XAndY;
@@ -1464,7 +1456,7 @@ export class CursorPrompt {
     display(toolIconSpec: string, instruction: ToolAssistanceInstruction, offset?: XAndY, relativePosition?: RelativePosition): void;
 }
 
-// @public
+// @public @deprecated
 export class CursorUpdatedEvent extends UiEvent<CursorUpdatedEventArgs> {
 }
 
@@ -1608,7 +1600,7 @@ export class DefaultToolSettingsProvider extends ToolUiProvider {
 // @public
 export function DefaultViewOverlay({ viewport, onPlayPause, featureOptions, }: ViewOverlayProps): React_2.JSX.Element | null;
 
-// @public
+// @public @deprecated
 export class DialogChangedEvent extends UiEvent<DialogChangedEventArgs> {
 }
 
@@ -1635,7 +1627,7 @@ export interface DialogInfo {
 
 // @internal
 export class DialogManagerBase {
-    constructor(onDialogChangedEvent: DialogChangedEvent);
+    constructor(onDialogChangedEvent: BeUiEvent<DialogChangedEventArgs>);
     // (undocumented)
     get activeDialog(): React_2.ReactNode | undefined;
     // (undocumented)
@@ -1652,7 +1644,7 @@ export class DialogManagerBase {
     static getDialogZIndexDefault(): number;
     static initialize(): void;
     // (undocumented)
-    get onDialogChangedEvent(): DialogChangedEvent;
+    get onDialogChangedEvent(): BeUiEvent<DialogChangedEventArgs>;
     openDialog(dialog: React_2.ReactNode, id?: string, parentDocument?: Document): void;
     // (undocumented)
     pushDialog(dialogInfo: DialogInfo): void;
@@ -1721,7 +1713,7 @@ export class ElementTooltip extends React_2.Component<CommonProps, ElementToolti
     readonly state: Readonly<ElementTooltipState>;
 }
 
-// @public
+// @public @deprecated
 export class ElementTooltipChangedEvent extends UiEvent<ElementTooltipChangedEventArgs> {
 }
 
@@ -2171,7 +2163,7 @@ export interface FrameworkVisibility {
 // @internal (undocumented)
 export const FRONTSTAGE_SETTINGS_NAMESPACE = "uifw-frontstageSettings";
 
-// @public
+// @public @deprecated
 export class FrontstageActivatedEvent extends UiEvent<FrontstageActivatedEventArgs> {
 }
 
@@ -2200,7 +2192,7 @@ export interface FrontstageConfig extends CommonProps {
     readonly viewNavigation?: WidgetConfig;
 }
 
-// @public
+// @public @deprecated
 export class FrontstageDeactivatedEvent extends UiEvent<FrontstageDeactivatedEventArgs> {
 }
 
@@ -2342,7 +2334,7 @@ export abstract class FrontstageProvider {
     abstract get id(): string;
 }
 
-// @public
+// @public @deprecated
 export class FrontstageReadyEvent extends UiEvent<FrontstageReadyEventArgs> {
 }
 
@@ -2659,7 +2651,7 @@ export class InputFieldMessage extends React_2.PureComponent<InputFieldMessagePr
     readonly state: Readonly<InputFieldMessageState>;
 }
 
-// @public
+// @public @deprecated
 export class InputFieldMessageAddedEvent extends UiEvent<InputFieldMessageEventArgs> {
 }
 
@@ -2671,7 +2663,7 @@ export interface InputFieldMessageEventArgs {
     target: Element;
 }
 
-// @public
+// @public @deprecated
 export class InputFieldMessageRemovedEvent extends UiEvent<{}> {
 }
 
@@ -2836,7 +2828,7 @@ export class KeyboardShortcutMenu extends React_2.PureComponent<CommonProps, Key
     readonly state: KeyboardShortcutMenuState;
 }
 
-// @public
+// @public @deprecated
 export class KeyboardShortcutMenuEvent extends UiEvent<KeyboardShortcutMenuState> {
 }
 
@@ -3053,7 +3045,7 @@ export class MenuItemHelpers {
 // @public @deprecated
 export type MenuItemProps = AbstractMenuItemProps;
 
-// @public
+// @public @deprecated
 export class MessageAddedEvent extends UiEvent<MessageAddedEventArgs> {
 }
 
@@ -3129,11 +3121,11 @@ export class MessageManager {
     static updateMessages(): void;
 }
 
-// @public
+// @public @deprecated
 export class MessagesUpdatedEvent extends UiEvent<{}> {
 }
 
-// @public
+// @public @deprecated
 export class ModalDialogChangedEvent extends DialogChangedEvent {
 }
 
@@ -3151,7 +3143,7 @@ export class ModalFrontstage extends React_2.Component<ModalFrontstageProps> {
     render(): React_2.JSX.Element;
 }
 
-// @public
+// @public @deprecated
 export class ModalFrontstageChangedEvent extends UiEvent<ModalFrontstageChangedEventArgs> {
 }
 
@@ -3161,7 +3153,7 @@ export interface ModalFrontstageChangedEventArgs {
     modalFrontstageCount: number;
 }
 
-// @public
+// @public @deprecated
 export class ModalFrontstageClosedEvent extends UiEvent<ModalFrontstageClosedEventArgs> {
 }
 
@@ -3208,7 +3200,7 @@ export interface ModalFrontstageProps extends CommonProps {
     title: string;
 }
 
-// @alpha
+// @alpha @deprecated
 export class ModalFrontstageRequestedCloseEvent extends UiEvent<ModalFrontstageRequestedCloseEventArgs> {
 }
 
@@ -3225,7 +3217,7 @@ export class ModelessDialog extends React_2.Component<ModelessDialogProps> {
     render(): React_2.ReactElement;
 }
 
-// @public
+// @public @deprecated
 export class ModelessDialogChangedEvent extends DialogChangedEvent {
 }
 
@@ -3254,7 +3246,7 @@ export class ModelessDialogRenderer extends React_2.PureComponent<CommonProps> {
     render(): React_2.ReactNode;
 }
 
-// @public
+// @public @deprecated
 export class MouseDownChangedEvent extends UiEvent<MouseDownChangedEventArgs> {
 }
 
@@ -3269,7 +3261,7 @@ export interface NameToReducerMap {
     [name: string]: (state: any, action: any) => any;
 }
 
-// @public
+// @public @deprecated
 export class NavigationAidActivatedEvent extends UiEvent<NavigationAidActivatedEventArgs> {
 }
 
@@ -3331,7 +3323,7 @@ export interface OpenChildWindowInfo {
     window: Window;
 }
 
-// @public
+// @public @deprecated
 export class OpenMessageCenterEvent extends UiEvent<{}> {
 }
 
@@ -3352,10 +3344,6 @@ export interface PanelPinnedChangedEventArgs {
 }
 
 // @internal (undocumented)
-export class PanelSizeChangedEvent extends UiEvent<PanelSizeChangedEventArgs> {
-}
-
-// @internal (undocumented)
 export interface PanelSizeChangedEventArgs {
     // (undocumented)
     panelDef: StagePanelDef;
@@ -3363,7 +3351,7 @@ export interface PanelSizeChangedEventArgs {
     size: number | undefined;
 }
 
-// @beta
+// @beta @deprecated
 export class PanelStateChangedEvent extends UiEvent<PanelStateChangedEventArgs> {
 }
 
@@ -3401,7 +3389,7 @@ export class PointerMessage extends React_2.Component<PointerMessageProps, Point
     static updateMessage(displayPoint: XAndY, relativePosition: RelativePosition): void;
 }
 
-// @public
+// @public @deprecated
 export class PointerMessageChangedEvent extends UiEvent<PointerMessageChangedEventArgs> {
 }
 
@@ -3529,7 +3517,7 @@ export class PopupRenderer extends React_2.Component<{}, PopupRendererState> {
     readonly state: PopupRendererState;
 }
 
-// @public
+// @public @deprecated
 export class PopupsChangedEvent extends UiEvent<PopupsChangedEventArgs> {
 }
 
@@ -4494,7 +4482,7 @@ export interface SupportsViewSelectorChange {
     supportsViewSelectorChange: boolean;
 }
 
-// @public
+// @public @deprecated
 export class SyncToolSettingsPropertiesEvent extends UiEvent<SyncToolSettingsPropertiesEventArgs> {
 }
 
@@ -4567,7 +4555,7 @@ export class TileLoadingIndicator extends React_2.PureComponent<CommonProps, Til
     render(): React_2.JSX.Element;
 }
 
-// @public
+// @public @deprecated
 export class ToolActivatedEvent extends UiEvent<ToolActivatedEventArgs> {
 }
 
@@ -4577,7 +4565,7 @@ export interface ToolActivatedEventArgs {
     toolId: string;
 }
 
-// @public
+// @public @deprecated
 export class ToolAssistanceChangedEvent extends UiEvent<ToolAssistanceChangedEventArgs> {
 }
 
@@ -4754,7 +4742,7 @@ export interface ToolbarWithOverflowProps extends CommonProps, NoChildrenProps {
     useDragInteraction?: boolean;
 }
 
-// @public
+// @public @deprecated
 export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> {
 }
 
@@ -5081,7 +5069,7 @@ export const UiStateStorageContext: React_2.Context<UiStateStorage>;
 // @public
 export function UiStateStorageHandler(props: UiSettingsProviderProps): React_2.JSX.Element;
 
-// @public
+// @public @deprecated
 export class UiSyncEvent extends BeUiEvent<UiSyncEventArgs> {
 }
 
@@ -5091,7 +5079,7 @@ export interface UiSyncEventArgs {
     eventIds: Set<string>;
 }
 
-// @public
+// @public @deprecated
 export class UiVisibilityChangedEvent extends UiEvent<UiVisibilityEventArgs> {
 }
 
@@ -5333,7 +5321,7 @@ export class ViewSelector extends React_2.Component<ViewSelectorProps, ViewSelec
     updateState(viewId?: any): Promise<void>;
 }
 
-// @beta
+// @beta @deprecated
 export class ViewSelectorChangedEvent extends UiEvent<ViewSelectorChangedEventArgs> {
 }
 
@@ -5602,7 +5590,7 @@ export class WidgetManager {
     addWidgetDef(widgetDef: WidgetDef, stageId: string | undefined, stageUsage: string | undefined, location: StagePanelLocation, section?: StagePanelSection): boolean;
     getWidgetDefs(stageId: string, stageUsage: string, location: StagePanelLocation, section?: StagePanelSection): ReadonlyArray<WidgetDef> | undefined;
     // @internal
-    readonly onWidgetsChanged: WidgetsChangedEvent;
+    readonly onWidgetsChanged: BeUiEvent<WidgetsChangedEventArgs>;
     removeWidgetDef(widgetId: string): boolean;
     // @internal (undocumented)
     get widgetCount(): number;
@@ -5643,10 +5631,6 @@ export function WidgetPanelsToolbars(): React_2.JSX.Element;
 export function WidgetPanelsToolSettings(): React_2.JSX.Element | null;
 
 // @internal
-export class WidgetsChangedEvent extends BeUiEvent<WidgetsChangedEventArgs> {
-}
-
-// @internal
 export interface WidgetsChangedEventArgs {
     // (undocumented)
     readonly items: ReadonlyArray<WidgetInfo>;
@@ -5666,7 +5650,7 @@ export enum WidgetState {
     Unloaded = 4
 }
 
-// @public
+// @public @deprecated
 export class WidgetStateChangedEvent extends UiEvent<WidgetStateChangedEventArgs> {
 }
 

--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -21,7 +21,7 @@ import * as React_2 from 'react';
 import ReactAutosuggest from 'react-autosuggest';
 import { RelativePosition } from '@itwin/appui-abstract';
 
-// @public
+// @public @deprecated
 export class ActivateSettingsTabEvent extends BeUiEvent<ActivateSettingsTabEventArgs> {
 }
 
@@ -206,10 +206,6 @@ export class Circle {
 // @public
 export interface ClassNameProps {
     className?: string;
-}
-
-// @internal
-export class CloseSettingsContainerEvent extends BeUiEvent<ProcessSettingsContainerCloseEventArgs> {
 }
 
 // @public
@@ -1247,7 +1243,7 @@ export interface PopupProps extends CommonProps {
     top: number;
 }
 
-// @public
+// @public @deprecated
 export class ProcessSettingsContainerCloseEvent extends BeUiEvent<ProcessSettingsContainerCloseEventArgs> {
 }
 
@@ -1259,7 +1255,7 @@ export interface ProcessSettingsContainerCloseEventArgs {
     readonly closeFuncArgs?: any;
 }
 
-// @public
+// @public @deprecated
 export class ProcessSettingsTabActivationEvent extends BeUiEvent<ProcessSettingsTabActivationEventArgs> {
 }
 
@@ -1485,9 +1481,9 @@ export class SettingsManager {
     closeSettingsContainer(closeFunc: (args: any) => void, closeFuncArgs?: any): void;
     getSettingEntries(stageId: string, stageUsage: string): Array<SettingsTabEntry>;
     // @internal
-    readonly onActivateSettingsTab: ActivateSettingsTabEvent;
+    readonly onActivateSettingsTab: BeUiEvent<ActivateSettingsTabEventArgs>;
     // @internal
-    readonly onCloseSettingsContainer: CloseSettingsContainerEvent;
+    readonly onCloseSettingsContainer: BeUiEvent<ProcessSettingsContainerCloseEventArgs>;
     readonly onProcessSettingsContainerClose: ProcessSettingsContainerCloseEvent;
     readonly onProcessSettingsTabActivation: ProcessSettingsTabActivationEvent;
     readonly onSettingsProvidersChanged: SettingsProvidersChangedEvent;
@@ -1498,7 +1494,7 @@ export class SettingsManager {
     removeSettingsProvider(providerId: string): boolean;
 }
 
-// @public
+// @public @deprecated
 export class SettingsProvidersChangedEvent extends BeUiEvent<SettingsProvidersChangedEventArgs> {
 }
 

--- a/common/api/imodel-components-react.api.md
+++ b/common/api/imodel-components-react.api.md
@@ -329,7 +329,7 @@ export interface CubeProps extends React_2.AllHTMLAttributes<HTMLDivElement>, Co
     rotMatrix: Matrix3d;
 }
 
-// @public
+// @public @deprecated
 export class CubeRotationChangeEvent extends UiEvent<CubeRotationChangeEventArgs> {
 }
 
@@ -425,7 +425,7 @@ export interface DrawingNavigationCanvasProps {
     zoom: number;
 }
 
-// @public
+// @public @deprecated
 export class DrawingViewportChangeEvent extends UiEvent<DrawingViewportChangeEventArgs> {
 }
 
@@ -801,7 +801,7 @@ export class SolarTimeline extends React_2.PureComponent<SolarTimelineComponentP
     render(): React_2.JSX.Element;
 }
 
-// @public
+// @public @deprecated
 export class StandardRotationChangeEvent extends UiEvent<StandardRotationChangeEventArgs> {
 }
 
@@ -931,7 +931,7 @@ export class UiIModelComponents {
 // @internal (undocumented)
 export function useFocusedThumb(sliderContainer: HTMLDivElement | undefined): boolean;
 
-// @public
+// @public @deprecated
 export class ViewClassFullNameChangedEvent extends UiEvent<ViewClassFullNameChangedEventArgs> {
 }
 
@@ -945,7 +945,7 @@ export interface ViewClassFullNameChangedEventArgs {
     viewport: Viewport;
 }
 
-// @public
+// @public @deprecated
 export class ViewIdChangedEvent extends UiEvent<ViewIdChangedEventArgs> {
 }
 
@@ -1018,7 +1018,7 @@ export interface ViewportProps extends CommonProps {
     viewState?: ViewStateProp;
 }
 
-// @public
+// @public @deprecated
 export class ViewRotationChangeEvent extends UiEvent<ViewRotationChangeEventArgs> {
 }
 

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -4,20 +4,27 @@ beta;AccuDrawCommandItems
 beta;AccuDrawDialog(props: AccuDrawDialogProps): React_2.JSX.Element
 beta;AccuDrawDialogProps 
 beta;AccuDrawGrabInputFocusEvent 
+deprecated;AccuDrawGrabInputFocusEvent 
 beta;AccuDrawKeyboardShortcuts
 alpha;AccuDrawPopupManager
 beta;AccuDrawSetCompassModeEvent 
+deprecated;AccuDrawSetCompassModeEvent 
 beta;AccuDrawSetCompassModeEventArgs
 beta;AccuDrawSetFieldFocusEvent 
+deprecated;AccuDrawSetFieldFocusEvent 
 beta;AccuDrawSetFieldFocusEventArgs
 beta;AccuDrawSetFieldLockEvent 
+deprecated;AccuDrawSetFieldLockEvent 
 beta;AccuDrawSetFieldLockEventArgs
 beta;AccuDrawSetFieldValueFromUiEvent 
+deprecated;AccuDrawSetFieldValueFromUiEvent 
 beta;AccuDrawSetFieldValueFromUiEventArgs
 beta;AccuDrawSetFieldValueToUiEvent 
+deprecated;AccuDrawSetFieldValueToUiEvent 
 beta;AccuDrawSetFieldValueToUiEventArgs
 beta;AccuDrawUiSettings
 beta;AccuDrawUiSettingsChangedEvent 
+deprecated;AccuDrawUiSettingsChangedEvent 
 beta;AccuDrawWidget(): React_2.JSX.Element
 beta;AccuDrawWidgetControl 
 public;Action
@@ -27,12 +34,15 @@ public;ActionsUnion
 public;ActionTypes
 public;ActionWithPayload
 public;ActiveContentChangedEvent 
+deprecated;ActiveContentChangedEvent 
 public;ActiveContentChangedEventArgs
 internal;ActiveFrontstageDefProvider({ frontstageDef, }: ActiveFrontstageDefProviderProps): React_2.JSX.Element
 public;ActivityCenterField(props: CommonProps): React_2.JSX.Element | null
 public;ActivityMessageCancelledEvent 
+deprecated;ActivityMessageCancelledEvent 
 public;ActivityMessageEventArgs
 public;ActivityMessageUpdatedEvent 
+deprecated;ActivityMessageUpdatedEvent 
 internal;addFrontstageWidgetDefs(frontstageDef: FrontstageDef): void
 internal;addPanelSectionWidgetDefs(frontstageDef: FrontstageDef, location: StagePanelLocation, section: StagePanelSection): void
 public;AllowedUiItemsProviderOverrides
@@ -78,6 +88,7 @@ alpha;CardContainer
 alpha;CardContainerProps 
 alpha;CardInfo
 alpha;CardSelectedEvent 
+deprecated;CardSelectedEvent 
 alpha;CardSelectedEventArgs
 public;ChildWindowLocationProps
 internal;clearKeyinPaletteHistory(): void
@@ -109,9 +120,11 @@ beta;connectIModelConnectionAndViewState: (mapStateToProps?: any, mapDispatchToP
 public;ContentCallback = (content: ContentProps) => void
 public;ContentControl 
 public;ContentControlActivatedEvent 
+deprecated;ContentControlActivatedEvent 
 public;ContentControlActivatedEventArgs
 public;ContentDialog(props: ContentDialogProps): React_2.JSX.Element
 public;ContentDialogChangedEvent 
+deprecated;ContentDialogChangedEvent 
 public;ContentDialogInfo
 public;ContentDialogProps 
 public;ContentDialogRenderer 
@@ -120,6 +133,7 @@ public;ContentGroupProps
 public;class ContentGroupProvider
 public;ContentLayout 
 public;ContentLayoutActivatedEvent 
+deprecated;ContentLayoutActivatedEvent 
 public;ContentLayoutActivatedEventArgs
 public;ContentLayoutComponentProps 
 public;ContentLayoutDef
@@ -141,7 +155,6 @@ public;CursorMenuItemProps
 public;CursorMenuPayload
 public;CursorPopup 
 public;CursorPopupContent(props: CommonDivProps): React_2.JSX.Element
-internal;CursorPopupFadeOutEvent 
 internal;CursorPopupFadeOutEventArgs
 public;CursorPopupManager
 alpha;CursorPopupMenu 
@@ -149,10 +162,10 @@ public;CursorPopupOptions
 public;CursorPopupProps =
 public;CursorPopupRenderer 
 internal;CursorPopupShow
-internal;CursorPopupUpdatePositionEvent 
 internal;CursorPopupUpdatePositionEventArgs
 internal;CursorPrompt
 public;CursorUpdatedEvent 
+deprecated;CursorUpdatedEvent 
 public;CursorUpdatedEventArgs
 public;CustomItemDef 
 public;CustomItemProps 
@@ -167,6 +180,7 @@ public;DefaultStatusbarItems
 internal;DefaultToolSettingsProvider 
 public;DefaultViewOverlay({ viewport, onPlayPause, featureOptions, }: ViewOverlayProps): React_2.JSX.Element | null
 public;DialogChangedEvent 
+deprecated;DialogChangedEvent 
 public;DialogChangedEventArgs
 internal;DialogGridContainer({ componentGenerator, containerClassName, }: DialogGridContainerProps): React_2.JSX.Element
 public;DialogInfo
@@ -177,6 +191,7 @@ internal;DockedStatusBarItem(props: StatusBarItemProps): React_2.JSX.Element
 beta;DrawingNavigationAidControl 
 public;ElementTooltip 
 public;ElementTooltipChangedEvent 
+deprecated;ElementTooltipChangedEvent 
 public;ElementTooltipChangedEventArgs
 public;EmphasizeElementsChangedArgs
 beta;ExpandableSection 
@@ -211,15 +226,18 @@ public;FrameworkUiAdmin
 public;FrameworkVisibility
 internal;FRONTSTAGE_SETTINGS_NAMESPACE = "uifw-frontstageSettings"
 public;FrontstageActivatedEvent 
+deprecated;FrontstageActivatedEvent 
 public;FrontstageActivatedEventArgs
 public;FrontstageConfig 
 public;FrontstageDeactivatedEvent 
+deprecated;FrontstageDeactivatedEvent 
 public;FrontstageDeactivatedEventArgs
 public;FrontstageDef
 internal;FrontstageEventArgs
 internal;FrontstageNineZoneStateChangedEventArgs 
 public;class FrontstageProvider
 public;FrontstageReadyEvent 
+deprecated;FrontstageReadyEvent 
 public;FrontstageReadyEventArgs
 public;FunctionType = (...args: any[]) => any
 internal;getBadgeClassName(badgeType: BadgeType | undefined): "uifw-badge-new" | "uifw-badge-tp" | undefined
@@ -258,8 +276,10 @@ alpha;InputEditorPopup
 beta;InputEditorPopupProps 
 public;InputFieldMessage 
 public;InputFieldMessageAddedEvent 
+deprecated;InputFieldMessageAddedEvent 
 public;InputFieldMessageEventArgs
 public;InputFieldMessageRemovedEvent 
+deprecated;InputFieldMessageRemovedEvent 
 alpha;InputStatus
 public;isBackstageActionItem(item: BackstageItem): item is BackstageActionItem
 public;isBackstageStageLauncher(item: BackstageItem): item is BackstageStageLauncher
@@ -281,6 +301,7 @@ public;KeyboardShortcut
 public;KeyboardShortcutContainer
 public;KeyboardShortcutMenu 
 public;KeyboardShortcutMenuEvent 
+deprecated;KeyboardShortcutMenuEvent 
 public;KeyboardShortcutMenuState
 public;KeyboardShortcutProps 
 public;KeyinEntry
@@ -306,32 +327,41 @@ alpha;MenuItemHelpers
 public;MenuItemProps = AbstractMenuItemProps
 deprecated;MenuItemProps = AbstractMenuItemProps
 public;MessageAddedEvent 
+deprecated;MessageAddedEvent 
 public;MessageAddedEventArgs
 public;MessageCenterField 
 public;MessageManager
 public;MessagesUpdatedEvent 
+deprecated;MessagesUpdatedEvent 
 public;ModalDialogChangedEvent 
+deprecated;ModalDialogChangedEvent 
 public;ModalDialogRenderer 
 public;ModalFrontstage 
 public;ModalFrontstageChangedEvent 
+deprecated;ModalFrontstageChangedEvent 
 public;ModalFrontstageChangedEventArgs
 public;ModalFrontstageClosedEvent 
+deprecated;ModalFrontstageClosedEvent 
 public;ModalFrontstageClosedEventArgs
 internal;ModalFrontstageComposer({ stageInfo, }:
 public;ModalFrontstageInfo
 internal;ModalFrontstageItem
 public;ModalFrontstageProps 
 alpha;ModalFrontstageRequestedCloseEvent 
+deprecated;ModalFrontstageRequestedCloseEvent 
 alpha;ModalFrontstageRequestedCloseEventArgs
 public;ModelessDialog 
 public;ModelessDialogChangedEvent 
+deprecated;ModelessDialogChangedEvent 
 public;ModelessDialogInfo
 public;ModelessDialogProps 
 public;ModelessDialogRenderer 
 public;MouseDownChangedEvent 
+deprecated;MouseDownChangedEvent 
 public;MouseDownChangedEventArgs
 public;NameToReducerMap
 public;NavigationAidActivatedEvent 
+deprecated;NavigationAidActivatedEvent 
 public;NavigationAidActivatedEventArgs
 public;NavigationAidControl 
 public;NavigationAidHost(props: NavigationAidHostProps): React_2.JSX.Element
@@ -343,17 +373,19 @@ public;NotifyMessageDetailsType = NotifyMessageDetails | ReactNotifyMessageDetai
 public;NotifyMessageType = MessageType
 public;OpenChildWindowInfo
 public;OpenMessageCenterEvent 
+deprecated;OpenMessageCenterEvent 
 public;OverflowToolbarOptions
 internal;packNineZoneState(state: NineZoneState): NineZoneState
 public;PanelPinnedChangedEventArgs
-internal;PanelSizeChangedEvent 
 internal;PanelSizeChangedEventArgs
 beta;PanelStateChangedEvent 
+deprecated;PanelStateChangedEvent 
 public;PanelStateChangedEventArgs
 public;Placement = Side | `${Side}-${Alignment}`
 internal;PlacementOrRelativePosition = Placement | RelativePosition
 public;PointerMessage 
 public;PointerMessageChangedEvent 
+deprecated;PointerMessageChangedEvent 
 public;PointerMessageChangedEventArgs
 public;PointerMessageProps 
 public;PopupContentType = HTMLElement | ReactContent
@@ -362,6 +394,7 @@ public;PopupManager
 public;PopupPropsBase
 public;PopupRenderer 
 public;PopupsChangedEvent 
+deprecated;PopupsChangedEvent 
 public;PopupsChangedEventArgs
 beta;PositionPopup 
 beta;PositionPopupContent(props: CommonDivProps): React_2.JSX.Element
@@ -481,6 +514,7 @@ public;StatusBarWidgetComposerControl
 public;class StatusBarWidgetControl 
 public;SupportsViewSelectorChange
 public;SyncToolSettingsPropertiesEvent 
+deprecated;SyncToolSettingsPropertiesEvent 
 public;SyncToolSettingsPropertiesEventArgs
 public;SyncUiEventDispatcher
 public;SyncUiEventId
@@ -489,8 +523,10 @@ public;ThemeId = `${ColorTheme}` | (string & {})
 public;ThemeManager: ConnectedComponent
 public;TileLoadingIndicator 
 public;ToolActivatedEvent 
+deprecated;ToolActivatedEvent 
 public;ToolActivatedEventArgs
 public;ToolAssistanceChangedEvent 
+deprecated;ToolAssistanceChangedEvent 
 public;ToolAssistanceChangedEventArgs
 public;ToolAssistanceField 
 internal;ToolAssistanceFieldDefaultProps = Pick
@@ -515,6 +551,7 @@ public;ToolbarUsage
 beta;ToolbarWithOverflow(props: ToolbarWithOverflowProps): React_2.JSX.Element
 beta;ToolbarWithOverflowProps 
 public;ToolIconChangedEvent 
+deprecated;ToolIconChangedEvent 
 public;ToolIconChangedEventArgs
 public;ToolInformation
 public;ToolItemDef 
@@ -543,8 +580,10 @@ public;UiSettingsProviderProps
 internal;UiStateStorageContext: React_2.Context
 public;UiStateStorageHandler(props: UiSettingsProviderProps): React_2.JSX.Element
 public;UiSyncEvent 
+deprecated;UiSyncEvent 
 public;UiSyncEventArgs
 public;UiVisibilityChangedEvent 
+deprecated;UiVisibilityChangedEvent 
 public;UiVisibilityEventArgs
 alpha;UnitSystemSelector(props: UnitSystemSelectorProps): React_2.JSX.Element
 beta;UnitSystemSelectorProps
@@ -602,6 +641,7 @@ public;ViewOverlayProps
 public;ViewportContentControl 
 beta;ViewSelector 
 beta;ViewSelectorChangedEvent 
+deprecated;ViewSelectorChangedEvent 
 beta;ViewSelectorChangedEventArgs
 beta;ViewSelectorDefaultProps = Pick
 beta;ViewSelectorProps
@@ -630,10 +670,10 @@ internal;WidgetPanelsStatusBar(props: CommonProps): React_2.JSX.Element | null
 internal;WidgetPanelsTab(): React_2.JSX.Element
 internal;WidgetPanelsToolbars(): React_2.JSX.Element
 internal;WidgetPanelsToolSettings(): React_2.JSX.Element | null
-internal;WidgetsChangedEvent 
 internal;WidgetsChangedEventArgs
 public;WidgetState
 public;WidgetStateChangedEvent 
+deprecated;WidgetStateChangedEvent 
 public;WidgetStateChangedEventArgs
 public;WidgetType
 internal;WrapperContext: React_2.Context

--- a/common/api/summary/core-react.exports.csv
+++ b/common/api/summary/core-react.exports.csv
@@ -1,6 +1,7 @@
 sep=;
 Release Tag;API Item
 public;ActivateSettingsTabEvent 
+deprecated;ActivateSettingsTabEvent 
 public;ActivateSettingsTabEventArgs
 internal;AnnularSector
 internal;Annulus
@@ -29,7 +30,6 @@ public;CheckListBoxItemProps
 public;CheckListBoxSeparator(): React_2.JSX.Element
 internal;Circle
 public;ClassNameProps
-internal;CloseSettingsContainerEvent 
 public;CommonDivProps 
 public;CommonProps 
 public;ConditionalIconItem
@@ -156,8 +156,10 @@ public;PopupContextMenu(props: PopupContextMenuProps): React_2.JSX.Element
 public;PopupContextMenuProps 
 public;PopupProps 
 public;ProcessSettingsContainerCloseEvent 
+deprecated;ProcessSettingsContainerCloseEvent 
 public;ProcessSettingsContainerCloseEventArgs
 public;ProcessSettingsTabActivationEvent 
+deprecated;ProcessSettingsTabActivationEvent 
 public;ProcessSettingsTabActivationEventArgs
 internal;PROXIMITY_THRESHOLD_DEFAULT = 100
 public;RadialButton 
@@ -181,6 +183,7 @@ public;SettingsContainer: ({ tabs, onSettingsTabSelected, currentSettingsTab, se
 public;SettingsContainerProps
 public;SettingsManager
 public;SettingsProvidersChangedEvent 
+deprecated;SettingsProvidersChangedEvent 
 public;SettingsProvidersChangedEventArgs
 public;SettingsTabEntry
 public;SettingsTabsProvider

--- a/common/api/summary/imodel-components-react.exports.csv
+++ b/common/api/summary/imodel-components-react.exports.csv
@@ -36,6 +36,7 @@ public;CubeNavigationHitBoxY
 public;CubeNavigationHitBoxZ
 public;CubeProps 
 public;CubeRotationChangeEvent 
+deprecated;CubeRotationChangeEvent 
 public;CubeRotationChangeEventArgs
 internal;CustomThumb(): React_2.JSX.Element
 public;DrawingNavigationAid 
@@ -43,6 +44,7 @@ public;DrawingNavigationAidProps
 internal;DrawingNavigationCanvas 
 internal;DrawingNavigationCanvasProps
 public;DrawingViewportChangeEvent 
+deprecated;DrawingViewportChangeEvent 
 public;DrawingViewportChangeEventArgs
 public;Face
 internal;FaceCell 
@@ -92,6 +94,7 @@ alpha;SolarDataProvider
 alpha;SolarPlaybackProgressHandler = (time: Date) => void
 alpha;SolarTimeline 
 public;StandardRotationChangeEvent 
+deprecated;StandardRotationChangeEvent 
 public;StandardRotationChangeEventArgs
 beta;StepFunctionProp = number | ((direction: string) => number | undefined)
 public;TimelineComponent(props: TimelineComponentProps): React_2.JSX.Element
@@ -107,13 +110,16 @@ public;TimelineScale
 public;UiIModelComponents
 internal;useFocusedThumb(sliderContainer: HTMLDivElement | undefined): boolean
 public;ViewClassFullNameChangedEvent 
+deprecated;ViewClassFullNameChangedEvent 
 public;ViewClassFullNameChangedEventArgs
 public;ViewIdChangedEvent 
+deprecated;ViewIdChangedEvent 
 public;ViewIdChangedEventArgs
 public;ViewportComponent(props: ViewportProps): React_2.JSX.Element
 public;ViewportComponentEvents
 public;ViewportProps 
 public;ViewRotationChangeEvent 
+deprecated;ViewRotationChangeEvent 
 public;ViewRotationChangeEventArgs
 public;ViewStateProp = ViewState | (() => ViewState)
 public;WeightEditor 

--- a/common/changes/@itwin/appui-react/deprecate-uievents-subclasses_2024-04-22-12-13.json
+++ b/common/changes/@itwin/appui-react/deprecate-uievents-subclasses_2024-04-22-12-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Deprecated all UI event classes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/core-react/deprecate-uievents-subclasses_2024-04-22-12-13.json
+++ b/common/changes/@itwin/core-react/deprecate-uievents-subclasses_2024-04-22-12-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Deprecated all UI event classes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/deprecate-uievents-subclasses_2024-04-22-12-13.json
+++ b/common/changes/@itwin/imodel-components-react/deprecate-uievents-subclasses_2024-04-22-12-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Deprecated all UI event classes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -3,16 +3,29 @@
 Table of contents:
 
 - [@itwin/appui-react](#itwinappui-react)
-  - [Changes](#changes)
-- [@itwin/core-react](#itwincore-react)
   - [Deprecations](#deprecations)
   - [Changes](#changes)
+- [@itwin/imodel-components-react](#itwinimodel-components-react)
+  - [Deprecations](#deprecations-1)
+- [@itwin/core-react](#itwincore-react)
+  - [Deprecations](#deprecations-2)
+  - [Changes](#changes-1)
 
 ## @itwin/appui-react
+
+### Deprecations
+
+- Deprecated all UI event classes (e.g. `ContentControlActivatedEvent`). These are only emitter classes that should not be exported. It is possible to use `BeUiEvent<EventArgs>` (`EventArgs` can be any of the exported event args interfaces e.g. `ContentControlActivatedEventArgs`) instead.
 
 ### Changes
 
 - Bump `FloatingViewportContentWrapper` to `@public`. [#801](https://github.com/iTwin/appui/pull/801)
+
+## @itwin/imodel-components-react
+
+### Deprecations
+
+- Deprecated all UI event classes (e.g. `StandardRotationChangeEvent`). These are only emitter classes that should not be exported. It is possible to use `BeUiEvent<EventArgs>` (`EventArgs` can be any of the exported event args interfaces e.g. `StandardRotationChangeEventArgs`) instead.
 
 ## @itwin/core-react
 
@@ -25,6 +38,7 @@ Table of contents:
 - `FlexWrapContainer` component in favor of [iTwinUI Flex](https://itwinui.bentley.com/docs/flex). [#795](https://github.com/iTwin/appui/pull/795)
 - `Gap` component in favor of [iTwinUI size variables](https://itwinui.bentley.com/docs/variables#size). [#795](https://github.com/iTwin/appui/pull/795)
 - `ScrollView` component in favor of [overflow property](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow). [#795](https://github.com/iTwin/appui/pull/795)
+- Deprecated all UI event classes (e.g. `SettingsProvidersChangedEvent`). These are only emitter classes that should not be exported. It is possible to use `BeUiEvent<EventArgs>` (`EventArgs` can be any of the exported event args interfaces e.g. `SettingsProvidersChangedEventArgs`) instead.
 
 ### Changes
 

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -115,6 +115,7 @@ export interface UiVisibilityEventArgs {
 
 /** UiVisibility Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<UiVisibilityEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class UiVisibilityChangedEvent extends UiEvent<UiVisibilityEventArgs> {}
@@ -262,6 +263,7 @@ export class UiFramework {
   /** Get Show Ui event.
    * @public
    */
+  // eslint-disable-next-line deprecation/deprecation
   public static readonly onUiVisibilityChanged = new UiVisibilityChangedEvent();
 
   /**

--- a/ui/appui-react/src/appui-react/accudraw/FrameworkAccuDraw.ts
+++ b/ui/appui-react/src/appui-react/accudraw/FrameworkAccuDraw.ts
@@ -52,7 +52,9 @@ export interface AccuDrawSetFieldFocusEventArgs {
 }
 
 /** AccuDraw Set Field Focus event
- * @beta */
+ * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<AccuDrawSetFieldFocusEventArgs>` instead.
+ */
 export class AccuDrawSetFieldFocusEvent extends BeUiEvent<AccuDrawSetFieldFocusEventArgs> {}
 
 /** Arguments for [[AccuDrawSetFieldValueToUiEvent]]
@@ -64,7 +66,9 @@ export interface AccuDrawSetFieldValueToUiEventArgs {
 }
 
 /** AccuDraw Set Field Value to Ui event
- * @beta */
+ * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<AccuDrawSetFieldValueToUiEventArgs>` instead.
+ */
 export class AccuDrawSetFieldValueToUiEvent extends BeUiEvent<AccuDrawSetFieldValueToUiEventArgs> {}
 
 /** Arguments for [[AccuDrawSetFieldValueFromUiEvent]]
@@ -75,7 +79,9 @@ export interface AccuDrawSetFieldValueFromUiEventArgs {
 }
 
 /** AccuDraw Set Field Value from Ui event
- * @beta */
+ * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<AccuDrawSetFieldValueFromUiEventArgs>` instead.
+ */
 export class AccuDrawSetFieldValueFromUiEvent extends BeUiEvent<AccuDrawSetFieldValueFromUiEventArgs> {}
 
 /** Arguments for [[AccuDrawSetFieldLockEvent]]
@@ -86,7 +92,9 @@ export interface AccuDrawSetFieldLockEventArgs {
 }
 
 /** AccuDraw Set Field Lock event
- * @beta */
+ * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<AccuDrawSetFieldLockEventArgs>` instead.
+ */
 export class AccuDrawSetFieldLockEvent extends BeUiEvent<AccuDrawSetFieldLockEventArgs> {}
 
 /** Arguments for [[AccuDrawSetCompassModeEvent]]
@@ -96,15 +104,21 @@ export interface AccuDrawSetCompassModeEventArgs {
 }
 
 /** AccuDraw Set Compass Mode event
- * @beta */
+ * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<AccuDrawSetCompassModeEventArgs>` instead.
+ */
 export class AccuDrawSetCompassModeEvent extends BeUiEvent<AccuDrawSetCompassModeEventArgs> {}
 
 /** AccuDraw Grab Input Focus event
- * @beta */
+ * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<{}>` instead.
+ */
 export class AccuDrawGrabInputFocusEvent extends BeUiEvent<{}> {}
 
 /** AccuDraw Ui Settings Changed event
- * @beta */
+ * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<{}>` instead.
+ */
 export class AccuDrawUiSettingsChangedEvent extends BeUiEvent<{}> {}
 
 /** Subclass of `AccuDraw` in `@itwin/core-frontend` to be used to initialize `IModelApp`.
@@ -130,22 +144,22 @@ export class FrameworkAccuDraw
 
   /** AccuDraw Set Field Focus event. */
   public static readonly onAccuDrawSetFieldFocusEvent =
-    new AccuDrawSetFieldFocusEvent();
+    new AccuDrawSetFieldFocusEvent(); // eslint-disable-line deprecation/deprecation
   /** AccuDraw Set Field Value to Ui event. */
   public static readonly onAccuDrawSetFieldValueToUiEvent =
-    new AccuDrawSetFieldValueToUiEvent();
+    new AccuDrawSetFieldValueToUiEvent(); // eslint-disable-line deprecation/deprecation
   /** AccuDraw Set Field Value from Ui event. */
   public static readonly onAccuDrawSetFieldValueFromUiEvent =
-    new AccuDrawSetFieldValueFromUiEvent();
+    new AccuDrawSetFieldValueFromUiEvent(); // eslint-disable-line deprecation/deprecation
   /** AccuDraw Set Field Lock event. */
   public static readonly onAccuDrawSetFieldLockEvent =
-    new AccuDrawSetFieldLockEvent();
+    new AccuDrawSetFieldLockEvent(); // eslint-disable-line deprecation/deprecation
   /** AccuDraw Set Mode event. */
   public static readonly onAccuDrawSetCompassModeEvent =
-    new AccuDrawSetCompassModeEvent();
+    new AccuDrawSetCompassModeEvent(); // eslint-disable-line deprecation/deprecation
   /** AccuDraw Grab Input Focus event. */
   public static readonly onAccuDrawGrabInputFocusEvent =
-    new AccuDrawGrabInputFocusEvent();
+    new AccuDrawGrabInputFocusEvent(); // eslint-disable-line deprecation/deprecation
 
   /** Determines if AccuDraw.rotationMode === RotationMode.Top */
   public static readonly isTopRotationConditional = new ConditionalBooleanValue(
@@ -195,7 +209,7 @@ export class FrameworkAccuDraw
 
   /** AccuDraw Grab Input Focus event. */
   public static readonly onAccuDrawUiSettingsChangedEvent =
-    new AccuDrawUiSettingsChangedEvent();
+    new AccuDrawUiSettingsChangedEvent(); // eslint-disable-line deprecation/deprecation
 
   /** Determines if notifications should be displayed for AccuDraw changes */
   public static get displayNotifications(): boolean {

--- a/ui/appui-react/src/appui-react/content/ContentControl.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentControl.tsx
@@ -30,6 +30,7 @@ export interface ContentControlActivatedEventArgs {
 
 /** ContentControl Activated Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ContentControlActivatedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ContentControlActivatedEvent extends UiEvent<ContentControlActivatedEventArgs> {}

--- a/ui/appui-react/src/appui-react/content/ContentLayout.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.tsx
@@ -569,6 +569,7 @@ export interface ContentLayoutActivatedEventArgs {
 
 /** Content Layout Activated Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ContentLayoutActivatedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ContentLayoutActivatedEvent extends UiEvent<ContentLayoutActivatedEventArgs> {}

--- a/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
+++ b/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
@@ -13,11 +13,11 @@ import type { ContentControl } from "./ContentControl";
 import { InternalContentLayoutManager } from "./InternalContentLayoutManager";
 import { IModelApp } from "@itwin/core-frontend";
 import type { ContentGroup } from "./ContentGroup";
-import { Logger } from "@itwin/core-bentley";
+import { BeUiEvent, Logger } from "@itwin/core-bentley";
 import { UiFramework } from "../UiFramework";
-import {
-  ActiveContentChangedEvent,
-  MouseDownChangedEvent,
+import type {
+  ActiveContentChangedEventArgs,
+  MouseDownChangedEventArgs,
 } from "../framework/FrameworkContent";
 import { InternalContentDialogManager } from "../dialog/InternalContentDialogManager";
 
@@ -29,7 +29,8 @@ export class InternalContentViewManager {
   private static _activeContent?: React.ReactNode;
 
   /** Gets the [[MouseDownChangedEvent]] */
-  public static readonly onMouseDownChangedEvent = new MouseDownChangedEvent();
+  public static readonly onMouseDownChangedEvent =
+    new BeUiEvent<MouseDownChangedEventArgs>();
 
   /** Determines if the mouse is down in a content view */
   public static get isMouseDown(): boolean {
@@ -44,7 +45,7 @@ export class InternalContentViewManager {
 
   /** Gets the [[ActiveContentChangedEvent]] */
   public static readonly onActiveContentChangedEvent =
-    new ActiveContentChangedEvent();
+    new BeUiEvent<ActiveContentChangedEventArgs>();
 
   /** Fires when floating contents are added or removed */
 

--- a/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
+++ b/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
@@ -7,7 +7,6 @@
  */
 
 import type * as React from "react";
-import { UiEvent } from "@itwin/appui-abstract";
 import { ViewUtilities } from "../utils/ViewUtilities";
 import type { ContentControl } from "./ContentControl";
 import { InternalContentLayoutManager } from "./InternalContentLayoutManager";
@@ -50,7 +49,7 @@ export class InternalContentViewManager {
   /** Fires when floating contents are added or removed */
 
   // eslint-disable-next-line deprecation/deprecation
-  public static readonly onAvailableContentChangedEvent = new UiEvent<{
+  public static readonly onAvailableContentChangedEvent = new BeUiEvent<{
     contentId: string;
   }>();
 

--- a/ui/appui-react/src/appui-react/cursor/CursorInformation.ts
+++ b/ui/appui-react/src/appui-react/cursor/CursorInformation.ts
@@ -46,6 +46,7 @@ export interface CursorUpdatedEventArgs {
 
 /** Cursor Updated Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<CursorUpdatedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class CursorUpdatedEvent extends UiEvent<CursorUpdatedEventArgs> {}
@@ -83,6 +84,7 @@ export class CursorInformation {
   }
 
   /** Gets the [[CursorUpdatedEvent]]. */
+  // eslint-disable-next-line deprecation/deprecation
   public static readonly onCursorUpdatedEvent = new CursorUpdatedEvent();
 
   /** Handles the mouse movement.  Sets the cursor position and direction and emits onCursorUpdatedEvent. */

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
@@ -7,9 +7,9 @@
  */
 
 import * as React from "react";
-import { Logger } from "@itwin/core-bentley";
+import { BeUiEvent, Logger } from "@itwin/core-bentley";
 import type { XAndY } from "@itwin/core-geometry";
-import { RelativePosition, UiEvent } from "@itwin/appui-abstract";
+import { RelativePosition } from "@itwin/appui-abstract";
 import type { RectangleProps, SizeProps } from "@itwin/core-react";
 import { Point, Size } from "@itwin/core-react";
 import { UiFramework } from "../../UiFramework";
@@ -36,24 +36,12 @@ export interface CursorPopupUpdatePositionEventArgs {
   pt: XAndY;
 }
 
-/** CursorPopup Update Position Event class.
- * @internal
- */
-// eslint-disable-next-line deprecation/deprecation
-export class CursorPopupUpdatePositionEvent extends UiEvent<CursorPopupUpdatePositionEventArgs> {}
-
 /** CursorPopup FadeOut Event Args interface.
  * @internal
  */
 export interface CursorPopupFadeOutEventArgs {
   id: string;
 }
-
-/** CursorPopup FadeOut Event class.
- * @internal
- */
-// eslint-disable-next-line deprecation/deprecation
-export class CursorPopupFadeOutEvent extends UiEvent<CursorPopupFadeOutEventArgs> {}
 
 /** Information maintained by CursorPopupManager about a CursorPopup
  * @internal
@@ -70,12 +58,6 @@ interface CursorPopupInfo {
   popupSize?: Size;
 }
 
-/** Cursor Popups Changed Event class.
- * @internal
- */
-// eslint-disable-next-line deprecation/deprecation
-class CursorPopupsChangedEvent extends UiEvent<{}> {}
-
 /** CursorPopup component
  * @public
  */
@@ -84,13 +66,12 @@ export class CursorPopupManager {
 
   /** @internal */
   public static readonly onCursorPopupUpdatePositionEvent =
-    new CursorPopupUpdatePositionEvent();
+    new BeUiEvent<CursorPopupUpdatePositionEventArgs>();
   /** @internal */
   public static readonly onCursorPopupFadeOutEvent =
-    new CursorPopupFadeOutEvent();
+    new BeUiEvent<CursorPopupFadeOutEventArgs>();
   /** @internal */
-  public static readonly onCursorPopupsChangedEvent =
-    new CursorPopupsChangedEvent();
+  public static readonly onCursorPopupsChangedEvent = new BeUiEvent<{}>();
   /** @internal */
   public static clearPopups() {
     this._popups.length = 0;

--- a/ui/appui-react/src/appui-react/dialog/DialogManagerBase.tsx
+++ b/ui/appui-react/src/appui-react/dialog/DialogManagerBase.tsx
@@ -7,6 +7,7 @@
  */
 
 import * as React from "react";
+import type { BeUiEvent } from "@itwin/core-bentley";
 import { Logger } from "@itwin/core-bentley";
 import { UiEvent } from "@itwin/appui-abstract";
 import { UiFramework } from "../UiFramework";
@@ -22,6 +23,7 @@ export interface DialogChangedEventArgs {
 
 /** Dialog Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<DialogChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class DialogChangedEvent extends UiEvent<DialogChangedEventArgs> {}
@@ -44,10 +46,10 @@ const ZINDEX_DEFAULT = 12000;
 export class DialogManagerBase {
   private static _sId = 0;
   private _dialogs: DialogInfo[] = new Array<DialogInfo>();
-  private _onDialogChangedEvent: DialogChangedEvent;
+  private _onDialogChangedEvent: BeUiEvent<DialogChangedEventArgs>;
   private static _topZIndex = ZINDEX_DEFAULT;
 
-  constructor(onDialogChangedEvent: DialogChangedEvent) {
+  constructor(onDialogChangedEvent: BeUiEvent<DialogChangedEventArgs>) {
     this._onDialogChangedEvent = onDialogChangedEvent;
   }
 
@@ -67,7 +69,7 @@ export class DialogManagerBase {
     return this._dialogs;
   }
 
-  public get onDialogChangedEvent(): DialogChangedEvent {
+  public get onDialogChangedEvent(): BeUiEvent<DialogChangedEventArgs> {
     return this._onDialogChangedEvent;
   }
 

--- a/ui/appui-react/src/appui-react/dialog/InternalContentDialogManager.tsx
+++ b/ui/appui-react/src/appui-react/dialog/InternalContentDialogManager.tsx
@@ -7,9 +7,10 @@
  */
 
 import type * as React from "react";
-import { Logger } from "@itwin/core-bentley";
+import { BeUiEvent, Logger } from "@itwin/core-bentley";
 import { getCssVariableAsNumber } from "@itwin/core-react";
 import { UiFramework } from "../UiFramework";
+import type { DialogChangedEventArgs } from "./DialogManagerBase";
 import { DialogManagerBase } from "./DialogManagerBase";
 import {
   IModelApp,
@@ -18,7 +19,6 @@ import {
   OutputMessageType,
 } from "@itwin/core-frontend";
 import type { ContentDialogInfo } from "../framework/FrameworkContent";
-import { ContentDialogChangedEvent } from "../framework/FrameworkContent";
 
 // cSpell:ignore ZINDEX modeless
 
@@ -31,7 +31,7 @@ const CONTENT_DIALOG_ZINDEX_DEFAULT = 2000;
 export class InternalContentDialogManager {
   /** Content Dialog Changed Event */
   public static readonly onContentDialogChangedEvent =
-    new ContentDialogChangedEvent();
+    new BeUiEvent<DialogChangedEventArgs>();
 
   /** @internal */
   public static readonly dialogManager: DialogManagerBase =

--- a/ui/appui-react/src/appui-react/dialog/InternalModalDialogManager.tsx
+++ b/ui/appui-react/src/appui-react/dialog/InternalModalDialogManager.tsx
@@ -7,8 +7,9 @@
  */
 
 import type * as React from "react";
+import type { DialogChangedEventArgs } from "./DialogManagerBase";
 import { DialogManagerBase } from "./DialogManagerBase";
-import { ModalDialogChangedEvent } from "../framework/FrameworkDialogs";
+import { BeUiEvent } from "@itwin/core-bentley";
 
 /** Modal Dialog Manager class displays and manages multiple modal dialogs
  * @internal
@@ -16,7 +17,7 @@ import { ModalDialogChangedEvent } from "../framework/FrameworkDialogs";
 export class InternalModalDialogManager {
   /** Modal Dialog Changed Event */
   public static readonly onModalDialogChangedEvent =
-    new ModalDialogChangedEvent();
+    new BeUiEvent<DialogChangedEventArgs>();
 
   /** @internal */
   public static readonly dialogManager: DialogManagerBase =

--- a/ui/appui-react/src/appui-react/dialog/InternalModelessDialogManager.tsx
+++ b/ui/appui-react/src/appui-react/dialog/InternalModelessDialogManager.tsx
@@ -7,8 +7,9 @@
  */
 
 import type * as React from "react";
-import { Logger } from "@itwin/core-bentley";
+import { BeUiEvent, Logger } from "@itwin/core-bentley";
 import { UiFramework } from "../UiFramework";
+import type { DialogChangedEventArgs } from "./DialogManagerBase";
 import { DialogManagerBase } from "./DialogManagerBase";
 import {
   IModelApp,
@@ -17,7 +18,6 @@ import {
   OutputMessageType,
 } from "@itwin/core-frontend";
 import type { ModelessDialogInfo } from "../framework/FrameworkDialogs";
-import { ModelessDialogChangedEvent } from "../framework/FrameworkDialogs";
 
 // cSpell:ignore ZINDEX modeless
 
@@ -27,7 +27,7 @@ import { ModelessDialogChangedEvent } from "../framework/FrameworkDialogs";
 export class InternalModelessDialogManager {
   /** Modeless Dialog Changed Event */
   public static readonly onModelessDialogChangedEvent =
-    new ModelessDialogChangedEvent();
+    new BeUiEvent<DialogChangedEventArgs>();
 
   /** @internal */
   public static readonly dialogManager: DialogManagerBase =

--- a/ui/appui-react/src/appui-react/feedback/ElementTooltip.tsx
+++ b/ui/appui-react/src/appui-react/feedback/ElementTooltip.tsx
@@ -15,6 +15,7 @@ import classnames from "classnames";
 import * as React from "react";
 import { offsetAndContainInContainer, Tooltip } from "../layout/popup/Tooltip";
 import type { NotifyMessageType } from "../messages/ReactNotifyMessageDetails";
+import { BeUiEvent } from "@itwin/core-bentley";
 
 /** [[ElementTooltip]] State.
  * @internal
@@ -39,6 +40,7 @@ export interface ElementTooltipChangedEventArgs {
 
 /** ElementTooltip Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ElementTooltipChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ElementTooltipChangedEvent extends UiEvent<ElementTooltipChangedEventArgs> {}
@@ -50,11 +52,12 @@ export class ElementTooltip extends React.Component<
   CommonProps,
   ElementTooltipState
 > {
-  private static _elementTooltipChangedEvent: ElementTooltipChangedEvent =
-    new ElementTooltipChangedEvent();
+  private static _elementTooltipChangedEvent =
+    new BeUiEvent<ElementTooltipChangedEventArgs>();
   private static _isTooltipVisible: boolean;
   private static _isTooltipHalted: boolean;
 
+  // eslint-disable-next-line deprecation/deprecation
   public static get onElementTooltipChangedEvent(): ElementTooltipChangedEvent {
     return ElementTooltip._elementTooltipChangedEvent;
   }

--- a/ui/appui-react/src/appui-react/framework/FrameworkContent.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkContent.ts
@@ -24,6 +24,7 @@ export interface MouseDownChangedEventArgs {
 
 /** Mouse Down Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<MouseDownChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class MouseDownChangedEvent extends UiEvent<MouseDownChangedEventArgs> {}
@@ -40,13 +41,16 @@ export interface ActiveContentChangedEventArgs {
 
 /** Active Content Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ActiveContentChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ActiveContentChangedEvent extends UiEvent<ActiveContentChangedEventArgs> {}
 
 /** Content Dialog Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<DialogChangedEventArgs>` instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class ContentDialogChangedEvent extends DialogChangedEvent {}
 
 /** @public */
@@ -62,6 +66,7 @@ export interface ContentDialogInfo {
  */
 export interface FrameworkContent {
   /** Gets the [[MouseDownChangedEvent]] */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onMouseDownChangedEvent: MouseDownChangedEvent;
 
   /** Determines if the mouse is down in a content view */
@@ -71,6 +76,7 @@ export interface FrameworkContent {
   setMouseDown(mouseDown: boolean): void;
 
   /** Gets the [[ActiveContentChangedEvent]] */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onActiveContentChangedEvent: ActiveContentChangedEvent;
 
   /** Fires when floating contents are added or removed */
@@ -191,6 +197,7 @@ export interface FrameworkContent {
    */
   readonly dialogs: FrameworkStackedDialog<ContentDialogInfo> & {
     /** Content Dialog Changed Event */
+    // eslint-disable-next-line deprecation/deprecation
     readonly onContentDialogChangedEvent: ContentDialogChangedEvent;
   };
 }

--- a/ui/appui-react/src/appui-react/framework/FrameworkDialogs.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkDialogs.ts
@@ -10,12 +10,16 @@ import { DialogChangedEvent } from "../dialog/DialogManagerBase";
 
 /** Modal Dialog Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<DialogChangedEventArgs>` instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class ModalDialogChangedEvent extends DialogChangedEvent {}
 
 /** Modeless Dialog Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<DialogChangedEventArgs>` instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class ModelessDialogChangedEvent extends DialogChangedEvent {}
 
 /** @public */
@@ -85,6 +89,7 @@ export interface FrameworkDialogs {
    */
   readonly modal: FrameworkDialog & {
     /** Modal Dialog Changed Event */
+    // eslint-disable-next-line deprecation/deprecation
     readonly onModalDialogChangedEvent: ModalDialogChangedEvent;
   };
 
@@ -94,6 +99,7 @@ export interface FrameworkDialogs {
    */
   readonly modeless: FrameworkStackedDialog<ModelessDialogInfo> & {
     /** Modeless Dialog Changed Event */
+    // eslint-disable-next-line deprecation/deprecation
     readonly onModelessDialogChangedEvent: ModelessDialogChangedEvent;
   };
 }

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -31,6 +31,7 @@ export interface FrontstageActivatedEventArgs {
 
 /** Frontstage Activated Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<FrontstageActivatedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class FrontstageActivatedEvent extends UiEvent<FrontstageActivatedEventArgs> {}
@@ -54,6 +55,7 @@ export interface FrontstageDeactivatedEventArgs {
 
 /** Frontstage Deactivated Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<FrontstageDeactivatedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class FrontstageDeactivatedEvent extends UiEvent<FrontstageDeactivatedEventArgs> {}
@@ -67,6 +69,7 @@ export interface FrontstageReadyEventArgs {
 
 /** Frontstage Ready Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<FrontstageReadyEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class FrontstageReadyEvent extends UiEvent<FrontstageReadyEventArgs> {}
@@ -80,6 +83,7 @@ export interface ModalFrontstageChangedEventArgs {
 
 /** Modal Frontstage Stack Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ModalFrontstageChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ModalFrontstageChangedEvent extends UiEvent<ModalFrontstageChangedEventArgs> {}
@@ -105,6 +109,7 @@ export interface ModalFrontstageClosedEventArgs {
  * to true it is up to the stage to register for this event and call the stageCloseFunc once it has saved
  * any unsaved data.
  * @alpha
+ * @deprecated in 4.13.x. Use `BeUiEvent<ModalFrontstageRequestedCloseEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ModalFrontstageRequestedCloseEvent extends UiEvent<ModalFrontstageRequestedCloseEventArgs> {}
@@ -121,6 +126,7 @@ export interface ModalFrontstageRequestedCloseEventArgs {
 
 /** Modal Frontstage Closed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ModalFrontstageClosedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ModalFrontstageClosedEvent extends UiEvent<ModalFrontstageClosedEventArgs> {}
@@ -134,6 +140,7 @@ export interface ToolActivatedEventArgs {
 
 /** Tool Activated Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ToolActivatedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ToolActivatedEvent extends UiEvent<ToolActivatedEventArgs> {}
@@ -147,6 +154,7 @@ export interface ToolIconChangedEventArgs {
 
 /** Tool Icon Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ToolIconChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> {}
@@ -181,26 +189,33 @@ export interface FrameworkFrontstages {
   readonly isLoading: boolean;
 
   /** Get Frontstage Deactivated event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onFrontstageDeactivatedEvent: FrontstageDeactivatedEvent;
 
   /** Get Frontstage Activated event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onFrontstageActivatedEvent: FrontstageActivatedEvent;
 
   /** Get Frontstage Activated event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onFrontstageReadyEvent: FrontstageReadyEvent;
 
   /** Get Modal Frontstage Changed event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onModalFrontstageChangedEvent: ModalFrontstageChangedEvent;
 
   /** Get Modal Frontstage Closed event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onModalFrontstageClosedEvent: ModalFrontstageClosedEvent;
 
   /** Get Modal Frontstage Requested Closed event.
    * @alpha
    */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onCloseModalFrontstageRequestedEvent: ModalFrontstageRequestedCloseEvent;
 
   /** Get Tool Activated event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onToolActivatedEvent: ToolActivatedEvent;
 
   /** Get ToolSetting Reload event. */
@@ -208,23 +223,29 @@ export interface FrameworkFrontstages {
   readonly onToolSettingsReloadEvent: UiEvent<void>;
 
   /** Get Tool Icon Changed event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onToolIconChangedEvent: ToolIconChangedEvent;
 
   /** Get Content Layout Activated event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onContentLayoutActivatedEvent: ContentLayoutActivatedEvent;
 
   /** Get Content Control Activated event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onContentControlActivatedEvent: ContentControlActivatedEvent;
 
   /** Get Navigation Aid Activated event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onNavigationAidActivatedEvent: NavigationAidActivatedEvent;
 
   /** Get Widget State Changed event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onWidgetStateChangedEvent: WidgetStateChangedEvent;
 
   /** Get panel state changed event.
    * @alpha
    */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onPanelStateChangedEvent: PanelStateChangedEvent;
 
   /** Get panel pinned changed event.

--- a/ui/appui-react/src/appui-react/framework/FrameworkToolSettings.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkToolSettings.ts
@@ -19,6 +19,7 @@ export interface SyncToolSettingsPropertiesEventArgs {
 
 /** Sync Tool Settings Properties Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<SyncToolSettingsPropertiesEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class SyncToolSettingsPropertiesEvent extends UiEvent<SyncToolSettingsPropertiesEventArgs> {}
@@ -58,6 +59,7 @@ export interface FrameworkToolSettings {
   readonly activeToolDescription: string;
 
   /** Get ToolSettings Properties sync event. */
+  // eslint-disable-next-line deprecation/deprecation
   readonly onSyncToolSettingsProperties: SyncToolSettingsPropertiesEvent;
   // eslint-disable-next-line deprecation/deprecation
   readonly onReloadToolSettingsProperties: UiEvent<void>;

--- a/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
+++ b/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
@@ -6,7 +6,7 @@
  * @module Frontstage
  */
 
-import { Logger } from "@itwin/core-bentley";
+import { BeUiEvent, Logger } from "@itwin/core-bentley";
 import type {
   IModelConnection,
   SelectedViewportChangedArgs,
@@ -16,19 +16,23 @@ import type {
 import { IModelApp, InteractiveTool } from "@itwin/core-frontend";
 import { UiEvent } from "@itwin/appui-abstract";
 import type { Size } from "@itwin/core-react";
-import { ContentControlActivatedEvent } from "../content/ContentControl";
+import type { ContentControlActivatedEventArgs } from "../content/ContentControl";
 import type { ContentGroup } from "../content/ContentGroup";
-import type { ContentLayoutDef } from "../content/ContentLayout";
-import { ContentLayoutActivatedEvent } from "../content/ContentLayout";
-import { NavigationAidActivatedEvent } from "../navigationaids/NavigationAidControl";
-import type { PanelPinnedChangedEventArgs } from "../stagepanels/StagePanelDef";
-import {
-  PanelSizeChangedEvent,
-  PanelStateChangedEvent,
+import type {
+  ContentLayoutActivatedEventArgs,
+  ContentLayoutDef,
+} from "../content/ContentLayout";
+import type { NavigationAidActivatedEventArgs } from "../navigationaids/NavigationAidControl";
+import type {
+  PanelPinnedChangedEventArgs,
+  PanelSizeChangedEventArgs,
+  PanelStateChangedEventArgs,
 } from "../stagepanels/StagePanelDef";
 import { UiFramework } from "../UiFramework";
-import type { WidgetDef } from "../widgets/WidgetDef";
-import { WidgetStateChangedEvent } from "../widgets/WidgetDef";
+import type {
+  WidgetDef,
+  WidgetStateChangedEventArgs,
+} from "../widgets/WidgetDef";
 import { ToolInformation } from "../toolsettings/ToolInformation";
 import type { ToolUiProvider } from "../toolsettings/ToolUiProvider";
 import type {
@@ -40,18 +44,16 @@ import type { FrontstageProvider } from "./FrontstageProvider";
 import { TimeTracker } from "../configurableui/TimeTracker";
 import type { WidgetState } from "../widgets/WidgetState";
 import type {
+  FrontstageActivatedEventArgs,
+  FrontstageDeactivatedEventArgs,
+  FrontstageReadyEventArgs,
+  ModalFrontstageChangedEventArgs,
+  ModalFrontstageClosedEventArgs,
   ModalFrontstageInfo,
   ModalFrontstageItem,
-} from "../framework/FrameworkFrontstages";
-import {
-  FrontstageActivatedEvent,
-  FrontstageDeactivatedEvent,
-  FrontstageReadyEvent,
-  ModalFrontstageChangedEvent,
-  ModalFrontstageClosedEvent,
-  ModalFrontstageRequestedCloseEvent,
-  ToolActivatedEvent,
-  ToolIconChangedEvent,
+  ModalFrontstageRequestedCloseEventArgs,
+  ToolActivatedEventArgs,
+  ToolIconChangedEventArgs,
 } from "../framework/FrameworkFrontstages";
 import type { SyncToolSettingsPropertiesEventArgs } from "../framework/FrameworkToolSettings";
 
@@ -191,31 +193,33 @@ export class InternalFrontstageManager {
 
   /** Get Frontstage Deactivated event. */
   public static readonly onFrontstageDeactivatedEvent =
-    new FrontstageDeactivatedEvent();
+    new BeUiEvent<FrontstageDeactivatedEventArgs>();
 
   /** Get Frontstage Activated event. */
   public static readonly onFrontstageActivatedEvent =
-    new FrontstageActivatedEvent();
+    new BeUiEvent<FrontstageActivatedEventArgs>();
 
   /** Get Frontstage Activated event. */
-  public static readonly onFrontstageReadyEvent = new FrontstageReadyEvent();
+  public static readonly onFrontstageReadyEvent =
+    new BeUiEvent<FrontstageReadyEventArgs>();
 
   /** Get Modal Frontstage Changed event. */
   public static readonly onModalFrontstageChangedEvent =
-    new ModalFrontstageChangedEvent();
+    new BeUiEvent<ModalFrontstageChangedEventArgs>();
 
   /** Get Modal Frontstage Closed event. */
   public static readonly onModalFrontstageClosedEvent =
-    new ModalFrontstageClosedEvent();
+    new BeUiEvent<ModalFrontstageClosedEventArgs>();
 
   /** Get Modal Frontstage Requested Closed event.
    * @alpha
    */
   public static readonly onCloseModalFrontstageRequestedEvent =
-    new ModalFrontstageRequestedCloseEvent();
+    new BeUiEvent<ModalFrontstageRequestedCloseEventArgs>();
 
   /** Get Tool Activated event. */
-  public static readonly onToolActivatedEvent = new ToolActivatedEvent();
+  public static readonly onToolActivatedEvent =
+    new BeUiEvent<ToolActivatedEventArgs>();
 
   /** Get ToolSetting Reload event. */
   // eslint-disable-next-line deprecation/deprecation
@@ -228,23 +232,24 @@ export class InternalFrontstageManager {
   public static readonly onToolPanelOpenedEvent = new UiEvent<void>();
 
   /** Get Tool Icon Changed event. */
-  public static readonly onToolIconChangedEvent = new ToolIconChangedEvent();
+  public static readonly onToolIconChangedEvent =
+    new BeUiEvent<ToolIconChangedEventArgs>();
 
   /** Get Content Layout Activated event. */
   public static readonly onContentLayoutActivatedEvent =
-    new ContentLayoutActivatedEvent();
+    new BeUiEvent<ContentLayoutActivatedEventArgs>();
 
   /** Get Content Control Activated event. */
   public static readonly onContentControlActivatedEvent =
-    new ContentControlActivatedEvent();
+    new BeUiEvent<ContentControlActivatedEventArgs>();
 
   /** Get Navigation Aid Activated event. */
   public static readonly onNavigationAidActivatedEvent =
-    new NavigationAidActivatedEvent();
+    new BeUiEvent<NavigationAidActivatedEventArgs>();
 
   /** Get Widget State Changed event. */
   public static readonly onWidgetStateChangedEvent =
-    new WidgetStateChangedEvent();
+    new BeUiEvent<WidgetStateChangedEventArgs>();
 
   /** @internal */
   // eslint-disable-next-line deprecation/deprecation
@@ -269,7 +274,7 @@ export class InternalFrontstageManager {
    * @alpha
    */
   public static readonly onPanelStateChangedEvent =
-    new PanelStateChangedEvent();
+    new BeUiEvent<PanelStateChangedEventArgs>();
 
   /** Get panel pinned changed event.
    * @alpha
@@ -279,7 +284,8 @@ export class InternalFrontstageManager {
     new UiEvent<PanelPinnedChangedEventArgs>();
 
   /** @internal */
-  public static readonly onPanelSizeChangedEvent = new PanelSizeChangedEvent();
+  public static readonly onPanelSizeChangedEvent =
+    new BeUiEvent<PanelSizeChangedEventArgs>();
 
   /** Clears the Frontstage map.
    */

--- a/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
+++ b/ui/appui-react/src/appui-react/frontstage/InternalFrontstageManager.ts
@@ -14,7 +14,6 @@ import type {
   Tool,
 } from "@itwin/core-frontend";
 import { IModelApp, InteractiveTool } from "@itwin/core-frontend";
-import { UiEvent } from "@itwin/appui-abstract";
 import type { Size } from "@itwin/core-react";
 import type { ContentControlActivatedEventArgs } from "../content/ContentControl";
 import type { ContentGroup } from "../content/ContentGroup";
@@ -223,13 +222,13 @@ export class InternalFrontstageManager {
 
   /** Get ToolSetting Reload event. */
   // eslint-disable-next-line deprecation/deprecation
-  public static readonly onToolSettingsReloadEvent = new UiEvent<void>();
+  public static readonly onToolSettingsReloadEvent = new BeUiEvent<void>();
 
   /** Get Tool Panel Opened event.
    * @internal
    */
   // eslint-disable-next-line deprecation/deprecation
-  public static readonly onToolPanelOpenedEvent = new UiEvent<void>();
+  public static readonly onToolPanelOpenedEvent = new BeUiEvent<void>();
 
   /** Get Tool Icon Changed event. */
   public static readonly onToolIconChangedEvent =
@@ -253,22 +252,22 @@ export class InternalFrontstageManager {
 
   /** @internal */
   // eslint-disable-next-line deprecation/deprecation
-  public static readonly onWidgetDefsUpdatedEvent = new UiEvent<void>();
+  public static readonly onWidgetDefsUpdatedEvent = new BeUiEvent<void>();
 
   /** @internal */
   public static readonly onFrontstageNineZoneStateChangedEvent =
     // eslint-disable-next-line deprecation/deprecation
-    new UiEvent<FrontstageNineZoneStateChangedEventArgs>();
+    new BeUiEvent<FrontstageNineZoneStateChangedEventArgs>();
 
   /** @internal */
   public static readonly onFrontstageRestoreLayoutEvent =
     // eslint-disable-next-line deprecation/deprecation
-    new UiEvent<FrontstageEventArgs>();
+    new BeUiEvent<FrontstageEventArgs>();
 
   /** @internal */
   public static readonly onFrontstageWidgetsChangedEvent =
     // eslint-disable-next-line deprecation/deprecation
-    new UiEvent<FrontstageEventArgs>();
+    new BeUiEvent<FrontstageEventArgs>();
 
   /** Get panel state changed event.
    * @alpha
@@ -281,7 +280,7 @@ export class InternalFrontstageManager {
    */
   public static readonly onPanelPinnedChangedEvent =
     // eslint-disable-next-line deprecation/deprecation
-    new UiEvent<PanelPinnedChangedEventArgs>();
+    new BeUiEvent<PanelPinnedChangedEventArgs>();
 
   /** @internal */
   public static readonly onPanelSizeChangedEvent =

--- a/ui/appui-react/src/appui-react/keyboardshortcut/KeyboardShortcutMenu.tsx
+++ b/ui/appui-react/src/appui-react/keyboardshortcut/KeyboardShortcutMenu.tsx
@@ -28,6 +28,7 @@ export interface KeyboardShortcutMenuState {
 
 /** KeyboardShortcut Menu Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<KeyboardShortcutMenuState>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class KeyboardShortcutMenuEvent extends UiEvent<KeyboardShortcutMenuState> {}
@@ -48,7 +49,7 @@ export class KeyboardShortcutMenu extends React.PureComponent<
 
   /** Get KeyboardShortcut Menu Event. */
   public static readonly onKeyboardShortcutMenuEvent =
-    new KeyboardShortcutMenuEvent();
+    new KeyboardShortcutMenuEvent(); // eslint-disable-line deprecation/deprecation
 
   public override componentDidMount() {
     KeyboardShortcutMenu.onKeyboardShortcutMenuEvent.addListener(

--- a/ui/appui-react/src/appui-react/messages/MessageManager.tsx
+++ b/ui/appui-react/src/appui-react/messages/MessageManager.tsx
@@ -107,48 +107,56 @@ export interface ToolAssistanceChangedEventArgs {
 
 /** Message Added Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<MessageAddedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class MessageAddedEvent extends UiEvent<MessageAddedEventArgs> {}
 
 /** Messages Updated Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<{}>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class MessagesUpdatedEvent extends UiEvent<{}> {}
 
 /** Activity Message Added Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ActivityMessageEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ActivityMessageUpdatedEvent extends UiEvent<ActivityMessageEventArgs> {}
 
 /** Activity Message Cancelled Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<{}>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ActivityMessageCancelledEvent extends UiEvent<{}> {}
 
 /** Input Field Message Added Event class
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<InputFieldMessageEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class InputFieldMessageAddedEvent extends UiEvent<InputFieldMessageEventArgs> {}
 
 /** Input Field Message Removed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<{}>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class InputFieldMessageRemovedEvent extends UiEvent<{}> {}
 
 /** Open Message Center Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<{}>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class OpenMessageCenterEvent extends UiEvent<{}> {}
 
 /** Tool Assistance Changed event class
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ToolAssistanceChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ToolAssistanceChangedEvent extends UiEvent<ToolAssistanceChangedEventArgs> {}
@@ -188,29 +196,31 @@ export class MessageManager {
   }[] = [];
 
   /** The MessageAddedEvent is fired when a message is added via outputMessage(). */
+  // eslint-disable-next-line deprecation/deprecation
   public static readonly onMessageAddedEvent = new MessageAddedEvent();
 
   /** The MessagesUpdatedEvent is fired when a message is added or the messages are cleared. */
+  // eslint-disable-next-line deprecation/deprecation
   public static readonly onMessagesUpdatedEvent = new MessagesUpdatedEvent();
 
   /** The ActivityMessageUpdatedEvent is fired when an Activity message updates via outputActivityMessage(). */
   public static readonly onActivityMessageUpdatedEvent =
-    new ActivityMessageUpdatedEvent();
+    new ActivityMessageUpdatedEvent(); // eslint-disable-line deprecation/deprecation
 
   /** The ActivityMessageCancelledEvent is fired when an Activity message is cancelled via
    * endActivityMessage(ActivityMessageEndReason.Cancelled) or
    * by the user clicking the 'Cancel' link.
    */
   public static readonly onActivityMessageCancelledEvent =
-    new ActivityMessageCancelledEvent();
+    new ActivityMessageCancelledEvent(); // eslint-disable-line deprecation/deprecation
 
   public static readonly onInputFieldMessageAddedEvent =
-    new InputFieldMessageAddedEvent();
+    new InputFieldMessageAddedEvent(); // eslint-disable-line deprecation/deprecation
   public static readonly onInputFieldMessageRemovedEvent =
-    new InputFieldMessageRemovedEvent();
+    new InputFieldMessageRemovedEvent(); // eslint-disable-line deprecation/deprecation
 
   public static readonly onOpenMessageCenterEvent =
-    new OpenMessageCenterEvent();
+    new OpenMessageCenterEvent(); // eslint-disable-line deprecation/deprecation
 
   /** @internal */
   public static readonly onDisplayMessage = new BeUiEvent<{
@@ -226,7 +236,7 @@ export class MessageManager {
    * @public
    */
   public static readonly onToolAssistanceChangedEvent =
-    new ToolAssistanceChangedEvent();
+    new ToolAssistanceChangedEvent(); // eslint-disable-line deprecation/deprecation
 
   /** List of messages as NotifyMessageDetailsType. */
   public static get messages(): Readonly<NotifyMessageDetailsType[]> {

--- a/ui/appui-react/src/appui-react/messages/Pointer.tsx
+++ b/ui/appui-react/src/appui-react/messages/Pointer.tsx
@@ -30,6 +30,7 @@ import type {
   NotifyMessageDetailsType,
   NotifyMessageType,
 } from "./ReactNotifyMessageDetails";
+import { BeUiEvent } from "@itwin/core-bentley";
 
 // cSpell:ignore noicon
 
@@ -68,6 +69,7 @@ export interface PointerMessageChangedEventArgs {
 
 /** Pointer Message Changed Event emitted by the [[PointerMessage]] component
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<PointerMessageChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class PointerMessageChangedEvent extends UiEvent<PointerMessageChangedEventArgs> {}
@@ -80,12 +82,6 @@ interface PointerMessagePositionChangedEventArgs {
   relativePosition: RelativePosition;
 }
 
-/** Pointer Message Position Changed Event emitted by the [[PointerMessage]] component
- * @internal
- */
-// eslint-disable-next-line deprecation/deprecation
-class PointerMessagePositionChangedEvent extends UiEvent<PointerMessagePositionChangedEventArgs> {}
-
 /** Pointer message pops up near pointer when attempting an invalid interaction.
  * @public
  */
@@ -93,11 +89,12 @@ export class PointerMessage extends React.Component<
   PointerMessageProps,
   PointerMessageState
 > {
-  private static _pointerMessageChangedEvent: PointerMessageChangedEvent =
-    new PointerMessageChangedEvent();
+  private static _pointerMessageChangedEvent =
+    new BeUiEvent<PointerMessageChangedEventArgs>();
   private static readonly _onPointerMessagePositionChangedEvent =
-    new PointerMessagePositionChangedEvent();
+    new BeUiEvent<PointerMessagePositionChangedEventArgs>();
 
+  // eslint-disable-next-line deprecation/deprecation
   public static get onPointerMessageChangedEvent(): PointerMessageChangedEvent {
     return PointerMessage._pointerMessageChangedEvent;
   }

--- a/ui/appui-react/src/appui-react/navigationaids/NavigationAidControl.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/NavigationAidControl.tsx
@@ -25,6 +25,7 @@ export interface NavigationAidActivatedEventArgs {
 
 /** NavigationAid Activated Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<NavigationAidActivatedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class NavigationAidActivatedEvent extends UiEvent<NavigationAidActivatedEventArgs> {}

--- a/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.tsx
@@ -23,6 +23,7 @@ import type { ModalFrontstageInfo } from "../framework/FrameworkFrontstages";
 import { UiFramework } from "../UiFramework";
 import type { SheetData } from "./SheetNavigationAid";
 import { SvgDocument, SvgPlaceholder } from "@itwin/itwinui-icons-react";
+import { BeUiEvent } from "@itwin/core-bentley";
 
 /** Data about a sheet card
  * @alpha
@@ -45,6 +46,7 @@ export interface CardSelectedEventArgs {
 
 /** Class for CardSelectedEvent
  * @alpha
+ * @deprecated in 4.13.x. Use `BeUiEvent<CardSelectedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class CardSelectedEvent extends UiEvent<CardSelectedEventArgs> {}
@@ -133,10 +135,10 @@ export interface CardContainerProps extends CommonProps {
  * @alpha
  */
 export class CardContainer extends React.Component<CardContainerProps> {
-  private static _cardSelectedEvent: CardSelectedEvent =
-    new CardSelectedEvent();
+  private static _cardSelectedEvent = new BeUiEvent<CardSelectedEventArgs>();
 
   /** Get CardSelectedEvent event */
+  // eslint-disable-next-line deprecation/deprecation
   public static get onCardSelectedEvent(): CardSelectedEvent {
     return CardContainer._cardSelectedEvent;
   }

--- a/ui/appui-react/src/appui-react/pickers/ViewSelector.tsx
+++ b/ui/appui-react/src/appui-react/pickers/ViewSelector.tsx
@@ -9,7 +9,7 @@
 import * as React from "react";
 import { UiEvent } from "@itwin/appui-abstract";
 import type { Id64String } from "@itwin/core-bentley";
-import { Logger } from "@itwin/core-bentley";
+import { BeUiEvent, Logger } from "@itwin/core-bentley";
 import type { IModelConnection, ViewState } from "@itwin/core-frontend";
 import { FuzzySearch, IModelApp } from "@itwin/core-frontend";
 import type { SupportsViewSelectorChange } from "../content/ContentControl";
@@ -35,6 +35,7 @@ export interface ViewSelectorChangedEventArgs {
 
 /** ViewSelector Changed Event class.
  * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<ViewSelectorChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ViewSelectorChangedEvent extends UiEvent<ViewSelectorChangedEventArgs> {}
@@ -87,11 +88,6 @@ interface ViewSelectorShowUpdateEventArgs {
   showUnknown: boolean;
 }
 
-/** ViewSelector Show Update Event class.
- */
-// eslint-disable-next-line deprecation/deprecation
-class ViewSelectorShowUpdateEvent extends UiEvent<ViewSelectorShowUpdateEventArgs> {}
-
 /** View Selector React component
  * @beta
  */
@@ -100,7 +96,7 @@ export class ViewSelector extends React.Component<
   ViewSelectorState
 > {
   private static readonly _onViewSelectorShowUpdateEvent =
-    new ViewSelectorShowUpdateEvent();
+    new BeUiEvent<ViewSelectorShowUpdateEventArgs>();
   private _removeShowUpdateListener?: () => void;
   private _isMounted = false;
   private _searchInput = "";
@@ -114,7 +110,7 @@ export class ViewSelector extends React.Component<
 
   /** Gets the [[ViewSelectorChangedEvent]] */
   public static readonly onViewSelectorChangedEvent =
-    new ViewSelectorChangedEvent();
+    new ViewSelectorChangedEvent(); // eslint-disable-line deprecation/deprecation
 
   /** Updates the ViewSelector show settings.
    */

--- a/ui/appui-react/src/appui-react/popup/PopupManager.tsx
+++ b/ui/appui-react/src/appui-react/popup/PopupManager.tsx
@@ -80,6 +80,7 @@ export interface PopupsChangedEventArgs {
 
 /** Popups Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<PopupsChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class PopupsChangedEvent extends UiEvent<PopupsChangedEventArgs> {}
@@ -129,6 +130,7 @@ export class PopupManager {
 
   private static _defaultOffset = { x: 8, y: 8 };
 
+  // eslint-disable-next-line deprecation/deprecation
   public static readonly onPopupsChangedEvent = new PopupsChangedEvent();
 
   public static get popupCount() {

--- a/ui/appui-react/src/appui-react/stagepanels/StagePanelDef.tsx
+++ b/ui/appui-react/src/appui-react/stagepanels/StagePanelDef.tsx
@@ -34,6 +34,7 @@ export interface PanelStateChangedEventArgs {
 
 /** Panel state changed event class.
  * @beta
+ * @deprecated in 4.13.x. Use `BeUiEvent<PanelStateChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class PanelStateChangedEvent extends UiEvent<PanelStateChangedEventArgs> {}
@@ -43,10 +44,6 @@ export interface PanelSizeChangedEventArgs {
   panelDef: StagePanelDef;
   size: number | undefined;
 }
-
-/** @internal */
-// eslint-disable-next-line deprecation/deprecation
-export class PanelSizeChangedEvent extends UiEvent<PanelSizeChangedEventArgs> {}
 
 /** Panel pinned changed event args interface.
  * @public

--- a/ui/appui-react/src/appui-react/syncui/InternalSyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/InternalSyncUiEventDispatcher.ts
@@ -6,7 +6,8 @@
  * @module SyncUi
  */
 
-import { UiSyncEvent } from "./UiSyncEvent";
+import { BeUiEvent } from "@itwin/core-bentley";
+import type { UiSyncEventArgs } from "./UiSyncEvent";
 
 /** This class is used to send eventIds to interested UI components so the component can determine if it needs
  * to refresh its display by calling setState on itself.
@@ -16,14 +17,14 @@ export class InternalSyncUiEventDispatcher {
   private _syncEventTimerId: number | undefined;
   private _eventIds: Set<string>;
   private _eventIdAdded;
-  private _uiSyncEvent: UiSyncEvent;
+  private _uiSyncEvent: BeUiEvent<UiSyncEventArgs>;
   private _timeoutPeriod;
   private _secondaryTimeoutPeriod;
 
   constructor() {
     this._eventIds = new Set<string>();
     this._eventIdAdded = false;
-    this._uiSyncEvent = new UiSyncEvent();
+    this._uiSyncEvent = new BeUiEvent<UiSyncEventArgs>();
     this._timeoutPeriod = 100;
     this._secondaryTimeoutPeriod = this._timeoutPeriod / 2;
   }
@@ -53,7 +54,7 @@ export class InternalSyncUiEventDispatcher {
   }
 
   /** Return UiSyncEvent so callers can register an event callback. */
-  public get onSyncUiEvent(): UiSyncEvent {
+  public get onSyncUiEvent(): BeUiEvent<UiSyncEventArgs> {
     return this._uiSyncEvent;
   }
 

--- a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
@@ -88,6 +88,7 @@ export class SyncUiEventDispatcher {
   }
 
   /** Return SyncUiEvent so callers can register an event callback. */
+  // eslint-disable-next-line deprecation/deprecation
   public static get onSyncUiEvent(): UiSyncEvent {
     return SyncUiEventDispatcher._uiEventDispatcher.onSyncUiEvent;
   }

--- a/ui/appui-react/src/appui-react/syncui/UiSyncEvent.ts
+++ b/ui/appui-react/src/appui-react/syncui/UiSyncEvent.ts
@@ -17,5 +17,6 @@ export interface UiSyncEventArgs {
 
 /** UiSync Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<UiSyncEventArgs>` instead.
  */
 export class UiSyncEvent extends BeUiEvent<UiSyncEventArgs> {}

--- a/ui/appui-react/src/appui-react/toolsettings/InternalToolSettingsManager.ts
+++ b/ui/appui-react/src/appui-react/toolsettings/InternalToolSettingsManager.ts
@@ -11,8 +11,9 @@ import { IModelApp } from "@itwin/core-frontend";
 import type { DialogItem, DialogPropertySyncItem } from "@itwin/appui-abstract";
 import { UiEvent } from "@itwin/appui-abstract";
 import { focusIntoContainer } from "@itwin/core-react";
-import { SyncToolSettingsPropertiesEvent } from "../framework/FrameworkToolSettings";
+import type { SyncToolSettingsPropertiesEventArgs } from "../framework/FrameworkToolSettings";
 import { SyncUiEventDispatcher } from "../syncui/SyncUiEventDispatcher";
+import { BeUiEvent } from "@itwin/core-bentley";
 
 /** Tool Settings Manager class. Used to generate UI components for Tool Settings.
  * @internal
@@ -153,7 +154,7 @@ export class InternalToolSettingsManager {
 
   /** Get ToolSettings Properties sync event. */
   public static readonly onSyncToolSettingsProperties =
-    new SyncToolSettingsPropertiesEvent();
+    new BeUiEvent<SyncToolSettingsPropertiesEventArgs>();
   // eslint-disable-next-line deprecation/deprecation
   public static readonly onReloadToolSettingsProperties = new UiEvent<void>();
 

--- a/ui/appui-react/src/appui-react/toolsettings/InternalToolSettingsManager.ts
+++ b/ui/appui-react/src/appui-react/toolsettings/InternalToolSettingsManager.ts
@@ -9,7 +9,6 @@
 import type { InteractiveTool } from "@itwin/core-frontend";
 import { IModelApp } from "@itwin/core-frontend";
 import type { DialogItem, DialogPropertySyncItem } from "@itwin/appui-abstract";
-import { UiEvent } from "@itwin/appui-abstract";
 import { focusIntoContainer } from "@itwin/core-react";
 import type { SyncToolSettingsPropertiesEventArgs } from "../framework/FrameworkToolSettings";
 import { SyncUiEventDispatcher } from "../syncui/SyncUiEventDispatcher";
@@ -156,7 +155,7 @@ export class InternalToolSettingsManager {
   public static readonly onSyncToolSettingsProperties =
     new BeUiEvent<SyncToolSettingsPropertiesEventArgs>();
   // eslint-disable-next-line deprecation/deprecation
-  public static readonly onReloadToolSettingsProperties = new UiEvent<void>();
+  public static readonly onReloadToolSettingsProperties = new BeUiEvent<void>();
 
   /** Gets the Id of the active tool. If a tool is not active, blank is returned.
    * @return  Id of the active tool, or blank if one is not active.

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -46,6 +46,7 @@ export interface WidgetStateChangedEventArgs {
 
 /** Widget State Changed Event class.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<WidgetStateChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class WidgetStateChangedEvent extends UiEvent<WidgetStateChangedEventArgs> {}

--- a/ui/appui-react/src/appui-react/widgets/WidgetManager.ts
+++ b/ui/appui-react/src/appui-react/widgets/WidgetManager.ts
@@ -32,11 +32,6 @@ export interface WidgetsChangedEventArgs {
   readonly items: ReadonlyArray<WidgetInfo>;
 }
 
-/** Event class for [[this.onWidgetsChanged]].
- * @internal
- */
-export class WidgetsChangedEvent extends BeUiEvent<WidgetsChangedEventArgs> {}
-
 function getWidgetManagerStableWidgetId(
   stageUsage: string | undefined,
   location: StagePanelLocation,
@@ -57,7 +52,7 @@ export class WidgetManager {
   /** Event raised when Widgets are changed.
    * @internal
    */
-  public readonly onWidgetsChanged = new WidgetsChangedEvent();
+  public readonly onWidgetsChanged = new BeUiEvent<WidgetsChangedEventArgs>();
 
   /** @internal */
   public get widgetCount(): number {

--- a/ui/appui-react/src/test/toolbar/useActiveToolIdSynchedItems.test.ts
+++ b/ui/appui-react/src/test/toolbar/useActiveToolIdSynchedItems.test.ts
@@ -4,15 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { renderHook } from "@testing-library/react-hooks";
-import { ToolActivatedEvent } from "../../appui-react";
+import type { ToolActivatedEventArgs } from "../../appui-react";
 import { useActiveToolIdSynchedItems } from "../../appui-react/toolbar/useActiveToolIdSynchedItems";
+import { BeUiEvent } from "@itwin/core-bentley";
 
 describe("useActiveToolIdSynchedItems", () => {
   it("Should update items on mount", () => {
     const items = [{ id: "Btn1", isActive: false }];
     const syncHost = {
       activeToolId: "Btn1",
-      onToolActivatedEvent: new ToolActivatedEvent(),
+      onToolActivatedEvent: new BeUiEvent<ToolActivatedEventArgs>(),
     };
 
     const { result } = renderHook(() => {
@@ -30,7 +31,7 @@ describe("useActiveToolIdSynchedItems", () => {
     ];
     const syncHost = {
       activeToolId: "Btn1",
-      onToolActivatedEvent: new ToolActivatedEvent(),
+      onToolActivatedEvent: new BeUiEvent<ToolActivatedEventArgs>(),
     };
 
     const { result } = renderHook(() => {
@@ -48,7 +49,7 @@ describe("useActiveToolIdSynchedItems", () => {
     const items = [{ id: "Btn1", isActive: true }];
     const syncHost = {
       activeToolId: "Btn1",
-      onToolActivatedEvent: new ToolActivatedEvent(),
+      onToolActivatedEvent: new BeUiEvent<ToolActivatedEventArgs>(),
     };
 
     const { result } = renderHook(() => {
@@ -77,7 +78,7 @@ describe("useActiveToolIdSynchedItems", () => {
     ];
     const syncHost = {
       activeToolId: "Btn3",
-      onToolActivatedEvent: new ToolActivatedEvent(),
+      onToolActivatedEvent: new BeUiEvent<ToolActivatedEventArgs>(),
     };
     const { result } = renderHook(() => {
       return useActiveToolIdSynchedItems(items, syncHost);
@@ -92,7 +93,7 @@ describe("useActiveToolIdSynchedItems", () => {
     const items = [{ id: "Btn1" }];
     const syncHost = {
       activeToolId: "Btn1",
-      onToolActivatedEvent: new ToolActivatedEvent(),
+      onToolActivatedEvent: new BeUiEvent<ToolActivatedEventArgs>(),
     };
     const spy = vi.spyOn(syncHost.onToolActivatedEvent, "removeListener");
     const { unmount } = renderHook(() => {

--- a/ui/core-react/src/core-react/settings/SettingsManager.tsx
+++ b/ui/core-react/src/core-react/settings/SettingsManager.tsx
@@ -37,6 +37,7 @@ export interface SettingsTabEntry {
 
 /** Event class for [[this.onSettingsProvidersChanged]] which is emitted when a new SettingsTabsProvider is added or removed.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<SettingsProvidersChangedEventArgs>` instead.
  */
 export class SettingsProvidersChangedEvent extends BeUiEvent<SettingsProvidersChangedEventArgs> {}
 
@@ -50,6 +51,7 @@ export interface SettingsProvidersChangedEventArgs {
 /** Event class for [[this.onProcessSettingsTabActivation]] which is emitted when a new Tab needs to be activated. This allows the current
  * settings page to save its settings before activating the new SettingTab.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ProcessSettingsTabActivationEventArgs>` instead.
  */
 export class ProcessSettingsTabActivationEvent extends BeUiEvent<ProcessSettingsTabActivationEventArgs> {}
 
@@ -64,13 +66,9 @@ export interface ProcessSettingsTabActivationEventArgs {
 /** Event class for [[this.onProcessSettingsContainerClose]] which is emitted when the settings container will be closed. This allows the current
  * settings page to save its settings before calling the function to close the container.
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ProcessSettingsContainerCloseEventArgs>` instead.
  */
 export class ProcessSettingsContainerCloseEvent extends BeUiEvent<ProcessSettingsContainerCloseEventArgs> {}
-
-/** Event class for [[this.onCloseSettingsContainer]] which is monitored by the settings container and indicates that some out process want to close the settings container.
- * @internal
- */
-export class CloseSettingsContainerEvent extends BeUiEvent<ProcessSettingsContainerCloseEventArgs> {}
 
 /** Arguments of [[this.onProcessSettingsContainerClose]] event.
  * @public
@@ -82,6 +80,7 @@ export interface ProcessSettingsContainerCloseEventArgs {
 
 /** Event class for [[this.onActivateSettingsTab]] which is emitted when API call needs to set the active settings tab (ie via Tool key-in).
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ActivateSettingsTabEventArgs>` instead.
  */
 export class ActivateSettingsTabEvent extends BeUiEvent<ActivateSettingsTabEventArgs> {}
 
@@ -114,29 +113,31 @@ export class SettingsManager {
   /** Event raised when SettingsProviders are changed.
    */
   public readonly onSettingsProvidersChanged =
-    new SettingsProvidersChangedEvent();
+    new SettingsProvidersChangedEvent(); // eslint-disable-line deprecation/deprecation
 
   /** Event raised solely for a settings page to monitor so it can save its settings before continuing tab activation.
    * See React hook function `useSaveBeforeActivatingNewSettingsTab`.
    */
   public readonly onProcessSettingsTabActivation =
-    new ProcessSettingsTabActivationEvent();
+    new ProcessSettingsTabActivationEvent(); // eslint-disable-line deprecation/deprecation
 
   /** Event raised when the settings container will be closed. Any setting page component that is 'modal' should register to
    * listen to this event so that it can save its state before closing. See React hook function `useSaveBeforeClosingSettingsContainer`.
    */
   public readonly onProcessSettingsContainerClose =
-    new ProcessSettingsContainerCloseEvent();
+    new ProcessSettingsContainerCloseEvent(); // eslint-disable-line deprecation/deprecation
 
   /** Event raised to change the active settings tab shown in UI. Monitored by the SettingsContainer.
    * @internal
    */
-  public readonly onActivateSettingsTab = new ActivateSettingsTabEvent();
+  public readonly onActivateSettingsTab =
+    new BeUiEvent<ActivateSettingsTabEventArgs>();
 
   /** Event monitored by SettingsContainer to process request to close the settings container.
    * @internal
    */
-  public readonly onCloseSettingsContainer = new CloseSettingsContainerEvent();
+  public readonly onCloseSettingsContainer =
+    new BeUiEvent<ProcessSettingsContainerCloseEventArgs>();
 
   /** @public */
   public get providers(): ReadonlyArray<SettingsTabsProvider> {

--- a/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponentEvents.ts
+++ b/ui/imodel-components-react/src/imodel-components-react/viewport/ViewportComponentEvents.ts
@@ -27,6 +27,7 @@ export interface DrawingViewportChangeEventArgs {
 
 /** Drawing View Change event
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<DrawingViewportChangeEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class DrawingViewportChangeEvent extends UiEvent<DrawingViewportChangeEventArgs> {}
@@ -42,6 +43,7 @@ export interface CubeRotationChangeEventArgs {
 
 /** 3d Cube Rotation Change event
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<CubeRotationChangeEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class CubeRotationChangeEvent extends UiEvent<CubeRotationChangeEventArgs> {}
@@ -55,6 +57,7 @@ export interface StandardRotationChangeEventArgs {
 
 /** Standard Rotation Change event
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<StandardRotationChangeEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class StandardRotationChangeEvent extends UiEvent<StandardRotationChangeEventArgs> {}
@@ -69,6 +72,7 @@ export interface ViewRotationChangeEventArgs {
 
 /** View Rotation Change event
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ViewRotationChangeEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ViewRotationChangeEvent extends UiEvent<ViewRotationChangeEventArgs> {}
@@ -84,6 +88,7 @@ export interface ViewClassFullNameChangedEventArgs {
 
 /** View Class Full Name Change event
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ViewClassFullNameChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ViewClassFullNameChangedEvent extends UiEvent<ViewClassFullNameChangedEventArgs> {}
@@ -99,6 +104,7 @@ export interface ViewIdChangedEventArgs {
 
 /** View Id Change event
  * @public
+ * @deprecated in 4.13.x. Use `BeUiEvent<ViewIdChangedEventArgs>` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class ViewIdChangedEvent extends UiEvent<ViewIdChangedEventArgs> {}
@@ -131,15 +137,16 @@ export class ViewportComponentEvents {
   public static readonly extents = Vector3d.createZero();
   public static readonly rotationMatrix = Matrix3d.createIdentity();
   public static readonly onDrawingViewportChangeEvent =
-    new DrawingViewportChangeEvent();
+    new DrawingViewportChangeEvent(); // eslint-disable-line deprecation/deprecation
   public static readonly onCubeRotationChangeEvent =
-    new CubeRotationChangeEvent();
+    new CubeRotationChangeEvent(); // eslint-disable-line deprecation/deprecation
   public static readonly onStandardRotationChangeEvent =
-    new StandardRotationChangeEvent();
+    new StandardRotationChangeEvent(); // eslint-disable-line deprecation/deprecation
   public static readonly onViewRotationChangeEvent =
-    new ViewRotationChangeEvent();
+    new ViewRotationChangeEvent(); // eslint-disable-line deprecation/deprecation
   public static readonly onViewClassFullNameChangedEvent =
-    new ViewClassFullNameChangedEvent();
+    new ViewClassFullNameChangedEvent(); // eslint-disable-line deprecation/deprecation
+  // eslint-disable-next-line deprecation/deprecation
   public static readonly onViewIdChangedEvent = new ViewIdChangedEvent();
 
   private static handleSelectedViewportChanged(


### PR DESCRIPTION
## Changes
Deprecated all UI event classes because they are only emitter classes and therefore should not be exported. I did not create separate properties to replace current public properties that use these event classes as type because users really should have no use for these classes (except `instanceof UiVisibilityChangedEvent` but they should see the deprecation for this use case and apply the suggested change `instanceof BeUiEvent<UiVisibilityEventArgs>`). Because behaviour does not change and users should not really be using these classes anyway (instanceof is a questionable use case for them), we can just change public properties to use `BeUiEvent` types in AppUI 6. 

## Testing
N/A
