### PR TITLE
Fix property grid text selection

### DIFF
--- a/common/changes/@itwin/components-react/jon-fix-property-grid-text-selection_2024-05-23-06-54.json
+++ b/common/changes/@itwin/components-react/jon-fix-property-grid-text-selection_2024-05-23-06-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Update PropertyGrid to allow browser context menu and user selection.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/jon-fix-property-grid-text-selection_2024-05-23-06-54.json
+++ b/common/changes/@itwin/core-react/jon-fix-property-grid-text-selection_2024-05-23-06-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -4,6 +4,7 @@ Table of contents:
 
 - [@itwin/components-react](#itwincomponents-react)
   - [Deprecations](#deprecations)
+  - [Changes](#changes)
 - [@itwin/core-react](#itwincore-react)
   - [Fixes](#fixes)
 
@@ -12,6 +13,13 @@ Table of contents:
 ### Deprecations
 
 - Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer` in favor of default `PrimitivePropertyValueRenderer`. [#832](https://github.com/iTwin/appui/pull/832)
+
+### Changes
+
+- Updated `VirtualizedPropertyGrid` component [#849](https://github.com/iTwin/appui/pull/849):
+  - Enable user selection for property records
+  - Display browser context menu on property records if `onPropertyContextMenu` and `isPropertySelectionOnRightClickEnabled` props are not set
+  - Increased area of an element selector to avoid column overlap
 
 ## @itwin/core-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -19,7 +19,7 @@ Table of contents:
 - Updated `VirtualizedPropertyGrid` component [#849](https://github.com/iTwin/appui/pull/849):
   - Enable user selection for property records
   - Display browser context menu on property records if `onPropertyContextMenu` and `isPropertySelectionOnRightClickEnabled` props are not set
-  - Increased area of an element selector to avoid column overlap
+  - Increased area of an element separator to avoid column overlap
 
 ## @itwin/core-react
 

--- a/docs/storybook/src/components/PropertyGrid.stories.tsx
+++ b/docs/storybook/src/components/PropertyGrid.stories.tsx
@@ -66,6 +66,7 @@ export const Basic: Story = {
       }),
       onDataChanged: new PropertyDataChangeEvent(),
     },
+    onPropertyContextMenu: undefined,
   },
 };
 

--- a/ui/components-react/src/components-react/properties/renderers/PropertyGridColumns.ts
+++ b/ui/components-react/src/components-react/properties/renderers/PropertyGridColumns.ts
@@ -88,7 +88,7 @@ export class PropertyGridColumnStyleProvider {
     ratio: number,
     needElementSeparator: boolean
   ): React.CSSProperties {
-    const separatorColumn = needElementSeparator ? "1px" : undefined;
+    const separatorColumn = needElementSeparator ? "auto" : undefined;
     const actionButtonColumn = needActionButtons
       ? this.actionButtonWidth
         ? `${this.actionButtonWidth}px`

--- a/ui/components-react/src/components-react/properties/renderers/PropertyView.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/PropertyView.tsx
@@ -59,11 +59,14 @@ export class PropertyView extends React.Component<
   };
 
   private _onContextMenu = (e: React.MouseEvent) => {
-    if (this.props.onContextMenu)
+    if (this.props.onContextMenu) {
       this.props.onContextMenu(this.props.propertyRecord, e);
-    if (this.props.onRightClick)
+      e.preventDefault();
+    }
+    if (this.props.onRightClick) {
       this.props.onRightClick(this.props.propertyRecord, this.props.uniqueKey);
-    e.preventDefault();
+      e.preventDefault();
+    }
     return false;
   };
 

--- a/ui/components-react/src/components-react/properties/renderers/PropertyView.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/PropertyView.tsx
@@ -116,6 +116,7 @@ export class PropertyView extends React.Component<
         {needElementSeparator ? (
           // eslint-disable-next-line deprecation/deprecation
           <ElementSeparator
+            style={{ margin: 0 }}
             movableArea={this.props.width}
             onRatioChanged={this.props.onColumnRatioChanged}
             ratio={ratio}

--- a/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
+++ b/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
@@ -20,12 +20,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  margin-top: auto;
-  margin-bottom: auto;
-}
+  margin-block: auto;
 
-.components-property-label-renderer-colon {
-  margin: auto 3px auto 0px;
+  &-colon::after {
+    content: ":";
+    margin-inline-end: var(--iui-size-2xs);
+  }
 }
 
 @mixin specific-property-label-renderer {

--- a/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.tsx
@@ -8,6 +8,7 @@
 
 import "./PropertyLabelRenderer.scss";
 import * as React from "react";
+import classnames from "classnames";
 
 /** Base properties for a property label renderer
  * @public
@@ -41,11 +42,10 @@ export class PropertyLabelRenderer extends React.PureComponent<PropertyLabelRend
     return (
       <>
         <span
-          className={`components-property-label-renderer ${
-            this.props.renderColon
-              ? "components-property-label-renderer-colon"
-              : ""
-          }`}
+          className={classnames(
+            "components-property-label-renderer",
+            this.props.renderColon && "components-property-label-renderer-colon"
+          )}
           title={title}
         >
           {this.props.children}

--- a/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.tsx
@@ -40,12 +40,16 @@ export class PropertyLabelRenderer extends React.PureComponent<PropertyLabelRend
         : /* istanbul ignore next */ undefined);
     return (
       <>
-        <span className="components-property-label-renderer" title={title}>
+        <span
+          className={`components-property-label-renderer ${
+            this.props.renderColon
+              ? "components-property-label-renderer-colon"
+              : ""
+          }`}
+          title={title}
+        >
           {this.props.children}
         </span>
-        {this.props.renderColon ? (
-          <span className="components-property-label-renderer-colon">:</span>
-        ) : undefined}
       </>
     );
   }

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
@@ -194,7 +194,9 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
       onPropertyRightClicked: this._isRightClickSupported()
         ? this._onPropertyRightClicked
         : undefined,
-      onPropertyContextMenu: this._onPropertyContextMenu,
+      onPropertyContextMenu: this.props.onPropertyContextMenu
+        ? this._onPropertyContextMenu
+        : undefined,
     };
 
     return (

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.scss
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.scss
@@ -11,10 +11,6 @@
   justify-content: center;
 }
 
-.components-virtualized-property-grid {
-  user-select: none;
-}
-
 .components-property-grid-wrapper {
   @include uicore-touch-scrolling;
   @include uicore-scrollbar();

--- a/ui/components-react/src/test/properties/renderers/PropertyView.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/PropertyView.test.tsx
@@ -80,7 +80,7 @@ describe("PropertyView", () => {
         />
       );
       expect(screen.getByRole("presentation")).satisfy(
-        styleMatch({ gridTemplateColumns: "25% 1px auto" })
+        styleMatch({ gridTemplateColumns: "25% auto auto" })
       );
     });
 
@@ -102,7 +102,7 @@ describe("PropertyView", () => {
       );
 
       expect(screen.getByRole("presentation")).satisfy(
-        styleMatch({ gridTemplateColumns: "25% 1px auto 60px" })
+        styleMatch({ gridTemplateColumns: "25% auto auto 60px" })
       );
     });
 
@@ -118,7 +118,7 @@ describe("PropertyView", () => {
       );
 
       expect(screen.getByRole("presentation")).satisfy(
-        styleMatch({ gridTemplateColumns: "25% 1px auto auto" })
+        styleMatch({ gridTemplateColumns: "25% auto auto auto" })
       );
     });
   });
@@ -187,7 +187,7 @@ describe("PropertyView", () => {
 
       expect(screen.getByRole("presentation")).satisfy(
         styleMatch({
-          gridTemplateColumns: "minmax(30px, 25%) 1px minmax(45px, 1fr)",
+          gridTemplateColumns: "minmax(30px, 25%) auto minmax(45px, 1fr)",
         })
       );
     });
@@ -211,7 +211,7 @@ describe("PropertyView", () => {
 
       expect(screen.getByRole("presentation")).satisfy(
         styleMatch({
-          gridTemplateColumns: "minmax(30px, 25%) 1px minmax(45px, 1fr) 60px",
+          gridTemplateColumns: "minmax(30px, 25%) auto minmax(45px, 1fr) 60px",
         })
       );
     });

--- a/ui/components-react/src/test/propertygrid/component/ColumnResizingPropertyListPropsSupplier.test.tsx
+++ b/ui/components-react/src/test/propertygrid/component/ColumnResizingPropertyListPropsSupplier.test.tsx
@@ -37,7 +37,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       );
 
       expect(screen.getByRole("presentation")).satisfy(
-        styleMatch({ gridTemplateColumns: "25% 1px auto" })
+        styleMatch({ gridTemplateColumns: "25% auto auto" })
       );
       await theUserTo.pointer([
         {
@@ -50,7 +50,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
-          styleMatch({ gridTemplateColumns: /^55(?:\.\d*|)% 1px auto/ })
+          styleMatch({ gridTemplateColumns: /^55(?:\.\d*|)% auto auto/ })
         );
       });
     });
@@ -66,7 +66,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       );
 
       expect(screen.getByRole("presentation")).satisfy(
-        styleMatch({ gridTemplateColumns: "25% 1px auto" })
+        styleMatch({ gridTemplateColumns: "25% auto auto" })
       );
       await theUserTo.pointer([
         {
@@ -79,7 +79,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
-          styleMatch({ gridTemplateColumns: "15% 1px auto" })
+          styleMatch({ gridTemplateColumns: "15% auto auto" })
         );
       });
     });
@@ -95,7 +95,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       );
 
       expect(screen.getByRole("presentation")).satisfy(
-        styleMatch({ gridTemplateColumns: "25% 1px auto" })
+        styleMatch({ gridTemplateColumns: "25% auto auto" })
       );
       await theUserTo.pointer([
         {
@@ -108,7 +108,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
-          styleMatch({ gridTemplateColumns: "60% 1px auto" })
+          styleMatch({ gridTemplateColumns: "60% auto auto" })
         );
       });
     });
@@ -132,7 +132,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       );
 
       expect(screen.getByRole("presentation")).satisfy(
-        styleMatch({ gridTemplateColumns: "25% 1px auto 30px" })
+        styleMatch({ gridTemplateColumns: "25% auto auto 30px" })
       );
       await theUserTo.pointer([
         {
@@ -148,7 +148,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       // (100 - 30 - 10 - 16 - 10) / 100
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
-          styleMatch({ gridTemplateColumns: "34% 1px auto 30px" })
+          styleMatch({ gridTemplateColumns: "34% auto auto 30px" })
         );
       });
     });
@@ -170,7 +170,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
 
       expect(screen.getByRole("presentation")).satisfy(
         styleMatch({
-          gridTemplateColumns: "minmax(100px, 25%) 1px minmax(100px, 1fr)",
+          gridTemplateColumns: "minmax(100px, 25%) auto minmax(100px, 1fr)",
         })
       );
       await theUserTo.pointer([
@@ -185,7 +185,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
           styleMatch({
-            gridTemplateColumns: "minmax(100px, 50%) 1px minmax(100px, 1fr)",
+            gridTemplateColumns: "minmax(100px, 50%) auto minmax(100px, 1fr)",
           })
         );
       });
@@ -206,7 +206,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
 
       expect(screen.getByRole("presentation")).satisfy(
         styleMatch({
-          gridTemplateColumns: "minmax(100px, 25%) 1px minmax(100px, 1fr)",
+          gridTemplateColumns: "minmax(100px, 25%) auto minmax(100px, 1fr)",
         })
       );
       await theUserTo.pointer([
@@ -221,7 +221,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
           styleMatch({
-            gridTemplateColumns: "minmax(100px, 10%) 1px minmax(100px, 1fr)",
+            gridTemplateColumns: "minmax(100px, 10%) auto minmax(100px, 1fr)",
           })
         );
       });
@@ -241,7 +241,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       );
       expect(screen.getByRole("presentation")).satisfy(
         styleMatch({
-          gridTemplateColumns: "minmax(100px, 25%) 1px minmax(100px, 1fr)",
+          gridTemplateColumns: "minmax(100px, 25%) auto minmax(100px, 1fr)",
         })
       );
       await theUserTo.pointer([
@@ -256,7 +256,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
           styleMatch({
-            gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)",
+            gridTemplateColumns: "minmax(100px, 80%) auto minmax(100px, 1fr)",
           })
         );
       });
@@ -277,7 +277,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
 
       expect(screen.getByRole("presentation")).satisfy(
         styleMatch({
-          gridTemplateColumns: "minmax(100px, 25%) 1px minmax(100px, 1fr)",
+          gridTemplateColumns: "minmax(100px, 25%) auto minmax(100px, 1fr)",
         })
       );
       await theUserTo.pointer([
@@ -292,7 +292,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
           styleMatch({
-            gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)",
+            gridTemplateColumns: "minmax(100px, 80%) auto minmax(100px, 1fr)",
           })
         );
       });
@@ -302,7 +302,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
           styleMatch({
-            gridTemplateColumns: "minmax(100px, 80%) 1px minmax(100px, 1fr)",
+            gridTemplateColumns: "minmax(100px, 80%) auto minmax(100px, 1fr)",
           })
         );
       });
@@ -323,7 +323,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
 
       expect(screen.getByRole("presentation")).satisfy(
         styleMatch({
-          gridTemplateColumns: "minmax(100px, 25%) 1px minmax(100px, 1fr)",
+          gridTemplateColumns: "minmax(100px, 25%) auto minmax(100px, 1fr)",
         })
       );
       await theUserTo.pointer([
@@ -338,7 +338,7 @@ describe("ColumnResizingPropertyListPropsSupplier", () => {
       await waitFor(() => {
         expect(screen.getByRole("presentation")).satisfy(
           styleMatch({
-            gridTemplateColumns: "minmax(100px, 10%) 1px minmax(100px, 1fr)",
+            gridTemplateColumns: "minmax(100px, 10%) auto minmax(100px, 1fr)",
           })
         );
       });

--- a/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
+++ b/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
@@ -65,6 +65,7 @@
   padding: 0px;
   opacity: 0;
   z-index: 1;
+  user-select: none;
 
   &--vertical {
     width: 100%;

--- a/ui/core-react/src/core-react/elementseparator/ElementSeparator.tsx
+++ b/ui/core-react/src/core-react/elementseparator/ElementSeparator.tsx
@@ -280,6 +280,7 @@ export const ElementSeparator = (props: ElementSeparatorProps) => {
       onPointerOver={onPointerOver}
       onPointerOut={onPointerOut}
       aria-label={translate("elementSeparator.label")}
+      tabIndex={-1}
     />
   );
 };


### PR DESCRIPTION
## Changes

- Moved `user-select: none` from property grid to element separator to allow a user to highlight the text values.
- Add `tabindex: -1` to element separator so it is not keyboard focusable. It already had `:focus { outline: 0; }` which hides the focus, this now disables focus.
- Changed `.components-property-label-renderer-colon` from a `<span>` to an `::after`.

## Testing

- Confirmed that resizing columns does not unintentionally highlight text.
- Used the <kbd>tab</kbd> to confirm that the resizer is no longer taking focus.
