### PR TITLE
Deprecate `provide*` methods of `UiItemsProvider`

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -865,7 +865,6 @@ export interface CommonToolbarItem {
     readonly isDisabled?: boolean | ConditionalBooleanValue;
     readonly isHidden?: boolean | ConditionalBooleanValue;
     readonly itemPriority: number;
-    // @alpha
     readonly layouts?: ToolbarItemLayouts;
 }
 
@@ -4205,13 +4204,13 @@ export class StandardFrontstageProvider extends FrontstageProvider {
     get id(): string;
 }
 
-// @alpha
+// @public
 export interface StandardLayoutToolbarItem {
     readonly orientation: ToolbarOrientation;
     readonly usage: ToolbarUsage;
 }
 
-// @alpha
+// @public
 export interface StandardLayoutWidget {
     readonly location: StagePanelLocation;
     readonly section: StagePanelSection;
@@ -4663,7 +4662,7 @@ export class ToolbarHelper {
 // @public
 export type ToolbarItem = ToolbarActionItem | ToolbarGroupItem | ToolbarCustomItem;
 
-// @alpha
+// @public
 export interface ToolbarItemLayouts {
     readonly standard?: StandardLayoutToolbarItem;
 }
@@ -5039,19 +5038,19 @@ export class UiItemsManager {
 
 // @public
 export interface UiItemsProvider {
-    // @alpha
     readonly getBackstageItems?: () => ReadonlyArray<BackstageItem>;
-    // @alpha
     readonly getStatusBarItems?: () => ReadonlyArray<StatusBarItem>;
-    // @alpha
     readonly getToolbarItems?: () => ReadonlyArray<ToolbarItem>;
-    // @alpha
     readonly getWidgets?: () => ReadonlyArray<Widget>;
     readonly id: string;
     readonly onUnregister?: () => void;
+    // @deprecated
     readonly provideBackstageItems?: () => ReadonlyArray<BackstageItem>;
+    // @deprecated
     readonly provideStatusBarItems?: (stageId: string, stageUsage: string) => ReadonlyArray<StatusBarItem>;
+    // @deprecated
     readonly provideToolbarItems?: (stageId: string, stageUsage: string, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation) => ReadonlyArray<ToolbarItem>;
+    // @deprecated
     readonly provideWidgets?: (stageId: string, stageUsage: string, location: StagePanelLocation, section?: StagePanelSection) => ReadonlyArray<Widget>;
 }
 
@@ -5421,7 +5420,6 @@ export interface Widget {
     readonly id: string;
     // (undocumented)
     readonly label?: string | ConditionalStringValue;
-    // @alpha
     readonly layouts?: WidgetLayouts;
     // (undocumented)
     readonly priority?: number;
@@ -5587,7 +5585,7 @@ export interface WidgetInfo {
     widgetDef: WidgetDef;
 }
 
-// @alpha
+// @public
 export interface WidgetLayouts {
     readonly standard?: StandardLayoutWidget;
 }

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -539,8 +539,8 @@ public;StandardContentToolsProvider
 beta;StandardContentToolsUiItemsProvider 
 public;StandardFrontstageProps
 public;StandardFrontstageProvider 
-alpha;StandardLayoutToolbarItem
-alpha;StandardLayoutWidget
+public;StandardLayoutToolbarItem
+public;StandardLayoutWidget
 public;StandardMessageBox 
 public;StandardMessageBoxProps 
 public;StandardNavigationToolsProvider 
@@ -625,7 +625,7 @@ beta;ToolbarDragInteractionContext: React_2.Context
 public;ToolbarGroupItem 
 public;ToolbarHelper
 public;ToolbarItem = ToolbarActionItem | ToolbarGroupItem | ToolbarCustomItem
-alpha;ToolbarItemLayouts
+public;ToolbarItemLayouts
 beta;ToolbarItemUtilities
 public;ToolbarOrientation
 beta;ToolbarPopup 
@@ -747,7 +747,7 @@ public;WidgetDef
 internal;WidgetEventArgs
 public;WidgetHost
 internal;WidgetInfo
-alpha;WidgetLayouts
+public;WidgetLayouts
 beta;WidgetManager
 public;WidgetPanelProps = Omit
 internal;WidgetPanelsFrontstage(): React_2.JSX.Element | null

--- a/common/changes/@itwin/appui-react/item-provider-provide-method-deprecation_2024-06-12-05-41.json
+++ b/common/changes/@itwin/appui-react/item-provider-provide-method-deprecation_2024-06-12-05-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Bumped `get*` methods of `UiItemsProvider` and all related types to `@public`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/appui-react/item-provider-provide-method-deprecation_2024-06-12-05-42.json
+++ b/common/changes/@itwin/appui-react/item-provider-provide-method-deprecation_2024-06-12-05-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Deprecated `provide*` methods of `UiItemsProvider`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,6 +5,7 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Deprecations](#deprecations)
   - [Additions](#additions)
+  - [Changes](#changes)
 
 ## @itwin/appui-react
 
@@ -19,6 +20,7 @@ Table of contents:
   - `IModelConnectedViewSelector` component. Use `ViewSelector` instead.
   - `SelectionInfoField` component. Use `SelectionCountField` instead.
   - Static methods and properties of `UiFramework` related to redux store.
+- Deprecated `provideToolbarItems`, `provideStatusBarItems`, `provideWidgets` and `provideBackstageItems` methods of `UiItemsProvider`. Use `getToolbarItems`, `getStatusBarItems`, `getWidgets` and `getBackstageItems` methods of `UiItemsProvider` instead.
 
 ### Additions
 
@@ -33,3 +35,7 @@ Table of contents:
   Currently applications might use `WidgetState` to control widget visibility programmatically and expect the widgets to stay hidden until a certain condition is met. Since this preview feature adds UI elements to control widget visibility, it might conflict with the application's logic. To avoid this, the application should use `UiItemsManager.register()` and `UiItemsManager.unregister()` to strictly manage what widgets are available to the end-user.
 
   Additionally an array of widget ids can be specified to only expose visibility controls for specific widgets. This allows applications to experiment with other use-cases, like keeping at least one widget visible at all times.
+
+### Changes
+
+- Bumped `getToolbarItems`, `getStatusBarItems`, `getWidgets` and `getBackstageItems` methods of `UiItemsProvider`, `layouts` property of `CommonToolbarItem` and `Widget`, `StandardLayoutToolbarItem`, `StandardLayoutWidget`, `ToolbarItemLayouts`, `WidgetLayouts` to `@public`.

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
@@ -11,6 +11,7 @@ import type {
   ConditionalStringValue,
 } from "@itwin/appui-abstract";
 import type { BadgeType, IconSpec } from "@itwin/core-react";
+import { UiItemsProvider } from "../ui-items-provider/UiItemsProvider";
 
 /** Used to specify the usage of the toolbar which determine the toolbar position.
  * @public
@@ -56,8 +57,7 @@ export interface CommonToolbarItem {
   /** Priority within a toolbar or group. */
   readonly itemPriority: number;
   /** Describes layout specific configuration of a toolbar item.
-   * @note Only used by `get*` methods of [[UiItemsProvider]].
-   * @alpha
+   * @note Only used by {@link UiItemsProvider.getToolbarItems}.
    */
   readonly layouts?: ToolbarItemLayouts;
 }
@@ -140,7 +140,7 @@ export function isToolbarCustomItem(
 }
 
 /** Describes toolbar item configuration specific for each layout.
- * @alpha
+ * @public
  */
 export interface ToolbarItemLayouts {
   /** Toolbar item configuration in a standard layout. */
@@ -148,7 +148,7 @@ export interface ToolbarItemLayouts {
 }
 
 /** Describes toolbar item configuration specific to a standard layout.
- * @alpha
+ * @public
  */
 export interface StandardLayoutToolbarItem {
   /** Describes toolbar usage. */

--- a/ui/appui-react/src/appui-react/ui-items-provider/UiItemsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/UiItemsProvider.ts
@@ -11,6 +11,7 @@ import type { StagePanelLocation } from "../stagepanels/StagePanelLocation";
 import type { StagePanelSection } from "../stagepanels/StagePanelSection";
 import type { StatusBarItem } from "../statusbar/StatusBarItem";
 import type {
+  CommonToolbarItem,
   ToolbarItem,
   ToolbarOrientation,
   ToolbarUsage,
@@ -25,7 +26,7 @@ export interface UiItemsProvider {
   readonly id: string;
 
   /** Provides toolbar items.
-   * @note Use {@link ToolbarItem.layouts} to map item to location previously specified by `provideToolbarItems` arguments.
+   * @note Use {@link CommonToolbarItem.layouts} to map item to location previously specified by `provideToolbarItems` arguments.
    */
   readonly getToolbarItems?: () => ReadonlyArray<ToolbarItem>;
   /** Provides status bar items. */
@@ -38,7 +39,7 @@ export interface UiItemsProvider {
   readonly getWidgets?: () => ReadonlyArray<Widget>;
 
   /** Provides toolbar items.
-   * @deprecated in 4.15.0. Use {@link UiItemsProvider.getToolbarItems} instead. To map item to location previously specified by arguments use {@link ToolbarItem.layouts}.
+   * @deprecated in 4.15.0. Use {@link UiItemsProvider.getToolbarItems} instead. To map item to location previously specified by arguments use {@link CommonToolbarItem.layouts}.
    */
   readonly provideToolbarItems?: (
     stageId: string,

--- a/ui/appui-react/src/appui-react/ui-items-provider/UiItemsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/UiItemsProvider.ts
@@ -25,26 +25,20 @@ export interface UiItemsProvider {
   readonly id: string;
 
   /** Provides toolbar items.
-   * @note Use [[ToolbarItem.layouts]] to map item to location previously specified by `provideToolbarItems` arguments.
-   * @alpha
+   * @note Use {@link ToolbarItem.layouts} to map item to location previously specified by `provideToolbarItems` arguments.
    */
   readonly getToolbarItems?: () => ReadonlyArray<ToolbarItem>;
-  /** Provides status bar items.
-   * @alpha
-   */
+  /** Provides status bar items. */
   readonly getStatusBarItems?: () => ReadonlyArray<StatusBarItem>;
-  /** Provides backstage items.
-   * @alpha
-   */
+  /** Provides backstage items. */
   readonly getBackstageItems?: () => ReadonlyArray<BackstageItem>;
   /** Provides widgets.
-   * @note Use [[Widget.layouts]] to map item to location previously specified by `provideWidgets` arguments.
-   * @alpha
+   * @note Use {@link Widget.layouts} to map item to location previously specified by `provideWidgets` arguments.
    */
   readonly getWidgets?: () => ReadonlyArray<Widget>;
 
   /** Provides toolbar items.
-   * @note Use [[UiItemsProvider.getToolbarItems]] instead. To map item to location previously specified by arguments use [[ToolbarItem.layouts]].
+   * @deprecated in 4.15.0. Use {@link UiItemsProvider.getToolbarItems} instead. To map item to location previously specified by arguments use {@link ToolbarItem.layouts}.
    */
   readonly provideToolbarItems?: (
     stageId: string,
@@ -53,18 +47,18 @@ export interface UiItemsProvider {
     toolbarOrientation: ToolbarOrientation
   ) => ReadonlyArray<ToolbarItem>;
   /** Provides status bar items.
-   * @note Use [[UiItemsProvider.getStatusBarItems]] instead.
+   * @deprecated in 4.15.0. Use {@link UiItemsProvider.getStatusBarItems} instead.
    */
   readonly provideStatusBarItems?: (
     stageId: string,
     stageUsage: string
   ) => ReadonlyArray<StatusBarItem>;
   /** Provides backstage items.
-   * @note Use [[UiItemsProvider.getBackstageItems]] instead.
+   * @deprecated in 4.15.0. Use {@link UiItemsProvider.getBackstageItems} instead.
    */
   readonly provideBackstageItems?: () => ReadonlyArray<BackstageItem>;
   /** Provides widgets.
-   * @note Use [[UiItemsProvider.getWidgets]] instead. To map item to location previously specified by arguments use [[Widget.layouts]].
+   * @deprecated in 4.15.0. Use {@link UiItemsProvider.getWidgets} instead. To map item to location previously specified by arguments use {@link Widget.layouts}.
    */
   readonly provideWidgets?: (
     stageId: string,

--- a/ui/appui-react/src/appui-react/widgets/Widget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/Widget.tsx
@@ -12,6 +12,7 @@ import type { BadgeType, IconSpec, SizeProps } from "@itwin/core-react";
 import type { StagePanelLocation } from "../stagepanels/StagePanelLocation";
 import type { WidgetState } from "./WidgetState";
 import type { StagePanelSection } from "../stagepanels/StagePanelSection";
+import { UiItemsProvider } from "../ui-items-provider/UiItemsProvider";
 
 /** Describes options of a floating widget.
  * @public
@@ -53,14 +54,13 @@ export interface Widget {
   readonly priority?: number;
   readonly tooltip?: string | ConditionalStringValue;
   /** Describes layout specific configuration of a widget.
-   * @note Only used by `get*` methods of [[UiItemsProvider]].
-   * @alpha
+   * @note Only used by {@link UiItemsProvider.getWidgetItems}.
    */
   readonly layouts?: WidgetLayouts;
 }
 
 /** Describes widget configuration specific for each layout.
- * @alpha
+ * @public
  */
 export interface WidgetLayouts {
   /** Widget configuration in a standard layout. */
@@ -68,7 +68,7 @@ export interface WidgetLayouts {
 }
 
 /** Describes widget configuration specific to a standard layout.
- * @alpha
+ * @public
  */
 export interface StandardLayoutWidget {
   /** Describes to which panel the widget is added. */

--- a/ui/appui-react/src/appui-react/widgets/Widget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/Widget.tsx
@@ -54,7 +54,7 @@ export interface Widget {
   readonly priority?: number;
   readonly tooltip?: string | ConditionalStringValue;
   /** Describes layout specific configuration of a widget.
-   * @note Only used by {@link UiItemsProvider.getWidgetItems}.
+   * @note Only used by {@link UiItemsProvider.getWidgets}.
    */
   readonly layouts?: WidgetLayouts;
 }


### PR DESCRIPTION
## Changes
Deprecated `provide*` methods of `UiItemsProvider`. As replacement bumped `get*` methods of `UiItemsProvider` and all related types to `@public`.

## Testing
N/A
