### PR TITLE
Disable onMouseDown propagation for `ExpansionToggle`

### DIFF
--- a/common/changes/@itwin/core-react/disable-button-propagation_2024-04-29-12-44.json
+++ b/common/changes/@itwin/core-react/disable-button-propagation_2024-04-29-12-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Disabled event propagation for `ExpansionToggle`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/core-react/disable-button-propagation_2024-04-29-12-44.json
+++ b/common/changes/@itwin/core-react/disable-button-propagation_2024-04-29-12-44.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Disabled event propagation for `ExpansionToggle`.",
+      "comment": "Disabled `onMouseDown` event propagation for `ExpansionToggle`.",
       "type": "none"
     }
   ],

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -64,6 +64,7 @@ Table of contents:
 
 - Reuse iTwinUI components and update the visuals of `MessageCenterField` component. The component will now display a visual indicator when new messages are added. [#746](https://github.com/iTwin/appui/pull/746)
 - Bump `useCrossOriginPopup` to `@public`. [#802](https://github.com/iTwin/appui/pull/802)
+- Disabled `onMouseDown` event propagation for `ExpansionToggle`. [#816](https://github.com/iTwin/appui/pull/816)
 
 ### Fixes
 
@@ -75,6 +76,7 @@ Table of contents:
 ### Fixes
 
 - Fix spacing between categories in `VirtualizedPropertyGrid`. [#812](https://github.com/iTwin/appui/pull/812)
+- Clipped node content when it does not fit in `VirtualizedPropertyGrid`. [#814](https://github.com/iTwin/appui/pull/814)
 
 ## @itwin/imodel-components-react
 

--- a/ui/core-react/src/core-react/tree/ExpansionToggle.tsx
+++ b/ui/core-react/src/core-react/tree/ExpansionToggle.tsx
@@ -38,6 +38,7 @@ export function ExpansionToggle(props: ExpansionToggleProps) {
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events
     <div
+      onMouseDown={(e) => e.stopPropagation()}
       onClick={props.onClick}
       className={className}
       style={props.style}


### PR DESCRIPTION
## Changes

Disabled `onMouseDown` propagation for `ExpansionToggle` as it was unnecessarily raising selection modification events.

## Testing

Manual testing in test app.
