### PR TITLE
ts5.3.3; update @itwin/build-tools to update doc generation

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4434,11 +4434,11 @@ export function StatusBarRightSection(props: CommonDivProps): React_2.JSX.Elemen
 // @public
 export enum StatusBarSection {
     Center = 1,
-    Context = 3,
+    Context = 3,// eslint-disable-line @typescript-eslint/no-duplicate-enum-values
     Left = 0,
-    Message = 0,
+    Message = 0,// eslint-disable-line @typescript-eslint/no-duplicate-enum-values
     Right = 2,
-    Selection = 2,
+    Selection = 2,// eslint-disable-line @typescript-eslint/no-duplicate-enum-values
     Stage = 1
 }
 

--- a/common/changes/@itwin/appui-codemod/ts53-itwin-build-tools_2024-05-07-18-39.json
+++ b/common/changes/@itwin/appui-codemod/ts53-itwin-build-tools_2024-05-07-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-codemod",
+      "comment": "upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-codemod"
+}

--- a/common/changes/@itwin/appui-react/ts53-itwin-build-tools_2024-05-07-18-39.json
+++ b/common/changes/@itwin/appui-react/ts53-itwin-build-tools_2024-05-07-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/ts53-itwin-build-tools_2024-05-07-18-39.json
+++ b/common/changes/@itwin/components-react/ts53-itwin-build-tools_2024-05-07-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/ts53-itwin-build-tools_2024-05-07-18-39.json
+++ b/common/changes/@itwin/core-react/ts53-itwin-build-tools_2024-05-07-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/ts53-itwin-build-tools_2024-05-07-18-39.json
+++ b/common/changes/@itwin/imodel-components-react/ts53-itwin-build-tools_2024-05-07-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -10,6 +10,6 @@
     "object-is": "1.0.2",
     "ssri": "^6.0.1",
     "tsutils": "~3.17.1",
-    "typescript": "~5.0.2"
+    "typescript": "~5.3.3"
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         version: 7.2.9(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@itwin/build-tools':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.4.0(@types/node@18.11.5)
+        specifier: ^3.7.0 || ^4.6.0-dev.27
+        version: 4.6.0-dev.27(@types/node@18.11.5)
       '@originjs/vite-plugin-commonjs':
         specifier: ~1.0.3
         version: 1.0.3
@@ -97,10 +97,10 @@ importers:
         version: 7.6.17(react-dom@17.0.2)(react@17.0.2)
       '@storybook/react':
         specifier: ^7.6.17
-        version: 7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+        version: 7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3)
       '@storybook/react-vite':
         specifier: ^7.6.17
-        version: 7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(vite@5.2.6)
+        version: 7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3)(vite@5.2.6)
       '@storybook/testing-library':
         specifier: ^0.2.2
         version: 0.2.2
@@ -118,10 +118,10 @@ importers:
         version: 7.1.33
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.0
-        version: 5.62.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.0.4)
+        version: 5.62.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/parser':
         specifier: ^6.1.0
-        version: 6.19.1(eslint@8.56.0)(typescript@5.0.4)
+        version: 6.19.1(eslint@8.56.0)(typescript@5.3.3)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.2.1(vite@5.2.6)
@@ -142,7 +142,7 @@ importers:
         version: 0.3.5(eslint@8.56.0)
       eslint-plugin-storybook:
         specifier: ^0.6.15
-        version: 0.6.15(eslint@8.56.0)(typescript@5.0.4)
+        version: 0.6.15(eslint@8.56.0)(typescript@5.3.3)
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -150,8 +150,8 @@ importers:
         specifier: ^7.6.17
         version: 7.6.17
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
       vite:
         specifier: ^5.2.0
         version: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
@@ -244,11 +244,11 @@ importers:
         version: 2.0.12
     devDependencies:
       '@itwin/build-tools':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.4.0(@types/node@18.11.5)
+        specifier: ^3.7.0 || ^4.6.0-dev.27
+        version: 4.6.0-dev.27(@types/node@18.11.5)
       '@itwin/eslint-plugin':
         specifier: ^4.0.0-dev.52
-        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.0.4)
+        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.3.3)
       '@types/react':
         specifier: ^17.0.37
         version: 17.0.75
@@ -271,8 +271,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
 
   ../../test-apps/appui-test-app/connected:
     dependencies:
@@ -401,11 +401,11 @@ importers:
         version: 2.0.12
     devDependencies:
       '@itwin/build-tools':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.4.0(@types/node@18.11.5)
+        specifier: ^3.7.0 || ^4.6.0-dev.27
+        version: 4.6.0-dev.27(@types/node@18.11.5)
       '@itwin/eslint-plugin':
         specifier: ^4.0.0-dev.52
-        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.0.4)
+        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.3.3)
       '@itwin/itwins-client':
         specifier: ^1.2.0
         version: 1.2.1
@@ -423,7 +423,7 @@ importers:
         version: 7.1.33
       '@typescript-eslint/parser':
         specifier: ^6.1.0
-        version: 6.19.1(eslint@8.56.0)(typescript@5.0.4)
+        version: 6.19.1(eslint@8.56.0)(typescript@5.3.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.5.0
         version: 3.6.0(vite@5.2.6)
@@ -461,8 +461,8 @@ importers:
         specifier: ^1.72.0
         version: 1.72.0
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
       vite:
         specifier: ^5.2.0
         version: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
@@ -582,11 +582,11 @@ importers:
         version: 2.0.12
     devDependencies:
       '@itwin/build-tools':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.4.0(@types/node@18.11.5)
+        specifier: ^3.7.0 || ^4.6.0-dev.27
+        version: 4.6.0-dev.27(@types/node@18.11.5)
       '@itwin/eslint-plugin':
         specifier: ^4.0.0-dev.52
-        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.0.4)
+        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.3.3)
       '@types/node':
         specifier: 18.11.5
         version: 18.11.5
@@ -601,7 +601,7 @@ importers:
         version: 7.1.33
       '@typescript-eslint/parser':
         specifier: ^6.1.0
-        version: 6.19.1(eslint@8.56.0)(typescript@5.0.4)
+        version: 6.19.1(eslint@8.56.0)(typescript@5.3.3)
       '@vitejs/plugin-react-swc':
         specifier: ^3.5.0
         version: 3.6.0(vite@5.2.6)
@@ -639,8 +639,8 @@ importers:
         specifier: ^1.72.0
         version: 1.72.0
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
       vite:
         specifier: ^5.2.0
         version: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
@@ -670,10 +670,10 @@ importers:
         version: 4.2.0
       ts-node:
         specifier: ^10.8.2
-        version: 10.9.2(@types/node@18.11.5)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.11.5)(typescript@5.3.3)
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
       yargs:
         specifier: ^17.6.2
         version: 17.7.2
@@ -695,7 +695,7 @@ importers:
         version: 16.0.0
       ts-jest:
         specifier: ^29.0.5
-        version: 29.1.2(jest@29.7.0)(typescript@5.0.4)
+        version: 29.1.2(jest@29.7.0)(typescript@5.3.3)
 
   ../../ui/appui-react:
     dependencies:
@@ -749,8 +749,8 @@ importers:
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0(@itwin/core-bentley@4.4.0)
       '@itwin/build-tools':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.4.0(@types/node@18.11.5)
+        specifier: ^3.7.0 || ^4.6.0-dev.27
+        version: 4.6.0-dev.27(@types/node@18.11.5)
       '@itwin/components-react':
         specifier: workspace:*
         version: link:../components-react
@@ -783,7 +783,7 @@ importers:
         version: 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-quantity@4.4.0)
       '@itwin/eslint-plugin':
         specifier: ^4.0.0-dev.52
-        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.0.4)
+        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.3.3)
       '@itwin/imodel-components-react':
         specifier: workspace:*
         version: link:../imodel-components-react
@@ -876,13 +876,13 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.2
-        version: 10.9.2(@types/node@18.11.5)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.11.5)(typescript@5.3.3)
       typemoq:
         specifier: ^2.1.0
         version: 2.1.0
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
       upath:
         specifier: ^2.0.1
         version: 2.0.1
@@ -933,8 +933,8 @@ importers:
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0(@itwin/core-bentley@4.4.0)
       '@itwin/build-tools':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.4.0(@types/node@18.11.5)
+        specifier: ^3.7.0 || ^4.6.0-dev.27
+        version: 4.6.0-dev.27(@types/node@18.11.5)
       '@itwin/core-bentley':
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0
@@ -952,7 +952,7 @@ importers:
         version: link:../core-react
       '@itwin/eslint-plugin':
         specifier: ^4.0.0-dev.52
-        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.0.4)
+        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.3.3)
       '@testing-library/dom':
         specifier: ^8.11.2
         version: 8.20.1
@@ -1030,13 +1030,13 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.2
-        version: 10.9.2(@types/node@18.11.5)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.11.5)(typescript@5.3.3)
       typemoq:
         specifier: ^2.1.0
         version: 2.1.0
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
       upath:
         specifier: ^2.0.1
         version: 2.0.1
@@ -1081,8 +1081,8 @@ importers:
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0(@itwin/core-bentley@4.4.0)
       '@itwin/build-tools':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.4.0(@types/node@18.11.5)
+        specifier: ^3.7.0 || ^4.6.0-dev.27
+        version: 4.6.0-dev.27(@types/node@18.11.5)
       '@itwin/core-bentley':
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0
@@ -1094,7 +1094,7 @@ importers:
         version: 4.4.0(@itwin/core-bentley@4.4.0)
       '@itwin/eslint-plugin':
         specifier: ^4.0.0-dev.52
-        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.0.4)
+        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.3.3)
       '@testing-library/dom':
         specifier: ^8.11.2
         version: 8.20.1
@@ -1163,13 +1163,13 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.2
-        version: 10.9.2(@types/node@18.11.5)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.11.5)(typescript@5.3.3)
       typemoq:
         specifier: ^2.1.0
         version: 2.1.0
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
       upath:
         specifier: ^2.0.1
         version: 2.0.1
@@ -1202,8 +1202,8 @@ importers:
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0(@itwin/core-bentley@4.4.0)
       '@itwin/build-tools':
-        specifier: ^3.7.0 || ^4.0.0
-        version: 4.4.0(@types/node@18.11.5)
+        specifier: ^3.7.0 || ^4.6.0-dev.27
+        version: 4.6.0-dev.27(@types/node@18.11.5)
       '@itwin/components-react':
         specifier: workspace:*
         version: link:../components-react
@@ -1230,7 +1230,7 @@ importers:
         version: link:../core-react
       '@itwin/eslint-plugin':
         specifier: ^4.0.0-dev.52
-        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.0.4)
+        version: 4.0.0-dev.52(eslint@8.56.0)(typescript@5.3.3)
       '@itwin/webgl-compatibility':
         specifier: ^3.7.0 || ^4.0.0
         version: 4.4.0
@@ -1299,13 +1299,13 @@ importers:
         version: 3.0.2
       ts-node:
         specifier: ^10.8.2
-        version: 10.9.2(@types/node@18.11.5)(typescript@5.0.4)
+        version: 10.9.2(@types/node@18.11.5)(typescript@5.3.3)
       typemoq:
         specifier: ^2.1.0
         version: 2.1.0
       typescript:
-        specifier: ~5.0.2
-        version: 5.0.4
+        specifier: ~5.3.3
+        version: 5.3.3
       upath:
         specifier: ^2.0.1
         version: 2.0.1
@@ -3602,23 +3602,23 @@ packages:
       - '@itwin/core-geometry'
     dev: false
 
-  /@itwin/build-tools@4.4.0(@types/node@18.11.5):
-    resolution: {integrity: sha512-EIDk3AxH19Z8/awG7XNPh++RDHfl1cjwaMzy3floDVokJqfArrb6m6ICB9VezCKQkuvrryON3aywJ428oPnq+g==}
+  /@itwin/build-tools@4.6.0-dev.27(@types/node@18.11.5):
+    resolution: {integrity: sha512-EFsmHcT+yRLgZ0cmMzDYRw4LSKmzRx/YpXy854eZKr3y9j8xq2r5TZTLpf85Y1oa8ZIPRHumSWOv2/yKK3qP0Q==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor': 7.36.4(@types/node@18.11.5)
+      '@microsoft/api-extractor': 7.40.6(@types/node@18.11.5)
       chalk: 3.0.0
       cpx2: 3.0.2
       cross-spawn: 7.0.3
       fs-extra: 8.1.0
-      glob: 7.2.3
+      glob: 10.3.12
       mocha: 10.2.0
       mocha-junit-reporter: 2.2.1(mocha@10.2.0)
       rimraf: 3.0.2
       tree-kill: 1.2.2
-      typedoc: 0.23.28(typescript@5.0.4)
-      typedoc-plugin-merge-modules: 4.1.0(typedoc@0.23.28)
-      typescript: 5.0.4
+      typedoc: 0.25.13(typescript@5.3.3)
+      typedoc-plugin-merge-modules: 4.1.0(typedoc@0.25.13)
+      typescript: 5.3.3
       wtfnode: 0.9.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -3908,7 +3908,7 @@ packages:
       - debug
     dev: false
 
-  /@itwin/eslint-plugin@4.0.0-dev.52(eslint@8.56.0)(typescript@5.0.4):
+  /@itwin/eslint-plugin@4.0.0-dev.52(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-y1X/+dRCxBJTZgJjQbKap/l7cAXx5MaRt1FWAsEzzJ48hEvUDBjLQfdtFXbjXRZWPyc1WQ2OyLnD4NnppsABOg==}
     engines: {node: ^18.18.0 || >=20.0.0}
     hasBin: true
@@ -3916,10 +3916,10 @@ packages:
       eslint: ^8.56.0
       typescript: ^3.7.0 || ^4.0.0 || ^5.0.0
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.0.2(@typescript-eslint/parser@7.0.2)(eslint@8.56.0)(typescript@5.0.4)
-      '@typescript-eslint/parser': 7.0.2(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/eslint-plugin': 7.0.2(@typescript-eslint/parser@7.0.2)(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 7.0.2(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
-      eslint-plugin-deprecation: 2.0.0(eslint@8.56.0)(typescript@5.0.4)
+      eslint-plugin-deprecation: 2.0.0(eslint@8.56.0)(typescript@5.3.3)
       eslint-plugin-import: 2.29.1(eslint@8.56.0)
       eslint-plugin-jam3: 0.2.3
       eslint-plugin-jsdoc: 48.1.0(eslint@8.56.0)
@@ -3927,7 +3927,7 @@ packages:
       eslint-plugin-prefer-arrow: 1.2.3(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
-      typescript: 5.0.4
+      typescript: 5.3.3
       workspace-tools: 0.36.4
     transitivePeerDependencies:
       - supports-color
@@ -4426,7 +4426,7 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.0.4)(vite@5.2.6):
+  /@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.3.3)(vite@5.2.6):
     resolution: {integrity: sha512-2D6y7fNvFmsLmRt6UCOFJPvFoPMJGT0Uh1Wg0RaigUp7kdQPs6yYn8Dmx6GZkOH/NW0yMTwRz/p0SRMMRo50vA==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -4438,8 +4438,8 @@ packages:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
-      react-docgen-typescript: 2.2.2(typescript@5.0.4)
-      typescript: 5.0.4
+      react-docgen-typescript: 2.2.2(typescript@5.3.3)
+      typescript: 5.3.3
       vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
     dev: true
 
@@ -4529,32 +4529,32 @@ packages:
       react: 17.0.2
     dev: true
 
-  /@microsoft/api-extractor-model@7.27.6(@types/node@18.11.5):
-    resolution: {integrity: sha512-eiCnlayyum1f7fS2nA9pfIod5VCNR1G+Tq84V/ijDrKrOFVa598BLw145nCsGDMoFenV6ajNi2PR5WCwpAxW6Q==}
+  /@microsoft/api-extractor-model@7.28.13(@types/node@18.11.5):
+    resolution: {integrity: sha512-39v/JyldX4MS9uzHcdfmjjfS6cYGAoXV+io8B5a338pkHiSt+gy2eXQ0Q7cGFJ7quSa1VqqlMdlPrB6sLR/cAw==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.59.7(@types/node@18.11.5)
+      '@rushstack/node-core-library': 4.0.2(@types/node@18.11.5)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.36.4(@types/node@18.11.5):
-    resolution: {integrity: sha512-21UECq8C/8CpHT23yiqTBQ10egKUacIpxkPyYR7hdswo/M5yTWdBvbq+77YC9uPKQJOUfOD1FImBQ1DzpsdeQQ==}
+  /@microsoft/api-extractor@7.40.6(@types/node@18.11.5):
+    resolution: {integrity: sha512-9N+XCIQB94Di+ETTzNGLqjgQydslynHou7QPgDhl5gZ+B/Q5hTv5jtqBglTUnTrC0trHdG5/YKN07ehGKlSb5g==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.27.6(@types/node@18.11.5)
+      '@microsoft/api-extractor-model': 7.28.13(@types/node@18.11.5)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.59.7(@types/node@18.11.5)
-      '@rushstack/rig-package': 0.4.1
-      '@rushstack/ts-command-line': 4.15.2
-      colors: 1.2.5
+      '@rushstack/node-core-library': 4.0.2(@types/node@18.11.5)
+      '@rushstack/rig-package': 0.5.2
+      '@rushstack/terminal': 0.9.0(@types/node@18.11.5)
+      '@rushstack/ts-command-line': 4.17.3(@types/node@18.11.5)
       lodash: 4.17.21
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.0.4
+      typescript: 5.3.3
     transitivePeerDependencies:
       - '@types/node'
     dev: true
@@ -5356,8 +5356,8 @@ packages:
     dev: true
     optional: true
 
-  /@rushstack/node-core-library@3.59.7(@types/node@18.11.5):
-    resolution: {integrity: sha512-ln1Drq0h+Hwa1JVA65x5mlSgUrBa1uHL+V89FqVWQgXd1vVIMhrtqtWGQrhTnFHxru5ppX+FY39VWELF/FjQCw==}
+  /@rushstack/node-core-library@4.0.2(@types/node@18.11.5):
+    resolution: {integrity: sha512-hyES82QVpkfQMeBMteQUnrhASL/KHPhd7iJ8euduwNJG4mu2GSOKybf0rOEjOm1Wz7CwJEUm9y0yD7jg2C1bfg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -5365,7 +5365,6 @@ packages:
         optional: true
     dependencies:
       '@types/node': 18.11.5
-      colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
       jju: 1.4.0
@@ -5374,20 +5373,35 @@ packages:
       z-schema: 5.0.5
     dev: true
 
-  /@rushstack/rig-package@0.4.1:
-    resolution: {integrity: sha512-AGRwpqlXNSp9LhUSz4HKI9xCluqQDt/obsQFdv/NYIekF3pTTPzc+HbQsIsjVjYnJ3DcmxOREVMhvrMEjpiq6g==}
+  /@rushstack/rig-package@0.5.2:
+    resolution: {integrity: sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==}
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
     dev: true
 
-  /@rushstack/ts-command-line@4.15.2:
-    resolution: {integrity: sha512-5+C2uoJY8b+odcZD6coEe2XNC4ZjGB4vCMESbqW/8DHRWC/qIHfANdmN9F1wz/lAgxz72i7xRoVtPY2j7e4gpQ==}
+  /@rushstack/terminal@0.9.0(@types/node@18.11.5):
+    resolution: {integrity: sha512-49RnIDooriXyqcd7mGyjh9CmjOjf/Vn8PkOQXHa1CS0/RrrynCJLFhRDkswf7gGXZW+6UhROOE8wTmbOrfUTSA==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
     dependencies:
+      '@rushstack/node-core-library': 4.0.2(@types/node@18.11.5)
+      '@types/node': 18.11.5
+      colors: 1.2.5
+    dev: true
+
+  /@rushstack/ts-command-line@4.17.3(@types/node@18.11.5):
+    resolution: {integrity: sha512-/PtTYW38A8iUviuCmQSccHfmx3uBh4Jm5YRPU2aTgYEgwT2jtg60vAbwnkMYkyaT1AbWpjZM3xq5uHYPURvStw==}
+    dependencies:
+      '@rushstack/terminal': 0.9.0(@types/node@18.11.5)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
-      colors: 1.2.5
       string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
     dev: true
 
   /@sinclair/typebox@0.27.8:
@@ -5623,7 +5637,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.6.17(typescript@5.0.4)(vite@5.2.6):
+  /@storybook/builder-vite@7.6.17(typescript@5.3.3)(vite@5.2.6):
     resolution: {integrity: sha512-2Q32qalI401EsKKr9Hkk8TAOcHEerqwsjCpQgTNJnCu6GgCVKoVUcb99oRbR9Vyg0xh+jb19XiWqqQujFtLYlQ==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -5654,7 +5668,7 @@ packages:
       fs-extra: 11.2.0
       magic-string: 0.30.5
       rollup: 3.29.4
-      typescript: 5.0.4
+      typescript: 5.3.3
       vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
     transitivePeerDependencies:
       - encoding
@@ -5999,7 +6013,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /@storybook/react-vite@7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)(vite@5.2.6):
+  /@storybook/react-vite@7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3)(vite@5.2.6):
     resolution: {integrity: sha512-4dIm3CuRl44X1TLzN3WoZh/bChzJF7Ud28li9atj9C8db0bb/y0zl8cahrsRFoR7/LyfqdOVLqaztrnA5SsWfg==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -6007,10 +6021,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.0.4)(vite@5.2.6)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.3.3)(vite@5.2.6)
       '@rollup/pluginutils': 5.1.0
-      '@storybook/builder-vite': 7.6.17(typescript@5.0.4)(vite@5.2.6)
-      '@storybook/react': 7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4)
+      '@storybook/builder-vite': 7.6.17(typescript@5.3.3)(vite@5.2.6)
+      '@storybook/react': 7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3)
       '@vitejs/plugin-react': 3.1.0(vite@5.2.6)
       magic-string: 0.30.5
       react: 17.0.2
@@ -6026,7 +6040,7 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/react@7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.0.4):
+  /@storybook/react@7.6.17(react-dom@17.0.2)(react@17.0.2)(typescript@5.3.3):
     resolution: {integrity: sha512-lVqzQSU03rRJWYW+gK2gq6mSo3/qtnVICY8B8oP7gc36jVu4ksDIu45bTfukM618ODkUZy0vZe6T4engK3azjA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -6059,7 +6073,7 @@ packages:
       react-element-to-jsx-string: 15.0.0(react-dom@17.0.2)(react@17.0.2)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      typescript: 5.0.4
+      typescript: 5.3.3
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - encoding
@@ -6781,7 +6795,7 @@ packages:
       '@types/node': 18.11.5
     optional: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6793,23 +6807,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.0
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@7.0.2(@typescript-eslint/parser@7.0.2)(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/eslint-plugin@7.0.2(@typescript-eslint/parser@7.0.2)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-/XtVZJtbaphtdrWjr+CJclaCVGPtOdBpFEnvtNf/jRV0IiEemRrL0qABex/nEt8isYcnFacm3nPHYQwL+Wb7qg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6821,10 +6835,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 7.0.2(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 7.0.2(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 7.0.2
-      '@typescript-eslint/type-utils': 7.0.2(eslint@8.56.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 7.0.2(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/type-utils': 7.0.2(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.0.2(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 7.0.2
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
@@ -6832,13 +6846,13 @@ packages:
       ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@6.19.1(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6850,16 +6864,16 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.19.1
       '@typescript-eslint/types': 6.19.1
-      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.19.1
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      typescript: 5.0.4
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@7.0.2(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/parser@7.0.2(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-GdwfDglCxSmU+QTS9vhz2Sop46ebNCXpPPvsByK7hu0rFGRHL+AusKQJ7SoN+LbLh6APFpQwHKmDSwN35Z700Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6871,11 +6885,11 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 7.0.2
       '@typescript-eslint/types': 7.0.2
-      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 7.0.2
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      typescript: 5.0.4
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6912,7 +6926,7 @@ packages:
       '@typescript-eslint/visitor-keys': 7.0.2
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6922,17 +6936,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@7.0.2(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/type-utils@7.0.2(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-IKKDcFsKAYlk8Rs4wiFfEwJTQlHcdn8CLwLaxwd6zb8HNiMcQIFX9sWax2k4Cjj7l7mGS5N1zl7RCHOVwHq2VQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -6942,12 +6956,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.0.4)
-      '@typescript-eslint/utils': 7.0.2(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.3.3)
+      '@typescript-eslint/utils': 7.0.2(eslint@8.56.0)(typescript@5.3.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.56.0
-      ts-api-utils: 1.0.3(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6972,7 +6986,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.3.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -6987,13 +7001,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.19.1(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@6.19.1(typescript@5.3.3):
     resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -7009,13 +7023,13 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -7031,13 +7045,13 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@7.0.2(typescript@5.0.4):
+  /@typescript-eslint/typescript-estree@7.0.2(typescript@5.3.3):
     resolution: {integrity: sha512-3AMc8khTcELFWcKcPc0xiLviEvvfzATpdPj/DXuOGIdQIIFybf4DMT1vKRbuAEOFMwhWt7NFLXRkbjsvKZQyvw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -7053,13 +7067,13 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.0.4)
-      typescript: 5.0.4
+      ts-api-utils: 1.0.3(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -7070,7 +7084,7 @@ packages:
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
       eslint: 8.56.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -7079,7 +7093,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.21.0(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@6.21.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -7090,7 +7104,7 @@ packages:
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       eslint: 8.56.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -7098,7 +7112,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@7.0.2(eslint@8.56.0)(typescript@5.0.4):
+  /@typescript-eslint/utils@7.0.2(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-PZPIONBIB/X684bhT1XlrkjNZJIEevwkKDsdwfiu1WeqBxYEEdIgVDgm8/bbKHVu+6YOpeRqcfImTdImx/4Bsw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -7109,7 +7123,7 @@ packages:
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 7.0.2
       '@typescript-eslint/types': 7.0.2
-      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 7.0.2(typescript@5.3.3)
       eslint: 8.56.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -9247,17 +9261,17 @@ packages:
       eslint: 8.56.0
     dev: true
 
-  /eslint-plugin-deprecation@2.0.0(eslint@8.56.0)(typescript@5.0.4):
+  /eslint-plugin-deprecation@2.0.0(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-OAm9Ohzbj11/ZFyICyR5N6LbOIvQMp7ZU2zI7Ej0jIc8kiGUERXPNMfw2QqqHD1ZHtjMub3yPZILovYEYucgoQ==}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
       typescript: ^4.2.4 || ^5.0.0
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       tslib: 2.6.2
-      tsutils: 3.21.0(typescript@5.0.4)
-      typescript: 5.0.4
+      tsutils: 3.21.0(typescript@5.3.3)
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9392,14 +9406,14 @@ packages:
       string.prototype.matchall: 4.0.10
     dev: true
 
-  /eslint-plugin-storybook@0.6.15(eslint@8.56.0)(typescript@5.0.4):
+  /eslint-plugin-storybook@0.6.15(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-lAGqVAJGob47Griu29KXYowI4G7KwMoJDOkEip8ujikuDLxU+oWJ1l0WL6F2oDO4QiyUFXvtDkEkISMOPzo+7w==}
     engines: {node: 12.x || 14.x || >= 16}
     peerDependencies:
       eslint: '>=6'
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
       requireindex: 1.2.0
       ts-dedent: 2.2.0
@@ -10134,6 +10148,18 @@ packages:
       minimatch: 9.0.3
       minipass: 6.0.2
       path-scurry: 1.10.1
+
+  /glob@10.3.12:
+    resolution: {integrity: sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 2.3.6
+      minimatch: 9.0.3
+      minipass: 7.1.0
+      path-scurry: 1.10.2
+    dev: true
 
   /glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
@@ -11027,7 +11053,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@18.11.5)(typescript@5.0.4)
+      ts-node: 10.9.2(@types/node@18.11.5)(typescript@5.3.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -11737,6 +11763,11 @@ packages:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
     engines: {node: 14 || >=16.14}
 
+  /lru-cache@10.2.2:
+    resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
+    engines: {node: 14 || >=16.14}
+    dev: true
+
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
@@ -11978,13 +12009,6 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimatch@7.4.6:
-    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
-    engines: {node: '>=10'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: true
-
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -12009,6 +12033,11 @@ packages:
   /minipass@6.0.2:
     resolution: {integrity: sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  /minipass@7.1.0:
+    resolution: {integrity: sha512-oGZRv2OT1lO2UF1zUcwdTb3wqUwI0kBGTgt/T7OdSj6M6N5m3o5uPf0AIW6lVxGGoiWUR7e2AwTE+xiwK8WQig==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dev: true
 
   /minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
@@ -12612,6 +12641,14 @@ packages:
       lru-cache: 10.1.0
       minipass: 6.0.2
 
+  /path-scurry@1.10.2:
+    resolution: {integrity: sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      lru-cache: 10.2.2
+      minipass: 7.1.0
+    dev: true
+
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
@@ -12999,12 +13036,12 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /react-docgen-typescript@2.2.2(typescript@5.0.4):
+  /react-docgen-typescript@2.2.2(typescript@5.3.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.3.3
     dev: true
 
   /react-docgen@7.0.3:
@@ -14314,13 +14351,13 @@ packages:
     hasBin: true
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.0.4):
+  /ts-api-utils@1.0.3(typescript@5.3.3):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.0.4
+      typescript: 5.3.3
     dev: true
 
   /ts-dedent@2.2.0:
@@ -14328,7 +14365,7 @@ packages:
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-jest@29.1.2(jest@29.7.0)(typescript@5.0.4):
+  /ts-jest@29.1.2(jest@29.7.0)(typescript@5.3.3):
     resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
     engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -14357,7 +14394,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.0.4
+      typescript: 5.3.3
       yargs-parser: 21.1.1
     dev: true
 
@@ -14365,7 +14402,7 @@ packages:
     resolution: {integrity: sha512-Ety4IvKMaeG34AyXMp5r11XiVZNDRL+XWxXbVVJjLvq2vxKRttEANBE7Za1bxCAZRdH2/sZT6jFyyTWxXz28hw==}
     dev: false
 
-  /ts-node@10.9.2(@types/node@18.11.5)(typescript@5.0.4):
+  /ts-node@10.9.2(@types/node@18.11.5)(typescript@5.3.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -14391,7 +14428,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.0.4
+      typescript: 5.3.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -14411,14 +14448,14 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsutils@3.21.0(typescript@5.0.4):
+  /tsutils@3.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.4
+      typescript: 5.3.3
     dev: true
 
   /tsx@4.7.1:
@@ -14540,26 +14577,26 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typedoc-plugin-merge-modules@4.1.0(typedoc@0.23.28):
+  /typedoc-plugin-merge-modules@4.1.0(typedoc@0.25.13):
     resolution: {integrity: sha512-0Qax5eSaiP86zX9LlQQWANjtgkMfSHt6/LRDsWXfK45Ifc3lrgjZG4ieE87BMi3p12r/F0qW9sHQRB18tIs0fg==}
     peerDependencies:
       typedoc: 0.23.x || 0.24.x
     dependencies:
-      typedoc: 0.23.28(typescript@5.0.4)
+      typedoc: 0.25.13(typescript@5.3.3)
     dev: true
 
-  /typedoc@0.23.28(typescript@5.0.4):
-    resolution: {integrity: sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==}
-    engines: {node: '>= 14.14'}
+  /typedoc@0.25.13(typescript@5.3.3):
+    resolution: {integrity: sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==}
+    engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 7.4.6
+      minimatch: 9.0.3
       shiki: 0.14.7
-      typescript: 5.0.4
+      typescript: 5.3.3
     dev: true
 
   /typemoq@2.1.0:
@@ -14572,9 +14609,9 @@ packages:
       postinstall-build: 5.0.3
     dev: true
 
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   /uc.micro@1.0.6:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "preferredVersionsHash": "89a5d665a17ed480da4ad7daf562f288bc17a116"
+  "preferredVersionsHash": "648d294e05d498de6e7f6ba4e040f1b82cff664b"
 }

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -37,6 +37,7 @@
     "react-redux": "^7.2.2"
   },
   "devDependencies": {
+    "@itwin/build-tools": "^3.7.0 || ^4.6.0-dev.27",
     "@originjs/vite-plugin-commonjs": "~1.0.3",
     "@storybook/addon-actions": "^7.6.17",
     "@storybook/addon-essentials": "^7.6.17",
@@ -62,9 +63,8 @@
     "eslint-plugin-storybook": "^0.6.15",
     "prop-types": "^15.8.1",
     "storybook": "^7.6.17",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "vite": "^5.2.0",
-    "vite-plugin-static-copy": "^1.0.1",
-    "@itwin/build-tools": "^3.7.0 || ^4.0.0"
+    "vite-plugin-static-copy": "^1.0.1"
   }
 }

--- a/test-apps/appui-test-app/appui-test-providers/package.json
+++ b/test-apps/appui-test-app/appui-test-providers/package.json
@@ -31,7 +31,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@itwin/build-tools": "^3.7.0 || ^4.0.0",
+    "@itwin/build-tools": "^3.7.0 || ^4.6.0-dev.27",
     "@itwin/eslint-plugin": "^4.0.0-dev.52",
     "@types/react": "^17.0.37",
     "@types/react-redux": "^7.1.18",
@@ -39,7 +39,7 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
     "eslint": "^8.44.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "eslint-config-prettier": "~8.8.0"
   },
   "dependencies": {

--- a/test-apps/appui-test-app/connected/package.json
+++ b/test-apps/appui-test-app/connected/package.json
@@ -38,7 +38,7 @@
     "NOTE: All tools used by scripts in this package must be listed as devDependencies"
   ],
   "devDependencies": {
-    "@itwin/build-tools": "^3.7.0 || ^4.0.0",
+    "@itwin/build-tools": "^3.7.0 || ^4.6.0-dev.27",
     "@itwin/eslint-plugin": "^4.0.0-dev.52",
     "@itwin/itwins-client": "^1.2.0",
     "@types/node": "18.11.5",
@@ -58,7 +58,7 @@
     "null-loader": "^4.0.1",
     "rimraf": "^3.0.2",
     "sass": "^1.72.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "vite": "^5.2.0",
     "vite-plugin-static-copy": "^1.0.1"
   },

--- a/test-apps/appui-test-app/standalone/package.json
+++ b/test-apps/appui-test-app/standalone/package.json
@@ -39,7 +39,7 @@
     "NOTE: All tools used by scripts in this package must be listed as devDependencies"
   ],
   "devDependencies": {
-    "@itwin/build-tools": "^3.7.0 || ^4.0.0",
+    "@itwin/build-tools": "^3.7.0 || ^4.6.0-dev.27",
     "@itwin/eslint-plugin": "^4.0.0-dev.52",
     "@types/node": "18.11.5",
     "@types/react": "^17.0.37",
@@ -58,7 +58,7 @@
     "null-loader": "^4.0.1",
     "rimraf": "^3.0.2",
     "sass": "^1.72.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "vite": "^5.2.0",
     "vite-plugin-static-copy": "^1.0.1"
   },

--- a/tools/codemod/package.json
+++ b/tools/codemod/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/jscodeshift": "^0.11.6",
     "jscodeshift": "^0.14.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "yargs": "^17.6.2",
     "postcss": "~8.4.23",
     "ts-node": "^10.8.2",

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -62,7 +62,7 @@
   ],
   "devDependencies": {
     "@itwin/appui-abstract": "^3.7.0 || ^4.0.0",
-    "@itwin/build-tools": "^3.7.0 || ^4.0.0",
+    "@itwin/build-tools": "^3.7.0 || ^4.6.0-dev.27",
     "@itwin/components-react": "workspace:*",
     "@itwin/core-bentley": "^3.7.0 || ^4.0.0",
     "@itwin/core-common": "^3.7.0 || ^4.0.0",
@@ -106,7 +106,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "upath": "^2.0.1",
     "vitest": "^1.4.0"
   },

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -53,7 +53,7 @@
   ],
   "devDependencies": {
     "@itwin/appui-abstract": "^3.7.0 || ^4.0.0",
-    "@itwin/build-tools": "^3.7.0 || ^4.0.0",
+    "@itwin/build-tools": "^3.7.0 || ^4.6.0-dev.27",
     "@itwin/core-bentley": "^3.7.0 || ^4.0.0",
     "@itwin/core-common": "^3.7.0 || ^4.0.0",
     "@itwin/core-geometry": "^3.7.0 || ^4.0.0",
@@ -87,7 +87,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "upath": "^2.0.1",
     "vitest": "^1.4.0"
   },

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -53,7 +53,7 @@
   ],
   "devDependencies": {
     "@itwin/appui-abstract": "^3.7.0 || ^4.0.0",
-    "@itwin/build-tools": "^3.7.0 || ^4.0.0",
+    "@itwin/build-tools": "^3.7.0 || ^4.6.0-dev.27",
     "@itwin/core-bentley": "^3.7.0 || ^4.0.0",
     "@itwin/core-common": "^3.7.0 || ^4.0.0",
     "@itwin/core-i18n": "^3.7.0 || ^4.0.0",
@@ -82,7 +82,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "upath": "^2.0.1",
     "vitest": "^1.4.0"
   },

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -57,7 +57,7 @@
   ],
   "devDependencies": {
     "@itwin/appui-abstract": "^3.7.0 || ^4.0.0",
-    "@itwin/build-tools": "^3.7.0 || ^4.0.0",
+    "@itwin/build-tools": "^3.7.0 || ^4.6.0-dev.27",
     "@itwin/components-react": "workspace:*",
     "@itwin/core-bentley": "^3.7.0 || ^4.0.0",
     "@itwin/core-common": "^3.7.0 || ^4.0.0",
@@ -91,7 +91,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.8.2",
     "typemoq": "^2.1.0",
-    "typescript": "~5.0.2",
+    "typescript": "~5.3.3",
     "upath": "^2.0.1",
     "vitest": "^1.4.0"
   },


### PR DESCRIPTION
Consume latest [@itwin/build-tools](https://github.com/iTwin/itwinjs-core/tree/master/tools/build) to produce documentation with newer TypeDoc schema. As a consequence, upgrade TypeScript to v5.3.3.

