### PR TITLE
Fix `FrontstageDef.create()` to handle `FrontstageProvider` shaped objects

### DIFF
--- a/common/changes/@itwin/appui-react/frontstage-provider-fix_2024-07-10-09-47.json
+++ b/common/changes/@itwin/appui-react/frontstage-provider-fix_2024-07-10-09-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `FrontstageDef.create()` if a non-instance `FrontstageProvider` is used.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -53,7 +53,7 @@ import type { WidgetConfig } from "../widgets/WidgetConfig";
 import type { WidgetControl } from "../widgets/WidgetControl";
 import { getWidgetState, WidgetDef, WidgetType } from "../widgets/WidgetDef";
 import { WidgetState } from "../widgets/WidgetState";
-import { FrontstageProvider } from "./FrontstageProvider";
+import type { FrontstageProvider } from "./FrontstageProvider";
 import { InternalFrontstageManager } from "./InternalFrontstageManager";
 import { StageUsage } from "./StageUsage";
 import type { Frontstage } from "./Frontstage";
@@ -322,8 +322,7 @@ export class FrontstageDef {
     const def = new FrontstageDef();
 
     let config;
-    // eslint-disable-next-line deprecation/deprecation
-    if (providerOrFrontstage instanceof FrontstageProvider) {
+    if ("frontstageConfig" in providerOrFrontstage) {
       def._frontstageProvider = providerOrFrontstage;
       config = providerOrFrontstage.frontstageConfig();
     } else {

--- a/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
@@ -196,6 +196,38 @@ describe("FrontstageDef", () => {
     expect(spy).toHaveBeenCalledWith("t1");
   });
 
+  describe("create", () => {
+    it("should create from FrontstageProvider instance", async () => {
+      const frontstageDef = await FrontstageDef.create(
+        new (class Provider extends FrontstageProvider {
+          public override get id(): string {
+            return "provider-1";
+          }
+          public override frontstageConfig(): FrontstageConfig {
+            return {
+              id: "frontstage-1",
+              contentGroup: TestUtils.TestContentGroup1,
+              version: 123,
+            };
+          }
+        })()
+      );
+      expect(frontstageDef.version).toEqual(123);
+    });
+
+    it("should create from FrontstageProvider object", async () => {
+      const frontstageDef = await FrontstageDef.create({
+        id: "provider-1",
+        frontstageConfig: () => ({
+          id: "frontstage-1",
+          contentGroup: TestUtils.TestContentGroup1,
+          version: 123,
+        }),
+      });
+      expect(frontstageDef.version).toEqual(123);
+    });
+  });
+
   describe("onWidgetStateChangedEvent", () => {
     it("should open a hidden widget", async () => {
       const activeFrontstageDef = new FrontstageDef();


### PR DESCRIPTION
## Changes

Replace `instanceof` check of `FrontstageProvider` with the property lookup to fix `FrontstageDef.create()` if a non-instance `FrontstageProvider` is used (i.e. in `UiFramework.frontstages.addFrontstageProvider`).

## Testing

Added additional unit tests.
