### PR TITLE
Remove the `theme-transition` class

### DIFF
--- a/common/changes/@itwin/appui-react/remove-theme-transition_2024-07-10-11-57.json
+++ b/common/changes/@itwin/appui-react/remove-theme-transition_2024-07-10-11-57.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Removed transitions when toggling themes. This fixes the flying floating elements like Tooltips and ComboBox menus when the page first loads.",
+      "comment": "Removed transitions when toggling themes. This fixes the unintentional \"flying-in\" of floating elements like Tooltips and ComboBox menus when the page first loads.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/remove-theme-transition_2024-07-10-11-57.json
+++ b/common/changes/@itwin/appui-react/remove-theme-transition_2024-07-10-11-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Removed transitions when toggling themes. This fixes the flying floating elements like Tooltips and ComboBox menus when the page first loads.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/core-react/remove-theme-transition_2024-07-10-11-57.json
+++ b/common/changes/@itwin/core-react/remove-theme-transition_2024-07-10-11-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Removed styling for the `theme-transition` class.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -168,10 +168,12 @@ Table of contents:
 ### Changes
 
 - Bump `AccuDrawWidget`, `SheetNavigationAid`, `StandardRotationNavigationAid` components to `@public`. [#888](https://github.com/iTwin/appui/pull/888)
+- No more transitions when toggling themes. [#905](https://github.com/iTwin/appui/pull/905)
 
 ### Fixes
 
 - Fixed `AccuDrawInputField` to correctly specify keyboard event modifiers in `UiFramework.keyboardShortcuts.processKey()`. [#894](https://github.com/iTwin/appui/pull/894)
+- Fixes the unintentional "flying-in" of floating elements like Tooltips and ComboBox menus when the page first loads. [#905](https://github.com/iTwin/appui/pull/905)
 
 ## @itwin/components-react
 
@@ -198,3 +200,7 @@ Table of contents:
 
 - Added `badgeKind` property to `ContextMenuItemProps`. It allows specifying the badge type using string values from `BadgeKind`. [#899](https://github.com/iTwin/appui/pull/899)
 - Added `Deprecated` badge. It can only be accessed by using `badgeKind` properties in components. [#899](https://github.com/iTwin/appui/pull/899)
+
+### Changes
+
+- Removed styling for the `theme-transition` class. [#890](https://github.com/iTwin/appui/pull/890)

--- a/ui/appui-react/src/appui-react/theme/ThemeManager.tsx
+++ b/ui/appui-react/src/appui-react/theme/ThemeManager.tsx
@@ -64,12 +64,7 @@ export function ThemeManager({ children, ...props }: ThemeManagerProps) {
   const theme = props.theme ?? reduxTheme ?? SYSTEM_PREFERRED_COLOR_THEME;
 
   React.useEffect(() => {
-    document.documentElement.classList.add("theme-transition");
     document.documentElement.setAttribute("data-theme", theme);
-    setTimeout(
-      () => document.documentElement.classList.remove("theme-transition"),
-      1000
-    );
   }, [theme]);
 
   const providerTheme = colorThemeToThemeTypeMap[theme];

--- a/ui/core-react/src/core-react/colorthemes.scss
+++ b/ui/core-react/src/core-react/colorthemes.scss
@@ -10,11 +10,3 @@
 
 $background: var(--iui-color-background);
 $accent: var(--iui-color-background-accent);
-
-html.theme-transition,
-html.theme-transition *,
-html.theme-transition *:before,
-html.theme-transition *:after {
-  transition: all 100ms !important;
-  transition-delay: 0 !important;
-}


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

In https://github.com/iTwin/appui/issues/886, @GerardasB pointed out how iTwinUI ComboBox's menu seems to incorrectly fly in when opening the ComboBox in a popout window. Additionally, in the WidgetActionDropdown → Default story, we can see the iTwinUI flying in similarly in some cases.

Upon some collective investigation, we realized it was because the `theme-transition` CSS class on the `documentElement` was applying a `transition` to all descendants. We guess this class was meant to show a smooth transition when changing themes. However, we think changing themes is not a regular action and the current abrupt transition is good enough.

Thus, we decided to remove this `theme-transition` class altogether. This is what this PR does.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

- [x] Confirmed that the Tooltip in the storybook doesn't fly in anymore and is shown correctly.