### PR TITLE
Fix active match index not working with adjacent text highlights

### DIFF
--- a/common/changes/@itwin/components-react/master_2024-07-04-14-20.json
+++ b/common/changes/@itwin/components-react/master_2024-07-04-14-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fixed `activeMatchIndex` not working correctly on adjacent matches in `HighlightedText`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -915,9 +915,6 @@ importers:
       lodash:
         specifier: ^4.17.10
         version: 4.17.21
-      react-highlight-words:
-        specifier: ^0.20.0
-        version: 0.20.0(react@18.3.1)
       react-window:
         specifier: ^1.8.9
         version: 1.8.10(react-dom@18.3.1)(react@18.3.1)
@@ -979,9 +976,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
-      '@types/react-highlight-words':
-        specifier: ^0.16.1
-        version: 0.16.7
       '@types/react-window':
         specifier: ^1.8.2
         version: 1.8.8
@@ -6638,12 +6632,6 @@ packages:
       '@types/react': 18.3.2
     dev: true
 
-  /@types/react-highlight-words@0.16.7:
-    resolution: {integrity: sha512-+upXTIaRd3rGvh1aDQSs9z5X+sV3UM6Jrmjk03GN2GXl4v/+iOJKQj2LZHo6Vp2IoTvMdtxgME26feqo12xXLg==}
-    dependencies:
-      '@types/react': 18.3.2
-    dev: true
-
   /@types/react-redux@7.1.33:
     resolution: {integrity: sha512-NF8m5AjWCkert+fosDsN3hAlHzpjSiXlVy9EgQEmLoBhaNXbmyeGs/aj5dQzKuF+/q+S7JQagorGDW8pJ28Hmg==}
     dependencies:
@@ -10294,10 +10282,6 @@ packages:
     hasBin: true
     dev: true
 
-  /highlight-words-core@1.2.2:
-    resolution: {integrity: sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==}
-    dev: false
-
   /hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
@@ -11882,10 +11866,6 @@ packages:
       p-is-promise: 2.1.0
     dev: false
 
-  /memoize-one@4.0.3:
-    resolution: {integrity: sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw==}
-    dev: false
-
   /memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
     dev: false
@@ -13067,17 +13047,6 @@ packages:
       react: '>=16.13.1'
     dependencies:
       '@babel/runtime': 7.23.8
-      react: 18.3.1
-    dev: false
-
-  /react-highlight-words@0.20.0(react@18.3.1):
-    resolution: {integrity: sha512-asCxy+jCehDVhusNmCBoxDf2mm1AJ//D+EzDx1m5K7EqsMBIHdZ5G4LdwbSEXqZq1Ros0G0UySWmAtntSph7XA==}
-    peerDependencies:
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
-    dependencies:
-      highlight-words-core: 1.2.2
-      memoize-one: 4.0.3
-      prop-types: 15.8.1
       react: 18.3.1
     dev: false
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -9,6 +9,7 @@ Table of contents:
   - [Fixes](#fixes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Changes](#changes-1)
+  - [Fixes](#fixes-1)
 
 ## @itwin/appui-react
 
@@ -165,3 +166,7 @@ Table of contents:
 ### Changes
 
 - Property grid array items' description will be shown next to the index when the items are non-primitive. [#890](https://github.com/iTwin/appui/pull/890)
+
+### Fixes
+
+- Fixed `activeMatchIndex` not working correctly on adjacent matches in `HighlightedText`. []()

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -169,4 +169,4 @@ Table of contents:
 
 ### Fixes
 
-- Fixed `activeMatchIndex` not working correctly on adjacent matches in `HighlightedText`. []()
+- Fixed `activeMatchIndex` not working correctly on adjacent matches in `HighlightedText`. [#898](https://github.com/iTwin/appui/pull/898)

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -69,7 +69,6 @@
     "@types/node": "18.11.5",
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.3.0",
-    "@types/react-highlight-words": "^0.16.1",
     "@types/react-window": "^1.8.2",
     "@vitest/coverage-v8": "^1.4.0",
     "cpx2": "^3.0.0",
@@ -102,7 +101,6 @@
     "immer": "9.0.6",
     "linkify-it": "~2.2.0",
     "lodash": "^4.17.10",
-    "react-highlight-words": "^0.20.0",
     "react-window": "^1.8.9",
     "rxjs": "^7.8.1",
     "ts-key-enum": "~2.0.12"

--- a/ui/components-react/src/test/common/HighlightedText.test.tsx
+++ b/ui/components-react/src/test/common/HighlightedText.test.tsx
@@ -33,4 +33,31 @@ describe("<HighlightedText />", () => {
       matchedNodes[1].classList.contains("components-activehighlight")
     ).toEqual(true);
   });
+
+  it("renders string with highlights on edges", () => {
+    const { container } = render(
+      <HighlightedText text="baaab" searchText="b" />
+    );
+    const matchedNodes = container.querySelectorAll("mark");
+    expect(matchedNodes.length).toEqual(2);
+  });
+
+  it("merges adjacent non-active chunks", () => {
+    const { container } = render(
+      <HighlightedText text="bbbbb" searchText="b" />
+    );
+    const matchedNodes = container.querySelectorAll("mark");
+    expect(matchedNodes.length).toEqual(1);
+  });
+
+  it("does not merge active chunk", () => {
+    const { container } = render(
+      <HighlightedText text="bbbbb" searchText="b" activeMatchIndex={2} />
+    );
+    const matchedNodes = container.querySelectorAll("mark");
+    expect(matchedNodes.length).toEqual(3);
+    expect(
+      matchedNodes[1].classList.contains("components-activehighlight")
+    ).toEqual(true);
+  });
 });


### PR DESCRIPTION
## Changes

Fixes https://github.com/iTwin/itwinjs-core/issues/3776. Due to a bug in `react-highlight-words`, `activeMatchIndex` does not correctly work when there are adjacent highlights. The issue was reported and has not been fixed in years so I am switching to using a custom implementation for text highlighting as it is fairly simple.

## Testing

Added additional unit tests and manually tested in a test app.
