### PR TITLE
Fix `PopupContextMenu` in `StatusBarPopover`

### DIFF
--- a/common/changes/@itwin/core-react/fix-popup-context-menu_2024-07-15-06-05.json
+++ b/common/changes/@itwin/core-react/fix-popup-context-menu_2024-07-15-06-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Fix `PopupContextMenu` to work in `StatusBarPopover`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/ui/core-react/src/core-react/contextmenu/PopupContextMenu.tsx
+++ b/ui/core-react/src/core-react/contextmenu/PopupContextMenu.tsx
@@ -87,6 +87,7 @@ export function PopupContextMenu(props: PopupContextMenuProps) {
       showArrow={false}
       moveFocus={true}
       style={{ ...style, border: "none" }}
+      portalTarget={props.target ?? undefined}
     >
       <ContextMenu
         opened={true}


### PR DESCRIPTION
## Changes
When `PopupContextMenu` is used as a nested popup in `StatusBarPopover` it is problematic because the logic of iTwinUI (Popover) and AppUI (Popup) clash since they portal to different places which then causes various issues (e.g. the nested `Popup` displays behind the main `Popover` or opening the nested `Popup` would close the `Popover`). As a simple fix I used `portalTarget` prop which will portal the `Popup` into the `Popover` (more specifically, the trigger button which is inside the Popover).

Additionally, `PopupContextMenu` will be deprecated in AppUI 4.16.0 and can be easily replaced with `DropdownMenu` or `DropdownButton` from iTwinUI. 

Fixes #909.

## Testing
Tested in standalone test-app.
