### PR TITLE
Do not start drag operation when only initial node is selected

### DIFF
--- a/common/changes/@itwin/components-react/drag-selection-improvement_2024-04-30-12-28.json
+++ b/common/changes/@itwin/components-react/drag-selection-improvement_2024-04-30-12-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Updated `TreeSelectionManager` to not start a drag operation when only one node is selected.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -12,6 +12,7 @@ Table of contents:
   - [Fixes](#fixes-1)
 - [@itwin/components-react](#itwincomponents-react)
   - [Fixes](#fixes-2)
+  - [Changes](#changes-2)
 - [@itwin/imodel-components-react](#itwinimodel-components-react)
   - [Deprecations](#deprecations-2)
 
@@ -75,6 +76,10 @@ Table of contents:
 ### Fixes
 
 - Fix spacing between categories in `VirtualizedPropertyGrid`. [#812](https://github.com/iTwin/appui/pull/812)
+
+### Changes
+
+- Updated `TreeSelectionManager` to not start a drag operation when only one node is selected.
 
 ## @itwin/imodel-components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -79,7 +79,7 @@ Table of contents:
 
 ### Changes
 
-- Updated `TreeSelectionManager` to not start a drag operation when only one node is selected.
+- Updated `TreeSelectionManager` to not start a drag operation when only one node is selected. [#818](https://github.com/iTwin/appui/pull/818)
 
 ## @itwin/imodel-components-react
 

--- a/ui/components-react/src/components-react/tree/controlled/internal/TreeSelectionManager.ts
+++ b/ui/components-react/src/components-react/tree/controlled/internal/TreeSelectionManager.ts
@@ -170,19 +170,15 @@ export class TreeSelectionManager
     window.addEventListener(
       "mouseup",
       () => {
+        this._selectionHandler.completeDragAction();
         /* istanbul ignore else */
         if (this._dragSelectionOperation) {
-          this._selectionHandler.completeDragAction();
           this._dragSelectionOperation.complete();
           this._dragSelectionOperation = undefined;
         }
       },
       { once: true }
     );
-    this._dragSelectionOperation = new Subject();
-    this.onDragSelection.emit({
-      selectionChanges: this._dragSelectionOperation,
-    });
   }
 
   public onNodeMouseMove(nodeId: string) {
@@ -198,10 +194,17 @@ export class TreeSelectionManager
         { from: item1 as string, to: item2 as string },
       ],
       updateSelection: (selections, deselections) => {
+        if (!this._dragSelectionOperation) {
+          this._dragSelectionOperation = new Subject();
+          this.onDragSelection.emit({
+            selectionChanges: this._dragSelectionOperation,
+          });
+        }
+
         // Assumes `updateSelection` will never be called with selection ranges
         const selectedNodeIds = selections as string[];
         const deselectedNodeIds = deselections as string[];
-        this._dragSelectionOperation!.next({
+        this._dragSelectionOperation.next({
           selectedNodes: selectedNodeIds,
           deselectedNodes: deselectedNodeIds,
         });


### PR DESCRIPTION
## Changes

Updated `TreeSelectionManager` to only start a drag operation when a second node is selected to avoid multiple `selectionModified` events being raised.

## Testing

Manual testing in test-app.
