### PR TITLE
Fix `FrontstageDef` to correctly update widgets while activating

### DIFF
--- a/common/changes/@itwin/appui-react/fix-778_2024-04-29-10-56.json
+++ b/common/changes/@itwin/appui-react/fix-778_2024-04-29-10-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `FrontstageDef` to correctly update widgets if a new provider is registered while a frontstage is activating.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -30,7 +30,7 @@ Table of contents:
 ### Fixes
 
 - Fix `FrameworkUiAdmin.showCard()` runtime error. [#803](https://github.com/iTwin/appui/pull/803)
-- Fix `FrontstageDef` to correctly update widgets if a new provider is registered while a frontstage is activated.
+- Fix `FrontstageDef` to correctly update widgets if a new provider is registered while a frontstage is activating.
 
 ## @itwin/core-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -30,6 +30,7 @@ Table of contents:
 ### Fixes
 
 - Fix `FrameworkUiAdmin.showCard()` runtime error. [#803](https://github.com/iTwin/appui/pull/803)
+- Fix `FrontstageDef` to correctly update widgets if a new provider is registered while a frontstage is activated.
 
 ## @itwin/core-react
 

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -932,8 +932,7 @@ export function useItemsManager(frontstageDef: FrontstageDef) {
     // Not initialized yet.
     if (!frontstageDef.nineZoneState) return;
 
-    // Need to refresh anytime frontstageDef changes because uiItemsProvider may have added something to
-    // another stage before it was possibly unloaded in this stage.
+    // Need to refresh because UiItemsProvider may have added something while another frontstage was active.
     refreshNineZoneState(frontstageDef);
   }, [frontstageDef]);
   React.useEffect(() => {


### PR DESCRIPTION
## Changes

Fixes #778 by correctly updating widgets if a new provider is registered while a frontstage is activating.

## Testing

Added a unit test.
