### PR TITLE
Add `controlWidgetVisibility` preview feature

### DIFF
--- a/common/changes/@itwin/appui-react/control-widget-visibility_2024-05-30-13-37.json
+++ b/common/changes/@itwin/appui-react/control-widget-visibility_2024-05-30-13-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add 'controlWidgetVisibility' preview feature.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -11,7 +11,9 @@
   "unsupportedPackageJsonSettings": {
     "pnpm": {
       "auditConfig": {
-        "ignoreCves": []
+        "ignoreCves": [
+          "CVE-2024-29415", // https://github.com/advisories/GHSA-2p57-rm9w-gvfp appui-storybook>storybook>@storybook/cli>@storybook/core-server>ip
+        ]
       }
     }
   }

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -2,11 +2,24 @@
 
 Table of contents:
 
+- [@itwin/appui-react](#itwinappui-react)
+  - [Additions](#additions)
+  - [Changes](#changes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Deprecations](#deprecations)
-  - [Changes](#changes)
+  - [Changes](#changes-1)
 - [@itwin/core-react](#itwincore-react)
   - [Fixes](#fixes)
+
+## @itwin/appui-react
+
+### Additions
+
+- `controlWidgetVisibility` preview feature. When enabled, additional UI elements are rendered to allow the end user of the layout to control widget visibility. [#856](https://github.com/iTwin/appui/pull/856)
+
+### Changes
+
+- The dropdown menu of `widgetActionDropdown` preview feature will now close once one of the menu items is activated. [#856](https://github.com/iTwin/appui/pull/856)
 
 ## @itwin/components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -17,6 +17,10 @@ Table of contents:
 
 - `controlWidgetVisibility` preview feature. When enabled, additional UI elements are rendered to allow the end user of the layout to control widget visibility. [#856](https://github.com/iTwin/appui/pull/856)
 
+  Currently applications might use `WidgetState` to control widget visibility programmatically and expect the widgets to stay hidden until a certain condition is met. Since this preview feature adds UI elements to control widget visibility, it might conflict with the application's logic. To avoid this, the application should use `UiItemsManager.register()` and `UiItemsManager.unregister()` to strictly manage what widgets are available to the end-user.
+
+  Additionally an array of widget ids can be specified to only expose visibility controls for specific widgets. This allows applications to experiment with other use-cases, like keeping at least one widget visible at all times.
+
 ### Changes
 
 - The dropdown menu of `widgetActionDropdown` preview feature will now close once one of the menu items is activated. [#856](https://github.com/iTwin/appui/pull/856)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -23,8 +23,8 @@ Table of contents:
 
 ### Changes
 
-- The dropdown menu of `widgetActionDropdown` preview feature will now close once one of the menu items is activated. [#856](https://github.com/iTwin/appui/pull/856)
-- The labels for the buttons in the widget title bar will now be rendered as tooltips, rather than using the `title` attribute. [#856](https://github.com/iTwin/appui/pull/856)
+- The dropdown menu of `widgetActionDropdown` preview feature will close once one of the menu items is activated. [#856](https://github.com/iTwin/appui/pull/856)
+- The labels for the buttons in the widget title bar will be rendered as tooltips, rather than using the `title` attribute. [#856](https://github.com/iTwin/appui/pull/856)
 
 ## @itwin/components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -24,6 +24,7 @@ Table of contents:
 ### Changes
 
 - The dropdown menu of `widgetActionDropdown` preview feature will now close once one of the menu items is activated. [#856](https://github.com/iTwin/appui/pull/856)
+- The labels for the buttons in the widget title bar will now be rendered as tooltips, rather than using the `title` attribute. [#856](https://github.com/iTwin/appui/pull/856)
 
 ## @itwin/components-react
 

--- a/docs/storybook/src/Utils.tsx
+++ b/docs/storybook/src/Utils.tsx
@@ -4,9 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import {
+  StagePanelLocation,
+  StagePanelSection,
   StageUsage,
   StandardFrontstageProps,
   StandardFrontstageProvider,
+  Widget,
 } from "@itwin/appui-react";
 import { createContentControl } from "./createContentControl";
 
@@ -50,5 +53,20 @@ export function removeProperty() {
     table: {
       disable: true,
     },
+  };
+}
+
+export function createWidget(id: number, overrides?: Partial<Widget>): Widget {
+  return {
+    id: `w${id}`,
+    label: `Widget ${id}`,
+    content: <>Widget {id} content</>,
+    layouts: {
+      standard: {
+        location: StagePanelLocation.Left,
+        section: StagePanelSection.Start,
+      },
+    },
+    ...overrides,
   };
 }

--- a/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
   args: {
     controlWidgetVisibility: true,
     visibleWidgets: 1,
-    dropdownThreshold: 2,
+    dropdownThreshold: 0,
   },
 } satisfies Meta<typeof PreviewStory>;
 

--- a/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
@@ -29,6 +29,12 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const NoDropdown: Story = {
+  args: {
+    dropdownThreshold: 10,
+  },
+};
+
 export const AllHidden: Story = {
   args: {
     visibleWidgets: 0,

--- a/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
@@ -18,8 +18,9 @@ const meta = {
     },
   },
   args: {
-    threshold: 2,
+    controlWidgetVisibility: true,
     visibleWidgets: 1,
+    dropdownThreshold: 2,
   },
 } satisfies Meta<typeof PreviewStory>;
 
@@ -28,8 +29,15 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const HiddenTabs: Story = {
+export const AllHidden: Story = {
   args: {
     visibleWidgets: 0,
+  },
+};
+
+export const SpecifiedIds: Story = {
+  args: {
+    controlWidgetVisibility: ["w1", "w2"],
+    visibleWidgets: 5,
   },
 };

--- a/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
@@ -17,6 +17,9 @@ const meta = {
       page: () => <Page />,
     },
   },
+  args: {
+    threshold: 2,
+  },
 } satisfies Meta<typeof PreviewStory>;
 
 export default meta;

--- a/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
@@ -19,6 +19,7 @@ const meta = {
   },
   args: {
     threshold: 2,
+    visibleWidgets: 1,
   },
 } satisfies Meta<typeof PreviewStory>;
 
@@ -26,3 +27,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const HiddenTabs: Story = {
+  args: {
+    visibleWidgets: 0,
+  },
+};

--- a/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.stories.tsx
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { Meta, StoryObj } from "@storybook/react";
+import { AppUiDecorator } from "../Decorators";
+import { Page } from "../AppUiStory";
+import { PreviewStory } from "./ControlWidgetVisibility";
+
+const meta = {
+  title: "PreviewFeatures/ControlWidgetVisibility",
+  component: PreviewStory,
+  tags: ["autodocs"],
+  decorators: [AppUiDecorator],
+  parameters: {
+    docs: {
+      page: () => <Page />,
+    },
+  },
+} satisfies Meta<typeof PreviewStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/docs/storybook/src/preview/ControlWidgetVisibility.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.tsx
@@ -3,10 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import {
-  PreviewFeatures,
   PreviewFeaturesProvider,
-  StagePanelLocation,
-  StagePanelSection,
   StagePanelState,
   UiItemsProvider,
   WidgetState,
@@ -19,33 +16,30 @@ function createProvider(): UiItemsProvider {
     id: "widgets",
     getWidgets: () => {
       return [
-        createWidget(1, {
-          canPopout: true,
-          layouts: {
-            standard: {
-              location: StagePanelLocation.Bottom,
-              section: StagePanelSection.Start,
-            },
-          },
-        }),
+        createWidget(1),
         createWidget(2, {
-          defaultState: WidgetState.Floating,
+          defaultState: WidgetState.Hidden,
+        }),
+        createWidget(3, {
+          defaultState: WidgetState.Hidden,
+        }),
+        createWidget(4, {
+          defaultState: WidgetState.Hidden,
         }),
       ];
     },
   };
 }
 
-type PreviewStoryProps = Pick<
-  Required<PreviewFeatures>,
-  "enableMaximizedFloatingWidget" | "enableMaximizedPanelWidget"
->;
-
 /** `enableMaximizedFloatingWidget` and `enableMaximizedPanelWidget` preview features. When enabled the widget will have a "maximize" button. */
-export function PreviewStory(props: PreviewStoryProps) {
+export function PreviewStory() {
   const provider = createProvider();
   return (
-    <PreviewFeaturesProvider features={props}>
+    <PreviewFeaturesProvider
+      features={{
+        controlWidgetVisibility: true,
+      }}
+    >
       <AppUiStory
         itemProviders={[provider]}
         frontstageProviders={[

--- a/docs/storybook/src/preview/ControlWidgetVisibility.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.tsx
@@ -11,22 +11,17 @@ import {
 import { AppUiStory } from "../AppUiStory";
 import { createFrontstageProvider, createWidget } from "../Utils";
 
-function createProvider(): UiItemsProvider {
+function createProvider(visibleWidgets: number): UiItemsProvider {
   return {
     id: "widgets",
     getWidgets: () => {
-      return [
-        createWidget(1),
-        createWidget(2, {
-          defaultState: WidgetState.Hidden,
-        }),
-        createWidget(3, {
-          defaultState: WidgetState.Hidden,
-        }),
-        createWidget(4, {
-          defaultState: WidgetState.Hidden,
-        }),
-      ];
+      const count = Math.max(5, visibleWidgets + 3);
+      return [...Array(count)].map((_, index) => {
+        const id = index + 1;
+        return createWidget(id, {
+          defaultState: index < visibleWidgets ? undefined : WidgetState.Hidden,
+        });
+      });
     },
   };
 }
@@ -34,11 +29,13 @@ function createProvider(): UiItemsProvider {
 interface PreviewStoryProps {
   /** Threshold of `widgetActionDropdown`. */
   threshold: number;
+  /** Number of non-hidden widgets. */
+  visibleWidgets: number;
 }
 
 /** `enableMaximizedFloatingWidget` and `enableMaximizedPanelWidget` preview features. When enabled the widget will have a "maximize" button. */
-export function PreviewStory({ threshold }: PreviewStoryProps) {
-  const provider = createProvider();
+export function PreviewStory({ threshold, visibleWidgets }: PreviewStoryProps) {
+  const provider = createProvider(visibleWidgets);
   return (
     <PreviewFeaturesProvider
       features={{

--- a/docs/storybook/src/preview/ControlWidgetVisibility.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.tsx
@@ -31,13 +31,19 @@ function createProvider(): UiItemsProvider {
   };
 }
 
+interface PreviewStoryProps {
+  /** Threshold of `widgetActionDropdown`. */
+  threshold: number;
+}
+
 /** `enableMaximizedFloatingWidget` and `enableMaximizedPanelWidget` preview features. When enabled the widget will have a "maximize" button. */
-export function PreviewStory() {
+export function PreviewStory({ threshold }: PreviewStoryProps) {
   const provider = createProvider();
   return (
     <PreviewFeaturesProvider
       features={{
         controlWidgetVisibility: true,
+        widgetActionDropdown: { threshold },
       }}
     >
       <AppUiStory

--- a/docs/storybook/src/preview/ControlWidgetVisibility.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.tsx
@@ -3,6 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import {
+  PreviewFeatures,
   PreviewFeaturesProvider,
   StagePanelState,
   UiItemsProvider,
@@ -26,21 +27,26 @@ function createProvider(visibleWidgets: number): UiItemsProvider {
   };
 }
 
-interface PreviewStoryProps {
-  /** Threshold of `widgetActionDropdown`. */
-  threshold: number;
+interface PreviewStoryProps
+  extends Pick<Required<PreviewFeatures>, "controlWidgetVisibility"> {
   /** Number of non-hidden widgets. */
   visibleWidgets: number;
+  /** Threshold of `widgetActionDropdown`. */
+  dropdownThreshold: number;
 }
 
 /** `enableMaximizedFloatingWidget` and `enableMaximizedPanelWidget` preview features. When enabled the widget will have a "maximize" button. */
-export function PreviewStory({ threshold, visibleWidgets }: PreviewStoryProps) {
+export function PreviewStory({
+  controlWidgetVisibility,
+  dropdownThreshold,
+  visibleWidgets,
+}: PreviewStoryProps) {
   const provider = createProvider(visibleWidgets);
   return (
     <PreviewFeaturesProvider
       features={{
-        controlWidgetVisibility: true,
-        widgetActionDropdown: { threshold },
+        controlWidgetVisibility,
+        widgetActionDropdown: { threshold: dropdownThreshold },
       }}
     >
       <AppUiStory

--- a/docs/storybook/src/preview/ReparentPopoutWidgets.tsx
+++ b/docs/storybook/src/preview/ReparentPopoutWidgets.tsx
@@ -22,7 +22,7 @@ import {
   MenuItem,
 } from "@itwin/itwinui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider } from "../Utils";
+import { createFrontstageProvider, createWidget } from "../Utils";
 
 function Content({ id }: { id: string }) {
   const [count, setCount] = React.useState(0);
@@ -53,43 +53,19 @@ function createProvider(): UiItemsProvider {
     id: "widgets",
     getWidgets: () => {
       return [
-        {
-          id: "w1",
-          label: "Widget 1",
+        createWidget(1, {
           canPopout: true,
           content: <Content id="1" />,
           defaultState: WidgetState.Floating,
-          layouts: {
-            standard: {
-              location: StagePanelLocation.Left,
-              section: StagePanelSection.Start,
-            },
-          },
-        },
-        {
-          id: "w2",
-          label: "Widget 2",
+        }),
+        createWidget(2, {
           canPopout: true,
           content: <Content id="2" />,
-          layouts: {
-            standard: {
-              location: StagePanelLocation.Left,
-              section: StagePanelSection.Start,
-            },
-          },
-        },
-        {
-          id: "w3",
-          label: "Widget 3",
+        }),
+        createWidget(3, {
           canPopout: true,
           content: <Content id="3" />,
-          layouts: {
-            standard: {
-              location: StagePanelLocation.Left,
-              section: StagePanelSection.Start,
-            },
-          },
-        },
+        }),
       ];
     },
   };

--- a/docs/storybook/src/preview/ReparentPopoutWidgets.tsx
+++ b/docs/storybook/src/preview/ReparentPopoutWidgets.tsx
@@ -6,8 +6,6 @@ import * as React from "react";
 import {
   PreviewFeatures,
   PreviewFeaturesProvider,
-  StagePanelLocation,
-  StagePanelSection,
   StagePanelState,
   UiItemsProvider,
   WidgetState,

--- a/docs/storybook/src/preview/WidgetActionDropdown.tsx
+++ b/docs/storybook/src/preview/WidgetActionDropdown.tsx
@@ -12,16 +12,14 @@ import {
   WidgetState,
 } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider } from "../Utils";
+import { createFrontstageProvider, createWidget } from "../Utils";
 
 function createProvider(): UiItemsProvider {
   return {
     id: "widgets",
     getWidgets: () => {
       return [
-        {
-          id: "w1",
-          label: "Widget 1",
+        createWidget(1, {
           canPopout: true,
           layouts: {
             standard: {
@@ -29,18 +27,10 @@ function createProvider(): UiItemsProvider {
               section: StagePanelSection.Start,
             },
           },
-        },
-        {
-          id: "w2",
-          label: "Widget 2",
+        }),
+        createWidget(1, {
           defaultState: WidgetState.Floating,
-          layouts: {
-            standard: {
-              location: StagePanelLocation.Left,
-              section: StagePanelSection.Start,
-            },
-          },
-        },
+        }),
       ];
     },
   };

--- a/docs/storybook/src/preview/WidgetActionDropdown.tsx
+++ b/docs/storybook/src/preview/WidgetActionDropdown.tsx
@@ -28,7 +28,7 @@ function createProvider(): UiItemsProvider {
             },
           },
         }),
-        createWidget(1, {
+        createWidget(2, {
           defaultState: WidgetState.Floating,
         }),
       ];
@@ -46,6 +46,7 @@ export function PreviewStory(props: PreviewStoryProps) {
       features={{
         enableMaximizedFloatingWidget: true,
         horizontalPanelAlignment: true,
+        controlWidgetVisibility: true,
         widgetActionDropdown: { threshold: props.threshold },
       }}
     >

--- a/docs/storybook/src/preview/WidgetActionDropdown.tsx
+++ b/docs/storybook/src/preview/WidgetActionDropdown.tsx
@@ -46,7 +46,6 @@ export function PreviewStory(props: PreviewStoryProps) {
       features={{
         enableMaximizedFloatingWidget: true,
         horizontalPanelAlignment: true,
-        controlWidgetVisibility: true,
         widgetActionDropdown: { threshold: props.threshold },
       }}
     >

--- a/e2e-tests/tests/Utils.ts
+++ b/e2e-tests/tests/Utils.ts
@@ -60,7 +60,7 @@ export function backstageItemLocator(page: Page, label: string) {
 }
 
 export function popoutButtonLocator(widget: Locator) {
-  return widget.locator('[title="Pop out active widget tab"]');
+  return widget.getByRole("button", { name: "Pop out active widget tab" });
 }
 
 type PanelLocatorArgs = { page: Page; side: PanelSide } | { tab: Locator };

--- a/e2e-tests/tests/floating-widget.test.ts
+++ b/e2e-tests/tests/floating-widget.test.ts
@@ -226,7 +226,7 @@ test.describe("floating widget send back outline", () => {
 
     await expect(widgetOutline).not.toBeVisible();
     await expect(tabOutline).not.toBeVisible();
-    await sendBackButton.hover();
+    await sendBackButton.hover({ position: { x: 1, y: 1 } }); // TODO: onMouseOut is called w/o explicit position
     await expect(widgetOutline).toBeVisible();
     await expect(tabOutline).toBeVisible();
     await page.mouse.move(0, 0);
@@ -249,7 +249,7 @@ test.describe("floating widget send back outline", () => {
     const outline = outlineLocator({ page, side: "left" });
 
     await expect(outline).not.toBeVisible();
-    await sendBackButton.hover();
+    await sendBackButton.hover({ position: { x: 1, y: 1 } }); // TODO: onMouseOut is called w/o explicit position
     await expect(outline).toBeVisible();
     await page.mouse.move(0, 0);
     await expect(outline).not.toBeVisible();
@@ -268,7 +268,7 @@ test.describe("floating widget send back outline", () => {
     const outline = outlineLocator({ panel, sectionId: 0 });
 
     await expect(outline).not.toBeVisible();
-    await sendBackButton.hover();
+    await sendBackButton.hover({ position: { x: 1, y: 1 } }); // TODO: onMouseOut is called w/o explicit position
     await expect(outline).toBeVisible();
     await page.mouse.move(0, 0);
     await expect(outline).not.toBeVisible();
@@ -297,7 +297,7 @@ test.describe("floating widget send back outline", () => {
     const outline = outlineLocator({ panel, sectionId: 1 });
 
     await expect(outline).not.toBeVisible();
-    await sendBackButton.hover();
+    await sendBackButton.hover({ position: { x: 1, y: 1 } }); // TODO: onMouseOut is called w/o explicit position
     await expect(outline).toBeVisible();
     await page.mouse.move(0, 0);
     await expect(outline).not.toBeVisible();

--- a/e2e-tests/tests/floating-widget.test.ts
+++ b/e2e-tests/tests/floating-widget.test.ts
@@ -217,7 +217,9 @@ test.describe("floating widget send back outline", () => {
   test("should show a widget (with tab) outline", async ({ page }) => {
     const tab = tabLocator(page, "FW-1");
     const floatingWidget = floatingWidgetLocator({ tab });
-    const sendBackButton = floatingWidget.getByTitle("Send to panel");
+    const sendBackButton = floatingWidget.getByRole("button", {
+      name: "Send to panel",
+    });
 
     const destTab = tabLocator(page, "WL-A");
     const [widgetOutline, tabOutline] = outlineLocator({ tab: destTab });
@@ -240,7 +242,9 @@ test.describe("floating widget send back outline", () => {
 
     const tab = tabLocator(page, "FW-1");
     const floatingWidget = floatingWidgetLocator({ tab });
-    const sendBackButton = floatingWidget.getByTitle("Send to panel");
+    const sendBackButton = floatingWidget.getByRole("button", {
+      name: "Send to panel",
+    });
 
     const outline = outlineLocator({ page, side: "left" });
 
@@ -256,7 +260,9 @@ test.describe("floating widget send back outline", () => {
 
     const tab = tabLocator(page, "FW-1");
     const floatingWidget = floatingWidgetLocator({ tab });
-    const sendBackButton = floatingWidget.getByTitle("Send to panel");
+    const sendBackButton = floatingWidget.getByRole("button", {
+      name: "Send to panel",
+    });
 
     const panel = panelLocator({ page, side: "left" });
     const outline = outlineLocator({ panel, sectionId: 0 });
@@ -280,7 +286,9 @@ test.describe("floating widget send back outline", () => {
     });
 
     const floatingWidget = floatingWidgetLocator({ tab });
-    const sendBackButton = floatingWidget.getByTitle("Send to panel");
+    const sendBackButton = floatingWidget.getByRole("button", {
+      name: "Send to panel",
+    });
 
     await setWidgetState(page, "WL-2", WidgetState.Hidden);
     await setWidgetState(page, "WL-3", WidgetState.Hidden);

--- a/e2e-tests/tests/stage-panel.test.ts
+++ b/e2e-tests/tests/stage-panel.test.ts
@@ -26,11 +26,13 @@ test.describe("WidgetApi", () => {
     const pinned = layoutInfoWidget.getByText("pinned=");
     await expect(pinned).toHaveText("pinned=true");
 
-    const unpinButton = panel.getByTitle("Unpin widget panel");
+    const unpinButton = panel.getByRole("button", {
+      name: "Unpin widget panel",
+    });
     await unpinButton.click();
     await expect(pinned).toHaveText("pinned=false");
 
-    const pinButton = panel.getByTitle("Pin widget panel");
+    const pinButton = panel.getByRole("button", { name: "Pin widget panel" });
     await pinButton.click();
     await expect(pinned).toHaveText("pinned=true");
   });

--- a/e2e-tests/tests/tool-settings.test.ts
+++ b/e2e-tests/tests/tool-settings.test.ts
@@ -234,7 +234,7 @@ test.describe("tool settings", () => {
     const finalStateField = page.locator("[value='qqPAtype in field']");
     await expect(widgetToolSettings).toBeVisible();
     await expect(finalStateField).toBeVisible();
-    await page.getByTitle("Dock to top").click();
+    await page.getByRole("button", { name: "Dock to top" }).click();
     await expect(widgetToolSettings).not.toBeVisible();
     await expect(finalStateField).toBeVisible();
   });

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
@@ -48,6 +48,9 @@ const availableFeatures: AvailableFeatures = {
     label: "Re-parent popout widgets",
     value: ["widget-layout-info", "widget-info-Floating"],
   },
+  controlWidgetVisibility: {
+    label: "Control widget visibility",
+  },
 };
 
 function PreviewFeatureList() {

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
@@ -175,6 +175,13 @@ export interface WidgetDragEndAction {
 }
 
 /** @internal */
+export interface WidgetTabAddToWidgetAction {
+  readonly type: "WIDGET_TAB_ADD_TO_WIDGET";
+  readonly id: TabState["id"];
+  readonly widgetId: WidgetState["id"];
+}
+
+/** @internal */
 export interface WidgetTabClickAction {
   readonly type: "WIDGET_TAB_CLICK";
   readonly side: PanelSide | undefined;
@@ -353,6 +360,7 @@ export type NineZoneAction =
   | PanelWidgetDragStartAction
   | WidgetDragAction
   | WidgetDragEndAction
+  | WidgetTabAddToWidgetAction
   | WidgetTabClickAction
   | WidgetTabCloseAction
   | WidgetTabDoubleClickAction

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
@@ -481,6 +481,10 @@ export function NineZoneStateReducer(
         home.floatingWidget
       );
     }
+    case "WIDGET_TAB_ADD_TO_WIDGET": {
+      const { id, widgetId } = action;
+      return addTabToWidget(state, id, widgetId);
+    }
     case "WIDGET_TAB_CLICK": {
       const { id, widgetId } = action;
       state = setWidgetActiveTabId(state, widgetId, id);

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
@@ -28,6 +28,10 @@ import {
   CloseTabButton,
   useCloseTab,
 } from "../../preview/control-widget-visibility/CloseTabButton";
+import {
+  AddTabButton,
+  useAddTab,
+} from "../../preview/control-widget-visibility/AddTabButton";
 
 /** @internal */
 export type WidgetFeature =
@@ -37,7 +41,8 @@ export type WidgetFeature =
   | "dock"
   | "horizontalAlign"
   | "pin"
-  | "closeTab";
+  | "closeTab"
+  | "addTab";
 
 /** @internal */
 export function TabBarButtons() {
@@ -60,6 +65,8 @@ export function TabBarButtons() {
         return <PinToggle key="pin" />;
       case "closeTab":
         return <CloseTabButton key="closeTab" />;
+      case "addTab":
+        return <AddTabButton key="addTab" />;
     }
     return undefined;
   });
@@ -80,7 +87,9 @@ export function useWidgetFeatures(): WidgetFeature[] {
   const horizontalPanelAlignButton = useHorizontalPanelAlignButton();
   const pinToggle = usePinToggle();
   const closeTab = useCloseTab();
+  const addTab = useAddTab();
   return [
+    ...(addTab ? (["addTab"] as const) : []),
     ...(closeTab ? (["closeTab"] as const) : []),
     ...(popoutToggle ? (["popout"] as const) : []),
     ...(maximizeToggle ? (["maximize"] as const) : []),

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
@@ -24,6 +24,10 @@ import {
   MaximizeToggle,
   useMaximizeToggle,
 } from "../../preview/enable-maximized-widget/MaximizeToggle";
+import {
+  CloseTabButton,
+  useCloseTab,
+} from "../../preview/control-widget-visibility/CloseTabButton";
 
 /** @internal */
 export type WidgetFeature =
@@ -32,7 +36,8 @@ export type WidgetFeature =
   | "sendBack"
   | "dock"
   | "horizontalAlign"
-  | "pin";
+  | "pin"
+  | "closeTab";
 
 /** @internal */
 export function TabBarButtons() {
@@ -53,6 +58,8 @@ export function TabBarButtons() {
         return <PreviewHorizontalPanelAlignButton key="horizontalAlign" />;
       case "pin":
         return <PinToggle key="pin" />;
+      case "closeTab":
+        return <CloseTabButton key="closeTab" />;
     }
     return undefined;
   });
@@ -72,7 +79,9 @@ export function useWidgetFeatures(): WidgetFeature[] {
   const dock = useDock();
   const horizontalPanelAlignButton = useHorizontalPanelAlignButton();
   const pinToggle = usePinToggle();
+  const closeTab = useCloseTab();
   return [
+    ...(closeTab ? (["closeTab"] as const) : []),
     ...(popoutToggle ? (["popout"] as const) : []),
     ...(maximizeToggle ? (["maximize"] as const) : []),
     ...(sendBack ? (["sendBack"] as const) : []),

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
@@ -25,13 +25,13 @@ import {
   useMaximizeToggle,
 } from "../../preview/enable-maximized-widget/MaximizeToggle";
 import {
-  CloseTabButton,
+  CloseWidgetButton,
   useCloseTab,
-} from "../../preview/control-widget-visibility/CloseTabButton";
+} from "../../preview/control-widget-visibility/CloseWidgetButton";
 import {
-  AddTabButton,
+  AddWidgetButton,
   useAddTab,
-} from "../../preview/control-widget-visibility/AddTabButton";
+} from "../../preview/control-widget-visibility/AddWidgetButton";
 
 /** @internal */
 export type WidgetFeature =
@@ -41,8 +41,8 @@ export type WidgetFeature =
   | "dock"
   | "horizontalAlign"
   | "pin"
-  | "closeTab"
-  | "addTab";
+  | "closeWidget"
+  | "addWidget";
 
 /** @internal */
 export function TabBarButtons() {
@@ -63,10 +63,10 @@ export function TabBarButtons() {
         return <PreviewHorizontalPanelAlignButton key="horizontalAlign" />;
       case "pin":
         return <PinToggle key="pin" />;
-      case "closeTab":
-        return <CloseTabButton key="closeTab" />;
-      case "addTab":
-        return <AddTabButton key="addTab" />;
+      case "closeWidget":
+        return <CloseWidgetButton key="closeWidget" />;
+      case "addWidget":
+        return <AddWidgetButton key="addWidget" />;
     }
     return undefined;
   });
@@ -89,8 +89,8 @@ export function useWidgetFeatures(): WidgetFeature[] {
   const closeTab = useCloseTab();
   const addTab = useAddTab();
   return [
-    ...(addTab ? (["addTab"] as const) : []),
-    ...(closeTab ? (["closeTab"] as const) : []),
+    ...(addTab ? (["addWidget"] as const) : []),
+    ...(closeTab ? (["closeWidget"] as const) : []),
     ...(popoutToggle ? (["popout"] as const) : []),
     ...(maximizeToggle ? (["maximize"] as const) : []),
     ...(sendBack ? (["sendBack"] as const) : []),

--- a/ui/appui-react/src/appui-react/layout/widget/Dock.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Dock.tsx
@@ -16,11 +16,11 @@ import { useIsMaximizedWidget } from "../../preview/enable-maximized-widget/useM
 /** @internal */
 export function Dock() {
   const dispatch = React.useContext(NineZoneDispatchContext);
-  const title = useLabel("dockToolSettingsTitle");
+  const label = useLabel("dockToolSettingsTitle");
   return (
     <ActionButton
       icon={<SvgDockTop />}
-      title={title}
+      label={label}
       onClick={() => {
         dispatch({
           type: "TOOL_SETTINGS_DOCK",

--- a/ui/appui-react/src/appui-react/layout/widget/NavigationArea.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/NavigationArea.scss
@@ -18,7 +18,6 @@
   box-sizing: border-box;
   height: 100%;
   grid-gap: 6px;
-  grid-column: 2;
   grid-template-columns: 1fr minmax($mls-navigation-aid-width, auto);
   grid-template-rows: minmax($mls-navigation-aid-width, auto) 1fr;
   justify-items: end;

--- a/ui/appui-react/src/appui-react/layout/widget/PinToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PinToggle.tsx
@@ -21,14 +21,14 @@ export function PinToggle() {
   const side = React.useContext(PanelSideContext);
   assert(!!side);
   const dispatch = React.useContext(NineZoneDispatchContext);
-  const pinPanelTitle = useLabel("pinPanelTitle");
-  const unpinPanelTitle = useLabel("unpinPanelTitle");
+  const pinLabel = useLabel("pinPanelTitle");
+  const unpinLabel = useLabel("unpinPanelTitle");
   const pinned = useLayout((state) => state.panels[side].pinned);
 
   return (
     <ActionButton
       icon={pinned ? <SvgPin /> : <SvgPinHollow />}
-      title={pinned ? unpinPanelTitle : pinPanelTitle}
+      label={pinned ? unpinLabel : pinLabel}
       onClick={() => {
         dispatch({
           side,

--- a/ui/appui-react/src/appui-react/layout/widget/PopoutToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PopoutToggle.tsx
@@ -17,12 +17,12 @@ import { ActionButton } from "../../preview/widget-action-dropdown/Button";
 export function PopoutToggle() {
   const dispatch = React.useContext(NineZoneDispatchContext);
   const activeTabId = useActiveTabId();
-  const popoutTitle = useLabel("popoutActiveTab");
+  const label = useLabel("popoutActiveTab");
 
   return (
     <ActionButton
       icon={<SvgWindowPopout />}
-      title={popoutTitle}
+      label={label}
       onClick={() => {
         dispatch({
           id: activeTabId,

--- a/ui/appui-react/src/appui-react/layout/widget/SendBack.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/SendBack.tsx
@@ -99,7 +99,7 @@ export function SendBack() {
   const id = useFloatingWidgetId();
   assert(!!id);
   const dispatch = React.useContext(NineZoneDispatchContext);
-  const title = useLabel("sendWidgetHomeTitle");
+  const label = useLabel("sendWidgetHomeTitle");
   const setActiveWidgetId = (newId: WidgetState["id"] | undefined) =>
     useActiveSendBackWidgetIdStore.setState(newId);
 
@@ -126,7 +126,7 @@ export function SendBack() {
   return (
     <ActionButton
       icon={<Icon />}
-      title={title}
+      label={label}
       onClick={onClick}
       buttonProps={eventHandlers}
       // TODO: can not pass down event handlers due to iTwinUI type issues.

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -12,6 +12,7 @@ import { Logger } from "@itwin/core-bentley";
 import { UiFramework } from "../UiFramework";
 import type { useTransientState } from "../widget-panels/useTransientState";
 import type { WidgetDef } from "../widgets/WidgetDef";
+import type { UiItemsManager } from "../ui-items-provider/UiItemsManager";
 
 /** List of known preview features. */
 interface KnownPreviewFeatures {
@@ -54,8 +55,11 @@ interface KnownPreviewFeatures {
    * @note There is a known limitation where iTwinUI v2 popover elements will be rendered in the main window. Prefer using iTwinUI v3 when using this feature.
    */
   reparentPopoutWidgets: boolean | WidgetDef["id"][];
-  /** If `true`, additional UI elements are rendered to allow the end user of the layout to control widget visibility. */
-  controlWidgetVisibility: boolean;
+  /** If `true`, additional UI elements are rendered to allow the end user of the layout to control widget visibility.
+   * Alternatively, an array of widget ids can be provided to only control specific widgets.
+   * @note Use {@link UiItemsManager} APIs to manage what widgets are available to the end-user.
+   */
+  controlWidgetVisibility: boolean | WidgetDef["id"][];
 }
 
 /** Object used trim to only known features at runtime.

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -50,13 +50,13 @@ interface KnownPreviewFeatures {
   /** If `true`, the [[Toolbar]] component will be replaced by a new iTwinUI based toolbar. */
   newToolbars: boolean;
   /** If `true`, popout widgets will not be rendered in a separate element tree, instead widget content will be re-parented to a popout content container.
-   * Alternatively, an array of widget ids can be provided to only re-parent specific widgets.
+   * Alternatively, an array of widget ids can be specified to only re-parent specific widgets.
    * @note Use {@link useTransientState} to save and restore DOM transient state when re-parenting widgets.
    * @note There is a known limitation where iTwinUI v2 popover elements will be rendered in the main window. Prefer using iTwinUI v3 when using this feature.
    */
   reparentPopoutWidgets: boolean | WidgetDef["id"][];
   /** If `true`, additional UI elements are rendered to allow the end user of the layout to control widget visibility.
-   * Alternatively, an array of widget ids can be provided to only control specific widgets.
+   * Alternatively, an array of widget ids can be specified to only control specific widgets.
    * @note Use {@link UiItemsManager} APIs to manage what widgets are available to the end-user.
    */
   controlWidgetVisibility: boolean | WidgetDef["id"][];

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -15,28 +15,28 @@ import type { WidgetDef } from "../widgets/WidgetDef";
 
 /** List of known preview features. */
 interface KnownPreviewFeatures {
-  /** If true, the panels and tool settings will always be rendered over the content.
+  /** If `true`, the panels and tool settings will always be rendered over the content.
    * The content will never change size.
    *
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/672
    */
   contentAlwaysMaxSize: boolean;
-  /** If true, the floating widget will have a "maximize" button. Use `enableMaximizedPanelWidget` to enable the feature for panel widgets.
+  /** If `true`, the floating widget will have a "maximize" button. Use `enableMaximizedPanelWidget` to enable the feature for panel widgets.
    *
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/673
    */
   enableMaximizedFloatingWidget: boolean;
-  /** If true, the panel widget will have a "maximize" button. Use `enableMaximizedFloatingWidget` to enable the feature for floating widgets.
+  /** If `true`, the panel widget will have a "maximize" button. Use `enableMaximizedFloatingWidget` to enable the feature for floating widgets.
    *
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/673
    */
   enableMaximizedPanelWidget: boolean;
-  /** If true, the active tab of a dragged widget will become active when dropped in a container.
+  /** If `true`, the active tab of a dragged widget will become active when dropped in a container.
    *
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/679
    */
   activateDroppedTab: boolean;
-  /** If true, the horizontal panels will have an additional "Align" button.
+  /** If `true`, the horizontal panels will have an additional "Align" button.
    *
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/706
    */
@@ -46,7 +46,7 @@ interface KnownPreviewFeatures {
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/723
    */
   widgetActionDropdown: { threshold: number };
-  /** If true, the [[Toolbar]] component will be replaced by a new iTwinUI based toolbar. */
+  /** If `true`, the [[Toolbar]] component will be replaced by a new iTwinUI based toolbar. */
   newToolbars: boolean;
   /** If `true`, popout widgets will not be rendered in a separate element tree, instead widget content will be re-parented to a popout content container.
    * Alternatively, an array of widget ids can be provided to only re-parent specific widgets.
@@ -54,6 +54,8 @@ interface KnownPreviewFeatures {
    * @note There is a known limitation where iTwinUI v2 popover elements will be rendered in the main window. Prefer using iTwinUI v3 when using this feature.
    */
   reparentPopoutWidgets: boolean | WidgetDef["id"][];
+  /** If `true`, additional capability is exposed in the UI to allow the end user of the layout to control widget visibility. */
+  controlWidgetVisibility: boolean;
 }
 
 /** Object used trim to only known features at runtime.
@@ -68,6 +70,7 @@ const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
   widgetActionDropdown: undefined,
   newToolbars: undefined,
   reparentPopoutWidgets: undefined,
+  controlWidgetVisibility: undefined,
 };
 
 /** List of preview features that can be enabled/disabled.

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -54,7 +54,7 @@ interface KnownPreviewFeatures {
    * @note There is a known limitation where iTwinUI v2 popover elements will be rendered in the main window. Prefer using iTwinUI v3 when using this feature.
    */
   reparentPopoutWidgets: boolean | WidgetDef["id"][];
-  /** If `true`, additional capability is exposed in the UI to allow the end user of the layout to control widget visibility. */
+  /** If `true`, additional UI elements are rendered to allow the end user of the layout to control widget visibility. */
   controlWidgetVisibility: boolean;
 }
 

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddTabButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddTabButton.tsx
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import * as React from "react";
+import { usePreviewFeatures } from "../PreviewFeatures";
+import { DropdownMenu, MenuItem } from "@itwin/itwinui-react";
+import { TabBarButton } from "../../layout/widget/Button";
+import { useLayout } from "../../layout/base/LayoutStore";
+import { getTabLocation } from "../../layout/state/TabLocation";
+import { SvgAdd } from "@itwin/itwinui-icons-react";
+import { NineZoneDispatchContext } from "../../layout/base/NineZone";
+import { WidgetIdContext } from "../../layout/widget/Widget";
+
+/** @internal */
+export function AddTabButton() {
+  const tabs = useHiddenTabs();
+  const dispatch = React.useContext(NineZoneDispatchContext);
+  const widgetId = React.useContext(WidgetIdContext);
+  if (!widgetId) return null;
+
+  const menuItems = tabs.map((tab) => {
+    return (
+      <MenuItem
+        key={tab.id}
+        onClick={() => {
+          dispatch({
+            type: "WIDGET_TAB_ADD_TO_WIDGET",
+            id: tab.id,
+            widgetId,
+          });
+          dispatch({
+            type: "WIDGET_TAB_OPEN",
+            id: tab.id,
+          });
+        }}
+      >
+        {tab.label}
+      </MenuItem>
+    );
+  });
+  return (
+    <DropdownMenu menuItems={(_close) => menuItems}>
+      <TabBarButton title="Add tab">
+        <SvgAdd />
+      </TabBarButton>
+    </DropdownMenu>
+  );
+}
+
+/** @internal */
+export function useAddTab() {
+  const tabs = useHiddenTabs();
+  const { controlWidgetVisibility } = usePreviewFeatures();
+  if (tabs.length === 0) return false;
+  return !!controlWidgetVisibility;
+}
+
+function useHiddenTabs() {
+  const hiddenTabs = useLayout((state) => {
+    const tabs = Object.values(state.tabs);
+    const toolSettingsTabId = state.toolSettings?.tabId;
+    return tabs.filter((tab) => {
+      if (tab.id === toolSettingsTabId) return false;
+      const location = getTabLocation(state, tab.id);
+      return !location;
+    });
+  }, true);
+  return hiddenTabs;
+}

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddTabButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddTabButton.tsx
@@ -15,39 +15,52 @@ import { getTabLocation } from "../../layout/state/TabLocation";
 import { SvgAdd } from "@itwin/itwinui-icons-react";
 import { NineZoneDispatchContext } from "../../layout/base/NineZone";
 import { WidgetIdContext } from "../../layout/widget/Widget";
+import { WidgetActionDropdownContext } from "../widget-action-dropdown/MoreButton";
 
 /** @internal */
 export function AddTabButton() {
-  const tabs = useHiddenTabs();
   const dispatch = React.useContext(NineZoneDispatchContext);
   const widgetId = React.useContext(WidgetIdContext);
+  const dropdownContext = React.useContext(WidgetActionDropdownContext);
+  const tabs = useHiddenTabs();
+
   if (!widgetId) return null;
 
-  const menuItems = tabs.map((tab) => {
+  const getMenuItems = (close?: () => void) =>
+    tabs.map((tab) => {
+      return (
+        <MenuItem
+          key={tab.id}
+          onClick={() => {
+            dispatch({
+              type: "WIDGET_TAB_ADD_TO_WIDGET",
+              id: tab.id,
+              widgetId,
+            });
+            dispatch({
+              type: "WIDGET_TAB_OPEN",
+              id: tab.id,
+            });
+            close?.();
+          }}
+        >
+          {tab.label}
+        </MenuItem>
+      );
+    });
+
+  const title = "Add tab";
+  const icon = <SvgAdd />;
+  if (dropdownContext !== undefined) {
     return (
-      <MenuItem
-        key={tab.id}
-        onClick={() => {
-          dispatch({
-            type: "WIDGET_TAB_ADD_TO_WIDGET",
-            id: tab.id,
-            widgetId,
-          });
-          dispatch({
-            type: "WIDGET_TAB_OPEN",
-            id: tab.id,
-          });
-        }}
-      >
-        {tab.label}
+      <MenuItem startIcon={icon} subMenuItems={getMenuItems()}>
+        {title}
       </MenuItem>
     );
-  });
+  }
   return (
-    <DropdownMenu menuItems={(_close) => menuItems}>
-      <TabBarButton title="Add tab">
-        <SvgAdd />
-      </TabBarButton>
+    <DropdownMenu menuItems={(close) => getMenuItems(close)}>
+      <TabBarButton title={title}>{icon}</TabBarButton>
     </DropdownMenu>
   );
 }

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddTabButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddTabButton.tsx
@@ -76,7 +76,8 @@ export function useAddTab() {
   return !!controlWidgetVisibility;
 }
 
-function useHiddenTabs() {
+/** @internal */
+export function useHiddenTabs() {
   const hiddenTabs = useLayout((state) => {
     const tabs = Object.values(state.tabs);
     const toolSettingsTabId = state.toolSettings?.tabId;

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddTabButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddTabButton.tsx
@@ -53,7 +53,10 @@ export function AddTabButton() {
   const icon = <SvgAdd />;
   if (dropdownContext !== undefined) {
     return (
-      <MenuItem startIcon={icon} subMenuItems={getMenuItems()}>
+      <MenuItem
+        startIcon={icon}
+        subMenuItems={getMenuItems(dropdownContext.onClose)}
+      >
         {title}
       </MenuItem>
     );

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddWidgetButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddWidgetButton.tsx
@@ -18,7 +18,10 @@ import { WidgetIdContext } from "../../layout/widget/Widget";
 import { WidgetActionDropdownContext } from "../widget-action-dropdown/MoreButton";
 
 /** @internal */
-export function AddTabButton() {
+export const label = "Add widget";
+
+/** @internal */
+export function AddWidgetButton() {
   const dispatch = React.useContext(NineZoneDispatchContext);
   const widgetId = React.useContext(WidgetIdContext);
   const dropdownContext = React.useContext(WidgetActionDropdownContext);
@@ -49,7 +52,6 @@ export function AddTabButton() {
       );
     });
 
-  const title = "Add tab";
   const icon = <SvgAdd />;
   if (dropdownContext !== undefined) {
     return (
@@ -57,13 +59,13 @@ export function AddTabButton() {
         startIcon={icon}
         subMenuItems={getMenuItems(dropdownContext.onClose)}
       >
-        {title}
+        {label}
       </MenuItem>
     );
   }
   return (
     <DropdownMenu menuItems={(close) => getMenuItems(close)}>
-      <TabBarButton title={title}>{icon}</TabBarButton>
+      <TabBarButton title={label}>{icon}</TabBarButton>
     </DropdownMenu>
   );
 }

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddWidgetButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/AddWidgetButton.tsx
@@ -65,7 +65,7 @@ export function AddWidgetButton() {
   }
   return (
     <DropdownMenu menuItems={(close) => getMenuItems(close)}>
-      <TabBarButton title={label}>{icon}</TabBarButton>
+      <TabBarButton label={label}>{icon}</TabBarButton>
     </DropdownMenu>
   );
 }

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseTabButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseTabButton.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from "react";
-import { SvgClose } from "@itwin/itwinui-icons-react";
+import { SvgCloseSmall } from "@itwin/itwinui-icons-react";
 import { ActionButton } from "../widget-action-dropdown/Button";
 import { WidgetState } from "../../widgets/WidgetState";
 import { usePreviewFeatures } from "../PreviewFeatures";
@@ -21,7 +21,7 @@ export function CloseTabButton() {
 
   return (
     <ActionButton
-      icon={<SvgClose />}
+      icon={<SvgCloseSmall />}
       title="Close tab"
       onClick={() => {
         widgetDef?.setWidgetState(WidgetState.Hidden);

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseTabButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseTabButton.tsx
@@ -15,7 +15,7 @@ import { NineZoneDispatchContext } from "../../layout/base/NineZone";
 
 /** @internal */
 export function CloseTabButton() {
-  const activeTabId = useActiveTabId();
+  const id = useActiveTabId();
   const dispatch = React.useContext(NineZoneDispatchContext);
 
   return (
@@ -25,7 +25,7 @@ export function CloseTabButton() {
       onClick={() => {
         dispatch({
           type: "WIDGET_TAB_HIDE",
-          id: activeTabId,
+          id,
         });
       }}
     />
@@ -34,6 +34,10 @@ export function CloseTabButton() {
 
 /** @internal */
 export function useCloseTab() {
+  const id = useActiveTabId();
   const { controlWidgetVisibility } = usePreviewFeatures();
+  if (Array.isArray(controlWidgetVisibility)) {
+    return controlWidgetVisibility.includes(id);
+  }
   return !!controlWidgetVisibility;
 }

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseTabButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseTabButton.tsx
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import * as React from "react";
+import { SvgClose } from "@itwin/itwinui-icons-react";
+import { ActionButton } from "../widget-action-dropdown/Button";
+import { WidgetState } from "../../widgets/WidgetState";
+import { usePreviewFeatures } from "../PreviewFeatures";
+import { useActiveTabId } from "../../layout/widget/Widget";
+import { useWidgetDef } from "../../widget-panels/Content";
+
+/** @internal */
+export function CloseTabButton() {
+  const activeTabId = useActiveTabId();
+  const widgetDef = useWidgetDef(activeTabId);
+
+  return (
+    <ActionButton
+      icon={<SvgClose />}
+      title="Close tab"
+      onClick={() => {
+        widgetDef?.setWidgetState(WidgetState.Hidden);
+      }}
+    />
+  );
+}
+
+/** @internal */
+export function useCloseTab() {
+  const { controlWidgetVisibility } = usePreviewFeatures();
+  return !!controlWidgetVisibility;
+}

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseTabButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseTabButton.tsx
@@ -9,22 +9,24 @@
 import * as React from "react";
 import { SvgCloseSmall } from "@itwin/itwinui-icons-react";
 import { ActionButton } from "../widget-action-dropdown/Button";
-import { WidgetState } from "../../widgets/WidgetState";
 import { usePreviewFeatures } from "../PreviewFeatures";
 import { useActiveTabId } from "../../layout/widget/Widget";
-import { useWidgetDef } from "../../widget-panels/Content";
+import { NineZoneDispatchContext } from "../../layout/base/NineZone";
 
 /** @internal */
 export function CloseTabButton() {
   const activeTabId = useActiveTabId();
-  const widgetDef = useWidgetDef(activeTabId);
+  const dispatch = React.useContext(NineZoneDispatchContext);
 
   return (
     <ActionButton
       icon={<SvgCloseSmall />}
       title="Close tab"
       onClick={() => {
-        widgetDef?.setWidgetState(WidgetState.Hidden);
+        dispatch({
+          type: "WIDGET_TAB_HIDE",
+          id: activeTabId,
+        });
       }}
     />
   );

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseWidgetButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseWidgetButton.tsx
@@ -14,14 +14,14 @@ import { useActiveTabId } from "../../layout/widget/Widget";
 import { NineZoneDispatchContext } from "../../layout/base/NineZone";
 
 /** @internal */
-export function CloseTabButton() {
+export function CloseWidgetButton() {
   const id = useActiveTabId();
   const dispatch = React.useContext(NineZoneDispatchContext);
 
   return (
     <ActionButton
       icon={<SvgCloseSmall />}
-      title="Close tab"
+      title="Close widget"
       onClick={() => {
         dispatch({
           type: "WIDGET_TAB_HIDE",

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseWidgetButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseWidgetButton.tsx
@@ -21,7 +21,7 @@ export function CloseWidgetButton() {
   return (
     <ActionButton
       icon={<SvgCloseSmall />}
-      title="Close widget"
+      label="Close widget"
       onClick={() => {
         dispatch({
           type: "WIDGET_TAB_HIDE",

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/NavigationWidget.scss
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/NavigationWidget.scss
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+@layer appui.preview {
+  .uifw-preview-navigationWidget {
+    display: grid;
+    grid-gap: 6px;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr auto;
+  }
+
+  .uifw-preview-navigationWidget_add {
+    pointer-events: all;
+    float: right;
+  }
+}

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/NavigationWidget.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/NavigationWidget.tsx
@@ -10,7 +10,7 @@ import "./NavigationWidget.scss";
 import * as React from "react";
 import { DropdownButton, MenuItem } from "@itwin/itwinui-react";
 import { SvgAdd } from "@itwin/itwinui-icons-react";
-import { useHiddenTabs } from "./AddTabButton";
+import { useUserControlledHiddenTabs } from "./AddTabButton";
 import { NineZoneDispatchContext } from "../../layout/base/NineZone";
 import { useLayout } from "../../layout/base/LayoutStore";
 import { panelSides } from "../../layout/widget-panels/Panel";
@@ -18,7 +18,7 @@ import { panelSides } from "../../layout/widget-panels/Panel";
 /** @internal */
 export function NavigationWidget({ children }: React.PropsWithChildren<{}>) {
   const dispatch = React.useContext(NineZoneDispatchContext);
-  const tabs = useHiddenTabs();
+  const tabs = useUserControlledHiddenTabs();
   const hasWidgets = useHasWidgets();
   const showAdd = tabs.length > 0 && !hasWidgets;
   return (

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/NavigationWidget.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/NavigationWidget.tsx
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Widget
+ */
+
+import "./NavigationWidget.scss";
+import * as React from "react";
+import { DropdownButton, MenuItem } from "@itwin/itwinui-react";
+import { SvgAdd } from "@itwin/itwinui-icons-react";
+import { useHiddenTabs } from "./AddTabButton";
+import { NineZoneDispatchContext } from "../../layout/base/NineZone";
+import { useLayout } from "../../layout/base/LayoutStore";
+import { panelSides } from "../../layout/widget-panels/Panel";
+
+/** @internal */
+export function NavigationWidget({ children }: React.PropsWithChildren<{}>) {
+  const dispatch = React.useContext(NineZoneDispatchContext);
+  const tabs = useHiddenTabs();
+  const hasWidgets = useHasWidgets();
+  const showAdd = tabs.length > 0 && !hasWidgets;
+  return (
+    <div className="uifw-preview-navigationWidget">
+      {children}
+      <div>
+        {showAdd && (
+          <DropdownButton
+            className="uifw-preview-navigationWidget_add"
+            startIcon={<SvgAdd />}
+            menuItems={(close) =>
+              tabs.map((tab) => {
+                return (
+                  <MenuItem
+                    key={tab.id}
+                    onClick={() => {
+                      dispatch({
+                        type: "WIDGET_TAB_SHOW",
+                        id: tab.id,
+                      });
+                      close();
+                    }}
+                  >
+                    {tab.label}
+                  </MenuItem>
+                );
+              })
+            }
+          >
+            Add tab
+          </DropdownButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function useHasWidgets() {
+  return useLayout((state) => {
+    if (state.floatingWidgets.allIds.length > 0) return true;
+
+    for (const side of panelSides) {
+      const panel = state.panels[side];
+      if (panel.widgets.length > 0) {
+        return true;
+      }
+    }
+    return false;
+  });
+}

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/NavigationWidget.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/NavigationWidget.tsx
@@ -10,12 +10,14 @@ import "./NavigationWidget.scss";
 import * as React from "react";
 import { DropdownButton, MenuItem } from "@itwin/itwinui-react";
 import { SvgAdd } from "@itwin/itwinui-icons-react";
-import { useUserControlledHiddenTabs } from "./AddTabButton";
+import { label, useUserControlledHiddenTabs } from "./AddWidgetButton";
 import { NineZoneDispatchContext } from "../../layout/base/NineZone";
 import { useLayout } from "../../layout/base/LayoutStore";
 import { panelSides } from "../../layout/widget-panels/Panel";
 
-/** @internal */
+/** Displays a dropdown button to un-hide widgets in the bottom-right corner of the navigation widget area.
+ * @internal
+ */
 export function NavigationWidget({ children }: React.PropsWithChildren<{}>) {
   const dispatch = React.useContext(NineZoneDispatchContext);
   const tabs = useUserControlledHiddenTabs();
@@ -48,7 +50,7 @@ export function NavigationWidget({ children }: React.PropsWithChildren<{}>) {
               })
             }
           >
-            Add tab
+            {label}
           </DropdownButton>
         )}
       </div>
@@ -56,6 +58,7 @@ export function NavigationWidget({ children }: React.PropsWithChildren<{}>) {
   );
 }
 
+/** Returns `false` if there are no floating widgets or panel sections. */
 function useHasWidgets() {
   return useLayout((state) => {
     if (state.floatingWidgets.allIds.length > 0) return true;

--- a/ui/appui-react/src/appui-react/preview/enable-maximized-widget/MaximizeToggle.tsx
+++ b/ui/appui-react/src/appui-react/preview/enable-maximized-widget/MaximizeToggle.tsx
@@ -25,23 +25,23 @@ export function MaximizeToggle() {
     MaximizedWidgetContext
   );
 
-  const { id, title, iconSpec } =
+  const { id, label, iconSpec } =
     maximizedWidget === widgetId
       ? {
           id: undefined,
-          title: "Restore",
+          label: "Restore",
           iconSpec: <SvgWindowMinimize />,
         }
       : {
           id: widgetId,
-          title: "Maximize",
+          label: "Maximize",
           iconSpec: <SvgWindowMaximize />,
         };
 
   return (
     <ActionButton
       icon={iconSpec}
-      title={title}
+      label={label}
       onClick={() => {
         setMaximizedWidget(id);
       }}

--- a/ui/appui-react/src/appui-react/preview/horizontal-panel-alignment/PreviewHorizontalPanelAlign.tsx
+++ b/ui/appui-react/src/appui-react/preview/horizontal-panel-alignment/PreviewHorizontalPanelAlign.tsx
@@ -179,7 +179,7 @@ export function PreviewHorizontalPanelAlignButton() {
     return (
       <MenuItem
         icon={getIcon(side, alignments[side])}
-        subMenuItems={getMenuItems()}
+        subMenuItems={getMenuItems(dropdownContext.onClose)}
       >
         {title}
       </MenuItem>

--- a/ui/appui-react/src/appui-react/preview/horizontal-panel-alignment/PreviewHorizontalPanelAlign.tsx
+++ b/ui/appui-react/src/appui-react/preview/horizontal-panel-alignment/PreviewHorizontalPanelAlign.tsx
@@ -151,7 +151,7 @@ export function PreviewHorizontalPanelAlignButton() {
   const { alignments, setAlignment } = React.useContext(
     HorizontalPanelAlignContext
   );
-  const title = "Align panel";
+  const label = "Align panel";
 
   const getMenuItems = (onClose?: () => void) =>
     [
@@ -181,13 +181,13 @@ export function PreviewHorizontalPanelAlignButton() {
         icon={getIcon(side, alignments[side])}
         subMenuItems={getMenuItems(dropdownContext.onClose)}
       >
-        {title}
+        {label}
       </MenuItem>
     );
   }
   return (
     <DropdownMenu menuItems={(close) => getMenuItems(close)}>
-      <TabBarButton title={title}>
+      <TabBarButton label={label}>
         {getIcon(side, alignments[side])}
       </TabBarButton>
     </DropdownMenu>

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/Button.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/Button.tsx
@@ -24,7 +24,14 @@ export function ActionButton(props: ActionButtonProps) {
   const dropdownContext = React.useContext(WidgetActionDropdownContext);
   if (dropdownContext !== undefined) {
     return (
-      <MenuItem icon={props.icon} onClick={props.onClick} {...props.menuProps}>
+      <MenuItem
+        icon={props.icon}
+        onClick={() => {
+          props.onClick?.();
+          dropdownContext.onClose();
+        }}
+        {...props.menuProps}
+      >
         {props.title}
       </MenuItem>
     );

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/Button.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/Button.tsx
@@ -12,7 +12,7 @@ import { WidgetActionDropdownContext } from "./MoreButton";
 import { TabBarButton } from "../../layout/widget/Button";
 
 interface ActionButtonProps {
-  title?: string;
+  label?: string;
   icon: React.JSX.Element;
   onClick?: () => void;
   menuProps?: React.ComponentProps<typeof MenuItem>;
@@ -32,14 +32,14 @@ export function ActionButton(props: ActionButtonProps) {
         }}
         {...props.menuProps}
       >
-        {props.title}
+        {props.label}
       </MenuItem>
     );
   }
   return (
     <TabBarButton
       onClick={props.onClick}
-      title={props.title}
+      label={props.label}
       {...props.buttonProps}
     >
       {props.icon}

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -81,25 +81,10 @@ export function useWidgetDef(id?: WidgetDef["id"]): WidgetDef | undefined {
   }
 
   React.useEffect(() => {
-    return InternalFrontstageManager.onFrontstageNineZoneStateChangedEvent.addListener(
-      (args) => {
-        if (
-          args.frontstageDef !== frontstage ||
-          !frontstage ||
-          frontstage.isStageClosing ||
-          frontstage.isApplicationClosing
-        )
-          return;
-        setWidgetDef(frontstage.findWidgetDef(tabId));
-      }
-    );
-  }, [frontstage, tabId]);
-
-  React.useEffect(() => {
     return UiItemsManager.onUiProviderRegisteredEvent.addListener(() => {
       setWidgetDef(frontstage?.findWidgetDef(tabId));
     });
   }, [frontstage, tabId]);
 
-  return widgetDef;
+  return widgetDef?.id === tabId ? widgetDef : undefined;
 }

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -65,14 +65,20 @@ export function WidgetContent() {
 }
 
 /** @internal */
-export function useWidgetDef(): WidgetDef | undefined {
-  const tabId = React.useContext(TabIdContext);
-  assert(!!tabId);
-
+export function useWidgetDef(id?: WidgetDef["id"]): WidgetDef | undefined {
   const frontstage = useActiveFrontstageDef();
+  const context = React.useContext(TabIdContext);
+  const tabId = id ?? context;
+  assert(!!tabId);
   const [widgetDef, setWidgetDef] = React.useState(() =>
     frontstage?.findWidgetDef(tabId)
   );
+
+  const [prevTabId, setPrevTabId] = React.useState(tabId);
+  if (prevTabId !== tabId) {
+    setPrevTabId(tabId);
+    setWidgetDef(frontstage?.findWidgetDef(tabId));
+  }
 
   React.useEffect(() => {
     return InternalFrontstageManager.onFrontstageNineZoneStateChangedEvent.addListener(

--- a/ui/appui-react/src/appui-react/widget-panels/Content.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Content.tsx
@@ -11,7 +11,6 @@ import { NonIdealState } from "@itwin/itwinui-react";
 import * as React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { useActiveFrontstageDef } from "../frontstage/FrontstageDef";
-import { InternalFrontstageManager } from "../frontstage/InternalFrontstageManager";
 import { ScrollableWidgetContent } from "../layout/widget/Content";
 import { TabIdContext } from "../layout/widget/ContentRenderer";
 import { UiItemsManager } from "../ui-items-provider/UiItemsManager";
@@ -65,10 +64,9 @@ export function WidgetContent() {
 }
 
 /** @internal */
-export function useWidgetDef(id?: WidgetDef["id"]): WidgetDef | undefined {
+export function useWidgetDef(): WidgetDef | undefined {
   const frontstage = useActiveFrontstageDef();
-  const context = React.useContext(TabIdContext);
-  const tabId = id ?? context;
+  const tabId = React.useContext(TabIdContext);
   assert(!!tabId);
   const [widgetDef, setWidgetDef] = React.useState(() =>
     frontstage?.findWidgetDef(tabId)

--- a/ui/appui-react/src/appui-react/widget-panels/Toolbars.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Toolbars.tsx
@@ -9,6 +9,7 @@
 import "./Toolbars.scss";
 import * as React from "react";
 import { useActiveFrontstageDef } from "../frontstage/FrontstageDef";
+import { NavigationWidget } from "../preview/control-widget-visibility/NavigationWidget";
 
 /** @internal */
 export function WidgetPanelsToolbars() {
@@ -18,7 +19,7 @@ export function WidgetPanelsToolbars() {
   return (
     <div className="uifw-widgetPanels-toolbars">
       {tools}
-      {navigation}
+      <NavigationWidget>{navigation}</NavigationWidget>
     </div>
   );
 }

--- a/ui/appui-react/src/appui-react/widgets/Widget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/Widget.tsx
@@ -42,7 +42,9 @@ export interface Widget {
    * It is not possible to disable the floating of a widget if `allowedPanels` is an empty array.
    */
   readonly canFloat?: boolean | CanFloatWidgetOptions;
-  /** Defaults to `Floating` if widget is not allowed to dock to any panels. Otherwise defaults to `Closed`. */
+  /** Defaults to `Floating` if widget is not allowed to dock to any panels. Otherwise defaults to `Closed`.
+   * @note If `Hidden` the widget will be hidden after the layout is restored independently of saved layout state.
+   */
   readonly defaultState?: WidgetState;
   /** Content of the Widget. */
   readonly content?: React.ReactNode;

--- a/ui/appui-react/src/test/layout/widget/Buttons.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/Buttons.test.tsx
@@ -29,7 +29,7 @@ describe("TabBarButtons", () => {
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    wrapper.getByTitle("Send back");
+    wrapper.getByRole("button", { name: "Send back" });
   });
 
   it("should render PopoutToggle in a floating widget that canPopout ", () => {
@@ -46,7 +46,7 @@ describe("TabBarButtons", () => {
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    wrapper.getByTitle("Popout");
+    wrapper.getByRole("button", { name: "Popout" });
   });
 
   it("should render Dock button in floating ToolSettings", () => {
@@ -66,7 +66,7 @@ describe("TabBarButtons", () => {
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    wrapper.getByTitle("Dock");
+    wrapper.getByRole("button", { name: "Dock" });
   });
 
   it("should render PinToggle in main panel widget", () => {
@@ -85,7 +85,7 @@ describe("TabBarButtons", () => {
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    wrapper.getByTitle("Unpin panel");
+    wrapper.getByRole("button", { name: "Unpin panel" });
   });
 
   it("should render PopoutToggle in main panel widget that canPopout", () => {
@@ -104,7 +104,7 @@ describe("TabBarButtons", () => {
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    wrapper.getByTitle("Popout widget");
+    wrapper.getByRole("button", { name: "Popout widget" });
   });
 
   it("should render popout button", () => {
@@ -123,6 +123,6 @@ describe("TabBarButtons", () => {
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    wrapper.getByTitle("Popout");
+    wrapper.getByRole("button", { name: "Popout" });
   });
 });

--- a/ui/appui-react/src/test/layout/widget/Dock.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/Dock.test.tsx
@@ -23,7 +23,7 @@ describe("Dock", () => {
         </NineZoneLabelsContext.Provider>
       </NineZoneDispatchContext.Provider>
     );
-    const button = component.getByTitle("Dock");
+    const button = component.getByRole("button", { name: "Dock" });
     fireEvent.click(button);
 
     expect(dispatch).toHaveBeenCalledWith({

--- a/ui/appui-react/src/test/layout/widget/PinToggle.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PinToggle.test.tsx
@@ -24,7 +24,7 @@ describe("PinToggle", () => {
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    component.getByTitle("Unpin panel");
+    component.getByRole("button", { name: "Unpin panel" });
   });
 
   it("should render in unpinned panel", () => {
@@ -32,7 +32,7 @@ describe("PinToggle", () => {
     state = updatePanelState(state, "left", (draft) => {
       draft.pinned = false;
     });
-    const { getByTitle } = render(
+    const component = render(
       <TestNineZoneProvider
         defaultState={state}
         labels={{
@@ -44,7 +44,7 @@ describe("PinToggle", () => {
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
     );
-    getByTitle("Pin panel");
+    component.getByRole("button", { name: "Pin panel" });
   });
 
   it("should dispatch PANEL_TOGGLE_PINNED", () => {
@@ -64,7 +64,7 @@ describe("PinToggle", () => {
       </TestNineZoneProvider>
     );
 
-    const button = component.getByTitle("Unpin panel");
+    const button = component.getByRole("button", { name: "Unpin panel" });
     fireEvent.click(button);
 
     expect(dispatch).toHaveBeenCalledOnce();

--- a/ui/appui-react/src/test/layout/widget/PopoutToggle.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PopoutToggle.test.tsx
@@ -31,7 +31,7 @@ describe("PopoutToggle", () => {
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    const button = component.getByTitle("Popout");
+    const button = component.getByRole("button", { name: "Popout" });
     fireEvent.click(button);
 
     expect(dispatch).toHaveBeenCalledWith({

--- a/ui/appui-react/src/test/layout/widget/SendBack.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/SendBack.test.tsx
@@ -30,7 +30,7 @@ describe("SendBack", () => {
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    component.getByTitle("Send back");
+    component.getByRole("button", { name: "Send back" });
   });
 
   it("should dispatch TOOL_SETTINGS_DOCK", () => {
@@ -49,7 +49,7 @@ describe("SendBack", () => {
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    const button = component.getByTitle("Send back");
+    const button = component.getByRole("button", { name: "Send back" });
     fireEvent.click(button);
 
     expect(dispatch).toHaveBeenCalledWith({
@@ -72,7 +72,7 @@ describe("SendBack", () => {
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
-    const button = component.getByTitle("Send back");
+    const button = component.getByRole("button", { name: "Send back" });
 
     fireEvent.mouseOver(button);
     expect(useActiveSendBackWidgetIdStore.getState()).equal("w1");

--- a/ui/appui-react/src/test/widget-panels/Content.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/Content.test.tsx
@@ -17,6 +17,7 @@ import { createNineZoneState } from "../../appui-react/layout/state/NineZoneStat
 import { addPanelWidget } from "../../appui-react/layout/state/internal/PanelStateHelpers";
 import { addTab } from "../../appui-react/layout/state/internal/TabStateHelpers";
 import { WidgetIdContext } from "../../appui-react/layout/widget/Widget";
+import { TabIdContext } from "../../appui-react/layout/widget/ContentRenderer";
 
 describe("WidgetContent", () => {
   it("should render", () => {
@@ -40,7 +41,9 @@ describe("WidgetContent", () => {
         measure={() => new Rectangle()}
       >
         <WidgetIdContext.Provider value="leftStart">
-          <WidgetContent />
+          <TabIdContext.Provider value="w1">
+            <WidgetContent />
+          </TabIdContext.Provider>
         </WidgetIdContext.Provider>
       </NineZoneProvider>
     );

--- a/ui/appui-react/src/test/widget-panels/Tab.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/Tab.test.tsx
@@ -49,7 +49,7 @@ describe("WidgetPanelsTab", () => {
       "get"
     ).mockImplementation(() => frontstageDef);
     const widgetDef = WidgetDef.create({
-      id: "w1",
+      id: "t1",
       badge: BadgeType.New,
     });
     vi.spyOn(frontstageDef, "findWidgetDef").mockReturnValue(widgetDef);

--- a/ui/appui-react/src/test/widget-panels/Toolbars.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/Toolbars.test.tsx
@@ -10,21 +10,9 @@ import {
   WidgetDef,
   WidgetPanelsToolbars,
 } from "../../appui-react";
-import { childStructure, selectorMatches } from "../TestUtils";
+import { TestNineZoneProvider } from "../layout/Providers";
 
 describe("WidgetPanelsToolbars", () => {
-  it("should not render", () => {
-    vi.spyOn(
-      UiFramework.frontstages,
-      "activeFrontstageDef",
-      "get"
-    ).mockImplementation(() => undefined);
-    const { container } = render(<WidgetPanelsToolbars />);
-    expect(container).to.satisfy(
-      childStructure("div.uifw-widgetPanels-toolbars:only-child:empty")
-    );
-  });
-
   it("should render toolbars", () => {
     const frontstageDef = new FrontstageDef();
     const contentManipulationWidget = WidgetDef.create({
@@ -46,9 +34,10 @@ describe("WidgetPanelsToolbars", () => {
     vi.spyOn(frontstageDef, "viewNavigation", "get").mockImplementation(
       () => viewNavigationWidget
     );
-    render(<WidgetPanelsToolbars />);
-    expect(screen.getByText(/tools.*navigation/)).to.satisfy(
-      selectorMatches(".uifw-widgetPanels-toolbars")
-    );
+    render(<WidgetPanelsToolbars />, {
+      wrapper: (props: any) => <TestNineZoneProvider {...props} />,
+    });
+    screen.getByText("tools");
+    screen.getByText("navigation");
   });
 });


### PR DESCRIPTION
## Changes

This PR adds a `controlWidgetVisibility` preview feature which renders additional UI elements to allow the end user of the layout to control widget visibility.

| Description  | Image |
| ------------- | ------------- |
| `Add widget` and `Close widget` buttons in a widget action dropdown | ![Screenshot 2024-05-31 at 13 43 55](https://github.com/iTwin/appui/assets/10091419/b9c39565-7179-4a8a-80e4-fabcc5997c4b) |
| `Add widget` and `Close widget` as separate title bar buttons | ![Screenshot 2024-05-31 at 13 49 33](https://github.com/iTwin/appui/assets/10091419/c7817a23-2307-420d-bb3e-19bb183212cd) |
| In case all widgets are hidden, a dropdown button is rendered in the bottom right of the navigation area | ![Screenshot 2024-05-31 at 13 45 09](https://github.com/iTwin/appui/assets/10091419/18d052f9-4e9a-46ab-adcc-efd8ed6e50de) |

### Additional changes:
- The dropdown menu of `widgetActionDropdown` will close once one of the menu items is activated. 
- The labels for the buttons in the widget title bar will be rendered as tooltips, rather than using the `title` attribute.

  | Before  | After |
  | ------------- | ------------- |
  | ![Screenshot 2024-05-31 at 13 38 31](https://github.com/iTwin/appui/assets/10091419/40d04649-a5ea-4d1a-9c61-fc3eeb0d7d26) |  ![Screenshot 2024-05-31 at 13 39 55](https://github.com/iTwin/appui/assets/10091419/8efa8c08-01fd-49c9-8d27-1d3c8b70a9c2) |

## Testing

Added a storybook story.
