### PR TITLE
Remove `ConditionalIconItem.isConditionalIconItem()` workaround

### DIFF
--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -224,8 +224,6 @@ export class ConditionalIconItem {
     static getValue(conditionalValue: ConditionalIconItem | string | undefined): IconSpec | undefined;
     // (undocumented)
     readonly iconGetter: () => IconSpec;
-    // @internal
-    static isConditionalIconItem(item: any): item is ConditionalIconItem;
     refresh(): boolean;
     static refreshValue(conditionalValue: ConditionalIconItem | string | undefined, eventIds: Set<string>): boolean;
     // (undocumented)

--- a/common/changes/@itwin/appui-react/issue-900_2024-07-09-07-50.json
+++ b/common/changes/@itwin/appui-react/issue-900_2024-07-09-07-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/issue-900_2024-07-09-07-50.json
+++ b/common/changes/@itwin/components-react/issue-900_2024-07-09-07-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/issue-900_2024-07-09-07-50.json
+++ b/common/changes/@itwin/core-react/issue-900_2024-07-09-07-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Remove `ConditionalIconItem.isConditionalIconItem()` workaround to fix an underscore prefix issue.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -11,6 +11,7 @@ import {
 import {
   CommandItemDef,
   SyncUiEventDispatcher,
+  ToolItemDef,
   ToolbarHelper,
   ToolbarItemUtilities,
   ToolbarOrientation,
@@ -212,16 +213,19 @@ export const ItemDef: Story = {
         125,
         new CommandItemDef({
           iconSpec: <SvgActivity />,
-          label: "Item 3",
-          execute: action("Item 3"),
+          label: "Item 1",
+          execute: () => {
+            bump();
+            action("Item 1")();
+          },
         })
       ),
       ToolbarHelper.createToolbarItemFromItemDef(
         127,
         new CommandItemDef({
           iconSpec: <SvgClipboard />,
-          label: "Item 4",
-          execute: action("Item 4"),
+          label: "Item 2",
+          execute: action("Item 2"),
         }),
         {
           ...createAbstractReactIcon(),
@@ -231,8 +235,8 @@ export const ItemDef: Story = {
         130,
         new CommandItemDef({
           iconSpec: <SvgAirplane />,
-          label: "Item 5",
-          execute: action("Item 5"),
+          label: "Item 3",
+          execute: action("Item 3"),
         }),
         {
           description: "Conditional icon overrides.",
@@ -244,16 +248,27 @@ export const ItemDef: Story = {
         [
           new CommandItemDef({
             iconSpec: <SvgActivity />,
-            label: "Item 6",
-            execute: action("Item 6"),
+            label: "Item 4",
+            execute: action("Item 4"),
           }),
           new CommandItemDef({
             iconSpec: <SvgClipboard />,
-            label: "Item 7",
-            execute: action("Item 7"),
+            label: "Item 5",
+            execute: action("Item 5"),
           }),
         ],
         200
+      ),
+      ToolbarHelper.createToolbarItemFromItemDef(
+        250,
+        new ToolItemDef({
+          toolId: "item6",
+          execute: action("Item 6"),
+          iconSpec: new ConditionalIconItem(
+            () => (getVal() % 2 === 0 ? <Svg3D /> : <Svg2D />),
+            [eventId]
+          ),
+        })
       ),
     ],
   },

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItemsManager.ts
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItemsManager.ts
@@ -136,7 +136,7 @@ export class ToolbarItemsManager {
           entry.syncEventIds.forEach((eventId: string) =>
             eventIds.add(eventId.toLowerCase())
           );
-        } else if (ConditionalIconItem.isConditionalIconItem(entry)) {
+        } else if (entry instanceof ConditionalIconItem) {
           entry.syncEventIds.forEach((eventId: string) =>
             eventIds.add(eventId.toLowerCase())
           );
@@ -187,7 +187,7 @@ export class ToolbarItemsManager {
         } else if (entry instanceof ConditionalStringValue) {
           if (ConditionalStringValue.refreshValue(entry, eventIds))
             itemsUpdated = true;
-        } else if (ConditionalIconItem.isConditionalIconItem(entry)) {
+        } else if (entry instanceof ConditionalIconItem) {
           if (ConditionalIconItem.refreshValue(entry, eventIds))
             itemsUpdated = true;
         }
@@ -229,7 +229,7 @@ export class ToolbarItemsManager {
         } else if (entry instanceof ConditionalStringValue) {
           if (ConditionalStringValue.refreshValue(entry, eventIds))
             updateRequired = true;
-        } else if (ConditionalIconItem.isConditionalIconItem(entry)) {
+        } else if (entry instanceof ConditionalIconItem) {
           if (ConditionalIconItem.refreshValue(entry, eventIds))
             updateRequired = true;
         }

--- a/ui/components-react/src/components-react/toolbar/useConditionalSynchedItems.ts
+++ b/ui/components-react/src/components-react/toolbar/useConditionalSynchedItems.ts
@@ -30,7 +30,7 @@ function gatherSyncIds<T extends {} | { items: T[] }>(
         entry.syncEventIds.forEach((eventId: string) =>
           eventIds.add(eventId.toLowerCase())
         );
-      } else if (ConditionalIconItem.isConditionalIconItem(entry)) {
+      } else if (entry instanceof ConditionalIconItem) {
         entry.syncEventIds.forEach((eventId: string) =>
           eventIds.add(eventId.toLowerCase())
         );
@@ -73,7 +73,7 @@ function refreshItems<T extends {} | { items: T[] }>(
           ConditionalBooleanValue.refreshValue(entry, eventIds)) ||
         (entry instanceof ConditionalStringValue &&
           ConditionalStringValue.refreshValue(entry, eventIds)) ||
-        (ConditionalIconItem.isConditionalIconItem(entry) &&
+        (entry instanceof ConditionalIconItem &&
           ConditionalIconItem.refreshValue(entry, eventIds))
       ) {
         itemsUpdated = true;

--- a/ui/core-react/src/core-react/icons/ConditionalIconItem.tsx
+++ b/ui/core-react/src/core-react/icons/ConditionalIconItem.tsx
@@ -27,17 +27,6 @@ export class ConditionalIconItem {
     this._value = value;
   }
 
-  /** A work-around for instanceOf
-   * @internal
-   */
-  public static isConditionalIconItem(item: any): item is ConditionalIconItem {
-    if (!item || typeof item !== "object") return false;
-    const itemPrototype = Object.getPrototypeOf(item);
-
-    if (itemPrototype.constructor.name !== "ConditionalIconItem") return false;
-
-    return true;
-  }
   /** The current IconSpec according to conditions */
   public get value(): IconSpec {
     if (undefined !== this._value) return this._value;
@@ -63,7 +52,7 @@ export class ConditionalIconItem {
   ): boolean {
     if (
       undefined === conditionalValue ||
-      !ConditionalIconItem.isConditionalIconItem(conditionalValue)
+      !(conditionalValue instanceof ConditionalIconItem)
     )
       return false;
 
@@ -84,7 +73,7 @@ export class ConditionalIconItem {
   ): IconSpec | undefined {
     if (undefined === conditionalValue) return undefined;
 
-    if (ConditionalIconItem.isConditionalIconItem(conditionalValue)) {
+    if (conditionalValue instanceof ConditionalIconItem) {
       const iconItem = conditionalValue;
       return iconItem.value;
     }

--- a/ui/core-react/src/core-react/icons/IconComponent.tsx
+++ b/ui/core-react/src/core-react/icons/IconComponent.tsx
@@ -118,7 +118,7 @@ function getIconSpecValue(
 ): Exclude<IconSpec, ConditionalIconItem | ConditionalStringValue> {
   let value = iconSpec;
   while (true) {
-    if (ConditionalIconItem.isConditionalIconItem(value)) {
+    if (value instanceof ConditionalIconItem) {
       value = ConditionalIconItem.getValue(value);
       continue;
     }

--- a/ui/core-react/src/core-react/utils/IconHelper.tsx
+++ b/ui/core-react/src/core-react/utils/IconHelper.tsx
@@ -39,7 +39,7 @@ export class IconHelper {
   ): React.ReactNode {
     if (!icon) return null;
 
-    if (ConditionalIconItem.isConditionalIconItem(icon))
+    if (icon instanceof ConditionalIconItem)
       return <Icon iconSpec={ConditionalIconItem.getValue(icon)} />;
     if (React.isValidElement(icon)) return <Icon iconSpec={icon} />;
 
@@ -81,7 +81,7 @@ export class IconHelper {
     internalData?: Map<string, any>
   ): string | ConditionalStringValue {
     let icon;
-    if (ConditionalIconItem.isConditionalIconItem(iconSpec)) {
+    if (iconSpec instanceof ConditionalIconItem) {
       icon = IconHelper.conditionalIconItemKey;
       if (internalData)
         internalData.set(IconHelper.conditionalIconItemKey, iconSpec);

--- a/ui/core-react/src/test/icons/ConditionalIconItem.test.tsx
+++ b/ui/core-react/src/test/icons/ConditionalIconItem.test.tsx
@@ -101,17 +101,4 @@ describe("ConditionalIconItem", () => {
       ConditionalIconItem.refreshValue(undefined, new Set<string>(["cat"]))
     ).toEqual(false);
   });
-
-  it("isConditionalIconItem should evaluate to true for instances", () => {
-    const sut = new ConditionalIconItem(
-      icon1Getter,
-      syncEventIds,
-      defaultIconSpec
-    );
-
-    expect(ConditionalIconItem.isConditionalIconItem(sut)).toEqual(true);
-    expect(ConditionalIconItem.isConditionalIconItem("icon.svg")).toEqual(
-      false
-    );
-  });
 });


### PR DESCRIPTION
## Changes

This PR fixes #900 by removing a `ConditionalIconItem.isConditionalIconItem()`. It was added as a workaround for #315, which I suspect might have happened due to the usage of **both** ESM and CJS modules.

## Testing

Tested in standalone test-app and storybook.
