### PR TITLE
Fix `ToolAssistanceField` icon size

### DIFF
--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.scss
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.scss
@@ -25,6 +25,10 @@ $key-size-modifier: 24px;
     overflow: hidden;
     text-overflow: ellipsis;
   }
+
+  .icon {
+    font-size: 16px;
+  }
 }
 
 .uifw-toolassistance-key {


### PR DESCRIPTION
## Changes
This reverts a change made in #848 which made the icon in the `ToolAssistanceField` component render with the wrong size. Now we force it to be 16x16.

## Testing
Tested in standalone test-app.
