### PR TITLE
Add `reparentPopoutWidgets` preview feature

### DIFF
--- a/common/changes/@itwin/appui-react/popout-reparent_2024-05-03-08-20.json
+++ b/common/changes/@itwin/appui-react/popout-reparent_2024-05-03-08-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add `reparentPopoutWidgets` preview feature.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -4,6 +4,7 @@ Table of contents:
 
 - [@itwin/appui-react](#itwinappui-react)
   - [Deprecations](#deprecations)
+  - [Additions](#additions)
   - [Changes](#changes)
   - [Fixes](#fixes)
 - [@itwin/core-react](#itwincore-react)
@@ -23,6 +24,13 @@ Table of contents:
 - Deprecated all UI event classes (e.g. `ContentControlActivatedEvent`). These are only emitter classes and applications should not use these classes to instantiate objects. Therefore they should not be exported. [#806](https://github.com/iTwin/appui/pull/806)
 - Deprecated all event args interfaces (e.g. `ContentControlActivatedEventArgs`). Event args should be inferred from a listener. If explicit type is needed use a type helper. [#806](https://github.com/iTwin/appui/pull/806)
 
+### Additions
+
+- `reparentPopoutWidgets` preview feature. When enabled, popout widgets will not be rendered in a separate element tree, instead widget content will be re-parented to a popout content container. This new behavior is similar to what is being done when moving widget between stage panels and floating widgets in a main window and has certain advantages:
+  - Persisted React state
+  - Persisted DOM state
+  - Same element tree (access to root context providers)
+
 ### Changes
 
 - Bump `FloatingViewportContentWrapper` to `@public`. [#801](https://github.com/iTwin/appui/pull/801)
@@ -30,7 +38,7 @@ Table of contents:
 ### Fixes
 
 - Fix `FrameworkUiAdmin.showCard()` runtime error. [#803](https://github.com/iTwin/appui/pull/803)
-- Fix `FrontstageDef` to correctly update widgets if a new provider is registered while a frontstage is activating.
+- Fix `FrontstageDef` to correctly update widgets if a new provider is registered while a frontstage is activating. [#815](https://github.com/iTwin/appui/pull/815)
 
 ## @itwin/core-react
 

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
@@ -44,6 +44,9 @@ const availableFeatures: AvailableFeatures = {
   newToolbars: {
     label: "Enable iTwinUI based toolbars",
   },
+  reparentPopoutWidgets: {
+    label: "Re-parent popout widgets",
+  },
 };
 
 function PreviewFeatureList() {

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -221,15 +221,15 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
           childWindow
         );
 
+        // Trigger first so popout can be converted back to main window widget
+        this.close(childWindowId, false);
+
         // UnmountComponentAtNode is deprecated in React 18, so if they are
         // using React 18 and passing in a createRoot function, unmount()
         // will be used
         if (this._roots[childWindowId]) {
           this._roots[childWindowId].unmount();
         } else ReactDOM.unmountComponentAtNode(reactConnectionDiv);
-
-        // Close after unmounting to correctly save/restore transient state.
-        this.close(childWindowId, false);
       });
     }
   }

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -220,14 +220,16 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
           childWindowId,
           childWindow
         );
-        // Trigger first so popout can be converted back to main window widget
-        this.close(childWindowId, false);
+
         // UnmountComponentAtNode is deprecated in React 18, so if they are
         // using React 18 and passing in a createRoot function, unmount()
         // will be used
         if (this._roots[childWindowId]) {
           this._roots[childWindowId].unmount();
         } else ReactDOM.unmountComponentAtNode(reactConnectionDiv);
+
+        // Close after unmounting to correctly save/restore transient state.
+        this.close(childWindowId, false);
       });
     }
   }

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -26,6 +26,7 @@ import { UiStateStorageHandler } from "../uistate/useUiStateStorage";
 import type { ChildWindow } from "./ChildWindowConfig";
 import { copyStyles } from "./CopyStyles";
 import "./InternalChildWindowManager.scss";
+import { onClosePopoutWidget } from "./PopoutWidget";
 
 const childHtml = `<!DOCTYPE html>
 <html>
@@ -254,6 +255,8 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
       (openWindow) => openWindow.childWindowId === childWindowId
     );
     if (windowIndex === -1) return false;
+    onClosePopoutWidget.raiseEvent({ windowId: childWindowId });
+
     const childWindow = this.openChildWindows[windowIndex];
     this.openChildWindows.splice(windowIndex, 1);
     if (processWindowClose) {

--- a/ui/appui-react/src/appui-react/childwindow/PopoutWidget.scss
+++ b/ui/appui-react/src/appui-react/childwindow/PopoutWidget.scss
@@ -2,9 +2,13 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 .uifw-popout-widget-filled-container {
   display: flex;
   height: 100%;
   width: 100%;
+}
+
+.uifw-childWindow-popoutWidget_reparented {
+  display: flex;
+  height: 100%;
 }

--- a/ui/appui-react/src/appui-react/childwindow/PopoutWidget.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/PopoutWidget.tsx
@@ -11,11 +11,9 @@ import * as React from "react";
 import type { WidgetDef } from "../widgets/WidgetDef";
 import { usePreviewFeatures } from "../preview/PreviewFeatures";
 import { useContainersStore } from "../layout/widget/ContentManager";
-import type { FrontstageDef } from "../frontstage/FrontstageDef";
 
 interface PopoutWidgetProps {
   widgetContainerId: string;
-  frontstageDef: FrontstageDef;
   widgetDef: WidgetDef;
 }
 
@@ -24,17 +22,11 @@ interface PopoutWidgetProps {
  */
 export function PopoutWidget({
   widgetContainerId,
-  frontstageDef,
   widgetDef,
 }: PopoutWidgetProps) {
   const { reparentPopoutWidgets } = usePreviewFeatures();
   if (reparentPopoutWidgets) {
-    return (
-      <ReparentedPopoutWidget
-        widgetContainerId={widgetContainerId}
-        frontstageDef={frontstageDef}
-      />
-    );
+    return <ReparentedPopoutWidget widgetContainerId={widgetContainerId} />;
   }
   return (
     <div
@@ -47,25 +39,16 @@ export function PopoutWidget({
 }
 
 function ReparentedPopoutWidget({
-  frontstageDef,
   widgetContainerId,
-}: Pick<PopoutWidgetProps, "widgetContainerId" | "frontstageDef">) {
-  const setContainer = useContainersStore((state) => state.setContainer);
+}: Pick<PopoutWidgetProps, "widgetContainerId">) {
+  const setPopoutContainer = useContainersStore(
+    (state) => state.setPopoutContainer
+  );
   const ref = React.useCallback(
     (instance: HTMLDivElement | null) => {
-      const nineZoneState = frontstageDef.nineZoneState;
-      if (!nineZoneState) return;
-
-      const popoutWidget = nineZoneState.popoutWidgets.byId[widgetContainerId];
-      if (!popoutWidget) return;
-
-      const widget = nineZoneState.widgets[widgetContainerId];
-      const tabId = widget.tabs[0];
-      if (!tabId) return;
-
-      setContainer(tabId, instance);
+      setPopoutContainer(widgetContainerId, instance);
     },
-    [setContainer, widgetContainerId, frontstageDef]
+    [setPopoutContainer, widgetContainerId]
   );
 
   return (

--- a/ui/appui-react/src/appui-react/childwindow/PopoutWidget.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/PopoutWidget.tsx
@@ -44,9 +44,9 @@ function ReparentedPopoutWidget({
   widgetContainerId,
 }: Pick<PopoutWidgetProps, "widgetContainerId">) {
   const setPopout = usePopoutsStore((state) => state.setPopout);
-  const setPopoutRef = React.useCallback(
-    (instance: HTMLDivElement | null) => {
-      setPopout(widgetContainerId, instance);
+  const setPopoutRef = React.useCallback<React.RefCallback<HTMLDivElement>>(
+    (instance) => {
+      setPopout(widgetContainerId, instance ?? undefined);
     },
     [setPopout, widgetContainerId]
   );

--- a/ui/appui-react/src/appui-react/childwindow/usePopoutsStore.ts
+++ b/ui/appui-react/src/appui-react/childwindow/usePopoutsStore.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import produce, { castDraft } from "immer";
+import { create } from "zustand";
+import type { WidgetState } from "../layout/state/WidgetState";
+import { BeEvent } from "@itwin/core-bentley";
+
+interface PopoutWidgetsStore {
+  popouts: { readonly [id in WidgetState["id"]]: Element | null };
+  setPopout: (widgetId: WidgetState["id"], container: Element | null) => void;
+  onClosePopoutWidget: BeEvent<(args: { windowId: string }) => void>;
+}
+
+/** @internal */
+export const usePopoutsStore = create<PopoutWidgetsStore>((set) => ({
+  popouts: {},
+  setPopout: (widgetId: WidgetState["id"], container: Element | null) => {
+    set((state) =>
+      produce(state, (draft) => {
+        draft.popouts[widgetId] = castDraft(container);
+      })
+    );
+  },
+  onClosePopoutWidget: new BeEvent<(args: { windowId: string }) => void>(),
+}));

--- a/ui/appui-react/src/appui-react/childwindow/usePopoutsStore.ts
+++ b/ui/appui-react/src/appui-react/childwindow/usePopoutsStore.ts
@@ -12,17 +12,25 @@ import type { WidgetState } from "../layout/state/WidgetState";
 import { BeEvent } from "@itwin/core-bentley";
 
 interface PopoutWidgetsStore {
-  popouts: { readonly [id in WidgetState["id"]]: Element | null };
-  setPopout: (widgetId: WidgetState["id"], container: Element | null) => void;
+  popouts: { readonly [id in WidgetState["id"]]: Element | undefined };
+  setPopout: (
+    widgetId: WidgetState["id"],
+    container: Element | undefined
+  ) => void;
   onClosePopoutWidget: BeEvent<(args: { windowId: string }) => void>;
 }
 
 /** @internal */
 export const usePopoutsStore = create<PopoutWidgetsStore>((set) => ({
   popouts: {},
-  setPopout: (widgetId: WidgetState["id"], container: Element | null) => {
+  setPopout: (widgetId: WidgetState["id"], container: Element | undefined) => {
     set((state) =>
       produce(state, (draft) => {
+        if (!container) {
+          delete draft.popouts[widgetId];
+          return;
+        }
+
         draft.popouts[widgetId] = castDraft(container);
       })
     );

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -787,7 +787,6 @@ export class FrontstageDef {
 
     const popoutContent = (
       <PopoutWidget
-        frontstageDef={this}
         widgetContainerId={widgetContainerId}
         widgetDef={widgetDef}
       />

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -787,6 +787,7 @@ export class FrontstageDef {
 
     const popoutContent = (
       <PopoutWidget
+        frontstageDef={this}
         widgetContainerId={widgetContainerId}
         widgetDef={widgetDef}
       />

--- a/ui/appui-react/src/appui-react/layout/widget/ContentContainer.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/ContentContainer.tsx
@@ -31,11 +31,11 @@ export function WidgetContentContainer(props: WidgetContentContainerProps) {
     const widget = getWidgetState(state, widgetId);
     return { minimized: widget.minimized, activeTabId: widget.activeTabId };
   }, true);
-  const ref = React.useCallback(
-    (instance: HTMLDivElement | null) => {
+  const ref = React.useCallback<React.RefCallback<HTMLDivElement>>(
+    (instance) => {
       if (!widgetContentManager) return;
 
-      widgetContentManager.setContainer(activeTabId, instance);
+      widgetContentManager.setContainer(activeTabId, instance ?? undefined);
     },
     [widgetContentManager, activeTabId]
   );

--- a/ui/appui-react/src/appui-react/layout/widget/ContentContainer.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/ContentContainer.tsx
@@ -32,7 +32,7 @@ export function WidgetContentContainer(props: WidgetContentContainerProps) {
     return { minimized: widget.minimized, activeTabId: widget.activeTabId };
   }, true);
   const ref = React.useCallback(
-    (instance: HTMLDivElement) => {
+    (instance: HTMLDivElement | null) => {
       if (!widgetContentManager) return;
 
       widgetContentManager.setContainer(activeTabId, instance);

--- a/ui/appui-react/src/appui-react/layout/widget/ContentManager.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/ContentManager.tsx
@@ -30,7 +30,9 @@ export function WidgetContentManager(props: WidgetContentManagerProps) {
     WidgetContentManagerContextArgs["setContainer"]
   >(
     (tabId, container) => {
-      container === null && saveTransientStateRef.current.raiseEvent(tabId);
+      if (!container) {
+        saveTransientStateRef.current.raiseEvent(tabId);
+      }
       setContentContainer(tabId, container);
     },
     [setContentContainer]
@@ -54,16 +56,21 @@ export function WidgetContentManager(props: WidgetContentManagerProps) {
 }
 
 interface ContainersStore {
-  containers: { readonly [id in TabState["id"]]: Element | null };
-  setContainer: (tabId: TabState["id"], container: Element | null) => void;
+  containers: { readonly [id in TabState["id"]]: Element | undefined };
+  setContainer: (tabId: TabState["id"], container: Element | undefined) => void;
 }
 
 /** @internal */
 export const useContainersStore = create<ContainersStore>((set) => ({
   containers: {},
-  setContainer: (tabId: TabState["id"], container: Element | null) => {
+  setContainer: (tabId: TabState["id"], container: Element | undefined) => {
     set((state) =>
       produce(state, (draft) => {
+        if (!container) {
+          delete draft.containers[tabId];
+          return;
+        }
+
         draft.containers[tabId] = castDraft(container);
       })
     );
@@ -72,7 +79,7 @@ export const useContainersStore = create<ContainersStore>((set) => ({
 
 /** @internal */
 export interface WidgetContentManagerContextArgs {
-  setContainer(tabId: TabState["id"], container: Element | null): void;
+  setContainer(tabId: TabState["id"], container: Element | undefined): void;
   onSaveTransientState: BeEvent<(tabId: TabState["id"]) => void>;
   onRestoreTransientState: BeEvent<(tabId: TabState["id"]) => void>;
 }

--- a/ui/appui-react/src/appui-react/layout/widget/ContentManager.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/ContentManager.tsx
@@ -11,7 +11,6 @@ import * as React from "react";
 import { create } from "zustand";
 import { BeEvent } from "@itwin/core-bentley";
 import type { TabState } from "../state/TabState";
-import type { WidgetState } from "../state/WidgetState";
 
 /** @internal */
 export interface WidgetContentManagerProps {
@@ -55,30 +54,17 @@ export function WidgetContentManager(props: WidgetContentManagerProps) {
 }
 
 interface ContainersStore {
-  popoutContainers: { readonly [id in WidgetState["id"]]: Element | null };
   containers: { readonly [id in TabState["id"]]: Element | null };
   setContainer: (tabId: TabState["id"], container: Element | null) => void;
-  setPopoutContainer: (
-    widgetId: WidgetState["id"],
-    container: Element | null
-  ) => void;
 }
 
 /** @internal */
 export const useContainersStore = create<ContainersStore>((set) => ({
   containers: {},
-  popoutContainers: {},
   setContainer: (tabId: TabState["id"], container: Element | null) => {
     set((state) =>
       produce(state, (draft) => {
         draft.containers[tabId] = castDraft(container);
-      })
-    );
-  },
-  setPopoutContainer: (tabId: TabState["id"], container: Element | null) => {
-    set((state) =>
-      produce(state, (draft) => {
-        draft.popoutContainers[tabId] = castDraft(container);
       })
     );
   },

--- a/ui/appui-react/src/appui-react/layout/widget/ContentManager.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/ContentManager.tsx
@@ -11,6 +11,7 @@ import * as React from "react";
 import { create } from "zustand";
 import { BeEvent } from "@itwin/core-bentley";
 import type { TabState } from "../state/TabState";
+import type { WidgetState } from "../state/WidgetState";
 
 /** @internal */
 export interface WidgetContentManagerProps {
@@ -54,17 +55,30 @@ export function WidgetContentManager(props: WidgetContentManagerProps) {
 }
 
 interface ContainersStore {
-  setContainer: (tabId: TabState["id"], container: Element | null) => void;
+  popoutContainers: { readonly [id in WidgetState["id"]]: Element | null };
   containers: { readonly [id in TabState["id"]]: Element | null };
+  setContainer: (tabId: TabState["id"], container: Element | null) => void;
+  setPopoutContainer: (
+    widgetId: WidgetState["id"],
+    container: Element | null
+  ) => void;
 }
 
 /** @internal */
 export const useContainersStore = create<ContainersStore>((set) => ({
   containers: {},
+  popoutContainers: {},
   setContainer: (tabId: TabState["id"], container: Element | null) => {
     set((state) =>
       produce(state, (draft) => {
         draft.containers[tabId] = castDraft(container);
+      })
+    );
+  },
+  setPopoutContainer: (tabId: TabState["id"], container: Element | null) => {
+    set((state) =>
+      produce(state, (draft) => {
+        draft.popoutContainers[tabId] = castDraft(container);
       })
     );
   },

--- a/ui/appui-react/src/appui-react/layout/widget/PopoutWidget.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PopoutWidget.tsx
@@ -9,14 +9,14 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { WidgetIdContext } from "./Widget";
-import { useContainersStore } from "./ContentManager";
 import { WidgetContentContainer } from "./ContentContainer";
+import { usePopoutsStore } from "../../childwindow/usePopoutsStore";
 
 /** @internal */
 export function PopoutWidget() {
   const widgetId = React.useContext(WidgetIdContext);
-  const popoutContainer = useContainersStore((state) =>
-    widgetId ? state.popoutContainers[widgetId] : undefined
+  const popoutContainer = usePopoutsStore((state) =>
+    widgetId ? state.popouts[widgetId] : undefined
   );
   if (!popoutContainer) return null;
   return ReactDOM.createPortal(<WidgetContentContainer />, popoutContainer);

--- a/ui/appui-react/src/appui-react/layout/widget/PopoutWidget.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PopoutWidget.tsx
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { WidgetIdContext } from "./Widget";
+import { useContainersStore } from "./ContentManager";
+import { WidgetContentContainer } from "./ContentContainer";
+
+/** @internal */
+export function PopoutWidget() {
+  const widgetId = React.useContext(WidgetIdContext);
+  const popoutContainer = useContainersStore((state) =>
+    widgetId ? state.popoutContainers[widgetId] : undefined
+  );
+  if (!popoutContainer) return null;
+  return ReactDOM.createPortal(<WidgetContentContainer />, popoutContainer);
+}

--- a/ui/appui-react/src/appui-react/layout/widget/PopoutWidgets.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PopoutWidgets.tsx
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import * as React from "react";
+import { useLayout } from "../base/LayoutStore";
+import { WidgetProvider } from "./Widget";
+import { PopoutWidget } from "./PopoutWidget";
+
+/** This component renders all popout widgets.
+ * @internal
+ */
+export function PopoutWidgets() {
+  const ids = useLayout((state) => state.popoutWidgets.allIds);
+  return (
+    <>
+      {ids.map((id) => {
+        return (
+          <WidgetProvider key={id} id={id}>
+            <PopoutWidget />
+          </WidgetProvider>
+        );
+      })}
+    </>
+  );
+}

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -10,6 +10,7 @@ import * as React from "react";
 import { create } from "zustand";
 import { Logger } from "@itwin/core-bentley";
 import { UiFramework } from "../UiFramework";
+import type { useTransientState } from "../widget-panels/useTransientState";
 
 /** List of known preview features. */
 interface KnownPreviewFeatures {
@@ -46,7 +47,9 @@ interface KnownPreviewFeatures {
   widgetActionDropdown: { threshold: number };
   /** If true, the [[Toolbar]] component will be replaced by a new iTwinUI based toolbar. */
   newToolbars: boolean;
-  /** If true, popout widgets will not be rendered in a separate element tree, instead widget content will be re-assigned to a popout content container. */
+  /** If true, popout widgets will not be rendered in a separate element tree, instead widget content will be re-parented to a popout content container.
+   * @note Use {@link useTransientState} to save and restore DOM transient state when re-parenting widgets.
+   */
   reparentPopoutWidgets: boolean;
 }
 

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -46,6 +46,8 @@ interface KnownPreviewFeatures {
   widgetActionDropdown: { threshold: number };
   /** If true, the [[Toolbar]] component will be replaced by a new iTwinUI based toolbar. */
   newToolbars: boolean;
+  /** If true, popout widgets will not be rendered in a separate element tree, instead widget content will be re-assigned to a popout content container. */
+  reparentPopoutWidgets: boolean;
 }
 
 /** Object used trim to only known features at runtime.
@@ -59,6 +61,7 @@ const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
   horizontalPanelAlignment: undefined,
   widgetActionDropdown: undefined,
   newToolbars: undefined,
+  reparentPopoutWidgets: undefined,
 };
 
 /** List of preview features that can be enabled/disabled.

--- a/ui/appui-react/src/appui-react/widget-panels/Content.scss
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.scss
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+.uifw-widgetPanels-content_themeProvider,
+.uifw-widgetPanels-content_themeProviderV2 {
+  height: 100%;
+}

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -25,6 +25,7 @@ import {
   getTabLocation,
   isPopoutTabLocation,
 } from "../layout/state/TabLocation";
+import { ThemeProvider as ThemeProviderV2 } from "@itwin/itwinui-react-v2";
 
 function WidgetFallback() {
   const { translate } = useTranslation();
@@ -73,12 +74,18 @@ export function WidgetContent() {
     return state.popoutContainers[tabLocation.popoutWidgetId] as HTMLElement;
   });
   return (
-    <ThemeProvider portalContainer={popoutContainer ?? undefined}>
-      <ScrollableWidgetContent itemId={itemId} providerId={providerId}>
-        <ErrorBoundary FallbackComponent={WidgetFallback}>
-          {widget?.reactNode}
-        </ErrorBoundary>
-      </ScrollableWidgetContent>
+    // Theme providers are required to open floating/popover elements in a popout widget window (instead of a main window).
+    <ThemeProvider
+      portalContainer={popoutContainer ?? undefined}
+      style={{ height: "100%" }}
+    >
+      <ThemeProviderV2 theme="inherit" style={{ height: "100%" }}>
+        <ScrollableWidgetContent itemId={itemId} providerId={providerId}>
+          <ErrorBoundary FallbackComponent={WidgetFallback}>
+            {widget?.reactNode}
+          </ErrorBoundary>
+        </ScrollableWidgetContent>
+      </ThemeProviderV2>
     </ThemeProvider>
   );
 }

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -19,13 +19,13 @@ import { isProviderItem } from "../ui-items-provider/isProviderItem";
 import type { WidgetDef } from "../widgets/WidgetDef";
 import { useTransientState } from "./useTransientState";
 import { useTranslation } from "../hooks/useTranslation";
-import { useContainersStore } from "../layout/widget/ContentManager";
 import { useLayoutStore } from "../layout/base/LayoutStore";
 import {
   getTabLocation,
   isPopoutTabLocation,
 } from "../layout/state/TabLocation";
 import { ThemeProvider as ThemeProviderV2 } from "@itwin/itwinui-react-v2";
+import { usePopoutsStore } from "../childwindow/usePopoutsStore";
 
 function WidgetFallback() {
   const { translate } = useTranslation();
@@ -66,12 +66,12 @@ export function WidgetContent() {
     () => layoutStore.subscribe((state) => (stateRef.current = state)),
     [layoutStore]
   );
-  const popoutContainer = useContainersStore((state) => {
+  const popoutContainer = usePopoutsStore((state) => {
     if (!tabId) return undefined;
     const tabLocation = getTabLocation(stateRef.current, tabId);
     if (!tabLocation) return undefined;
     if (!isPopoutTabLocation(tabLocation)) return undefined;
-    return state.popoutContainers[tabLocation.popoutWidgetId] as HTMLElement;
+    return state.popouts[tabLocation.popoutWidgetId] as HTMLElement;
   });
   return (
     // Theme providers are required to open floating/popover elements in a popout widget window (instead of a main window).

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -5,6 +5,7 @@
 /** @packageDocumentation
  * @module Widget
  */
+import "./Content.scss";
 import { assert } from "@itwin/core-bentley";
 import { SvgError } from "@itwin/itwinui-illustrations-react";
 import { NonIdealState, ThemeProvider } from "@itwin/itwinui-react";
@@ -77,9 +78,12 @@ export function WidgetContent() {
     // Theme providers are required to open floating/popover elements in a popout widget window (instead of a main window).
     <ThemeProvider
       portalContainer={popoutContainer ?? undefined}
-      style={{ height: "100%" }}
+      className="uifw-widgetPanels-content_themeProvider"
     >
-      <ThemeProviderV2 theme="inherit" style={{ height: "100%" }}>
+      <ThemeProviderV2
+        theme="inherit"
+        className="uifw-widgetPanels-content_themeProviderV2"
+      >
         <ScrollableWidgetContent itemId={itemId} providerId={providerId}>
           <ErrorBoundary FallbackComponent={WidgetFallback}>
             {widget?.reactNode}

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -7,7 +7,7 @@
  */
 import { assert } from "@itwin/core-bentley";
 import { SvgError } from "@itwin/itwinui-illustrations-react";
-import { NonIdealState } from "@itwin/itwinui-react";
+import { NonIdealState, ThemeProvider } from "@itwin/itwinui-react";
 import * as React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useActiveFrontstageDef } from "../frontstage/FrontstageDef";
@@ -19,6 +19,12 @@ import { isProviderItem } from "../ui-items-provider/isProviderItem";
 import type { WidgetDef } from "../widgets/WidgetDef";
 import { useTransientState } from "./useTransientState";
 import { useTranslation } from "../hooks/useTranslation";
+import { useContainersStore } from "../layout/widget/ContentManager";
+import { useLayoutStore } from "../layout/base/LayoutStore";
+import {
+  getTabLocation,
+  isPopoutTabLocation,
+} from "../layout/state/TabLocation";
 
 function WidgetFallback() {
   const { translate } = useTranslation();
@@ -35,6 +41,7 @@ function WidgetFallback() {
 
 /** @internal */
 export function WidgetContent() {
+  const tabId = React.useContext(TabIdContext);
   const widget = useWidgetDef();
   // istanbul ignore next
   const itemId = widget?.id ?? widget?.label ?? "unknown";
@@ -51,12 +58,28 @@ export function WidgetContent() {
     widget?.initialConfig && isProviderItem(widget?.initialConfig)
       ? widget?.initialConfig.providerId
       : undefined;
+
+  const layoutStore = useLayoutStore();
+  const stateRef = React.useRef(layoutStore.getState());
+  React.useEffect(
+    () => layoutStore.subscribe((state) => (stateRef.current = state)),
+    [layoutStore]
+  );
+  const popoutContainer = useContainersStore((state) => {
+    if (!tabId) return undefined;
+    const tabLocation = getTabLocation(stateRef.current, tabId);
+    if (!tabLocation) return undefined;
+    if (!isPopoutTabLocation(tabLocation)) return undefined;
+    return state.popoutContainers[tabLocation.popoutWidgetId] as HTMLElement;
+  });
   return (
-    <ScrollableWidgetContent itemId={itemId} providerId={providerId}>
-      <ErrorBoundary FallbackComponent={WidgetFallback}>
-        {widget?.reactNode}
-      </ErrorBoundary>
-    </ScrollableWidgetContent>
+    <ThemeProvider portalContainer={popoutContainer ?? undefined}>
+      <ScrollableWidgetContent itemId={itemId} providerId={providerId}>
+        <ErrorBoundary FallbackComponent={WidgetFallback}>
+          {widget?.reactNode}
+        </ErrorBoundary>
+      </ScrollableWidgetContent>
+    </ThemeProvider>
   );
 }
 

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -65,6 +65,7 @@ import { WidgetContentRenderers } from "../layout/widget/ContentRenderer";
 import { useCursor } from "../layout/widget-panels/CursorOverlay";
 import { WidgetPanelExpanders } from "../layout/widget-panels/Expander";
 import { useTranslation } from "../hooks/useTranslation";
+import { PopoutWidgets } from "../layout/widget/PopoutWidgets";
 
 function WidgetPanelsFrontstageComponent() {
   const activeModalFrontstageInfo = useActiveModalFrontstageInfo();
@@ -97,6 +98,7 @@ function WidgetPanelsFrontstageComponent() {
           </StandardLayout>
           <WidgetContentRenderers />
           <FloatingWidgets />
+          <PopoutWidgets />
         </ToolbarPopupAutoHideContext.Provider>
       </PreviewHorizontalPanelAlignFeatureProvider>
     </MaximizedWidgetProvider>


### PR DESCRIPTION
## Changes

This PR adds the `reparentPopoutWidgets` preview feature which will reparent widget content to a popout content container when enabled.

## Testing

Manual testing with a standalone test app.
