### PR TITLE
Clip node content in VirtualizedPropertyGrid

### DIFF
--- a/common/changes/@itwin/components-react/clip-grid-content_2024-04-26-08-52.json
+++ b/common/changes/@itwin/components-react/clip-grid-content_2024-04-26-08-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Fixed node content overflow in `VirtualizedPropertyGrid`.",
+      "comment": "Clipped node content when it does not fit in `VirtualizedPropertyGrid`.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/clip-grid-content_2024-04-26-08-52.json
+++ b/common/changes/@itwin/components-react/clip-grid-content_2024-04-26-08-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fixed node content overflow in `VirtualizedPropertyGrid`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.scss
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.scss
@@ -98,3 +98,7 @@
 .virtualized-grid-node-content {
   height: 100%;
 }
+
+.virtualized-grid-node-content-wrapper-item {
+  overflow: hidden;
+}


### PR DESCRIPTION
## Changes

Clipped `VirtualizedPropertyGrid` node content when it does not fit. Closes [813](https://github.com/iTwin/appui/issues/813).

## Testing

Manual testing in storybook.
