### PR TITLE
Deprecate `RadialMenu` and `RadialButton` components

### DIFF
--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -1266,7 +1266,7 @@ export interface ProcessSettingsTabActivationEventArgs {
 // @internal
 export const PROXIMITY_THRESHOLD_DEFAULT = 100;
 
-// @public
+// @public @deprecated
 export class RadialButton extends React_2.Component<RadialButtonProps, RadialButtonState> {
     constructor(props: RadialButtonProps);
     // (undocumented)
@@ -1276,7 +1276,7 @@ export class RadialButton extends React_2.Component<RadialButtonProps, RadialBut
     readonly state: Readonly<RadialButtonState>;
 }
 
-// @public
+// @public @deprecated
 export interface RadialButtonProps extends CommonProps {
     // @internal (undocumented)
     annularSector?: AnnularSector;
@@ -1287,7 +1287,7 @@ export interface RadialButtonProps extends CommonProps {
     selected?: boolean;
 }
 
-// @public
+// @public @deprecated
 export class RadialMenu extends React_2.Component<RadialMenuProps, RadialMenuState> {
     constructor(props: RadialMenuProps);
     // (undocumented)
@@ -1305,7 +1305,7 @@ export class RadialMenu extends React_2.Component<RadialMenuProps, RadialMenuSta
     readonly state: Readonly<RadialMenuState>;
 }
 
-// @public
+// @public @deprecated
 export interface RadialMenuProps extends CommonProps {
     children?: React_2.ReactNode;
     innerRadius: number;

--- a/common/api/summary/core-react.exports.csv
+++ b/common/api/summary/core-react.exports.csv
@@ -209,9 +209,13 @@ public;ProcessSettingsTabActivationEventArgs
 deprecated;ProcessSettingsTabActivationEventArgs
 internal;PROXIMITY_THRESHOLD_DEFAULT = 100
 public;RadialButton 
+deprecated;RadialButton 
 public;RadialButtonProps 
+deprecated;RadialButtonProps 
 public;RadialMenu 
+deprecated;RadialMenu 
 public;RadialMenuProps 
+deprecated;RadialMenuProps 
 public;RadialSizeType = ProgressRadialProps["size"]
 deprecated;RadialSizeType = ProgressRadialProps["size"]
 public;RatioChangeResult

--- a/common/changes/@itwin/core-react/deprecate-radial-menu_2024-05-23-07-38.json
+++ b/common/changes/@itwin/core-react/deprecate-radial-menu_2024-05-23-07-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Deprecate RadialMenu and RadialButton components.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -12,6 +12,7 @@ Table of contents:
 ### Deprecations
 
 - Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer` in favor of default `PrimitivePropertyValueRenderer`. [#832](https://github.com/iTwin/appui/pull/832)
+- Deprecated `RadialMenu` and `RadialButton` components that were designed for a retired design pattern in favor of `ContextMenu` or [iTwinUI dropdown menu](https://itwinui.bentley.com/docs/dropdownmenu).
 
 ## @itwin/core-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -12,7 +12,7 @@ Table of contents:
 ### Deprecations
 
 - Deprecated `DoublePropertyValueRenderer` and `NavigationPropertyValueRenderer` in favor of default `PrimitivePropertyValueRenderer`. [#832](https://github.com/iTwin/appui/pull/832)
-- Deprecated `RadialMenu` and `RadialButton` components that were designed for a retired design pattern in favor of `ContextMenu` or [iTwinUI dropdown menu](https://itwinui.bentley.com/docs/dropdownmenu).
+- Deprecated `RadialMenu` and `RadialButton` components that were designed for a retired design pattern in favor of `ContextMenu` or [iTwinUI dropdown menu](https://itwinui.bentley.com/docs/dropdownmenu). [#850](https://github.com/iTwin/appui/pull/850)
 
 ## @itwin/core-react
 

--- a/docs/storybook/src/deprecated/RadialMenu.stories.tsx
+++ b/docs/storybook/src/deprecated/RadialMenu.stories.tsx
@@ -9,7 +9,7 @@ import { Svg2D, Svg3D, SvgActivity } from "@itwin/itwinui-icons-react";
 import { AppUiDecorator } from "../Decorators";
 
 const meta = {
-  title: "Components/RadialMenu",
+  title: "Deprecated/RadialMenu",
   component: RadialMenu,
   tags: ["autodocs"],
   decorators: [AppUiDecorator],

--- a/ui/core-react/eslint.config.js
+++ b/ui/core-react/eslint.config.js
@@ -18,4 +18,10 @@ module.exports = [
       ...prettierConfig.rules,
     },
   },
+  {
+    files: ["src/test/**/*.{ts,tsx}"],
+    rules: {
+      "deprecation/deprecation": "off",
+    },
+  },
 ];

--- a/ui/core-react/src/core-react/radialmenu/RadialMenu.tsx
+++ b/ui/core-react/src/core-react/radialmenu/RadialMenu.tsx
@@ -16,8 +16,11 @@ import { Point } from "../utils/Point";
 import type { CommonProps } from "../utils/Props";
 import { AnnularSector, Annulus } from "./Annulus";
 
+/* eslint-disable deprecation/deprecation */
+
 /** Properties for [[RadialMenu]]
  * @public
+ * @deprecated in 4.14.x. Props of deprecated component {@link RadialMenu}.
  */
 export interface RadialMenuProps extends CommonProps {
   /** Whether to show RadialMenu */
@@ -48,9 +51,9 @@ interface RadialMenuState {
   sectors: AnnularSector[];
 }
 
-/**
- * A context menu arranged in a radial layout.
+/** A context menu arranged in a radial layout.
  * @public
+ * @deprecated in 4.14.x. Use {@link https://itwinui.bentley.com/docs/dropdownmenu dropdown menu} instead.
  */
 export class RadialMenu extends React.Component<
   RadialMenuProps,
@@ -208,6 +211,7 @@ export class RadialMenu extends React.Component<
 
 /** Properties for [[RadialButton]] component
  * @public
+ * @deprecated in 4.14.x. Props of deprecated component {@link RadialButton}.
  */
 export interface RadialButtonProps extends CommonProps {
   /** Whether label is rotated to radial menu. Default: Inherit */
@@ -224,14 +228,13 @@ export interface RadialButtonProps extends CommonProps {
   children?: React.ReactNode;
 }
 
-/** @internal */
 interface RadialButtonState {
   hover: boolean;
 }
 
-/**
- * Button for use within a [[RadialMenu]]
+/** Button for use within a [[RadialMenu]]
  * @public
+ * @deprecated in 4.14.x. Component used in a deprecated component {@link RadialMenu}.
  */
 export class RadialButton extends React.Component<
   RadialButtonProps,

--- a/ui/core-react/src/core-react/radialmenu/RadialMenu.tsx
+++ b/ui/core-react/src/core-react/radialmenu/RadialMenu.tsx
@@ -15,6 +15,7 @@ import { Icon } from "../icons/IconComponent";
 import { Point } from "../utils/Point";
 import type { CommonProps } from "../utils/Props";
 import { AnnularSector, Annulus } from "./Annulus";
+import type { ContextMenu } from "../contextmenu/ContextMenu";
 
 /* eslint-disable deprecation/deprecation */
 
@@ -53,7 +54,7 @@ interface RadialMenuState {
 
 /** A context menu arranged in a radial layout.
  * @public
- * @deprecated in 4.14.x. Use {@link https://itwinui.bentley.com/docs/dropdownmenu dropdown menu} instead.
+ * @deprecated in 4.14.x. Use {@link ContextMenu} or {@link https://itwinui.bentley.com/docs/dropdownmenu iTwinUI dropdown menu} instead.
  */
 export class RadialMenu extends React.Component<
   RadialMenuProps,

--- a/ui/core-react/src/test/UiCore.test.ts
+++ b/ui/core-react/src/test/UiCore.test.ts
@@ -25,13 +25,11 @@ describe("UiCore", () => {
 
   it("translate should return the key (in test environment)", async () => {
     await TestUtils.initializeUiCore();
-    // eslint-disable-next-line deprecation/deprecation
     expect(UiCore.translate("test1.test2")).toEqual("test1.test2");
   });
 
   it("translate should return blank and log error if UiCore not initialized", () => {
     const spyLogger = vi.spyOn(Logger, "logError");
-    // eslint-disable-next-line deprecation/deprecation
     expect(UiCore.translate("xyz")).toEqual("");
     expect(spyLogger).toHaveBeenCalledOnce();
   });

--- a/ui/core-react/src/test/base/Centered.test.tsx
+++ b/ui/core-react/src/test/base/Centered.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { Centered } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<Centered />", () => {
   it("content renders correctly", () => {
     render(<Centered>Test content</Centered>);

--- a/ui/core-react/src/test/base/DivWithOutsideClick.test.tsx
+++ b/ui/core-react/src/test/base/DivWithOutsideClick.test.tsx
@@ -7,8 +7,6 @@ import userEvent from "@testing-library/user-event";
 import * as React from "react";
 import { DivWithOutsideClick } from "../../core-react";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<DivWithOutsideClick />", () => {
   it("should use onOutsideClick", async () => {
     const theUserTo = userEvent.setup();

--- a/ui/core-react/src/test/base/FillCentered.test.tsx
+++ b/ui/core-react/src/test/base/FillCentered.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { FillCentered } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<FillCentered />", () => {
   it("has correct text", () => {
     render(<FillCentered>Test content</FillCentered>);

--- a/ui/core-react/src/test/base/FlexWrapContainer.test.tsx
+++ b/ui/core-react/src/test/base/FlexWrapContainer.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { FlexWrapContainer } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<FlexWrapContainer />", () => {
   it("content renders correctly", () => {
     render(<FlexWrapContainer>Test content</FlexWrapContainer>);

--- a/ui/core-react/src/test/base/Gap.test.tsx
+++ b/ui/core-react/src/test/base/Gap.test.tsx
@@ -6,8 +6,6 @@ import { render, screen } from "@testing-library/react";
 import * as React from "react";
 import { Gap } from "../../core-react";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<Gap />", () => {
   it("renders correctly", () => {
     render(<Gap data-testid="tested" />);

--- a/ui/core-react/src/test/base/ScrollView.test.tsx
+++ b/ui/core-react/src/test/base/ScrollView.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { ScrollView } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<ScrollView />", () => {
   it("content renders correctly", () => {
     render(<ScrollView>Test content</ScrollView>);

--- a/ui/core-react/src/test/button/UnderlinedButton.test.tsx
+++ b/ui/core-react/src/test/button/UnderlinedButton.test.tsx
@@ -8,8 +8,6 @@ import { UnderlinedButton } from "../../core-react/button/UnderlinedButton";
 import userEvent from "@testing-library/user-event";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<UnderlinedButton />", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
   beforeEach(() => {

--- a/ui/core-react/src/test/checklistbox/CheckListBox.test.tsx
+++ b/ui/core-react/src/test/checklistbox/CheckListBox.test.tsx
@@ -12,8 +12,6 @@ import {
 } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<CheckListBox />", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
   beforeEach(() => {

--- a/ui/core-react/src/test/dialog/Dialog.test.tsx
+++ b/ui/core-react/src/test/dialog/Dialog.test.tsx
@@ -10,8 +10,6 @@ import { GlobalDialog } from "../../core-react/dialog/GlobalDialog";
 import { DialogButtonType } from "@itwin/appui-abstract";
 import userEvent from "@testing-library/user-event";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("Dialog", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
   beforeEach(async () => {

--- a/ui/core-react/src/test/elementseparator/ElementSeparator.test.tsx
+++ b/ui/core-react/src/test/elementseparator/ElementSeparator.test.tsx
@@ -11,8 +11,6 @@ import { Orientation } from "../../core-react/enums/Orientation";
 import { classesFromElement } from "../TestUtils";
 import type { Mock } from "vitest";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("ElementSeparator", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
   const throttleMs = 16;

--- a/ui/core-react/src/test/expandable/ExpandableList.test.tsx
+++ b/ui/core-react/src/test/expandable/ExpandableList.test.tsx
@@ -9,8 +9,6 @@ import TestUtils from "../TestUtils";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("ExpandableList", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
   beforeEach(() => {

--- a/ui/core-react/src/test/imagecheckbox/ImageCheckBox.test.tsx
+++ b/ui/core-react/src/test/imagecheckbox/ImageCheckBox.test.tsx
@@ -7,8 +7,6 @@ import { ImageCheckBox } from "../../core-react";
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "@testing-library/react";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<ImageCheckBox />", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
   beforeEach(() => {

--- a/ui/core-react/src/test/inputs/InputLabel.test.tsx
+++ b/ui/core-react/src/test/inputs/InputLabel.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { InputLabel, InputStatus } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<InputLabel />", () => {
   it("renders correctly", () => {
     render(

--- a/ui/core-react/src/test/inputs/iconinput/IconInput.test.tsx
+++ b/ui/core-react/src/test/inputs/iconinput/IconInput.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { IconInput } from "../../../core-react";
 import { classesFromElement } from "../../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("IconInput", () => {
   it("renders correctly", () => {
     render(<IconInput icon={<div data-testid="tested" />} />);

--- a/ui/core-react/src/test/inputs/numberinput/NumberInput.test.tsx
+++ b/ui/core-react/src/test/inputs/numberinput/NumberInput.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { Key } from "ts-key-enum";
 import { NumberInput } from "../../../core-react/inputs/numberinput/NumberInput";
 
-/* eslint-disable deprecation/deprecation */
-
 function parseDollar(stringValue: string) {
   const noDollarSign = stringValue.replace(/^\$/, "");
   let n = parseFloat(noDollarSign);

--- a/ui/core-react/src/test/listbox/listbox.test.tsx
+++ b/ui/core-react/src/test/listbox/listbox.test.tsx
@@ -9,8 +9,6 @@ import { fireEvent, render } from "@testing-library/react";
 import type { ListboxValue } from "../../core-react/listbox/Listbox";
 import { Listbox, ListboxItem } from "../../core-react/listbox/Listbox";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<ListBox />", () => {
   const listItems = [
     "London",

--- a/ui/core-react/src/test/loading/LoadingBar.test.tsx
+++ b/ui/core-react/src/test/loading/LoadingBar.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { LoadingBar } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<LoadingBar />", () => {
   it("renders correctly", () => {
     const { container } = render(<LoadingBar />);

--- a/ui/core-react/src/test/loading/LoadingPrompt.test.tsx
+++ b/ui/core-react/src/test/loading/LoadingPrompt.test.tsx
@@ -6,8 +6,6 @@ import { render, screen } from "@testing-library/react";
 import * as React from "react";
 import { LoadingPrompt } from "../../core-react";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<LoadingPrompt />", () => {
   it("renders with text correctly", () => {
     render(<LoadingPrompt title="title" />);

--- a/ui/core-react/src/test/loading/LoadingSpinner.test.tsx
+++ b/ui/core-react/src/test/loading/LoadingSpinner.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { LoadingSpinner } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<LoadingSpinner />", () => {
   it("renders with message correctly", () => {
     render(<LoadingSpinner message="test" />);

--- a/ui/core-react/src/test/loading/LoadingStatus.test.tsx
+++ b/ui/core-react/src/test/loading/LoadingStatus.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { LoadingStatus } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<LoadingStatus />", () => {
   it("renders with message correctly", () => {
     render(<LoadingStatus message="test" />);

--- a/ui/core-react/src/test/notification/MessageRenderer.test.tsx
+++ b/ui/core-react/src/test/notification/MessageRenderer.test.tsx
@@ -7,8 +7,6 @@ import { MessageRenderer } from "../../core-react/notification/MessageRenderer";
 import { UnderlinedButton } from "../../core-react/button/UnderlinedButton";
 import { render, screen } from "@testing-library/react";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("MessageRenderer", () => {
   describe("Span", () => {
     it("with message text", () => {

--- a/ui/core-react/src/test/searchbox/SearchBox.test.tsx
+++ b/ui/core-react/src/test/searchbox/SearchBox.test.tsx
@@ -7,8 +7,6 @@ import { SearchBox } from "../../core-react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("SearchBox", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
   const throttleMs = 16;

--- a/ui/core-react/src/test/tabs/Tabs.test.tsx
+++ b/ui/core-react/src/test/tabs/Tabs.test.tsx
@@ -8,8 +8,6 @@ import * as React from "react";
 import { Orientation, Tabs, VerticalTabs } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<Tabs />", () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
   beforeEach(() => {

--- a/ui/core-react/src/test/tabs/VerticalTabs.test.tsx
+++ b/ui/core-react/src/test/tabs/VerticalTabs.test.tsx
@@ -7,8 +7,6 @@ import * as React from "react";
 import { VerticalTabs } from "../../core-react";
 import { classesFromElement } from "../TestUtils";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<VerticalTabs />", () => {
   it("should render", () => {
     const { container } = render(<VerticalTabs labels={[]} />);

--- a/ui/core-react/src/test/text/BlockText.test.tsx
+++ b/ui/core-react/src/test/text/BlockText.test.tsx
@@ -6,8 +6,6 @@ import { render, screen } from "@testing-library/react";
 import * as React from "react";
 import { BlockText } from "../../core-react";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<BlockText />", () => {
   it("renders correctly", () => {
     render(<BlockText>Tested content</BlockText>);

--- a/ui/core-react/src/test/text/BodyText.test.tsx
+++ b/ui/core-react/src/test/text/BodyText.test.tsx
@@ -8,7 +8,6 @@ import { BodyText } from "../../core-react";
 
 describe("<BodyText />", () => {
   it("renders correctly", () => {
-    // eslint-disable-next-line deprecation/deprecation
     render(<BodyText>Tested content</BodyText>);
 
     expect(

--- a/ui/core-react/src/test/text/DisabledText.test.tsx
+++ b/ui/core-react/src/test/text/DisabledText.test.tsx
@@ -6,8 +6,6 @@ import { render, screen } from "@testing-library/react";
 import * as React from "react";
 import { DisabledText } from "../../core-react";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<DisabledText />", () => {
   it("renders correctly", () => {
     render(<DisabledText>Tested content</DisabledText>);

--- a/ui/core-react/src/test/text/MutedText.test.tsx
+++ b/ui/core-react/src/test/text/MutedText.test.tsx
@@ -6,8 +6,6 @@ import { render, screen } from "@testing-library/react";
 import * as React from "react";
 import { MutedText } from "../../core-react";
 
-/* eslint-disable deprecation/deprecation */
-
 describe("<MutedText />", () => {
   it("renders correctly", () => {
     render(<MutedText>Tested content</MutedText>);

--- a/ui/core-react/src/test/utils/hooks/useDisposable.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useDisposable.test.tsx
@@ -22,7 +22,6 @@ describe("useDisposable", () => {
   it("creates disposable and disposes it on unmount", () => {
     const { result, unmount } = renderHook(
       (props: { createDisposable: () => IDisposable }) =>
-        // eslint-disable-next-line deprecation/deprecation
         useDisposable(props.createDisposable),
       { initialProps: { createDisposable } }
     );
@@ -35,7 +34,6 @@ describe("useDisposable", () => {
   it("disposes old disposable when creating new one", () => {
     const { result, rerender } = renderHook(
       (props: { createDisposable: () => IDisposable }) =>
-        // eslint-disable-next-line deprecation/deprecation
         useDisposable(props.createDisposable),
       { initialProps: { createDisposable } }
     );


### PR DESCRIPTION
## Changes

This PR deprecates `RadialMenu` and `RadialButton` components that were designed specifically for a 9-Zone UI layout.

## Testing

N/A
