### PR TITLE
Show property record description next to array indices

### DIFF
--- a/common/changes/@itwin/components-react/master_2024-07-02-06-46.json
+++ b/common/changes/@itwin/components-react/master_2024-07-02-06-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Show label next to index for array property items",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/components-react/master_2024-07-02-06-46.json
+++ b/common/changes/@itwin/components-react/master_2024-07-02-06-46.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Show label next to index for array property items",
+      "comment": "Property grid: Show array items' description next to the index when the items are non-primitive.",
       "type": "none"
     }
   ],

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
@@ -54,14 +54,7 @@ export class MutableCategorizedArrayProperty
     this._children = record.getChildrenRecords().map((child, index) => {
       const newName = `${child.property.name}_${index}`;
       let newDisplayLabel = `[${index + 1}]`;
-
-      if (
-        child.description &&
-        ((child.value.valueFormat === PropertyValueFormat.Array &&
-          child.value.items.length > 1) ||
-          (child.value.valueFormat === PropertyValueFormat.Struct &&
-            Object.keys(child.value.members).length > 1))
-      ) {
+      if (child.description && child.value.valueFormat !== PropertyValueFormat.Primitive) {
         newDisplayLabel += ` ${child.description}`;
       }
 

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
@@ -6,7 +6,10 @@
 /** @packageDocumentation
  * @module PropertyGrid
  */
-import type { PropertyRecord } from "@itwin/appui-abstract";
+import {
+  type PropertyRecord,
+  PropertyValueFormat,
+} from "@itwin/appui-abstract";
 import type {
   IMutableCategorizedPropertyItem,
   IMutableFlatGridItem,
@@ -50,7 +53,18 @@ export class MutableCategorizedArrayProperty
     const childrenDepth = depth + (this._renderLabel ? 1 : 0);
     this._children = record.getChildrenRecords().map((child, index) => {
       const newName = `${child.property.name}_${index}`;
-      const newDisplayLabel = `[${index + 1}] ${child.property.displayLabel}`;
+      let newDisplayLabel = `[${index + 1}]`;
+
+      if (
+        child.description &&
+        ((child.value.valueFormat === PropertyValueFormat.Array &&
+          child.value.items.length > 1) ||
+          (child.value.valueFormat === PropertyValueFormat.Struct &&
+            Object.keys(child.value.members).length > 1))
+      ) {
+        newDisplayLabel += ` ${child.description}`;
+      }
+
       return gridItemFactory.createCategorizedProperty(
         child,
         this.selectionKey,

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
@@ -50,7 +50,7 @@ export class MutableCategorizedArrayProperty
     const childrenDepth = depth + (this._renderLabel ? 1 : 0);
     this._children = record.getChildrenRecords().map((child, index) => {
       const newName = `${child.property.name}_${index}`;
-      const newDisplayLabel = `[${index + 1}]`;
+      const newDisplayLabel = `[${index + 1}] ${child.property.displayLabel}`;
       return gridItemFactory.createCategorizedProperty(
         child,
         this.selectionKey,

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-items/MutableCategorizedArrayProperty.ts
@@ -54,7 +54,10 @@ export class MutableCategorizedArrayProperty
     this._children = record.getChildrenRecords().map((child, index) => {
       const newName = `${child.property.name}_${index}`;
       let newDisplayLabel = `[${index + 1}]`;
-      if (child.description && child.value.valueFormat !== PropertyValueFormat.Primitive) {
+      if (
+        child.description &&
+        child.value.valueFormat !== PropertyValueFormat.Primitive
+      ) {
         newDisplayLabel += ` ${child.description}`;
       }
 

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
@@ -177,7 +177,7 @@ describe("CategorizedArrayProperty", () => {
       });
     });
 
-    it("Should append property description to non-primitive items that have more that 1 items", () => {
+    it("Should append property description to non-primitive items", () => {
       const propertyRecord = TestUtils.createArrayProperty(
         "CADID1",
         [

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
@@ -162,9 +162,93 @@ describe("CategorizedArrayProperty", () => {
         const expectedRecord = arrayChildren[index];
 
         const expectedOverrideName = `${expectedRecord.property.name}_${index}`;
-        const expectedOverrideDisplayLabel = `[${index + 1}] ${
-          expectedRecord.property.displayLabel
-        }`;
+        const expectedOverrideDisplayLabel = `[${index + 1}]`;
+
+        expect(parentSelectionKey).toEqual(
+          GridUtils.getSelectionKey(propertyRecord, expectedParentSelectionKey)
+        );
+        expect(parentCategorySelectionKey).toEqual(
+          expectedParentCategorySelectionKey
+        );
+        expect(depth).toEqual(2);
+        expect(record).toEqual(expectedRecord);
+        expect(overrideName).toEqual(expectedOverrideName);
+        expect(overrideDisplayLabel).toEqual(expectedOverrideDisplayLabel);
+      });
+    });
+
+    it("Should append property description to non-primitive items that have more that 1 items", () => {
+      const propertyRecord = TestUtils.createArrayProperty(
+        "CADID1",
+        [
+          TestUtils.createPrimitiveStringProperty("CADID1_1", "V1"),
+          TestUtils.createStructProperty("CADID1_2"),
+          TestUtils.createArrayProperty("CADID1_3"),
+          TestUtils.createStructProperty("CADID1_4", {
+            prop1: TestUtils.createPrimitiveStringProperty(
+              "CADID1_4_1",
+              "test"
+            ),
+          }),
+          TestUtils.createArrayProperty("CADID1_5", [
+            TestUtils.createPrimitiveStringProperty("CADID1_5_1", "test"),
+          ]),
+          TestUtils.createStructProperty("CADID1_6", {
+            prop1: TestUtils.createPrimitiveStringProperty(
+              "CADID1_6_1",
+              "test"
+            ),
+            prop2: TestUtils.createPrimitiveStringProperty(
+              "CADID1_6_2",
+              "test"
+            ),
+          }),
+          TestUtils.createArrayProperty("CADID1_7", [
+            TestUtils.createPrimitiveStringProperty("CADID1_7_1", "test"),
+            TestUtils.createPrimitiveStringProperty("CADID1_7_2", "test"),
+          ]),
+        ].map((record, idx) => {
+          record.description = `${idx}`;
+          return record;
+        })
+      );
+
+      GridUtils.createCategorizedPropertyStub(
+        propertyRecord.getChildrenRecords(),
+        factoryStub
+      );
+
+      const expectedParentSelectionKey = "Cat1_Struct";
+      const expectedParentCategorySelectionKey = "Cat1";
+      new MutableCategorizedArrayProperty(
+        propertyRecord,
+        expectedParentSelectionKey,
+        expectedParentCategorySelectionKey,
+        1,
+        factoryStub
+      );
+
+      const arrayChildren = propertyRecord.getChildrenRecords();
+      expect(factoryStub.createCategorizedProperty).toHaveBeenCalledTimes(
+        arrayChildren.length
+      );
+
+      const createCategorizedProperty = factoryStub.createCategorizedProperty;
+      assert(vi.isMockFunction(createCategorizedProperty));
+      createCategorizedProperty.mock.calls.forEach((args, index) => {
+        const [
+          record,
+          parentSelectionKey,
+          parentCategorySelectionKey,
+          depth,
+          overrideName,
+          overrideDisplayLabel,
+        ] = args;
+        const expectedRecord = arrayChildren[index];
+
+        const expectedOverrideName = `${expectedRecord.property.name}_${index}`;
+        const expectedOverrideDisplayLabel =
+          index < 5 ? `[${index + 1}]` : `[${index + 1}] ${index}`;
 
         expect(parentSelectionKey).toEqual(
           GridUtils.getSelectionKey(propertyRecord, expectedParentSelectionKey)

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
@@ -162,7 +162,9 @@ describe("CategorizedArrayProperty", () => {
         const expectedRecord = arrayChildren[index];
 
         const expectedOverrideName = `${expectedRecord.property.name}_${index}`;
-        const expectedOverrideDisplayLabel = `[${index + 1}]`;
+        const expectedOverrideDisplayLabel = `[${index + 1}] ${
+          expectedRecord.property.displayLabel
+        }`;
 
         expect(parentSelectionKey).toEqual(
           GridUtils.getSelectionKey(propertyRecord, expectedParentSelectionKey)

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
@@ -237,7 +237,9 @@ describe("CategorizedArrayProperty", () => {
 
         const expectedOverrideName = `${expectedRecord.property.name}_${index}`;
         const expectedOverrideDisplayLabel =
-          index === 0 ? `[${index + 1}]` : `[${index + 1}] Description_${index}`;
+          index === 0
+            ? `[${index + 1}]`
+            : `[${index + 1}] Description_${index}`;
 
         expect(parentSelectionKey).toEqual(
           GridUtils.getSelectionKey(propertyRecord, expectedParentSelectionKey)

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
@@ -197,7 +197,7 @@ describe("CategorizedArrayProperty", () => {
             TestUtils.createPrimitiveStringProperty("CADID1_7_2", "test"),
           ]),
         ].map((record, idx) => {
-          record.description = `${idx}`;
+          record.description = `Description_${idx}`;
           return record;
         })
       );
@@ -237,7 +237,7 @@ describe("CategorizedArrayProperty", () => {
 
         const expectedOverrideName = `${expectedRecord.property.name}_${index}`;
         const expectedOverrideDisplayLabel =
-          index === 0 ? `[${index + 1}]` : `[${index + 1}] ${index}`;
+          index === 0 ? `[${index + 1}]` : `[${index + 1}] Description_${index}`;
 
         expect(parentSelectionKey).toEqual(
           GridUtils.getSelectionKey(propertyRecord, expectedParentSelectionKey)

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/CategorizedArrayProperty.test.ts
@@ -182,17 +182,6 @@ describe("CategorizedArrayProperty", () => {
         "CADID1",
         [
           TestUtils.createPrimitiveStringProperty("CADID1_1", "V1"),
-          TestUtils.createStructProperty("CADID1_2"),
-          TestUtils.createArrayProperty("CADID1_3"),
-          TestUtils.createStructProperty("CADID1_4", {
-            prop1: TestUtils.createPrimitiveStringProperty(
-              "CADID1_4_1",
-              "test"
-            ),
-          }),
-          TestUtils.createArrayProperty("CADID1_5", [
-            TestUtils.createPrimitiveStringProperty("CADID1_5_1", "test"),
-          ]),
           TestUtils.createStructProperty("CADID1_6", {
             prop1: TestUtils.createPrimitiveStringProperty(
               "CADID1_6_1",
@@ -248,7 +237,7 @@ describe("CategorizedArrayProperty", () => {
 
         const expectedOverrideName = `${expectedRecord.property.name}_${index}`;
         const expectedOverrideDisplayLabel =
-          index < 5 ? `[${index + 1}]` : `[${index + 1}] ${index}`;
+          index === 0 ? `[${index + 1}]` : `[${index + 1}] ${index}`;
 
         expect(parentSelectionKey).toEqual(
           GridUtils.getSelectionKey(propertyRecord, expectedParentSelectionKey)

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/FlatGridTestUtils.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/FlatGridTestUtils.ts
@@ -107,7 +107,7 @@ export class FlatGridTestUtils {
       };
       if (isParentArray) {
         const name = `${record.property.name}_${index}`;
-        const displayLabel = `[${index + 1}] ${record.property.displayLabel}`;
+        const displayLabel = `[${index + 1}]`;
 
         itemToSave.item = this.overridePropertyDescription(
           record,

--- a/ui/components-react/src/test/propertygrid/component/internal/flat-items/FlatGridTestUtils.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/flat-items/FlatGridTestUtils.ts
@@ -107,7 +107,7 @@ export class FlatGridTestUtils {
       };
       if (isParentArray) {
         const name = `${record.property.name}_${index}`;
-        const displayLabel = `[${index + 1}]`;
+        const displayLabel = `[${index + 1}] ${record.property.displayLabel}`;
 
         itemToSave.item = this.overridePropertyDescription(
           record,


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
Part of https://github.com/iTwin/presentation/issues/654
Property record description (if present) will be shown next to the index for array property items.
This should improve user experience when browsing through the property grid having many related instances.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
A unit test was added.