### PR TITLE
Add required width property to fix column resizing in storybook.

### DIFF
--- a/docs/storybook/src/components/PropertyGrid.stories.tsx
+++ b/docs/storybook/src/components/PropertyGrid.stories.tsx
@@ -37,6 +37,7 @@ const meta = {
   decorators: [PaddingDecorator, AppUiDecorator],
   args: {
     height: 600,
+    width: 1300,
   },
 } satisfies Meta<typeof VirtualizedPropertyGridWithDataProvider>;
 


### PR DESCRIPTION
## Changes

Add the required `width` property to the property grid storybook to fix column resizing.

## Testing

N/A
