### PR TITLE
Fix unintentional popout widget transition

### DIFF
--- a/common/changes/@itwin/appui-react/fix-886_2024-06-26-15-22.json
+++ b/common/changes/@itwin/appui-react/fix-886_2024-06-26-15-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fixed unexpected popout widget transition when popover is opened.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -6,11 +6,12 @@ Table of contents:
   - [Deprecations](#deprecations)
   - [Additions](#additions)
   - [Changes](#changes)
+  - [Fixes](#fixes)
 - [@itwin/core-react](#itwincore-react)
   - [Additions](#additions-1)
   - [Deprecations](#deprecations-1)
 - [@itwin/components-react](#itwincomponents-react)
-  - [Fixes](#fixes)
+  - [Fixes](#fixes-1)
 
 ## @itwin/appui-react
 
@@ -78,6 +79,10 @@ Table of contents:
 - Bumped `getToolbarItems`, `getStatusBarItems`, `getWidgets` and `getBackstageItems` methods of `UiItemsProvider`, `layouts` property of `CommonToolbarItem` and `Widget`, `StandardLayoutToolbarItem`, `StandardLayoutWidget`, `ToolbarItemLayouts`, `WidgetLayouts` to `@public`. [#874](https://github.com/iTwin/appui/pull/874)
 - Changed `StandardMessageBox` from a class to a functional component. [#883](https://github.com/iTwin/appui/pull/883)
 - Changed components to use iTwinUI dialogs. [#883](https://github.com/iTwin/appui/pull/883)
+
+### Fixes
+
+- Fixed unexpected popout widget transition when popover is opened. [#887](https://github.com/iTwin/appui/pull/887)
 
 ## @itwin/core-react
 

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.scss
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.scss
@@ -12,3 +12,7 @@
   height: 100%;
   width: 100%;
 }
+
+.uifw-childwindow-internalChildWindowManager_portalContainer {
+  position: fixed;
+}

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -27,6 +27,7 @@ import type { ChildWindow } from "./ChildWindowConfig";
 import { copyStyles } from "./CopyStyles";
 import "./InternalChildWindowManager.scss";
 import { usePopoutsStore } from "../preview/reparent-popout-widgets/usePopoutsStore";
+import type { WidgetDef } from "../widgets/WidgetDef";
 
 const childHtml = `<!DOCTYPE html>
 <html>
@@ -156,33 +157,12 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
         window: childWindow,
         parentWindow: window,
       });
-      let element: React.FunctionComponentElement<any>;
-      if (content.props.widgetDef) {
-        const tabId = content.props.widgetDef.id as string;
-        element = (
-          // eslint-disable-next-line deprecation/deprecation
-          <Provider store={UiFramework.store}>
-            <TabIdContext.Provider value={tabId}>
-              <UiStateStorageHandler>
-                <ThemeManager>
-                  <div className="uifw-child-window-container-host">
-                    <PopupRenderer />
-                    <ModalDialogRenderer />
-                    <ModelessDialogRenderer />
-                    <CursorPopupMenu />
-                    <div className="uifw-child-window-container nz-widget-widget">
-                      {content}
-                    </div>
-                  </div>
-                </ThemeManager>
-              </UiStateStorageHandler>
-            </TabIdContext.Provider>
-          </Provider>
-        );
-      } else {
-        element = (
-          // eslint-disable-next-line deprecation/deprecation
-          <Provider store={UiFramework.store}>
+      const widgetDef = content.props.widgetDef as WidgetDef | undefined;
+      const tabId = widgetDef?.id;
+      const element = (
+        // eslint-disable-next-line deprecation/deprecation
+        <Provider store={UiFramework.store}>
+          <TabIdContext.Provider value={tabId}>
             <UiStateStorageHandler>
               <ThemeManager>
                 <div className="uifw-child-window-container-host">
@@ -196,9 +176,9 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
                 </div>
               </ThemeManager>
             </UiStateStorageHandler>
-          </Provider>
-        );
-      }
+          </TabIdContext.Provider>
+        </Provider>
+      );
 
       setTimeout(() => {
         copyStyles(childWindow.document);

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -174,6 +174,7 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
                     {content}
                   </div>
                 </div>
+                <div className="uifw-childwindow-internalChildWindowManager_portalContainer" />
               </ThemeManager>
             </UiStateStorageHandler>
           </TabIdContext.Provider>

--- a/ui/appui-react/src/appui-react/preview/reparent-popout-widgets/PopoutThemeProvider.tsx
+++ b/ui/appui-react/src/appui-react/preview/reparent-popout-widgets/PopoutThemeProvider.tsx
@@ -29,16 +29,23 @@ export function PopoutThemeProvider({ children }: React.PropsWithChildren<{}>) {
     () => layoutStore.subscribe((state) => (stateRef.current = state)),
     [layoutStore]
   );
-  const popoutContainer = usePopoutsStore((state) => {
+  const portalContainer = usePopoutsStore((state) => {
     if (!tabId) return undefined;
     const tabLocation = getTabLocation(stateRef.current, tabId);
     if (!tabLocation) return undefined;
     if (!isPopoutTabLocation(tabLocation)) return undefined;
-    return state.popouts[tabLocation.popoutWidgetId];
+    const popout = state.popouts[tabLocation.popoutWidgetId];
+    if (!popout) return undefined;
+
+    const container = popout.ownerDocument.querySelector<HTMLDivElement>(
+      ".uifw-childwindow-internalChildWindowManager_portalContainer"
+    );
+    return container ?? undefined;
   });
+
   return (
     <ThemeProvider
-      portalContainer={popoutContainer ?? undefined}
+      portalContainer={portalContainer}
       className="uifw-preview-reparentPopoutWidgets-popoutThemeProvider"
     >
       {children}


### PR DESCRIPTION
## Changes

This PR fixes #886 by portalling popovers to a container with fixed position.

## Testing

Tested via standalone test app. `Layout Info` widget can be used to reproduce this issue.
