### PR TITLE
Fix popout widget changing position on second monitor

### DIFF
--- a/common/changes/@itwin/appui-react/moving-popout-widget-second-monitor-fix_2024-07-18-05-55.json
+++ b/common/changes/@itwin/appui-react/moving-popout-widget-second-monitor-fix_2024-07-18-05-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fixed popout widget changing position on a secondary montitor.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/childwindow/ChildWindowConfig.ts
+++ b/ui/appui-react/src/appui-react/childwindow/ChildWindowConfig.ts
@@ -11,6 +11,10 @@ export interface ChildWindow extends Window {
   expectedWidth?: number;
   /** Expected height of the child window. */
   expectedHeight?: number;
+  /** Expected top value of the child window. */
+  expectedTop?: number;
+  /** Expected left value of the child window. */
+  expectedLeft?: number;
   /** Difference between expected child window width and actual value when opened. */
   deltaWidth?: number;
   /** Difference between expected child window height and actual value when opened. */

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -192,6 +192,13 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
             childWindow.deltaHeight =
               childWindow.expectedHeight - childWindow.innerHeight;
           }
+
+          if (childWindow.expectedLeft && childWindow.expectedTop) {
+            childWindow.deltaLeft =
+              childWindow.expectedLeft - childWindow.screenLeft;
+            childWindow.deltaTop =
+              childWindow.expectedTop - childWindow.screenTop;
+          }
         });
       });
 
@@ -295,8 +302,8 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
     if (!childWindow) return false;
     childWindow.expectedHeight = location.height;
     childWindow.expectedWidth = location.width;
-    childWindow.deltaLeft = location.left - childWindow.screenLeft;
-    childWindow.deltaTop = location.top - childWindow.screenTop;
+    childWindow.expectedLeft = location.left;
+    childWindow.expectedTop = location.top;
 
     if (url.length === 0) {
       childWindow.document.write(childHtml);


### PR DESCRIPTION
## Changes
Moved `deltaLeft` and `deltaTop` calculations after rendering the content. Seems like when the popout widget is on the second monitor `left` and `top` values are set correctly only after the content is rendered.

Fixes #896.

## Testing
Tested in electron. Regular browsers are not relevant because they will always open the child window on the primary monitor.
