### PR TITLE
Deprecate `FrontstageProvider`

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -1139,7 +1139,7 @@ export interface ContentGroupProps {
 // @public
 export abstract class ContentGroupProvider {
     applyUpdatesToSavedProps(contentGroupProps: ContentGroupProps): ContentGroupProps;
-    abstract contentGroup(config: FrontstageConfig): Promise<ContentGroup>;
+    abstract contentGroup(frontstage: Frontstage): Promise<ContentGroup>;
     onFrontstageDeactivated(): Promise<void>;
     prepareToSaveProps(contentGroupProps: ContentGroupProps): ContentGroupProps;
 }
@@ -1269,6 +1269,9 @@ export function createAction<T extends string, P>(type: T, payload: P): ActionWi
 
 // @internal
 export function createStableWidgetDef(widgetDef: WidgetDef, stableId: string): WidgetDef;
+
+// @public
+export function createStandardFrontstage(props: StandardFrontstageProps): Frontstage;
 
 // @public
 export class CubeNavigationAidControl extends NavigationAidControl {
@@ -1977,6 +1980,8 @@ export interface FrameworkFrontstages {
     readonly activeNestedFrontstage: FrontstageDef | undefined;
     readonly activeToolId: string;
     readonly activeToolInformation: ToolInformation | undefined;
+    addFrontstage(frontstage: Frontstage): void;
+    // @deprecated
     addFrontstageProvider(frontstageProvider: FrontstageProvider): void;
     clearFrontstageDefs(): void;
     clearFrontstageProviders(): void;
@@ -2212,6 +2217,9 @@ export interface FrameworkVisibility {
     useProximityOpacity: boolean;
 }
 
+// @public
+export type Frontstage = FrontstageConfig;
+
 // @internal (undocumented)
 export const FRONTSTAGE_SETTINGS_NAMESPACE = "uifw-frontstageSettings";
 
@@ -2227,7 +2235,7 @@ export interface FrontstageActivatedEventArgs {
     deactivatedFrontstageDef?: FrontstageDef;
 }
 
-// @public
+// @public @deprecated
 export interface FrontstageConfig extends CommonProps {
     readonly bottomPanel?: StagePanelConfig;
     readonly contentGroup: ContentGroup | ContentGroupProvider;
@@ -2274,7 +2282,7 @@ export class FrontstageDef {
     get contentLayoutDef(): ContentLayoutDef | undefined;
     // (undocumented)
     get contentManipulation(): WidgetDef | undefined;
-    static create(provider: FrontstageProvider): Promise<FrontstageDef>;
+    static create(providerOrFrontstage: FrontstageProvider | Frontstage): Promise<FrontstageDef>;
     // @internal (undocumented)
     get dispatch(): NineZoneDispatch;
     set dispatch(dispatch: NineZoneDispatch);
@@ -2289,7 +2297,7 @@ export class FrontstageDef {
     get floatingContentControls(): ContentControl[] | undefined;
     // @beta
     floatWidget(widgetId: string, position?: XAndY, size?: SizeProps): void;
-    // (undocumented)
+    // @deprecated (undocumented)
     get frontstageProvider(): FrontstageProvider | undefined;
     // (undocumented)
     getFloatingWidgetContainerBounds(floatingWidgetId: string | undefined): RectangleProps | undefined;
@@ -2302,7 +2310,7 @@ export class FrontstageDef {
     // (undocumented)
     get id(): string;
     // @internal
-    initializeFromConfig(config: FrontstageConfig): Promise<void>;
+    initializeFromConfig(config: Frontstage): Promise<void>;
     // (undocumented)
     get isApplicationClosing(): boolean;
     // (undocumented)
@@ -2380,7 +2388,7 @@ export interface FrontstageNineZoneStateChangedEventArgs extends FrontstageEvent
     state: NineZoneState | undefined;
 }
 
-// @public
+// @public @deprecated
 export abstract class FrontstageProvider {
     abstract frontstageConfig(): FrontstageConfig;
     abstract get id(): string;
@@ -4276,7 +4284,7 @@ export interface StandardFrontstageProps {
     version?: number;
 }
 
-// @public
+// @public @deprecated
 export class StandardFrontstageProvider extends FrontstageProvider {
     constructor(props: StandardFrontstageProps);
     // (undocumented)

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -2390,7 +2390,7 @@ export interface FrontstageNineZoneStateChangedEventArgs extends FrontstageEvent
 
 // @public @deprecated
 export abstract class FrontstageProvider {
-    abstract frontstageConfig(): FrontstageConfig;
+    abstract frontstageConfig(): Frontstage;
     abstract get id(): string;
 }
 
@@ -4288,7 +4288,7 @@ export interface StandardFrontstageProps {
 export class StandardFrontstageProvider extends FrontstageProvider {
     constructor(props: StandardFrontstageProps);
     // (undocumented)
-    frontstageConfig(): FrontstageConfig;
+    frontstageConfig(): Frontstage;
     // (undocumented)
     get id(): string;
 }

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -1977,6 +1977,7 @@ export interface FrameworkFrontstages {
     readonly activeNestedFrontstage: FrontstageDef | undefined;
     readonly activeToolId: string;
     readonly activeToolInformation: ToolInformation | undefined;
+    // @beta
     addFrontstage(frontstage: Frontstage): void;
     // @deprecated
     addFrontstageProvider(frontstageProvider: FrontstageProvider): void;

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -1271,9 +1271,6 @@ export function createAction<T extends string, P>(type: T, payload: P): ActionWi
 export function createStableWidgetDef(widgetDef: WidgetDef, stableId: string): WidgetDef;
 
 // @public
-export function createStandardFrontstage(props: StandardFrontstageProps): Frontstage;
-
-// @public
 export class CubeNavigationAidControl extends NavigationAidControl {
     constructor(info: ConfigurableCreateInfo, options: any);
     // (undocumented)
@@ -2402,6 +2399,11 @@ export class FrontstageReadyEvent extends UiEvent<FrontstageReadyEventArgs> {
 export interface FrontstageReadyEventArgs {
     // (undocumented)
     frontstageDef: FrontstageDef;
+}
+
+// @beta
+export namespace FrontstageUtilities {
+    export function createStandardFrontstage(props: StandardFrontstageProps): Frontstage;
 }
 
 // @public @deprecated

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -184,7 +184,6 @@ deprecated;createAction
 public;createAction
 deprecated;createAction
 internal;createStableWidgetDef(widgetDef: WidgetDef, stableId: string): WidgetDef
-public;createStandardFrontstage(props: StandardFrontstageProps): Frontstage
 public;CubeNavigationAidControl 
 public;CursorDirection
 public;CursorDirectionParts
@@ -295,6 +294,7 @@ public;FrontstageReadyEvent
 deprecated;FrontstageReadyEvent 
 public;FrontstageReadyEventArgs
 deprecated;FrontstageReadyEventArgs
+beta;FrontstageUtilities
 public;FunctionType = (...args: any[]) => any
 deprecated;FunctionType = (...args: any[]) => any
 internal;getBadgeClassName(badgeType: BadgeType | undefined): "uifw-badge-new" | "uifw-badge-tp" | undefined

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -184,6 +184,7 @@ deprecated;createAction
 public;createAction
 deprecated;createAction
 internal;createStableWidgetDef(widgetDef: WidgetDef, stableId: string): WidgetDef
+public;createStandardFrontstage(props: StandardFrontstageProps): Frontstage
 public;CubeNavigationAidControl 
 public;CursorDirection
 public;CursorDirectionParts
@@ -273,12 +274,14 @@ beta;FrameworkToolAdmin
 public;FrameworkToolSettings
 public;FrameworkUiAdmin 
 public;FrameworkVisibility
+public;Frontstage = FrontstageConfig
 internal;FRONTSTAGE_SETTINGS_NAMESPACE = "uifw-frontstageSettings"
 public;FrontstageActivatedEvent 
 deprecated;FrontstageActivatedEvent 
 public;FrontstageActivatedEventArgs
 deprecated;FrontstageActivatedEventArgs
 public;FrontstageConfig 
+deprecated;FrontstageConfig 
 public;FrontstageDeactivatedEvent 
 deprecated;FrontstageDeactivatedEvent 
 public;FrontstageDeactivatedEventArgs
@@ -287,6 +290,7 @@ public;FrontstageDef
 internal;FrontstageEventArgs
 internal;FrontstageNineZoneStateChangedEventArgs 
 public;class FrontstageProvider
+deprecated;class FrontstageProvider
 public;FrontstageReadyEvent 
 deprecated;FrontstageReadyEvent 
 public;FrontstageReadyEventArgs
@@ -574,6 +578,7 @@ public;StandardContentToolsProvider
 beta;StandardContentToolsUiItemsProvider 
 public;StandardFrontstageProps
 public;StandardFrontstageProvider 
+deprecated;StandardFrontstageProvider 
 public;StandardLayoutToolbarItem
 public;StandardLayoutWidget
 public;StandardMessageBoxProps 

--- a/common/changes/@itwin/appui-react/frontstage-provider_2024-06-14-11-43.json
+++ b/common/changes/@itwin/appui-react/frontstage-provider_2024-06-14-11-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Deprecate APIs related to `FrontstageProvider` class.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -41,7 +41,7 @@ Table of contents:
 - Deprecated `NestedFrontstage` class. Use `NestedFrontstageAppButton` component instead. [#875](https://github.com/iTwin/appui/pull/875)
 - Deprecated `ToolbarHelper` class. Use functions from `ToolbarItemUtilities` namespace instead. [#875](https://github.com/iTwin/appui/pull/875)
 - Deprecated `KeyboardShortcutProps.item`, `CursorMenuItemProps.item` properties. Use properties of the object instead. [#875](https://github.com/iTwin/appui/pull/875)
-- Deprecated all APIs associated to `FrontstageProvider` class which added unnecessary bloat and layer of complication as it would always map to a single frontstage and forced API consumers to use inheritance. [#878](https://github.com/iTwin/appui/pull/878)
+- Deprecated all APIs associated with `FrontstageProvider` class which added unnecessary bloat and layer of complication as it would always map to a single frontstage and forced API consumers to use inheritance. [#878](https://github.com/iTwin/appui/pull/878)
   - `addFrontstageProvider()` property of `FrameworkFrontstages` interface. Use `FrameworkFrontstages.addFrontstage()` instead.
   - `frontstageProvider` getter of `FrontstageDef` class. Use `FrontstageDef.id` to look up a frontstage.
   - `FrontstageProvider` class. Use `Frontstage` interface instead.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -41,6 +41,12 @@ Table of contents:
 - Deprecated `NestedFrontstage` class. Use `NestedFrontstageAppButton` component instead. [#875](https://github.com/iTwin/appui/pull/875)
 - Deprecated `ToolbarHelper` class. Use functions from `ToolbarItemUtilities` namespace instead. [#875](https://github.com/iTwin/appui/pull/875)
 - Deprecated `KeyboardShortcutProps.item`, `CursorMenuItemProps.item` properties. Use properties of the object instead. [#875](https://github.com/iTwin/appui/pull/875)
+- Deprecated all APIs associated to `FrontstageProvider` class which added unnecessary bloat and layer of complication as it would always map to a single frontstage and forced API consumers to use inheritance. [#878](https://github.com/iTwin/appui/pull/878)
+  - `addFrontstageProvider()` property of `FrameworkFrontstages` interface. Use `FrameworkFrontstages.addFrontstage()` instead.
+  - `frontstageProvider` getter of `FrontstageDef` class. Use `FrontstageDef.id` to look up a frontstage.
+  - `FrontstageProvider` class. Use `Frontstage` interface instead.
+  - `StandardFrontstageProvider` class. Use `FrontstageUtilities.createStandardFrontstage()` function instead.
+  - `FrontstageConfig` interface. Use `Frontstage` type instead.
 
 ### Additions
 
@@ -55,6 +61,11 @@ Table of contents:
 - Added `ToolbarItems` namespace with functions to create commonly used toolbar items. [#875](https://github.com/iTwin/appui/pull/875)
 - Added `ToolbarItemUtilities.createForTool()` function to create a toolbar item for a specified tool type.[#875](https://github.com/iTwin/appui/pull/875)
 - Added `KeyboardShortcutProps.execute()`, `CursorMenuItemProps.execute()` properties to replace execute action of deprecated `item` properties. [#875](https://github.com/iTwin/appui/pull/875)
+- Added additional APIs to support `FrontstageProvider` deprecation. [#878](https://github.com/iTwin/appui/pull/878)
+  - Added `FrontstageUtilities` namespace to provide utilities for creating frontstages.
+  - `addFrontstage()` property to `FrameworkFrontstages` interface.
+  - `Frontstage` alias type to rename existing `FrontstageConfig`.
+  - Expanded a union type of a static `FrontstageDef.create()` method to allow `Frontstage` type together with `FrontstageProvider`.
 
 ### Changes
 

--- a/docs/storybook/src/Utils.tsx
+++ b/docs/storybook/src/Utils.tsx
@@ -4,34 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import {
-  FrontstageConfig,
+  Frontstage,
   StagePanelLocation,
   StagePanelSection,
   StageUsage,
   StandardFrontstageProps,
-  StandardFrontstageProvider,
   Widget,
+  createStandardFrontstage,
 } from "@itwin/appui-react";
 import { createContentControl } from "./createContentControl";
 
-export function createFrontstageProvider(
+export function createFrontstage(
   overrides?: Partial<StandardFrontstageProps> & {
     content?: React.ReactNode;
-    contentManipulation?: FrontstageConfig["contentManipulation"];
+    contentManipulation?: Frontstage["contentManipulation"];
   }
-) {
-  return new (class extends StandardFrontstageProvider {
-    public override frontstageConfig(): FrontstageConfig {
-      const config = super.frontstageConfig();
-
-      const contentManipulation =
-        overrides?.contentManipulation ?? config.contentManipulation;
-      return {
-        ...config,
-        contentManipulation,
-      };
-    }
-  })({
+): Frontstage {
+  const config = createStandardFrontstage({
     id: "main-frontstage",
     usage: StageUsage.Private,
     version: Math.random(),
@@ -63,6 +52,13 @@ export function createFrontstageProvider(
     hideNavigationAid: true,
     ...overrides,
   });
+
+  const contentManipulation =
+    overrides?.contentManipulation ?? config.contentManipulation;
+  return {
+    ...config,
+    contentManipulation,
+  };
 }
 
 export function removeProperty() {

--- a/docs/storybook/src/Utils.tsx
+++ b/docs/storybook/src/Utils.tsx
@@ -5,12 +5,12 @@
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import {
   Frontstage,
+  FrontstageUtilities,
   StagePanelLocation,
   StagePanelSection,
   StageUsage,
   StandardFrontstageProps,
   Widget,
-  createStandardFrontstage,
 } from "@itwin/appui-react";
 import { createContentControl } from "./createContentControl";
 
@@ -20,7 +20,7 @@ export function createFrontstage(
     contentManipulation?: Frontstage["contentManipulation"];
   }
 ): Frontstage {
-  const config = createStandardFrontstage({
+  const config = FrontstageUtilities.createStandardFrontstage({
     id: "main-frontstage",
     usage: StageUsage.Private,
     version: Math.random(),

--- a/docs/storybook/src/components/ViewSelector.stories.tsx
+++ b/docs/storybook/src/components/ViewSelector.stories.tsx
@@ -10,7 +10,7 @@ import {
   UiFramework,
 } from "@itwin/appui-react";
 import { AppUiStory, Page } from "../AppUiStory";
-import { createFrontstageProvider } from "../Utils";
+import { createFrontstage } from "../Utils";
 
 const StoryDecorator: Decorator = (Story) => {
   return (
@@ -20,8 +20,8 @@ const StoryDecorator: Decorator = (Story) => {
       onInitialize={async () => {
         UiFramework.visibility.autoHideUi = false;
       }}
-      frontstageProviders={[
-        createFrontstageProvider({
+      frontstages={[
+        createFrontstage({
           contentGroupProps: {
             id: "ViewportContentGroup",
             layout: StandardContentLayouts.singleView,

--- a/docs/storybook/src/frontstage/Frontstage.tsx
+++ b/docs/storybook/src/frontstage/Frontstage.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { StandardFrontstageProps } from "@itwin/appui-react";
 import { AppUiStory, AppUiStoryProps } from "../AppUiStory";
-import { createFrontstageProvider } from "../Utils";
+import { createFrontstage } from "../Utils";
 
 type FrontstageStoryProps = Pick<AppUiStoryProps, "itemProviders"> &
   Pick<StandardFrontstageProps, "hideStatusBar" | "hideToolSettings"> & {
@@ -13,16 +13,12 @@ type FrontstageStoryProps = Pick<AppUiStoryProps, "itemProviders"> &
 
 /** [FrontstageProvider](https://www.itwinjs.org/reference/appui-react/frontstage/frontstageprovider/) can be used to configure a frontstage. */
 export function FrontstageStory(props: FrontstageStoryProps) {
-  const frontstageProvider = createFrontstageProvider({
+  const frontstage = createFrontstage({
     ...props.frontstage,
     hideStatusBar: props.hideStatusBar,
     hideToolSettings: props.hideToolSettings,
   });
   return (
-    <AppUiStory
-      layout="fullscreen"
-      frontstageProviders={[frontstageProvider]}
-      {...props}
-    />
+    <AppUiStory layout="fullscreen" frontstages={[frontstage]} {...props} />
   );
 }

--- a/docs/storybook/src/frontstage/Nested.tsx
+++ b/docs/storybook/src/frontstage/Nested.tsx
@@ -12,14 +12,14 @@ import {
 } from "@itwin/appui-react";
 import { SvgPlaceholder } from "@itwin/itwinui-icons-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider } from "../Utils";
+import { createFrontstage } from "../Utils";
 
 type FrontstageStoryProps = {
   frontstage?: Partial<StandardFrontstageProps>;
 };
 
 function createNestedFrontstage() {
-  return createFrontstageProvider({
+  return createFrontstage({
     id: createNestedFrontstage.id,
     content: (
       <h1
@@ -36,7 +36,6 @@ function createNestedFrontstage() {
     cornerButton: <NestedFrontstageAppButton />,
   });
 }
-
 createNestedFrontstage.id = "nested-frontstage";
 
 /** [openNestedFrontstage](https://www.itwinjs.org/reference/appui-react/frontstage/frameworkfrontstages/#opennestedfrontstage) can be used to open a nested frontstage. */
@@ -44,10 +43,7 @@ export function NestedFrontstageStory(props: FrontstageStoryProps) {
   return (
     <AppUiStory
       layout="fullscreen"
-      frontstageProviders={() => [
-        createFrontstageProvider(),
-        createNestedFrontstage(),
-      ]}
+      frontstages={() => [createFrontstage(), createNestedFrontstage()]}
       itemProviders={[
         {
           id: "toolbar",

--- a/docs/storybook/src/frontstage/SplitViewport.stories.tsx
+++ b/docs/storybook/src/frontstage/SplitViewport.stories.tsx
@@ -26,7 +26,7 @@ import {
 } from "@itwin/itwinui-icons-react";
 import { AppUiDecorator } from "../Decorators";
 import { Page } from "../AppUiStory";
-import { createFrontstageProvider, removeProperty } from "../Utils";
+import { createFrontstage, removeProperty } from "../Utils";
 import { SplitViewportStory } from "./SplitViewport";
 
 const meta = {
@@ -41,7 +41,7 @@ const meta = {
     layout: "fullscreen",
   },
   argTypes: {
-    frontstageProviders: removeProperty(),
+    frontstages: removeProperty(),
     itemProviders: removeProperty(),
   },
 } satisfies Meta<typeof SplitViewportStory>;
@@ -76,8 +76,8 @@ UiFramework.content.onActiveContentChangedEvent.addListener(() => {
 
 export const Default: Story = {
   args: {
-    frontstageProviders: [
-      createFrontstageProvider({
+    frontstages: [
+      createFrontstage({
         contentGroupProps: {
           id: "split-vertical-group",
           layout: StandardContentLayouts.twoVerticalSplit,

--- a/docs/storybook/src/frontstage/SplitViewport.tsx
+++ b/docs/storybook/src/frontstage/SplitViewport.tsx
@@ -6,7 +6,7 @@ import { AppUiStory, AppUiStoryProps } from "../AppUiStory";
 
 /** This story shows two separate views. Depending on which view is active, the tools in the toolbars will change*/
 export function SplitViewportStory(
-  props: Pick<AppUiStoryProps, "frontstageProviders" | "itemProviders">
+  props: Pick<AppUiStoryProps, "frontstages" | "itemProviders">
 ) {
   return <AppUiStory layout="fullscreen" {...props} />;
 }

--- a/docs/storybook/src/frontstage/ToolSettings.stories.tsx
+++ b/docs/storybook/src/frontstage/ToolSettings.stories.tsx
@@ -8,7 +8,7 @@ import { IModelViewportControl, UiFramework } from "@itwin/appui-react";
 import { IModelApp } from "@itwin/core-frontend";
 import { AppUiDecorator } from "../Decorators";
 import { Page } from "../AppUiStory";
-import { createFrontstageProvider, removeProperty } from "../Utils";
+import { createFrontstage, removeProperty } from "../Utils";
 import { ToolSettingsStory } from "./ToolSettings";
 import { CustomTool } from "../tools/ToolSettingsProperties";
 
@@ -24,7 +24,7 @@ const meta = {
     layout: "fullscreen",
   },
   argTypes: {
-    frontstageProviders: removeProperty(),
+    frontstages: removeProperty(),
     onFrontstageActivated: removeProperty(),
   },
 } satisfies Meta<typeof ToolSettingsStory>;
@@ -34,8 +34,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    frontstageProviders: [
-      createFrontstageProvider({
+    frontstages: [
+      createFrontstage({
         contentGroupProps: {
           id: "ViewportContentGroup",
           layout: StandardContentLayouts.singleView,

--- a/docs/storybook/src/frontstage/ToolSettings.tsx
+++ b/docs/storybook/src/frontstage/ToolSettings.tsx
@@ -6,7 +6,7 @@ import { AppUiStory, AppUiStoryProps } from "../AppUiStory";
 
 /** [FrontstageProvider](https://www.itwinjs.org/reference/appui-react/frontstage/frontstageprovider/) can be used to configure a frontstage. */
 export function ToolSettingsStory(
-  props: Pick<AppUiStoryProps, "frontstageProviders" | "onFrontstageActivated">
+  props: Pick<AppUiStoryProps, "frontstages" | "onFrontstageActivated">
 ) {
   return (
     <AppUiStory

--- a/docs/storybook/src/frontstage/notifications/OutputPrompt.tsx
+++ b/docs/storybook/src/frontstage/notifications/OutputPrompt.tsx
@@ -9,7 +9,7 @@ import {
   ToolAssistanceField,
 } from "@itwin/appui-react";
 import { AppUiStory } from "../../AppUiStory";
-import { createFrontstageProvider } from "../../Utils";
+import { createFrontstage } from "../../Utils";
 import { IModelApp } from "@itwin/core-frontend";
 
 /** [outputPrompt](https://www.itwinjs.org/reference/appui-react/notification/appnotificationmanager/outputprompt/) displays a prompt message in the status bar. */
@@ -17,8 +17,8 @@ export function NotificationsStory() {
   return (
     <AppUiStory
       layout="fullscreen"
-      frontstageProviders={[
-        createFrontstageProvider({
+      frontstages={[
+        createFrontstage({
           hideStatusBar: false,
         }),
       ]}

--- a/docs/storybook/src/hooks/useIsBackstageOpen.stories.tsx
+++ b/docs/storybook/src/hooks/useIsBackstageOpen.stories.tsx
@@ -13,14 +13,14 @@ import {
   useIsBackstageOpen,
 } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider } from "../Utils";
+import { createFrontstage } from "../Utils";
 
 function HookStory() {
   return (
     <AppUiStory
       appBackstage={<BackstageComposer />}
-      frontstageProviders={() => [
-        createFrontstageProvider({
+      frontstages={() => [
+        createFrontstage({
           contentGroupProps: {
             id: "ViewportContentGroup",
             layout: StandardContentLayouts.singleView,

--- a/docs/storybook/src/keyboard/KeyboardShortcuts.tsx
+++ b/docs/storybook/src/keyboard/KeyboardShortcuts.tsx
@@ -11,7 +11,7 @@ import {
 } from "@itwin/appui-react";
 import { Input } from "@itwin/itwinui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider, createWidget } from "../Utils";
+import { createFrontstage, createWidget } from "../Utils";
 
 function createProvider(): UiItemsProvider {
   return {
@@ -52,8 +52,8 @@ export function KeyboardShortcutsStory({
       {processKeys && <KeyboardShortcutHandler />}
       <AppUiStory
         itemProviders={[provider]}
-        frontstageProviders={[
-          createFrontstageProvider({
+        frontstages={[
+          createFrontstage({
             leftPanelProps: {
               defaultState: StagePanelState.Open,
               pinned: true,

--- a/docs/storybook/src/preview/ControlWidgetVisibility.tsx
+++ b/docs/storybook/src/preview/ControlWidgetVisibility.tsx
@@ -10,7 +10,7 @@ import {
   WidgetState,
 } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider, createWidget } from "../Utils";
+import { createFrontstage, createWidget } from "../Utils";
 
 function createProvider(visibleWidgets: number): UiItemsProvider {
   return {
@@ -51,8 +51,8 @@ export function PreviewStory({
     >
       <AppUiStory
         itemProviders={[provider]}
-        frontstageProviders={[
-          createFrontstageProvider({
+        frontstages={[
+          createFrontstage({
             leftPanelProps: {
               defaultState: StagePanelState.Open,
               pinned: true,

--- a/docs/storybook/src/preview/EnableMaximizedWidget.tsx
+++ b/docs/storybook/src/preview/EnableMaximizedWidget.tsx
@@ -12,7 +12,7 @@ import {
   WidgetState,
 } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider, createWidget } from "../Utils";
+import { createFrontstage, createWidget } from "../Utils";
 
 function createProvider(): UiItemsProvider {
   return {
@@ -48,8 +48,8 @@ export function PreviewStory(props: PreviewStoryProps) {
     <PreviewFeaturesProvider features={props}>
       <AppUiStory
         itemProviders={[provider]}
-        frontstageProviders={[
-          createFrontstageProvider({
+        frontstages={[
+          createFrontstage({
             leftPanelProps: {
               defaultState: StagePanelState.Open,
               pinned: true,

--- a/docs/storybook/src/preview/ReparentPopoutWidgets.tsx
+++ b/docs/storybook/src/preview/ReparentPopoutWidgets.tsx
@@ -20,7 +20,7 @@ import {
   MenuItem,
 } from "@itwin/itwinui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider, createWidget } from "../Utils";
+import { createFrontstage, createWidget } from "../Utils";
 
 function Content({ id }: { id: string }) {
   const [count, setCount] = React.useState(0);
@@ -81,8 +81,8 @@ export function PreviewStory(props: PreviewStoryProps) {
     <PreviewFeaturesProvider features={props}>
       <AppUiStory
         itemProviders={[provider]}
-        frontstageProviders={[
-          createFrontstageProvider({
+        frontstages={[
+          createFrontstage({
             leftPanelProps: {
               defaultState: StagePanelState.Open,
               pinned: true,

--- a/docs/storybook/src/preview/WidgetActionDropdown.tsx
+++ b/docs/storybook/src/preview/WidgetActionDropdown.tsx
@@ -12,7 +12,7 @@ import {
   WidgetState,
 } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider, createWidget } from "../Utils";
+import { createFrontstage, createWidget } from "../Utils";
 
 function createProvider(): UiItemsProvider {
   return {
@@ -51,8 +51,8 @@ export function PreviewStory(props: PreviewStoryProps) {
     >
       <AppUiStory
         itemProviders={[provider]}
-        frontstageProviders={[
-          createFrontstageProvider({
+        frontstages={[
+          createFrontstage({
             leftPanelProps: {
               defaultState: StagePanelState.Open,
               pinned: true,

--- a/docs/storybook/src/widget/EmptyState.tsx
+++ b/docs/storybook/src/widget/EmptyState.tsx
@@ -11,7 +11,7 @@ import {
 } from "@itwin/appui-react";
 import { Button } from "@itwin/itwinui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider } from "../Utils";
+import { createFrontstage } from "../Utils";
 
 interface EmptyStateStoryProps {
   /** Toggle this on to hide the widget when there is no data to display. */
@@ -34,15 +34,16 @@ export function EmptyStateStory(props: EmptyStateStoryProps) {
       },
     ],
   } satisfies UiItemsProvider;
-  const frontstageProvider = createFrontstageProvider({
-    leftPanelProps: {
-      defaultState: StagePanelState.Open,
-    },
-  });
   return (
     <AppUiStory
       itemProviders={[provider]}
-      frontstageProviders={[frontstageProvider]}
+      frontstages={[
+        createFrontstage({
+          leftPanelProps: {
+            defaultState: StagePanelState.Open,
+          },
+        }),
+      ]}
     />
   );
 }

--- a/docs/storybook/src/widget/Widget.tsx
+++ b/docs/storybook/src/widget/Widget.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { action } from "@storybook/addon-actions";
 import { StagePanelState, UiItemsProvider, Widget } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstageProvider } from "../Utils";
+import { createFrontstage } from "../Utils";
 
 export function StoryWidget({ id }: { id: string }) {
   React.useEffect(() => {
@@ -37,8 +37,8 @@ export function WidgetStory(props: Widget) {
   const provider = createProvider(props);
   return (
     <AppUiStory
-      frontstageProviders={[
-        createFrontstageProvider({
+      frontstages={[
+        createFrontstage({
           leftPanelProps: {
             defaultState: StagePanelState.Open,
             pinned: true,

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/ContentLayout.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/ContentLayout.tsx
@@ -9,11 +9,11 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  FrontstageConfig,
+  createStandardFrontstage,
+  Frontstage,
   IModelViewportControl,
   StageUsage,
   StandardContentToolsUiItemsProvider,
-  StandardFrontstageProvider,
   StandardNavigationToolsUiItemsProvider,
   StandardStatusbarUiItemsProvider,
   UiFramework,
@@ -70,7 +70,7 @@ export class ContentLayoutStageContentGroupProvider extends ContentGroupProvider
   }
 
   public override async contentGroup(
-    config: FrontstageConfig
+    config: Frontstage
   ): Promise<ContentGroup> {
     const savedViewLayoutProps = await getSavedViewLayoutProps(
       config.id,
@@ -136,8 +136,8 @@ export class ContentLayoutStage {
   }
 
   public static register(localizationNamespace: string) {
-    UiFramework.frontstages.addFrontstageProvider(
-      new StandardFrontstageProvider({
+    UiFramework.frontstages.addFrontstage(
+      createStandardFrontstage({
         id: ContentLayoutStage.stageId,
         version: 1.1,
         contentGroupProps: ContentLayoutStage._contentGroupProvider,

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/ContentLayout.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/ContentLayout.tsx
@@ -9,8 +9,8 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  createStandardFrontstage,
   Frontstage,
+  FrontstageUtilities,
   IModelViewportControl,
   StageUsage,
   StandardContentToolsUiItemsProvider,
@@ -137,7 +137,7 @@ export class ContentLayoutStage {
 
   public static register(localizationNamespace: string) {
     UiFramework.frontstages.addFrontstage(
-      createStandardFrontstage({
+      FrontstageUtilities.createStandardFrontstage({
         id: ContentLayoutStage.stageId,
         version: 1.1,
         contentGroupProps: ContentLayoutStage._contentGroupProvider,

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomContent.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomContent.tsx
@@ -7,11 +7,10 @@ import {
   BackstageAppButton,
   ContentGroup,
   ContentGroupProvider,
+  createStandardFrontstage,
   IModelViewportControl,
   StageUsage,
   StandardContentToolsUiItemsProvider,
-  StandardFrontstageProps,
-  StandardFrontstageProvider,
   StandardNavigationToolsUiItemsProvider,
   StandardStatusbarUiItemsProvider,
   UiFramework,
@@ -81,19 +80,16 @@ export class CustomContentFrontstage {
   private static _contentGroupProvider = new CustomContentGroupProvider();
 
   public static register(localizationNamespace: string) {
-    const cornerButton = <BackstageAppButton />;
-    const customStageProps: StandardFrontstageProps = {
-      id: CustomContentFrontstage.stageId,
-      version: 1.1,
-      contentGroupProps: CustomContentFrontstage._contentGroupProvider,
-      hideNavigationAid: false,
-      cornerButton,
-      usage: StageUsage.General,
-    };
-
     CustomContentFrontstage.registerToolProviders(localizationNamespace);
-    UiFramework.frontstages.addFrontstageProvider(
-      new StandardFrontstageProvider(customStageProps)
+    UiFramework.frontstages.addFrontstage(
+      createStandardFrontstage({
+        id: CustomContentFrontstage.stageId,
+        version: 1.1,
+        contentGroupProps: CustomContentFrontstage._contentGroupProvider,
+        hideNavigationAid: false,
+        cornerButton: <BackstageAppButton />,
+        usage: StageUsage.General,
+      })
     );
   }
 

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomContent.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomContent.tsx
@@ -7,7 +7,7 @@ import {
   BackstageAppButton,
   ContentGroup,
   ContentGroupProvider,
-  createStandardFrontstage,
+  FrontstageUtilities,
   IModelViewportControl,
   StageUsage,
   StandardContentToolsUiItemsProvider,
@@ -82,7 +82,7 @@ export class CustomContentFrontstage {
   public static register(localizationNamespace: string) {
     CustomContentFrontstage.registerToolProviders(localizationNamespace);
     UiFramework.frontstages.addFrontstage(
-      createStandardFrontstage({
+      FrontstageUtilities.createStandardFrontstage({
         id: CustomContentFrontstage.stageId,
         version: 1.1,
         contentGroupProps: CustomContentFrontstage._contentGroupProvider,

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomFrontstageProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/CustomFrontstageProvider.tsx
@@ -5,11 +5,7 @@
 import * as React from "react";
 // __PUBLISH_EXTRACT_START__ AppUI.FrontstageProvider.Imports
 import { StandardContentLayouts } from "@itwin/appui-abstract";
-import {
-  ContentGroup,
-  FrontstageConfig,
-  FrontstageProvider,
-} from "@itwin/appui-react";
+import { ContentGroup } from "@itwin/appui-react";
 // __PUBLISH_EXTRACT_END__
 import {
   ReactContentControl,
@@ -17,32 +13,23 @@ import {
 } from "../content/ReactContentControl";
 
 // __PUBLISH_EXTRACT_START__ AppUI.FrontstageProvider
-class CustomFrontstageProvider extends FrontstageProvider {
-  public override get id(): string {
-    return "example:CustomFrontstage";
-  }
-
-  public override frontstageConfig(): FrontstageConfig {
-    const contentGroup = new ContentGroup({
-      id: `${this.id}:content-group`,
-      layout: StandardContentLayouts.singleView,
-      contents: [
-        {
-          id: `${this.id}:content`,
-          classId: ReactContentControl,
-          applicationData: {
-            node: <h1>Custom Content</h1>,
-          } satisfies ReactContentControlOptions,
-        },
-      ],
-    });
-    return {
-      id: this.id,
-      version: 1,
-      contentGroup,
-    };
-  }
-}
+const customFrontstageProvider = {
+  id: "example:CustomFrontstage",
+  version: 1,
+  contentGroup: new ContentGroup({
+    id: "content-group",
+    layout: StandardContentLayouts.singleView,
+    contents: [
+      {
+        id: "content",
+        classId: ReactContentControl,
+        applicationData: {
+          node: <h1>Custom Content</h1>,
+        } satisfies ReactContentControlOptions,
+      },
+    ],
+  }),
+};
 // __PUBLISH_EXTRACT_END__
 
-export { CustomFrontstageProvider };
+export { customFrontstageProvider };

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/PopoutWindowsFrontstage.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/PopoutWindowsFrontstage.tsx
@@ -9,11 +9,11 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  FrontstageConfig,
+  createStandardFrontstage,
+  Frontstage,
   IModelViewportControl,
   StageUsage,
   StandardContentToolsUiItemsProvider,
-  StandardFrontstageProvider,
   StandardNavigationToolsUiItemsProvider,
   StandardStatusbarUiItemsProvider,
   UiFramework,
@@ -66,7 +66,7 @@ export class PopoutWindowsFrontstageGroupProvider extends ContentGroupProvider {
   }
 
   public override async contentGroup(
-    config: FrontstageConfig
+    config: Frontstage
   ): Promise<ContentGroup> {
     const savedViewLayoutProps = await getSavedViewLayoutProps(
       config.id,
@@ -132,8 +132,8 @@ export class PopoutWindowsFrontstage {
   }
 
   public static register(localizationNamespace: string) {
-    UiFramework.frontstages.addFrontstageProvider(
-      new StandardFrontstageProvider({
+    UiFramework.frontstages.addFrontstage(
+      createStandardFrontstage({
         id: PopoutWindowsFrontstage.stageId,
         version: 1.1,
         contentGroupProps: PopoutWindowsFrontstage._contentGroupProvider,

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/PopoutWindowsFrontstage.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/PopoutWindowsFrontstage.tsx
@@ -9,8 +9,8 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  createStandardFrontstage,
   Frontstage,
+  FrontstageUtilities,
   IModelViewportControl,
   StageUsage,
   StandardContentToolsUiItemsProvider,
@@ -133,7 +133,7 @@ export class PopoutWindowsFrontstage {
 
   public static register(localizationNamespace: string) {
     UiFramework.frontstages.addFrontstage(
-      createStandardFrontstage({
+      FrontstageUtilities.createStandardFrontstage({
         id: PopoutWindowsFrontstage.stageId,
         version: 1.1,
         contentGroupProps: PopoutWindowsFrontstage._contentGroupProvider,

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/SynchronizedFloatingViewport.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/SynchronizedFloatingViewport.tsx
@@ -9,8 +9,8 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  createStandardFrontstage,
   Frontstage,
+  FrontstageUtilities,
   IModelViewportControl,
   StageUsage,
   StandardContentToolsUiItemsProvider,
@@ -146,7 +146,7 @@ export class SynchronizedFloatingViewportStage {
     );
 
     UiFramework.frontstages.addFrontstage(
-      createStandardFrontstage({
+      FrontstageUtilities.createStandardFrontstage({
         id: SynchronizedFloatingViewportStage.stageId,
         version: 1.1,
         contentGroupProps:

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/SynchronizedFloatingViewport.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/SynchronizedFloatingViewport.tsx
@@ -9,12 +9,11 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  FrontstageConfig,
+  createStandardFrontstage,
+  Frontstage,
   IModelViewportControl,
   StageUsage,
   StandardContentToolsUiItemsProvider,
-  StandardFrontstageProps,
-  StandardFrontstageProvider,
   StandardNavigationToolsUiItemsProvider,
   StandardStatusbarUiItemsProvider,
   UiFramework,
@@ -71,7 +70,7 @@ export class SynchronizedFloatingViewportContentGroupProvider extends ContentGro
   }
 
   public override async contentGroup(
-    config: FrontstageConfig
+    config: Frontstage
   ): Promise<ContentGroup> {
     const savedViewLayoutProps = await getSavedViewLayoutProps(
       config.id,
@@ -146,17 +145,15 @@ export class SynchronizedFloatingViewportStage {
       />
     );
 
-    const synchronizedFloatingViewportStageProps: StandardFrontstageProps = {
-      id: SynchronizedFloatingViewportStage.stageId,
-      version: 1.1,
-      contentGroupProps:
-        SynchronizedFloatingViewportStage._contentGroupProvider,
-      cornerButton,
-      usage: StageUsage.General,
-    };
-
-    UiFramework.frontstages.addFrontstageProvider(
-      new StandardFrontstageProvider(synchronizedFloatingViewportStageProps)
+    UiFramework.frontstages.addFrontstage(
+      createStandardFrontstage({
+        id: SynchronizedFloatingViewportStage.stageId,
+        version: 1.1,
+        contentGroupProps:
+          SynchronizedFloatingViewportStage._contentGroupProvider,
+        cornerButton,
+        usage: StageUsage.General,
+      })
     );
     this.registerToolProviders(localizationNamespace);
   }

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/TestFrontstageProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/TestFrontstageProvider.tsx
@@ -7,8 +7,6 @@ import {
   ConfigurableCreateInfo,
   ContentControl,
   ContentGroup,
-  FrontstageConfig,
-  FrontstageProvider,
 } from "@itwin/appui-react";
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 
@@ -32,15 +30,9 @@ class CustomContentControl extends ContentControl {
 }
 
 /** Used in e2e tests to test different configurations. */
-export class TestFrontstageProvider extends FrontstageProvider {
-  public static readonly stageId = "appui-test-providers:TestFrontstage";
-
-  public get id(): string {
-    return TestFrontstageProvider.stageId;
-  }
-
-  public override frontstageConfig(): FrontstageConfig {
-    const id = this.id;
+export const testFrontstageProvider = (() => {
+  {
+    const id = "appui-test-providers:TestFrontstage";
     const contentGroup = new ContentGroup({
       id: "test-group",
       layout: StandardContentLayouts.singleView,
@@ -75,4 +67,4 @@ export class TestFrontstageProvider extends FrontstageProvider {
       },
     };
   }
-}
+})();

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/WidgetApiStage.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/WidgetApiStage.tsx
@@ -11,13 +11,13 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  FrontstageConfig,
+  createStandardFrontstage,
+  Frontstage,
   IModelViewportControl,
   StagePanelState,
   StageUsage,
   StandardContentToolsUiItemsProvider,
   StandardFrontstageProps,
-  StandardFrontstageProvider,
   StandardNavigationToolsUiItemsProvider,
   StandardStatusbarUiItemsProvider,
   StateManager,
@@ -100,7 +100,7 @@ export class WidgetApiStageContentGroupProvider extends ContentGroupProvider {
   }
 
   public override async contentGroup(
-    config: FrontstageConfig
+    config: Frontstage
   ): Promise<ContentGroup> {
     const savedViewLayoutProps = await getSavedViewLayoutProps(
       config.id,
@@ -147,25 +147,22 @@ export class WidgetApiStageContentGroupProvider extends ContentGroupProvider {
 }
 
 /** Tool settings widget can be configured by providing an URL param `toolSettings` with values `off` or `hidden`. */
-class WidgetApiFrontstage extends StandardFrontstageProvider {
-  public override frontstageConfig() {
-    const config = super.frontstageConfig();
-    const urlParams = new URLSearchParams(window.location.search);
-    const noToolSettings = urlParams.get("toolSettings") === "off";
-    const hiddenToolSettings = urlParams.get("toolSettings") === "hidden";
-    const toolSettings = noToolSettings
-      ? undefined
-      : {
-          id: "WidgetApi:ToolSettings",
-          defaultState: hiddenToolSettings ? WidgetState.Hidden : undefined,
-        };
+function createWidgetApiFrontstage(props: StandardFrontstageProps): Frontstage {
+  const config = createStandardFrontstage(props);
+  const urlParams = new URLSearchParams(window.location.search);
+  const noToolSettings = urlParams.get("toolSettings") === "off";
+  const hiddenToolSettings = urlParams.get("toolSettings") === "hidden";
+  const toolSettings = noToolSettings
+    ? undefined
+    : {
+        id: "WidgetApi:ToolSettings",
+        defaultState: hiddenToolSettings ? WidgetState.Hidden : undefined,
+      };
 
-    const updatedConfig: FrontstageConfig = {
-      ...config,
-      toolSettings,
-    };
-    return updatedConfig;
-  }
+  return {
+    ...config,
+    toolSettings,
+  };
 }
 
 export class WidgetApiStage {
@@ -210,8 +207,8 @@ export class WidgetApiStage {
       },
     };
 
-    UiFramework.frontstages.addFrontstageProvider(
-      new WidgetApiFrontstage(widgetApiStageProps)
+    UiFramework.frontstages.addFrontstage(
+      createWidgetApiFrontstage(widgetApiStageProps)
     );
     this.registerToolProviders(localizationNamespace);
   }

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/WidgetApiStage.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/WidgetApiStage.tsx
@@ -11,8 +11,8 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  createStandardFrontstage,
   Frontstage,
+  FrontstageUtilities,
   IModelViewportControl,
   StagePanelState,
   StageUsage,
@@ -148,7 +148,7 @@ export class WidgetApiStageContentGroupProvider extends ContentGroupProvider {
 
 /** Tool settings widget can be configured by providing an URL param `toolSettings` with values `off` or `hidden`. */
 function createWidgetApiFrontstage(props: StandardFrontstageProps): Frontstage {
-  const config = createStandardFrontstage(props);
+  const config = FrontstageUtilities.createStandardFrontstage(props);
   const urlParams = new URLSearchParams(window.location.search);
   const noToolSettings = urlParams.get("toolSettings") === "off";
   const hiddenToolSettings = urlParams.get("toolSettings") === "hidden";

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/registerCustomFrontstage.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/registerCustomFrontstage.tsx
@@ -5,10 +5,10 @@
 // __PUBLISH_EXTRACT_START__ AppUI.Frontstage.Register.Imports
 import { UiFramework } from "@itwin/appui-react";
 // __PUBLISH_EXTRACT_END__
-import { CustomFrontstageProvider } from "./CustomFrontstageProvider";
+import { customFrontstageProvider } from "./CustomFrontstageProvider";
 
 export function registerCustomFrontstage() {
   // __PUBLISH_EXTRACT_START__ AppUI.Frontstage.Register
-  UiFramework.frontstages.addFrontstageProvider(new CustomFrontstageProvider());
+  UiFramework.frontstages.addFrontstage(customFrontstageProvider);
   // __PUBLISH_EXTRACT_END__
 }

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/registerStandardFrontstage.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/registerStandardFrontstage.tsx
@@ -6,8 +6,8 @@ import * as React from "react";
 // __PUBLISH_EXTRACT_START__ AppUI.StandardFrontstageProvider.Imports
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import {
+  createStandardFrontstage,
   StageUsage,
-  StandardFrontstageProvider,
   UiFramework,
 } from "@itwin/appui-react";
 // __PUBLISH_EXTRACT_END__
@@ -19,8 +19,8 @@ import {
 export async function registerStandardFrontstage() {
   // __PUBLISH_EXTRACT_START__ AppUI.StandardFrontstageProvider
   const id = "example:StandardFrontstage";
-  UiFramework.frontstages.addFrontstageProvider(
-    new StandardFrontstageProvider({
+  UiFramework.frontstages.addFrontstage(
+    createStandardFrontstage({
       id,
       usage: StageUsage.General,
       contentGroupProps: {

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/registerStandardFrontstage.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/registerStandardFrontstage.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 // __PUBLISH_EXTRACT_START__ AppUI.StandardFrontstageProvider.Imports
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import {
-  createStandardFrontstage,
+  FrontstageUtilities,
   StageUsage,
   UiFramework,
 } from "@itwin/appui-react";
@@ -20,7 +20,7 @@ export async function registerStandardFrontstage() {
   // __PUBLISH_EXTRACT_START__ AppUI.StandardFrontstageProvider
   const id = "example:StandardFrontstage";
   UiFramework.frontstages.addFrontstage(
-    createStandardFrontstage({
+    FrontstageUtilities.createStandardFrontstage({
       id,
       usage: StageUsage.General,
       contentGroupProps: {

--- a/test-apps/appui-test-app/connected/src/frontend/appui/AppUi.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/appui/AppUi.tsx
@@ -16,7 +16,7 @@ import {
   KeyboardShortcutUtilities,
   UiFramework,
 } from "@itwin/appui-react";
-import { SignInFrontstage } from "./frontstages/SignInFrontstage";
+import { signInFrontstage } from "./frontstages/SignInFrontstage";
 import { IModelOpenFrontstage } from "./frontstages/IModelOpenFrontstage";
 
 /** Example Ui Configuration for an iTwin.js App */
@@ -30,7 +30,7 @@ export class AppUi {
   /** Define Frontstages
    */
   private static defineFrontstages() {
-    UiFramework.frontstages.addFrontstageProvider(new SignInFrontstage());
+    UiFramework.frontstages.addFrontstage(signInFrontstage);
     IModelOpenFrontstage.register();
   }
 

--- a/test-apps/appui-test-app/connected/src/frontend/appui/frontstages/IModelOpenFrontstage.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/appui/frontstages/IModelOpenFrontstage.tsx
@@ -12,9 +12,9 @@ import {
   ConfigurableCreateInfo,
   ContentControl,
   ContentGroupProps,
+  FrontstageUtilities,
   StageUsage,
   StandardFrontstageProps,
-  StandardFrontstageProvider,
   UiFramework,
   UiItemsManager,
   UiItemsProvider,
@@ -81,8 +81,8 @@ export class IModelOpenFrontstage {
         hideStatusBar: true,
       };
 
-      UiFramework.frontstages.addFrontstageProvider(
-        new StandardFrontstageProvider(stageProps)
+      UiFramework.frontstages.addFrontstage(
+        FrontstageUtilities.createStandardFrontstage(stageProps)
       );
       UiItemsManager.register(new BackstageItemsProvider());
     }

--- a/test-apps/appui-test-app/connected/src/frontend/appui/frontstages/MainFrontstage.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/appui/frontstages/MainFrontstage.tsx
@@ -13,7 +13,8 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  FrontstageConfig,
+  Frontstage,
+  FrontstageUtilities,
   IModelViewportControl,
   SettingsModalFrontstage,
   StageContentLayout,
@@ -21,7 +22,6 @@ import {
   StageUsage,
   StandardContentToolsUiItemsProvider,
   StandardFrontstageProps,
-  StandardFrontstageProvider,
   StandardNavigationToolsUiItemsProvider,
   StandardStatusbarUiItemsProvider,
   UiFramework,
@@ -122,7 +122,7 @@ export class InitialIModelContentStageProvider extends ContentGroupProvider {
   }
 
   public override async contentGroup(
-    config: FrontstageConfig
+    config: Frontstage
   ): Promise<ContentGroup> {
     const viewIdsSelected = SampleAppIModelApp.getInitialViewIds();
     const iModelConnection = UiFramework.getIModelConnection();
@@ -242,8 +242,8 @@ export class MainFrontstage {
       usage: StageUsage.General,
     };
 
-    UiFramework.frontstages.addFrontstageProvider(
-      new StandardFrontstageProvider(stageProps)
+    UiFramework.frontstages.addFrontstage(
+      FrontstageUtilities.createStandardFrontstage(stageProps)
     );
     this.registerUiItemProviders();
   }

--- a/test-apps/appui-test-app/connected/src/frontend/appui/frontstages/SignInFrontstage.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/appui/frontstages/SignInFrontstage.tsx
@@ -9,8 +9,7 @@ import {
   ConfigurableCreateInfo,
   ContentControl,
   ContentGroup,
-  FrontstageConfig,
-  FrontstageProvider,
+  Frontstage,
   StageUsage,
 } from "@itwin/appui-react";
 import { IModelApp } from "@itwin/core-frontend";
@@ -53,29 +52,18 @@ class SignInControl extends ContentControl {
   };
 }
 
-export class SignInFrontstage extends FrontstageProvider {
-  public static stageId = "ui-test-app:SignIn";
-  public get id(): string {
-    return SignInFrontstage.stageId;
-  }
-
-  public override frontstageConfig(): FrontstageConfig {
-    const contentGroup = new ContentGroup({
-      id: "sign-in-stage",
-      layout: StandardContentLayouts.singleView,
-      contents: [
-        {
-          id: "sign-in",
-          classId: SignInControl,
-        },
-      ],
-    });
-
-    return {
-      id: this.id,
-      version: 1,
-      contentGroup,
-      usage: StageUsage.Private,
-    };
-  }
-}
+export const signInFrontstage: Frontstage = {
+  id: "ui-test-app:SignIn",
+  version: 1,
+  contentGroup: new ContentGroup({
+    id: "sign-in-stage",
+    layout: StandardContentLayouts.singleView,
+    contents: [
+      {
+        id: "sign-in",
+        classId: SignInControl,
+      },
+    ],
+  }),
+  usage: StageUsage.Private,
+};

--- a/test-apps/appui-test-app/connected/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/index.tsx
@@ -93,7 +93,7 @@ import { ExternalIModel } from "./appui/ExternalIModel";
 import { MainFrontstage } from "./appui/frontstages/MainFrontstage";
 import { AppSettingsTabsProvider } from "./appui/settingsproviders/AppSettingsTabsProvider";
 import { IModelOpenFrontstage } from "./appui/frontstages/IModelOpenFrontstage";
-import { SignInFrontstage } from "./appui/frontstages/SignInFrontstage";
+import { signInFrontstage } from "./appui/frontstages/SignInFrontstage";
 import {
   AbstractUiItemsProvider,
   AppPreviewFeatures,
@@ -547,7 +547,7 @@ export class SampleAppIModelApp {
   }
 
   public static async showSignInPage() {
-    await SampleAppIModelApp.showFrontstage(SignInFrontstage.stageId);
+    await SampleAppIModelApp.showFrontstage(signInFrontstage.id);
   }
 
   // called after the user has signed in (or access token is still valid)

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
@@ -7,7 +7,7 @@ import {
   AccuDrawWidget,
   BackstageAppButton,
   BackstageItemUtilities,
-  createStandardFrontstage,
+  FrontstageUtilities,
   StagePanelLocation,
   StagePanelSection,
   StageUsage,
@@ -46,9 +46,8 @@ export async function initializeEditor() {
   await EditTools.initialize();
 }
 
-const frontstageId = "standalone:editor-frontstage";
-export const editorFrontstage = createStandardFrontstage({
-  id: frontstageId,
+export const editorFrontstage = FrontstageUtilities.createStandardFrontstage({
+  id: "standalone:editor-frontstage",
   contentGroupProps: new InitialIModelContentStageProvider(),
   usage: StageUsage.General,
   cornerButton: <BackstageAppButton />,
@@ -62,7 +61,7 @@ function createUiItemsProvider(): UiItemsProvider {
     id,
     getBackstageItems: () => [
       BackstageItemUtilities.createStageLauncher(
-        frontstageId,
+        editorFrontstage.id,
         400,
         0,
         "Editor",

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/EditorFrontstageProvider.tsx
@@ -7,10 +7,10 @@ import {
   AccuDrawWidget,
   BackstageAppButton,
   BackstageItemUtilities,
+  createStandardFrontstage,
   StagePanelLocation,
   StagePanelSection,
   StageUsage,
-  StandardFrontstageProvider,
   ToolbarActionItem,
   ToolbarItemUtilities,
   ToolbarOrientation,
@@ -47,7 +47,7 @@ export async function initializeEditor() {
 }
 
 const frontstageId = "standalone:editor-frontstage";
-export const editorFrontstageProvider = new StandardFrontstageProvider({
+export const editorFrontstage = createStandardFrontstage({
   id: frontstageId,
   contentGroupProps: new InitialIModelContentStageProvider(),
   usage: StageUsage.General,

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
@@ -17,7 +17,7 @@ import {
   ConfigurableCreateInfo,
   ContentControl,
   ContentGroupProps,
-  createStandardFrontstage,
+  FrontstageUtilities,
   StageUsage,
   StandardFrontstageProps,
   UiFramework,
@@ -139,7 +139,7 @@ export class LocalFileOpenFrontstage {
         };
 
         UiFramework.frontstages.addFrontstage(
-          createStandardFrontstage(stageProps)
+          FrontstageUtilities.createStandardFrontstage(stageProps)
         );
         UiItemsManager.register(new LocalFileOpenStageBackstageItemsProvider());
       } else {

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
@@ -17,9 +17,9 @@ import {
   ConfigurableCreateInfo,
   ContentControl,
   ContentGroupProps,
+  createStandardFrontstage,
   StageUsage,
   StandardFrontstageProps,
-  StandardFrontstageProvider,
   UiFramework,
   UiItemsManager,
   UiItemsProvider,
@@ -138,8 +138,8 @@ export class LocalFileOpenFrontstage {
           hideStatusBar: true,
         };
 
-        UiFramework.frontstages.addFrontstageProvider(
-          new StandardFrontstageProvider(stageProps)
+        UiFramework.frontstages.addFrontstage(
+          createStandardFrontstage(stageProps)
         );
         UiItemsManager.register(new LocalFileOpenStageBackstageItemsProvider());
       } else {

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/MainFrontstage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/MainFrontstage.tsx
@@ -15,8 +15,8 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  createStandardFrontstage,
   Frontstage,
+  FrontstageUtilities,
   IModelViewportControl,
   SettingsModalFrontstage,
   StageContentLayout,
@@ -264,7 +264,9 @@ export class MainFrontstage {
       usage: StageUsage.General,
     };
 
-    UiFramework.frontstages.addFrontstage(createStandardFrontstage(stageProps));
+    UiFramework.frontstages.addFrontstage(
+      FrontstageUtilities.createStandardFrontstage(stageProps)
+    );
     this.registerUiItemProviders();
   }
 

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/MainFrontstage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/MainFrontstage.tsx
@@ -15,7 +15,8 @@ import {
   ContentGroupProps,
   ContentGroupProvider,
   ContentProps,
-  FrontstageConfig,
+  createStandardFrontstage,
+  Frontstage,
   IModelViewportControl,
   SettingsModalFrontstage,
   StageContentLayout,
@@ -23,7 +24,6 @@ import {
   StageUsage,
   StandardContentToolsUiItemsProvider,
   StandardFrontstageProps,
-  StandardFrontstageProvider,
   StandardNavigationToolsUiItemsProvider,
   StandardStatusbarUiItemsProvider,
   UiFramework,
@@ -126,7 +126,7 @@ export class InitialIModelContentStageProvider extends ContentGroupProvider {
   }
 
   public override async contentGroup(
-    config: FrontstageConfig
+    config: Frontstage
   ): Promise<ContentGroup> {
     const viewIdsSelected = SampleAppIModelApp.getInitialViewIds();
     const iModelConnection = UiFramework.getIModelConnection();
@@ -264,9 +264,7 @@ export class MainFrontstage {
       usage: StageUsage.General,
     };
 
-    UiFramework.frontstages.addFrontstageProvider(
-      new StandardFrontstageProvider(stageProps)
-    );
+    UiFramework.frontstages.addFrontstage(createStandardFrontstage(stageProps));
     this.registerUiItemProviders();
   }
 

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/CustomFrontstage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/CustomFrontstage.tsx
@@ -9,8 +9,6 @@ import {
   ContentControl,
   ContentGroup,
   ContentToolWidgetComposer,
-  FrontstageConfig,
-  FrontstageProvider,
 } from "@itwin/appui-react";
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 
@@ -36,29 +34,19 @@ class CustomContentControl extends ContentControl {
 // __PUBLISH_EXTRACT_END__
 
 // __PUBLISH_EXTRACT_START__ Example_Custom_Frontstage_Provider
-export class CustomFrontstageProvider extends FrontstageProvider {
-  public override get id(): string {
-    return "example:CustomFrontstage";
-  }
-
-  public override frontstageConfig(): FrontstageConfig {
-    const id = this.id;
-    const contentGroup = new ContentGroup({
-      id: "test-group",
-      layout: StandardContentLayouts.singleView,
-      contents: [{ id: "custom-content", classId: CustomContentControl }],
-    });
-    return {
-      id,
-      version: 1,
-      contentGroup,
-      contentManipulation: {
-        id: `${id}-contentManipulationTools`,
-        content: (
-          <ContentToolWidgetComposer cornerButton={<BackstageAppButton />} />
-        ),
-      },
-    };
-  }
-}
+export const customFrontstage = {
+  id: "example:CustomFrontstage",
+  version: 1,
+  contentGroup: new ContentGroup({
+    id: "test-group",
+    layout: StandardContentLayouts.singleView,
+    contents: [{ id: "custom-content", classId: CustomContentControl }],
+  }),
+  contentManipulation: {
+    id: "contentManipulationTools",
+    content: (
+      <ContentToolWidgetComposer cornerButton={<BackstageAppButton />} />
+    ),
+  },
+};
 // __PUBLISH_EXTRACT_END__

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/ViewportFrontstage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/ViewportFrontstage.tsx
@@ -7,9 +7,8 @@ import {
   BackstageAppButton,
   ContentGroup,
   ContentGroupProvider,
+  createStandardFrontstage,
   IModelViewportControl,
-  StandardFrontstageProps,
-  StandardFrontstageProvider,
   UiFramework,
 } from "@itwin/appui-react";
 import React from "react";
@@ -37,14 +36,13 @@ export class ViewportFrontstageGroupProvider extends ContentGroupProvider {
 
 // __PUBLISH_EXTRACT_START__ Example_Register_Viewport_Frontstage
 export function registerViewportFrontstage(): void {
-  const stageProps: StandardFrontstageProps = {
-    id: "example:ViewportFrontstage",
-    contentGroupProps: new ViewportFrontstageGroupProvider(),
-    cornerButton: <BackstageAppButton />,
-    usage: "General",
-  };
-  UiFramework.frontstages.addFrontstageProvider(
-    new StandardFrontstageProvider(stageProps)
+  UiFramework.frontstages.addFrontstage(
+    createStandardFrontstage({
+      id: "example:ViewportFrontstage",
+      contentGroupProps: new ViewportFrontstageGroupProvider(),
+      cornerButton: <BackstageAppButton />,
+      usage: "General",
+    })
   );
 }
 // __PUBLISH_EXTRACT_END__

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/ViewportFrontstage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/example-stages/ViewportFrontstage.tsx
@@ -7,7 +7,7 @@ import {
   BackstageAppButton,
   ContentGroup,
   ContentGroupProvider,
-  createStandardFrontstage,
+  FrontstageUtilities,
   IModelViewportControl,
   UiFramework,
 } from "@itwin/appui-react";
@@ -37,7 +37,7 @@ export class ViewportFrontstageGroupProvider extends ContentGroupProvider {
 // __PUBLISH_EXTRACT_START__ Example_Register_Viewport_Frontstage
 export function registerViewportFrontstage(): void {
   UiFramework.frontstages.addFrontstage(
-    createStandardFrontstage({
+    FrontstageUtilities.createStandardFrontstage({
       id: "example:ViewportFrontstage",
       contentGroupProps: new ViewportFrontstageGroupProvider(),
       cornerButton: <BackstageAppButton />,

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -101,7 +101,7 @@ import {
   previewFeaturesToggleProvider,
   registerCustomFrontstage,
   SynchronizedFloatingViewportStage,
-  TestFrontstageProvider,
+  testFrontstageProvider,
   WidgetApiStage,
 } from "@itwin/appui-test-providers";
 import { getUrlParam, useHandleURLParams } from "./UrlParams";
@@ -110,7 +110,7 @@ import {
   registerExampleFrontstages,
 } from "./appui/frontstages/example-stages/ExampleStagesBackstageProvider";
 import {
-  editorFrontstageProvider,
+  editorFrontstage,
   editorUiItemsProvider,
   initializeEditor,
 } from "./appui/frontstages/EditorFrontstageProvider";
@@ -391,7 +391,7 @@ export class SampleAppIModelApp {
     CustomContentFrontstage.register(AppUiTestProviders.localizationNamespace);
     WidgetApiStage.register(AppUiTestProviders.localizationNamespace);
     ContentLayoutStage.register(AppUiTestProviders.localizationNamespace);
-    UiFramework.frontstages.addFrontstageProvider(new TestFrontstageProvider());
+    UiFramework.frontstages.addFrontstage(testFrontstageProvider);
     registerCustomFrontstage();
     SynchronizedFloatingViewportStage.register(
       AppUiTestProviders.localizationNamespace
@@ -400,12 +400,12 @@ export class SampleAppIModelApp {
 
     if (ProcessDetector.isElectronAppFrontend) {
       await initializeEditor();
-      UiFramework.frontstages.addFrontstageProvider(editorFrontstageProvider);
+      UiFramework.frontstages.addFrontstage(editorFrontstage);
       UiItemsManager.register(editorUiItemsProvider, {
-        stageIds: [editorFrontstageProvider.id],
+        stageIds: [editorFrontstage.id],
       });
       UiItemsManager.register(new StandardContentToolsUiItemsProvider(), {
-        stageIds: [editorFrontstageProvider.id],
+        stageIds: [editorFrontstage.id],
       });
     }
 
@@ -458,7 +458,7 @@ export class SampleAppIModelApp {
     if (this.iModelParams && this.iModelParams.stageId)
       stageId = this.iModelParams.stageId;
     else if (SampleAppIModelApp.testAppConfiguration?.readWrite) {
-      stageId = editorFrontstageProvider.id;
+      stageId = editorFrontstage.id;
     } else {
       stageId = defaultFrontstage;
     }

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -75,6 +75,7 @@ export * from "./appui-react/frontstage/Frontstage";
 export * from "./appui-react/frontstage/FrontstageConfig";
 export * from "./appui-react/frontstage/FrontstageDef";
 export * from "./appui-react/frontstage/FrontstageProvider";
+export * from "./appui-react/frontstage/FrontstageUtilities";
 export * from "./appui-react/frontstage/ModalFrontstage";
 export * from "./appui-react/frontstage/ModalSettingsStage";
 export * from "./appui-react/frontstage/NestedFrontstage";

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -71,6 +71,7 @@ export * from "./appui-react/framework/FrameworkKeyboardShortcuts";
 export * from "./appui-react/framework/FrameworkToolSettings";
 export * from "./appui-react/framework/FrameworkVisibility";
 
+export * from "./appui-react/frontstage/Frontstage";
 export * from "./appui-react/frontstage/FrontstageConfig";
 export * from "./appui-react/frontstage/FrontstageDef";
 export * from "./appui-react/frontstage/FrontstageProvider";

--- a/ui/appui-react/src/appui-react/content/ContentGroup.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentGroup.tsx
@@ -17,8 +17,8 @@ import {
 } from "../configurableui/ConfigurableUiControl";
 import { UiFramework } from "../UiFramework";
 import type { ContentControl } from "./ContentControl";
-import type { FrontstageConfig } from "../frontstage/FrontstageConfig";
 import { InternalConfigurableUiManager } from "../configurableui/InternalConfigurableUiManager";
+import type { Frontstage } from "../frontstage/Frontstage";
 
 /** Properties for content displayed in a content view
  * @public
@@ -49,8 +49,8 @@ export interface ContentGroupProps {
  * @public
  */
 export abstract class ContentGroupProvider {
-  /** Return the contentGroup based on the `FrontstageConfig`. */
-  public abstract contentGroup(config: FrontstageConfig): Promise<ContentGroup>;
+  /** Return the contentGroup based on the `Frontstage`. */
+  public abstract contentGroup(frontstage: Frontstage): Promise<ContentGroup>;
 
   /** Allow provider to update any data stored in ContentGroupProps. Typically this may
    * be to remove applicationData entries.

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -20,6 +20,7 @@ import type {
 } from "../stagepanels/StagePanelDef";
 import type { WidgetDef, WidgetStateChangedEvent } from "../widgets/WidgetDef";
 import type { WidgetState } from "../widgets/WidgetState";
+import type { Frontstage } from "../frontstage/Frontstage";
 
 /** Frontstage Activated Event Args interface.
  * @public
@@ -188,8 +189,7 @@ export interface ModalFrontstageItem {
   timeTracker: TimeTracker;
 }
 
-/**
- * [[UiFramework.frontstages]] interface
+/** [[UiFramework.frontstages]] interface
  * @public
  */
 export interface FrameworkFrontstages {
@@ -270,10 +270,15 @@ export interface FrameworkFrontstages {
    */
   clearFrontstageProviders(): void;
 
-  /** Add a Frontstage via a [[FrontstageProvider]].
+  /** Adds a frontstage provider.
    * @param frontstageProvider  FrontstageProvider representing the Frontstage to add
+   * @deprecated in 4.15.0. Use {@link FrameworkFrontstages.addFrontstage} instead.
    */
+  // eslint-disable-next-line deprecation/deprecation
   addFrontstageProvider(frontstageProvider: FrontstageProvider): void;
+
+  /** Adds a frontstage. */
+  addFrontstage(frontstage: Frontstage): void;
 
   /** Find a loaded Frontstage with a given id. If the id is not provided, the active Frontstage is returned. If
    * no cached FrontstageDef is found but a FrontstageProvider is registered a FrontstageDef will be created, cached, and

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -277,7 +277,9 @@ export interface FrameworkFrontstages {
   // eslint-disable-next-line deprecation/deprecation
   addFrontstageProvider(frontstageProvider: FrontstageProvider): void;
 
-  /** Adds a frontstage. */
+  /** Adds a frontstage.
+   * @beta
+   */
   addFrontstage(frontstage: Frontstage): void;
 
   /** Find a loaded Frontstage with a given id. If the id is not provided, the active Frontstage is returned. If

--- a/ui/appui-react/src/appui-react/frontstage/Frontstage.ts
+++ b/ui/appui-react/src/appui-react/frontstage/Frontstage.ts
@@ -7,16 +7,9 @@
  */
 
 import type { FrontstageConfig } from "./FrontstageConfig";
-import type { Frontstage } from "./Frontstage";
 
-/** Provides a definition required to create a Frontstage.
+/** Configuration from which a frontstage is created.
  * @public
- * @deprecated in 4.15.0. Use {@link Frontstage} instead.
  */
-export abstract class FrontstageProvider {
-  /** Get the FrontstageProvider id. */
-  public abstract get id(): string;
-  /** Return the frontstage configuration. */
-  // eslint-disable-next-line deprecation/deprecation
-  public abstract frontstageConfig(): FrontstageConfig;
-}
+// eslint-disable-next-line deprecation/deprecation
+export type Frontstage = FrontstageConfig;

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageConfig.ts
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageConfig.ts
@@ -13,9 +13,11 @@ import type {
 } from "../content/ContentGroup";
 import type { StagePanelConfig } from "../stagepanels/StagePanelConfig";
 import type { WidgetConfig } from "../widgets/WidgetConfig";
+import type { Frontstage } from "./Frontstage";
 
 /** Configuration from which a frontstage is created.
  * @public
+ * @deprecated in 4.15.0. Use {@link Frontstage} instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export interface FrontstageConfig extends CommonProps {

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -623,7 +623,7 @@ export class FrontstageDef {
     return contentControls;
   }
 
-  /** Initializes a FrontstageDef from FrontstageConfig.
+  /** Initializes a FrontstageDef from frontstage.
    * @internal
    */
   public async initializeFromConfig(config: Frontstage): Promise<void> {
@@ -1033,10 +1033,10 @@ function createWidgetDef(
 }
 
 function createStagePanelDef(
-  frontstageConfig: Frontstage,
+  frontstage: Frontstage,
   location: StagePanelLocation
 ): StagePanelDef {
-  const config = getStagePanel(location, frontstageConfig);
+  const config = getStagePanel(location, frontstage);
 
   const panelDef = new StagePanelDef();
   panelDef.initializeFromConfig(config, location);

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageProvider.ts
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageProvider.ts
@@ -6,7 +6,6 @@
  * @module Frontstage
  */
 
-import type { FrontstageConfig } from "./FrontstageConfig";
 import type { Frontstage } from "./Frontstage";
 
 /** Provides a definition required to create a Frontstage.
@@ -17,6 +16,5 @@ export abstract class FrontstageProvider {
   /** Get the FrontstageProvider id. */
   public abstract get id(): string;
   /** Return the frontstage configuration. */
-  // eslint-disable-next-line deprecation/deprecation
-  public abstract frontstageConfig(): FrontstageConfig;
+  public abstract frontstageConfig(): Frontstage;
 }

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageUtilities.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageUtilities.tsx
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Frontstage
+ */
+
+import * as React from "react";
+import { ContentGroup, ContentGroupProvider } from "../content/ContentGroup";
+import { ContentToolWidgetComposer } from "../widgets/ContentToolWidgetComposer";
+import { ViewToolWidgetComposer } from "../widgets/ViewToolWidgetComposer";
+import { StatusBarComposer } from "../statusbar/StatusBarComposer";
+import { StagePanelState } from "../stagepanels/StagePanelState";
+import type { Frontstage } from "./Frontstage";
+import type { UiItemsProvider } from "../ui-items-provider/UiItemsProvider";
+import type { StandardFrontstageProps } from "./StandardFrontstageProvider";
+
+/** Helper namespace to create frontstages.
+ * @beta
+ */
+export namespace FrontstageUtilities {
+  /** Creates an empty frontstage. All toolbar buttons, widgets and other UI items must be provided by {@link UiItemsProvider}. */
+  export function createStandardFrontstage(
+    props: StandardFrontstageProps
+  ): Frontstage {
+    const contentGroup =
+      props.contentGroupProps instanceof ContentGroupProvider
+        ? props.contentGroupProps
+        : new ContentGroup(props.contentGroupProps);
+    return {
+      id: props.id,
+      version: props.version ?? 1.0,
+      contentGroup,
+      usage: props.usage,
+      defaultTool: props.defaultTool,
+      contentManipulation: {
+        id: `${props.id}-contentManipulationTools`,
+        content: (
+          <ContentToolWidgetComposer cornerButton={props.cornerButton} />
+        ),
+      },
+      viewNavigation: {
+        id: `${props.id}-viewNavigationTools`,
+        content: (
+          <ViewToolWidgetComposer hideNavigationAid={props.hideNavigationAid} />
+        ),
+      },
+      toolSettings: props.hideToolSettings
+        ? undefined
+        : {
+            id: `${props.id}-toolSettings`,
+          },
+      statusBar: props.hideStatusBar
+        ? undefined
+        : {
+            id: `${props.id}-statusBar`,
+            content: <StatusBarComposer items={[]} />,
+          },
+      leftPanel: {
+        sizeSpec: 300,
+        pinned: false,
+        defaultState: StagePanelState.Minimized,
+        ...props.leftPanelProps,
+      },
+      topPanel: {
+        sizeSpec: 90,
+        pinned: false,
+        defaultState: StagePanelState.Minimized,
+        ...props.topPanelProps,
+      },
+      rightPanel: {
+        defaultState: StagePanelState.Open,
+        ...props.rightPanelProps,
+      },
+      bottomPanel: {
+        sizeSpec: 180,
+        defaultState: StagePanelState.Open,
+        ...props.bottomPanelProps,
+      },
+    };
+  }
+}

--- a/ui/appui-react/src/appui-react/frontstage/StandardFrontstageProvider.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/StandardFrontstageProvider.tsx
@@ -12,7 +12,6 @@ import { ContentGroup, ContentGroupProvider } from "../content/ContentGroup";
 import { FrontstageProvider } from "./FrontstageProvider";
 import { ContentToolWidgetComposer } from "../widgets/ContentToolWidgetComposer";
 import { ViewToolWidgetComposer } from "../widgets/ViewToolWidgetComposer";
-import type { FrontstageConfig } from "./FrontstageConfig";
 import type { StagePanelConfig } from "../stagepanels/StagePanelConfig";
 import type { StageUsage } from "./StageUsage";
 import { StatusBarComposer } from "../statusbar/StatusBarComposer";
@@ -139,13 +138,12 @@ export function createStandardFrontstage(
   };
 }
 
-/* eslint-disable deprecation/deprecation */
-
 /** FrontstageProvider that provides an "empty" stage. All tool buttons, statusbar items, and widgets must
  * be provided by one or more item providers, see [[UiItemsProvider]].
  * @public
  * @deprecated in 4.15.0. Use {@link createStandardFrontstage} instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class StandardFrontstageProvider extends FrontstageProvider {
   constructor(private props: StandardFrontstageProps) {
     super();
@@ -155,7 +153,7 @@ export class StandardFrontstageProvider extends FrontstageProvider {
     return this.props.id;
   }
 
-  public override frontstageConfig(): FrontstageConfig {
+  public override frontstageConfig(): Frontstage {
     const config = createStandardFrontstage(this.props);
     return config;
   }

--- a/ui/appui-react/src/appui-react/frontstage/StandardFrontstageProvider.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/StandardFrontstageProvider.tsx
@@ -6,18 +6,16 @@
  * @module Frontstage
  */
 
-import * as React from "react";
-import type { ContentGroupProps } from "../content/ContentGroup";
-import { ContentGroup, ContentGroupProvider } from "../content/ContentGroup";
+import type * as React from "react";
+import type {
+  ContentGroupProps,
+  ContentGroupProvider,
+} from "../content/ContentGroup";
 import { FrontstageProvider } from "./FrontstageProvider";
-import { ContentToolWidgetComposer } from "../widgets/ContentToolWidgetComposer";
-import { ViewToolWidgetComposer } from "../widgets/ViewToolWidgetComposer";
 import type { StagePanelConfig } from "../stagepanels/StagePanelConfig";
 import type { StageUsage } from "./StageUsage";
-import { StatusBarComposer } from "../statusbar/StatusBarComposer";
-import { StagePanelState } from "../stagepanels/StagePanelState";
 import type { Frontstage } from "./Frontstage";
-import type { UiItemsProvider } from "../ui-items-provider/UiItemsProvider";
+import { FrontstageUtilities } from "./FrontstageUtilities";
 
 /** Widget panel properties used in a {@link StandardFrontstageProps}.
  * @public
@@ -76,72 +74,10 @@ export interface StandardFrontstageProps {
   bottomPanelProps?: WidgetPanelProps;
 }
 
-/** Frontstage that provides an "empty" stage. All tool buttons, status bar items, and widgets must
- * be provided by one or more item providers, see {@link UiItemsProvider}.
- * @public
- */
-export function createStandardFrontstage(
-  props: StandardFrontstageProps
-): Frontstage {
-  const contentGroup =
-    props.contentGroupProps instanceof ContentGroupProvider
-      ? props.contentGroupProps
-      : new ContentGroup(props.contentGroupProps);
-  return {
-    id: props.id,
-    version: props.version ?? 1.0,
-    contentGroup,
-    usage: props.usage,
-    defaultTool: props.defaultTool,
-    contentManipulation: {
-      id: `${props.id}-contentManipulationTools`,
-      content: <ContentToolWidgetComposer cornerButton={props.cornerButton} />,
-    },
-    viewNavigation: {
-      id: `${props.id}-viewNavigationTools`,
-      content: (
-        <ViewToolWidgetComposer hideNavigationAid={props.hideNavigationAid} />
-      ),
-    },
-    toolSettings: props.hideToolSettings
-      ? undefined
-      : {
-          id: `${props.id}-toolSettings`,
-        },
-    statusBar: props.hideStatusBar
-      ? undefined
-      : {
-          id: `${props.id}-statusBar`,
-          content: <StatusBarComposer items={[]} />,
-        },
-    leftPanel: {
-      sizeSpec: 300,
-      pinned: false,
-      defaultState: StagePanelState.Minimized,
-      ...props.leftPanelProps,
-    },
-    topPanel: {
-      sizeSpec: 90,
-      pinned: false,
-      defaultState: StagePanelState.Minimized,
-      ...props.topPanelProps,
-    },
-    rightPanel: {
-      defaultState: StagePanelState.Open,
-      ...props.rightPanelProps,
-    },
-    bottomPanel: {
-      sizeSpec: 180,
-      defaultState: StagePanelState.Open,
-      ...props.bottomPanelProps,
-    },
-  };
-}
-
 /** FrontstageProvider that provides an "empty" stage. All tool buttons, statusbar items, and widgets must
  * be provided by one or more item providers, see [[UiItemsProvider]].
  * @public
- * @deprecated in 4.15.0. Use {@link createStandardFrontstage} instead.
+ * @deprecated in 4.15.0. Use {@link FrontstageUtilities.createStandardFrontstage} instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class StandardFrontstageProvider extends FrontstageProvider {
@@ -154,7 +90,7 @@ export class StandardFrontstageProvider extends FrontstageProvider {
   }
 
   public override frontstageConfig(): Frontstage {
-    const config = createStandardFrontstage(this.props);
+    const config = FrontstageUtilities.createStandardFrontstage(this.props);
     return config;
   }
 }


### PR DESCRIPTION
## Changes

This PR deprecates APIs related to the `FrontstageProvider` class. Instead, a `Frontstage` type should be used directly to configure a frontstage.
See `NextVersion.md` or the API summary for a full list of deprecations and their suggested replacements.

## Testing

N/A
