### PR TITLE
Add notification stories

### DIFF
--- a/docs/storybook/src/AppUiStory.tsx
+++ b/docs/storybook/src/AppUiStory.tsx
@@ -12,6 +12,7 @@ import {
   Title,
 } from "@storybook/blocks";
 import {
+  AppNotificationManager,
   ConfigurableUiContent,
   FrameworkToolAdmin,
   FrontstageProvider,
@@ -66,6 +67,7 @@ export function AppUiStory(props: AppUiStoryProps) {
           })
         ),
         authorizationClient: new DemoAuthClient(),
+        notifications: new AppNotificationManager(),
       });
       await UiFramework.initialize(undefined);
 

--- a/docs/storybook/src/frontstage/notifications/OutputMessage.stories.tsx
+++ b/docs/storybook/src/frontstage/notifications/OutputMessage.stories.tsx
@@ -1,0 +1,59 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { Meta, StoryObj } from "@storybook/react";
+import { OutputMessagePriority, OutputMessageType } from "@itwin/core-frontend";
+import { Page } from "../../AppUiStory";
+import { NotificationsStory } from "./OutputMessage";
+
+const meta = {
+  title: "Frontstage/Notifications/OutputMessage",
+  component: NotificationsStory,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      page: () => <Page />,
+    },
+    layout: "fullscreen",
+  },
+  args: {
+    messagePriority: OutputMessagePriority.Debug,
+    briefMessage: "Brief message",
+  },
+} satisfies Meta<typeof NotificationsStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const Error: Story = {
+  args: {
+    messagePriority: OutputMessagePriority.Error,
+  },
+};
+
+export const Detailed: Story = {
+  args: {
+    detailedMessage: "Detailed message",
+  },
+};
+
+export const Pointer: Story = {
+  args: {
+    messageType: OutputMessageType.Pointer,
+  },
+};
+
+export const Alert: Story = {
+  args: {
+    messageType: OutputMessageType.Alert,
+  },
+};
+
+export const Sticky: Story = {
+  args: {
+    messageType: OutputMessageType.Sticky,
+  },
+};

--- a/docs/storybook/src/frontstage/notifications/OutputMessage.tsx
+++ b/docs/storybook/src/frontstage/notifications/OutputMessage.tsx
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from "react";
+import {
+  IModelApp,
+  NotifyMessageDetails,
+  OutputMessageAlert,
+  OutputMessagePriority,
+  OutputMessageType,
+} from "@itwin/core-frontend";
+import { AppUiStory } from "../../AppUiStory";
+import { UiFramework } from "@itwin/appui-react";
+import { RelativePosition } from "@itwin/appui-abstract";
+
+interface NotificationsStoryProps {
+  messagePriority: OutputMessagePriority;
+  briefMessage: string | HTMLElement;
+  detailedMessage?: string | HTMLElement;
+  messageType?: OutputMessageType;
+  messageAlert?: OutputMessageAlert;
+}
+
+/** [AppNotificationManager.outputMessage](https://www.itwinjs.org/reference/appui-react/notification/appnotificationmanager/) can be used to display notifications. */
+export function NotificationsStory({
+  messagePriority,
+  briefMessage,
+  detailedMessage,
+  messageType,
+  messageAlert,
+  ...props
+}: NotificationsStoryProps) {
+  React.useEffect(() => {
+    return () => {
+      UiFramework.dialogs.modal.close();
+      UiFramework.dialogs.modeless.close();
+    };
+  }, []);
+  return (
+    <AppUiStory
+      layout="fullscreen"
+      onFrontstageActivated={() => {
+        const message = new NotifyMessageDetails(
+          messagePriority,
+          briefMessage,
+          detailedMessage,
+          messageType,
+          messageAlert
+        );
+        // Needed for pointer message.
+        message.viewport = document.documentElement;
+        IModelApp.notifications.outputMessage(message);
+      }}
+      {...props}
+    >
+      <PointerPosition />
+    </AppUiStory>
+  );
+}
+
+// Update pointer message position.
+function PointerPosition() {
+  React.useEffect(() => {
+    const listener = (e: PointerEvent) => {
+      IModelApp.notifications.updatePointerMessage(
+        {
+          x: e.clientX + 10,
+          y: e.clientY - 10,
+        },
+        // TODO: required in AppNotificationManager
+        RelativePosition.Top
+      );
+    };
+    document.addEventListener("pointermove", listener);
+    return () => {
+      document.removeEventListener("pointermove", listener);
+    };
+  }, []);
+  return null;
+}

--- a/docs/storybook/src/frontstage/notifications/OutputPrompt.stories.tsx
+++ b/docs/storybook/src/frontstage/notifications/OutputPrompt.stories.tsx
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { Meta, StoryObj } from "@storybook/react";
+import { NotificationsStory } from "./OutputPrompt";
+import { Page } from "../../AppUiStory";
+
+const meta = {
+  title: "Frontstage/Notifications/OutputPrompt",
+  component: NotificationsStory,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      page: () => <Page />,
+    },
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof NotificationsStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/docs/storybook/src/frontstage/notifications/OutputPrompt.tsx
+++ b/docs/storybook/src/frontstage/notifications/OutputPrompt.tsx
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from "react";
+import {
+  StatusBarItemUtilities,
+  StatusBarSection,
+  ToolAssistanceField,
+} from "@itwin/appui-react";
+import { AppUiStory } from "../../AppUiStory";
+import { createFrontstageProvider } from "../../Utils";
+import { IModelApp } from "@itwin/core-frontend";
+
+/** [outputPrompt](https://www.itwinjs.org/reference/appui-react/notification/appnotificationmanager/outputprompt/) displays a prompt message in the status bar. */
+export function NotificationsStory() {
+  return (
+    <AppUiStory
+      layout="fullscreen"
+      frontstageProviders={[
+        createFrontstageProvider({
+          hideStatusBar: false,
+        }),
+      ]}
+      itemProviders={[
+        {
+          id: "provider-1",
+          getStatusBarItems: () => [
+            StatusBarItemUtilities.createCustomItem(
+              "uifw.ToolAssistance",
+              StatusBarSection.Left,
+              0,
+              <>
+                <ToolAssistanceField />
+                <Prompt />
+              </>
+            ),
+          ],
+        },
+      ]}
+    />
+  );
+}
+
+// TODO: should be possible to output prompt before the tool assistance field is mounted.
+function Prompt() {
+  React.useEffect(() => {
+    IModelApp.notifications.outputPrompt("Prompt message");
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Changes

This PR adds storybook stories to demonstrate `AppNotificationManager` APIs.
A couple of issues were identified:

- `updatePointerMessage` requires a `relativePosition` parameter (that is optional in base class).
- `Alert` message type produces a dialog that is poorly styled
- `outputPrompt` timing issues (API must be called after the tool assistance field is mounted)

## Testing

N/A
