### PR TITLE
Re-open popout widgets in electron app

### DIFF
--- a/common/changes/@itwin/appui-react/issue-867_2024-06-11-11-51.json
+++ b/common/changes/@itwin/appui-react/issue-867_2024-06-11-11-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Re-open popout widgets when switching frontstages in an electron app.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -366,7 +366,7 @@ export function addPanelSectionWidgetDefs(
   }
 }
 
-/** Sends back popout widgets if app is not not an electron app. */
+/** Sends back popout widgets if app is not an electron app. */
 function processPopoutWidgets(frontstageDef: FrontstageDef) {
   if (ProcessDetector.isElectronAppFrontend) return;
 

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -366,11 +366,9 @@ export function addPanelSectionWidgetDefs(
   }
 }
 
+/** Sends back popout widgets if app is not not an electron app. */
 function processPopoutWidgets(frontstageDef: FrontstageDef) {
-  // Electron reopens popout windows w/o user interaction.
-  if (ProcessDetector.isElectronAppFrontend) {
-    return;
-  }
+  if (ProcessDetector.isElectronAppFrontend) return;
 
   assert(!!frontstageDef.nineZoneState);
   const state = frontstageDef.nineZoneState;
@@ -379,6 +377,18 @@ function processPopoutWidgets(frontstageDef: FrontstageDef) {
       type: "POPOUT_WIDGET_SEND_BACK",
       id,
     });
+  }
+}
+
+/** Opens popout widgets if app is an electron app. */
+function openPopoutWidgets(frontstageDef: FrontstageDef) {
+  // Only electron can reopen popout windows w/o user interaction.
+  if (!ProcessDetector.isElectronAppFrontend) return;
+
+  assert(!!frontstageDef.nineZoneState);
+  const state = frontstageDef.nineZoneState;
+  for (const id of state.popoutWidgets.allIds) {
+    frontstageDef.openPopoutWidgetContainer(id, undefined);
   }
 }
 
@@ -722,6 +732,7 @@ export function useSavedFrontstageState(frontstageDef: FrontstageDef) {
       // Switching to previously initialized frontstage.
       if (frontstageDef.nineZoneState) {
         processPopoutWidgets(frontstageDef);
+        openPopoutWidgets(frontstageDef);
         return;
       }
 


### PR DESCRIPTION
## Changes

This PR fixes #867 by correctly reopening popout widgets when switching to the initialized frontstage in an electron app.

## Testing

Tested manually in a standalone test app.
