### PR TITLE
Added storybook's `.cache` to gitignore

### DIFF
--- a/docs/storybook/.gitignore
+++ b/docs/storybook/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.cache
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

After working on #905, I noticed that storybook created some cache files that weren't gitignored. This small PR adds `.cache` to storybook's gitignore.

Old result of `git status`:
<img width="542" alt="image" src="https://github.com/iTwin/appui/assets/45748283/58d5cd7e-9692-45ec-b083-33f66d9ee0b9">


## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Confirmed that the `.cache` files were no longer appearing as untracked files.