### PR TITLE
Change DockedBar position to relative

### DIFF
--- a/common/changes/@itwin/appui-react/fix-docked-bar-position_2024-05-08-04-51.json
+++ b/common/changes/@itwin/appui-react/fix-docked-bar-position_2024-05-08-04-51.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Change DockedBar position to relative.",
+      "comment": "Fixed `StatusBar` and `ToolSettings` not being visible when `contentAlwaysMaxSize` preview feature is enabled.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/fix-docked-bar-position_2024-05-08-04-51.json
+++ b/common/changes/@itwin/appui-react/fix-docked-bar-position_2024-05-08-04-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Change DockedBar position to relative.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -2,19 +2,11 @@
 
 Table of contents:
 
-- [@itwin/appui-react](#itwinappui-react)
-  - [Fixes](#fixes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Deprecations](#deprecations)
-
-## @itwin/appui-react
-
-### Fixes
-
-- Fixed `StatusBar` and `ToolSettings` not being visible when `contentAlwaysMaxSize` preview feature is enabled. [#836](https://github.com/iTwin/appui/pull/836)
 
 ## @itwin/components-react
 
 ### Deprecations
 
-- Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer` in favor of default `PrimitivePropertyValueRenderer`. [#832](https://github.com/iTwin/appui/pull/832)
+- Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer` in favor of default `PrimitivePropertyValueRenderer`.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -2,11 +2,19 @@
 
 Table of contents:
 
+- [@itwin/appui-react](#itwinappui-react)
+  - [Fixes](#fixes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Deprecations](#deprecations)
+
+## @itwin/appui-react
+
+### Fixes
+
+- Fixed `StatusBar` and `ToolSettings` not being visible when `contentAlwaysMaxSize` preview feature is enabled. [#836](https://github.com/iTwin/appui/pull/836)
 
 ## @itwin/components-react
 
 ### Deprecations
 
-- Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer` in favor of default `PrimitivePropertyValueRenderer`.
+- Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer` in favor of default `PrimitivePropertyValueRenderer`. [#832](https://github.com/iTwin/appui/pull/832)

--- a/ui/appui-react/src/appui-react/widget-panels/DockedBar.scss
+++ b/ui/appui-react/src/appui-react/widget-panels/DockedBar.scss
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .uifw-dockedBar {
+  position: relative;
   background-color: var(--iui-color-background);
   height: var(--iui-component-height);
 


### PR DESCRIPTION
## Changes
When `contentAlwaysMaxSize` preview feature is enabled, the content takes up the whole window. In [this PR](https://github.com/iTwin/appui/pull/821) I removed `position: absolute` from status bar and tool settings but they are needed in this situation so the bars can be displayed above the content.

## Testing
Tested in test-app.
