### PR TITLE
Deprecate unused property value renderers

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -587,7 +587,7 @@ export class DisplayValuePropertyDataFilterer extends PropertyRecordDataFilterer
     recordMatchesFilter(node: PropertyRecord): Promise<PropertyDataFilterResult>;
 }
 
-// @public
+// @public @deprecated
 export class DoublePropertyValueRenderer implements IPropertyValueRenderer {
     canRender(record: PropertyRecord): boolean;
     render(record: PropertyRecord, context?: PropertyValueRendererContext): React_3.JSX.Element;
@@ -1602,7 +1602,7 @@ export class NavigationPropertyTypeConverter extends TypeConverter {
     sortCompare(a: Primitives.Value, b: Primitives.Value, ignoreCase?: boolean): number;
 }
 
-// @public
+// @public @deprecated
 export class NavigationPropertyValueRenderer implements IPropertyValueRenderer {
     canRender(record: PropertyRecord): boolean;
     render(record: PropertyRecord, context?: PropertyValueRendererContext): React_3.JSX.Element;

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -66,6 +66,7 @@ public;Direction
 internal;DirectionHelpers
 public;DisplayValuePropertyDataFilterer 
 public;DoublePropertyValueRenderer 
+deprecated;DoublePropertyValueRenderer 
 internal;DragAction
 public;EditableTreeDataProvider 
 public;EditorContainer(props: EditorContainerProps): React_3.JSX.Element
@@ -181,6 +182,7 @@ public;MutableTreeModel
 public;MutableTreeModelNode 
 public;NavigationPropertyTypeConverter 
 public;NavigationPropertyValueRenderer 
+deprecated;NavigationPropertyValueRenderer 
 public;NextObserver
 public;NonPrimitivePropertyLabelRenderer 
 public;NonPrimitivePropertyLabelRendererProps 

--- a/common/changes/@itwin/components-react/deprecate_renderers_2024-05-07-11-19.json
+++ b/common/changes/@itwin/components-react/deprecate_renderers_2024-05-07-11-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer`",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -904,9 +904,6 @@ importers:
       '@itwin/itwinui-variables':
         specifier: ^3.0.0
         version: 3.1.0
-      '@types/shortid':
-        specifier: ~0.0.29
-        version: 0.0.32
       classnames:
         specifier: 2.3.1
         version: 2.3.1
@@ -928,9 +925,6 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
-      shortid:
-        specifier: ~2.2.15
-        version: 2.2.16
       ts-key-enum:
         specifier: ~2.0.12
         version: 2.0.12
@@ -6734,10 +6728,6 @@ packages:
       '@types/node': 18.11.5
     dev: true
 
-  /@types/shortid@0.0.32:
-    resolution: {integrity: sha512-LwWF89yy6Ol8abraYbVedIKzMlgJCTx8zm40yx9t0ZPOJaVR0OmSO4zRRAKfyOJtCwZrEBmhueZX8OiNbQydYw==}
-    dev: false
-
   /@types/sizzle@2.3.8:
     resolution: {integrity: sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==}
     dev: false
@@ -12120,10 +12110,6 @@ packages:
       uid-safe: 2.1.5
     dev: false
 
-  /nanoid@2.1.11:
-    resolution: {integrity: sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==}
-    dev: false
-
   /nanoid@3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -13812,13 +13798,6 @@ packages:
       vscode-oniguruma: 1.7.0
       vscode-textmate: 8.0.0
     dev: true
-
-  /shortid@2.2.16:
-    resolution: {integrity: sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    dependencies:
-      nanoid: 2.1.11
-    dev: false
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/components-react](#itwincomponents-react)
+  - [Deprecations](#deprecations)
+
+## @itwin/components-react
+
+### Deprecations
+
+- Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer` in favor of default `PrimitivePropertyValueRenderer`.

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -100,7 +100,6 @@
     "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "@itwin/itwinui-react": "^3.6.0",
-    "@types/shortid": "~0.0.29",
     "classnames": "2.3.1",
     "immer": "9.0.6",
     "linkify-it": "~2.2.0",
@@ -108,7 +107,6 @@
     "react-highlight-words": "^0.20.0",
     "react-window": "^1.8.9",
     "rxjs": "^7.8.1",
-    "shortid": "~2.2.15",
     "ts-key-enum": "~2.0.12"
   }
 }

--- a/ui/components-react/src/components-react/properties/ValueRendererManager.tsx
+++ b/ui/components-react/src/components-react/properties/ValueRendererManager.tsx
@@ -11,10 +11,8 @@ import type { PropertyRecord } from "@itwin/appui-abstract";
 import { PropertyValueFormat } from "@itwin/appui-abstract";
 import type { Orientation } from "@itwin/core-react";
 import { ArrayPropertyValueRenderer } from "./renderers/value/ArrayPropertyValueRenderer";
-import { DoublePropertyValueRenderer } from "./renderers/value/DoublePropertyValueRenderer";
 import { MergedPropertyValueRenderer } from "./renderers/value/MergedPropertyValueRenderer";
 import { MultilineTextPropertyValueRenderer } from "./renderers/value/MultilineTextPropertyValueRenderer";
-import { NavigationPropertyValueRenderer } from "./renderers/value/NavigationPropertyValueRenderer";
 import { PrimitivePropertyValueRenderer } from "./renderers/value/PrimitivePropertyValueRenderer";
 import { StructPropertyValueRenderer } from "./renderers/value/StructPropertyValueRenderer";
 import { UrlPropertyValueRenderer } from "./renderers/value/UrlPropertyValueRenderer";
@@ -194,16 +192,8 @@ export class PropertyValueRendererManager {
 }
 
 PropertyValueRendererManager.defaultManager.registerRenderer(
-  "navigation",
-  new NavigationPropertyValueRenderer()
-);
-PropertyValueRendererManager.defaultManager.registerRenderer(
   "url",
   new UrlPropertyValueRenderer()
-);
-PropertyValueRendererManager.defaultManager.registerRenderer(
-  "double",
-  new DoublePropertyValueRenderer()
 );
 PropertyValueRendererManager.defaultManager.registerRenderer(
   "multiline",

--- a/ui/components-react/src/components-react/properties/renderers/value/DoublePropertyValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/DoublePropertyValueRenderer.tsx
@@ -18,6 +18,7 @@ import { convertRecordToString } from "./Common";
 
 /** Default Double Property Renderer
  * @public
+ * @deprecated in 4.14.0. Use [[PrimitivePropertyValueRenderer]] instead.
  */
 export class DoublePropertyValueRenderer implements IPropertyValueRenderer {
   /** Checks if the renderer can handle given property */

--- a/ui/components-react/src/components-react/properties/renderers/value/NavigationPropertyValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/NavigationPropertyValueRenderer.tsx
@@ -18,6 +18,7 @@ import { convertRecordToString } from "./Common";
 
 /** Default Navigation Property Renderer
  * @public
+ * @deprecated in 4.14.0. Use [[PrimitivePropertyValueRenderer]] instead.
  */
 export class NavigationPropertyValueRenderer implements IPropertyValueRenderer {
   /** Checks if the renderer can handle given property */

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableFlatGridItem.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableFlatGridItem.ts
@@ -6,9 +6,9 @@
  * @module PropertyGrid
  */
 import { immerable } from "immer";
-import shortid from "shortid";
 import type { PropertyDescription } from "@itwin/appui-abstract";
 import { PropertyRecord, PropertyValueFormat } from "@itwin/appui-abstract";
+import { Guid } from "@itwin/core-bentley";
 import type { PropertyCategory } from "../../PropertyDataProvider";
 
 /**
@@ -63,7 +63,7 @@ export abstract class MutableFlatPropertyGridItem
 {
   public [immerable] = true;
 
-  public readonly key: string = shortid.generate();
+  public readonly key: string = Guid.createValue();
   protected _isExpanded: boolean = false;
   protected _lastInNumberOfCategories: number = 0;
   protected _isLastInRootCategory: boolean = false;

--- a/ui/components-react/src/test/properties/renderers/value/DoublePropertyValueRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/value/DoublePropertyValueRenderer.test.tsx
@@ -23,6 +23,8 @@ function createDoubleProperty(value: number, displayValue?: string) {
   return property;
 }
 
+/* eslint-disable deprecation/deprecation */
+
 describe("DoublePropertyValueRenderer", () => {
   describe("render", () => {
     it("renders double property from display value", () => {

--- a/ui/components-react/src/test/properties/renderers/value/NavigationPropertyValueRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/value/NavigationPropertyValueRenderer.test.tsx
@@ -10,6 +10,8 @@ import type { PropertyValueRendererContext } from "../../../../components-react/
 import TestUtils from "../../../TestUtils";
 import type { PropertyConverterInfo } from "@itwin/appui-abstract";
 
+/* eslint-disable deprecation/deprecation */
+
 describe("NavigationPropertyValueRenderer", () => {
   const instanceKey = { className: "", id: Id64.fromUint32Pair(1, 0) };
 

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/FlatGridTestUtils.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/FlatGridTestUtils.ts
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { PropertyRecord, PropertyValueFormat } from "@itwin/appui-abstract";
+import { Guid } from "@itwin/core-bentley";
 import type {
   CategorizedPropertyTypes,
   IMutableCategorizedPropertyItem,
@@ -15,7 +16,6 @@ import type { MutableGridCategory } from "../../../../../components-react/proper
 import type { MutableCategorizedPrimitiveProperty } from "../../../../../components-react/propertygrid/internal/flat-items/MutableCategorizedPrimitiveProperty";
 import type { MutableCategorizedArrayProperty } from "../../../../../components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty";
 import type { MutableCategorizedStructProperty } from "../../../../../components-react/propertygrid/internal/flat-items/MutableCategorizedStructProperty";
-import shortid from "shortid";
 import type { MutableGridItemFactory } from "../../../../../components-react/propertygrid/internal/flat-items/MutableGridItemFactory";
 import type {
   CategorizedPropertyItem,
@@ -286,7 +286,7 @@ export class FlatGridTestUtils {
     isExpanded?: boolean
   ) {
     Object.assign(mockItem, {
-      key: shortid.generate(),
+      key: Guid.createValue(),
       type: mockItem.type ?? {},
       isExpanded: mockItem.isExpanded ?? {},
       selectionKey: mockItem.selectionKey ?? {},


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

Deprecated property value renderers that are no longer used. Follow up to https://github.com/iTwin/appui/pull/831

Additionally removed deprecated `shortid` dependency.

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
