### PR TITLE
Change pw link handling to open to a new tab instead

### DIFF
--- a/common/changes/@itwin/components-react/nam-open-pw-new-tab_2024-06-03-18-31.json
+++ b/common/changes/@itwin/components-react/nam-open-pw-new-tab_2024-06-03-18-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "change pw link handling to open to a new tab instead",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridCommons.ts
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridCommons.ts
@@ -134,7 +134,7 @@ export class PropertyGridCommons {
     const foundLink = linksArray[0];
     // istanbul ignore else
     if (foundLink && foundLink.url) {
-      if (foundLink.schema === "mailto:" || foundLink.schema === "pw:")
+      if (foundLink.schema === "mailto:")
         location.href = foundLink.url;
       else {
         const windowOpen = window.open(foundLink.url, "_blank");

--- a/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
@@ -73,12 +73,15 @@ describe("PropertyGrid Commons", () => {
       );
     });
 
-    it("sets location href value to value got in the text if it is an ProjectWise Explorer link", async () => {
+    it("open new window if value got in the text is an ProjectWise Explorer link", async () => {
+      const spy = vi.spyOn(window, "open");
+      spy.mockReturnValue(null);
+
       PropertyGridCommons.handleLinkClick(
         "pw://server.bentley.com:datasource-01/Documents/ProjectName"
       );
-      expect(locationMockRef.object.href).toEqual(
-        "pw://server.bentley.com:datasource-01/Documents/ProjectName"
+      expect(spy).toHaveBeenCalledWith(
+        "pw://server.bentley.com:datasource-01/Documents/ProjectName", "_blank"
       );
     });
 


### PR DESCRIPTION

## Changes

Remove link handling where opening a `pw://` link redirects within the current browser tab that has the property grid component. Instead, a new browser tab will be opened, containing the `pw://` link if the scheme is supported. Else, the new page opened is just blank.

## Testing

Refactored unit test in PropertyGridCommons.test.ts
