### PR TITLE
Open 'pw' scheme links in a new window

### DIFF
--- a/common/changes/@itwin/components-react/issue-857_2024-06-03-16-26.json
+++ b/common/changes/@itwin/components-react/issue-857_2024-06-03-16-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Update `VirtualizedPropertyGrid` and `UrlPropertyValueRenderer` to open links with `pw` scheme in a new window.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -39,6 +39,7 @@ Table of contents:
   - Enable user selection for property records
   - Display browser context menu on property records if `onPropertyContextMenu` and `isPropertySelectionOnRightClickEnabled` props are not set
   - Increased area of an element separator to avoid column overlap
+- Changed handlers of `VirtualizedPropertyGrid` and `UrlPropertyValueRenderer` components to open links with `pw` scheme in a new window.
 
 ## @itwin/core-react
 

--- a/docs/storybook/src/components/PropertyGrid.stories.tsx
+++ b/docs/storybook/src/components/PropertyGrid.stories.tsx
@@ -344,6 +344,25 @@ export const NestedCategories: Story = {
   },
 };
 
+export const Links: Story = {
+  args: {
+    dataProvider: {
+      getData: async () => ({
+        label: PropertyRecord.fromString("Record 1"),
+        categories: [{ name: "Group_1", label: "Group 1", expand: true }],
+        records: {
+          Group_1: [
+            PropertyRecord.fromString("https://www.bentley.com"),
+            PropertyRecord.fromString("pw://test"),
+          ],
+        },
+      }),
+      onDataChanged: new PropertyDataChangeEvent(),
+    },
+    onPropertyContextMenu: undefined,
+  },
+};
+
 rendererManager.registerRenderer("customRendererStructPropertyRenderer", {
   canRender: () => true,
   render: (record) => {

--- a/ui/components-react/src/components-react/properties/renderers/value/UrlPropertyValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/UrlPropertyValueRenderer.tsx
@@ -51,19 +51,15 @@ export class UrlPropertyValueRenderer implements IPropertyValueRenderer {
   }
 }
 
-/**
- * Default URI onClick event, sets location.href to the whole URI value without matching it
- * against URL regex.
- */
-function urlOnClick(text: string) {
-  if (text.startsWith("mailto:") || text.startsWith("pw:"))
+function handleClick(text: string) {
+  if (text.startsWith("mailto:")) {
     location.href = text;
-  else {
+  } else {
     const windowOpen = window.open(text, "_blank");
-    if (windowOpen) windowOpen.focus();
+    windowOpen?.focus();
   }
 }
 
 const URI_PROPERTY_LINK_HANDLER: LinkElementsInfo = {
-  onClick: urlOnClick,
+  onClick: handleClick,
 };

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridCommons.ts
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridCommons.ts
@@ -133,11 +133,11 @@ export class PropertyGridCommons {
     if (linksArray.length <= 0) return;
     const foundLink = linksArray[0];
     if (foundLink && foundLink.url) {
-      if (foundLink.schema === "mailto:" || foundLink.schema === "pw:")
+      if (foundLink.schema === "mailto:") {
         location.href = foundLink.url;
-      else {
+      } else {
         const windowOpen = window.open(foundLink.url, "_blank");
-        if (windowOpen) windowOpen.focus();
+        windowOpen?.focus();
       }
     }
   }

--- a/ui/components-react/src/test/properties/renderers/value/UrlPropertyValueRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/value/UrlPropertyValueRenderer.test.tsx
@@ -136,8 +136,9 @@ describe("UrlPropertyValueRenderer", () => {
         )[0];
         expect(linkElement.textContent).toEqual("pw:Test property");
 
+        const spy = vi.spyOn(window, "open");
         fireEvent.click(linkElement);
-        expect(locationMockRef.object.href).toEqual("pw:Test property");
+        expect(spy).toHaveBeenCalledWith("pw:Test property", "_blank");
       });
 
       it("sets location.href to the whole URI value, when link starting with mailto: is clicked", () => {

--- a/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
@@ -74,11 +74,13 @@ describe("PropertyGrid Commons", () => {
     });
 
     it("sets location href value to value got in the text if it is an ProjectWise Explorer link", async () => {
+      const spy = vi.spyOn(window, "open");
       PropertyGridCommons.handleLinkClick(
         "pw://server.bentley.com:datasource-01/Documents/ProjectName"
       );
-      expect(locationMockRef.object.href).toEqual(
-        "pw://server.bentley.com:datasource-01/Documents/ProjectName"
+      expect(spy).toHaveBeenCalledWith(
+        "pw://server.bentley.com:datasource-01/Documents/ProjectName",
+        "_blank"
       );
     });
 


### PR DESCRIPTION
## Changes

This PR fixes #857 by updating handlers of `VirtualizedPropertyGrid` and `UrlPropertyValueRenderer` components to open links with `pw` scheme in a new window.

## Testing

Updated unit tests and added story.
