### PR TITLE
Portal editor to same container used to portal other components

### DIFF
--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -1230,6 +1230,7 @@ export interface PopupProps extends CommonProps {
     onOpen?: () => void;
     onOutsideClick?: (e: MouseEvent) => void;
     onWheel?: (e: WheelEvent) => void;
+    portalTarget?: HTMLElement;
     position: RelativePosition;
     // @beta
     repositionOnResize?: boolean;

--- a/common/api/summary/components-react.exports.csv
+++ b/common/api/summary/components-react.exports.csv
@@ -127,7 +127,6 @@ public;IMutableGridCategoryItem
 public;IMutableGridItemFactory
 public;IMutablePropertyGridModel
 internal;InternalToolbarComponent(props: InternalToolbarComponentProps): React_3.JSX.Element
-internal;InternalToolbarComponentProps 
 alpha;IntlFormatter 
 deprecated;IntlFormatter 
 public;IntTypeConverter 

--- a/common/changes/@itwin/components-react/editor-popup_2024-06-14-11-20.json
+++ b/common/changes/@itwin/components-react/editor-popup_2024-06-14-11-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Portal editors to the same container used to portal other components.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/editor-popup_2024-06-14-11-20.json
+++ b/common/changes/@itwin/core-react/editor-popup_2024-06-14-11-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/core-react/editor-popup_2024-06-14-11-20.json
+++ b/common/changes/@itwin/core-react/editor-popup_2024-06-14-11-20.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "",
+      "comment": "Added `portalTarget` to `Popup` component.",
       "type": "none"
     }
   ],

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -7,6 +7,7 @@ Table of contents:
   - [Additions](#additions)
   - [Changes](#changes)
 - [@itwin/core-react](#itwincore-react)
+  - [Additions](#additions-1)
   - [Deprecations](#deprecations-1)
 - [@itwin/components-react](#itwincomponents-react)
   - [Fixes](#fixes)
@@ -63,6 +64,10 @@ Table of contents:
 - Bumped `getToolbarItems`, `getStatusBarItems`, `getWidgets` and `getBackstageItems` methods of `UiItemsProvider`, `layouts` property of `CommonToolbarItem` and `Widget`, `StandardLayoutToolbarItem`, `StandardLayoutWidget`, `ToolbarItemLayouts`, `WidgetLayouts` to `@public`. [#874](https://github.com/iTwin/appui/pull/874)
 
 ## @itwin/core-react
+
+### Additions
+
+- Added `portalTarget` to `Popup` component to allow portaling `Popup` to specific element. [#879](https://github.com/iTwin/appui/pull/879)
 
 ### Deprecations
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -8,6 +8,8 @@ Table of contents:
   - [Changes](#changes)
 - [@itwin/core-react](#itwincore-react)
   - [Deprecations](#deprecations-1)
+- [@itwin/components-react](#itwincomponents-react)
+  - [Fixes](#fixes)
 
 ## @itwin/appui-react
 
@@ -73,3 +75,9 @@ Table of contents:
 - Deprecated `useEffectSkipFirst`. Use `useEffect` instead. [#866](https://github.com/iTwin/appui/pull/866)
 - Deprecated `ResizableContainerObserver`. Please use third party packages. [#866](https://github.com/iTwin/appui/pull/866)
 - Deprecated `Omit`. Use TypeScript `Omit`. [#866](https://github.com/iTwin/appui/pull/866)
+
+## @itwin/components-react
+
+### Fixes
+
+- Portal editors to the same container used to portal other components.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -80,4 +80,4 @@ Table of contents:
 
 ### Fixes
 
-- Portal editors to the same container used to portal other components.
+- Portal editors to the same container used to portal other components. [#879](https://github.com/iTwin/appui/pull/879)

--- a/ui/components-react/src/components-react/editors/PopupButton.tsx
+++ b/ui/components-react/src/components-react/editors/PopupButton.tsx
@@ -171,6 +171,11 @@ export class PopupButton extends React.PureComponent<
           showShadow={showShadow}
           moveFocus={moveFocus}
           focusTarget={this.props.focusTarget}
+          portalTarget={
+            this._buttonRef.current?.ownerDocument.querySelector(
+              ".uifw-configurableui-portalContainer"
+            ) ?? undefined
+          }
         >
           {this.props.children}
         </Popup>

--- a/ui/core-react/src/core-react/popup/Popup.tsx
+++ b/ui/core-react/src/core-react/popup/Popup.tsx
@@ -90,6 +90,9 @@ export interface PopupProps extends CommonProps {
 
   /** Content */
   children?: React.ReactNode;
+
+  /** Target that should be used when portaling popup. */
+  portalTarget?: HTMLElement;
 }
 
 /** @internal */
@@ -650,9 +653,11 @@ export class Popup extends React.Component<PopupProps, PopupState> {
 
   private getContainer() {
     return (
+      this.props.portalTarget ??
       this.state.parentDocument.body.querySelector(
         '[data-root-container="appui-root-id"]'
-      ) ?? this.state.parentDocument.body
+      ) ??
+      this.state.parentDocument.body
     );
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Container used to portal components had higher z-index than `Popup` components. Changed editors to use same portal container. Required to fix https://github.com/iTwin/viewer-components-react/issues/921.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Tested manually