### PR TITLE
Fix `mixed-decls` warnings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 lib
 build
 coverage
+dist
 
 # rush specific
 .rush

--- a/common/changes/@itwin/appui-react/fix-mixed-decl_2024-07-30-11-26.json
+++ b/common/changes/@itwin/appui-react/fix-mixed-decl_2024-07-30-11-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix mixed-decls Sass warnings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/fix-mixed-decl_2024-07-30-11-26.json
+++ b/common/changes/@itwin/components-react/fix-mixed-decl_2024-07-30-11-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fix mixed-decls Sass warnings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/fix-mixed-decl_2024-07-30-11-26.json
+++ b/common/changes/@itwin/core-react/fix-mixed-decl_2024-07-30-11-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Fix mixed-decls Sass warnings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/fix-mixed-decl_2024-07-30-11-26.json
+++ b/common/changes/@itwin/imodel-components-react/fix-mixed-decl_2024-07-30-11-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Fix mixed-decls Sass warnings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -162,7 +162,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.2.0
-        version: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+        version: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
       vite-plugin-static-copy:
         specifier: ^1.0.1
         version: 1.0.1(vite@5.2.6)
@@ -466,14 +466,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       sass:
-        specifier: ^1.72.0
-        version: 1.72.0
+        specifier: ^1.77.7
+        version: 1.77.8
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
       vite:
         specifier: ^5.2.0
-        version: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+        version: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
       vite-plugin-static-copy:
         specifier: ^1.0.1
         version: 1.0.1(vite@5.2.6)
@@ -644,14 +644,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       sass:
-        specifier: ^1.72.0
-        version: 1.72.0
+        specifier: ^1.77.7
+        version: 1.77.8
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
       vite:
         specifier: ^5.2.0
-        version: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+        version: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
       vite-plugin-static-copy:
         specifier: ^1.0.1
         version: 1.0.1(vite@5.2.6)
@@ -4433,7 +4433,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.3.3)
       typescript: 5.3.3
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -5662,7 +5662,7 @@ packages:
       magic-string: 0.30.5
       rollup: 3.29.4
       typescript: 5.3.3
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6023,7 +6023,7 @@ packages:
       react: 18.3.1
       react-docgen: 7.0.3
       react-dom: 18.3.1(react@18.3.1)
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - encoding
@@ -7133,7 +7133,7 @@ packages:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.4.8
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -7149,7 +7149,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7165,7 +7165,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13599,8 +13599,8 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass@1.72.0:
-    resolution: {integrity: sha512-Gpczt3WA56Ly0Mn8Sl21Vj94s1axi9hDIzDFn9Ph9x3C3p4nNyvsqJoQyVXKou6cBlfFWEgRW4rT8Tb4i3XnVA==}
+  /sass@1.77.8:
+    resolution: {integrity: sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
@@ -14810,7 +14810,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -14832,10 +14832,10 @@ packages:
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       picocolors: 1.0.0
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
     dev: true
 
-  /vite@5.2.6(@types/node@18.11.5)(sass@1.72.0):
+  /vite@5.2.6(@types/node@18.11.5)(sass@1.77.8):
     resolution: {integrity: sha512-FPtnxFlSIKYjZ2eosBQamz4CbyrTizbZ3hnGJlh/wMtCrlp1Hah6AzBLjGI5I2urTfNnpovpHdrL6YRuBOPnCA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -14867,7 +14867,7 @@ packages:
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.13.0
-      sass: 1.72.0
+      sass: 1.77.8
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -14916,7 +14916,7 @@ packages:
       strip-literal: 2.1.0
       tinybench: 2.6.0
       tinypool: 0.8.3
-      vite: 5.2.6(@types/node@18.11.5)(sass@1.72.0)
+      vite: 5.2.6(@types/node@18.11.5)(sass@1.77.8)
       vite-node: 1.6.0(@types/node@18.11.5)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -16,6 +16,9 @@ Table of contents:
   - [Deprecations](#deprecations-2)
   - [Additions](#additions-2)
   - [Changes](#changes-2)
+  - [Fixes](#fixes-2)
+- [@itwin/imodel-components-react](#itwinimodel-components-react)
+  - [Fixes](#fixes-3)
 
 ## @itwin/appui-react
 
@@ -222,6 +225,7 @@ Table of contents:
 - Fixed icon alignment and warning status color of notification manager in `MessageCenterField` component. [#901](https://github.com/iTwin/appui/pull/901)
 - Fixed the unintentional "flying-in" of floating elements like Tooltips and ComboBox menus when the page first loads. [#905](https://github.com/iTwin/appui/pull/905)
 - Fixed `ToolAssistanceField` icon size. [#937](https://github.com/iTwin/appui/pull/937)
+- Fixed [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) Sass warnings. [#939](https://github.com/iTwin/appui/pull/939)
 
 ## @itwin/components-react
 
@@ -242,6 +246,7 @@ Table of contents:
 
 - Fixed `activeMatchIndex` not working correctly on adjacent matches in `HighlightedText`. [#898](https://github.com/iTwin/appui/pull/898)
 - Fixed widget tab styling to match the SVG and CSS icon size. [#901](https://github.com/iTwin/appui/pull/901)
+- Fixed [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) Sass warnings. [#939](https://github.com/iTwin/appui/pull/939)
 
 ## @itwin/core-react
 
@@ -345,3 +350,13 @@ Table of contents:
 ### Changes
 
 - Removed styling for the `theme-transition` class. [#890](https://github.com/iTwin/appui/pull/890)
+
+### Fixes
+
+- Fixed [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) Sass warnings. [#939](https://github.com/iTwin/appui/pull/939)
+
+## @itwin/imodel-components-react
+
+### Fixes
+
+- Fixed [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) Sass warnings. [#939](https://github.com/iTwin/appui/pull/939)

--- a/e2e-tests/tests/statusbar/status-bar-indicator.test.ts
+++ b/e2e-tests/tests/statusbar/status-bar-indicator.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import { expect, test } from "@playwright/test";
 import { openComponentExamples } from "../Utils";
-import { stat } from "fs";
 
 test("status bar indicator test", async ({ page, baseURL }) => {
   await openComponentExamples(page, baseURL);

--- a/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/ComponentExamples.scss
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/frontstages/ComponentExamples.scss
@@ -31,15 +31,13 @@ $component-examples-rightpanel-width: 200px;
 
   .component-examples-items {
     background: $buic-background-dialog;
-
     height: 100%;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
 
     @include uicore-touch-scrolling;
     @include uicore-scrollbar();
-
-    display: flex;
-    flex-direction: column;
 
     .component-examples-item {
       display: flex;

--- a/test-apps/appui-test-app/connected/package.json
+++ b/test-apps/appui-test-app/connected/package.json
@@ -57,7 +57,7 @@
     "npm-run-all": "^4.1.5",
     "null-loader": "^4.0.1",
     "rimraf": "^3.0.2",
-    "sass": "^1.72.0",
+    "sass": "^1.77.7",
     "typescript": "~5.3.3",
     "vite": "^5.2.0",
     "vite-plugin-static-copy": "^1.0.1"

--- a/test-apps/appui-test-app/standalone/package.json
+++ b/test-apps/appui-test-app/standalone/package.json
@@ -57,7 +57,7 @@
     "npm-run-all": "^4.1.5",
     "null-loader": "^4.0.1",
     "rimraf": "^3.0.2",
-    "sass": "^1.72.0",
+    "sass": "^1.77.7",
     "typescript": "~5.3.3",
     "vite": "^5.2.0",
     "vite-plugin-static-copy": "^1.0.1"

--- a/test-apps/appui-test-app/standalone/package.json
+++ b/test-apps/appui-test-app/standalone/package.json
@@ -6,10 +6,9 @@
   "version": "0.0.0",
   "homepage": "http://localhost:3000/",
   "scripts": {
-    "build": "npm run build:backend && npm run frontend:tsc",
+    "build": "npm run build:backend && npm run build:frontend",
     "build:backend": "tsc -p tsconfig.backend.json",
     "build:frontend": "npm run copy:webfont && npm run pseudolocalize && vite build",
-    "frontend:tsc": "tsc",
     "clean": "rimraf lib build .rush/temp/package-deps*.json",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "start": "run-p start:webserver start:electron",

--- a/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/appui/frontstages/LocalFileStage.tsx
@@ -8,7 +8,6 @@ import { IModelReadRpcInterface, ViewQueryParams } from "@itwin/core-common";
 import { IModelConnection, SpatialViewState } from "@itwin/core-frontend";
 
 import { ElectronApp } from "@itwin/core-electron/lib/cjs/ElectronFrontend";
-import { OpenDialogOptions } from "electron";
 
 import {
   BackstageAppButton,
@@ -231,11 +230,10 @@ function LocalFilePage(props: LocalFilePageProps) {
   );
 
   const handleElectronFileOpen = React.useCallback(async () => {
-    const opts: OpenDialogOptions = {
+    const val = await ElectronApp.dialogIpc.showOpenDialog({
       properties: ["openFile"],
       filters: [{ name: "iModels", extensions: ["ibim", "bim"] }],
-    };
-    const val = await ElectronApp.dialogIpc.showOpenDialog(opts);
+    });
     if (val.canceled) return;
 
     const filePath = val.filePaths[0];

--- a/test-apps/appui-test-app/standalone/vite.config.mts
+++ b/test-apps/appui-test-app/standalone/vite.config.mts
@@ -1,9 +1,30 @@
-import { defineConfig } from "vite";
+import { createLogger, defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 
+const customLogger = createLogger();
+const warn = customLogger.warn;
+
+customLogger.warn = (msg, options) => {
+  if (
+    msg.includes(`Module "fs" has been externalized`) &&
+    msg.includes("node_modules/electron/index.js")
+  )
+    return;
+  if (
+    msg.includes(`Module "path" has been externalized`) &&
+    msg.includes("node_modules/electron/index.js")
+  )
+    return;
+  warn(msg, options);
+};
+
 // https://vitejs.dev/config/
 export default defineConfig({
+  build: {
+    chunkSizeWarningLimit: 7000,
+  },
+  customLogger,
   plugins: [
     react(),
     viteStaticCopy({

--- a/ui/appui-react/src/appui-react/layout/target/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/target/_variables.scss
@@ -23,6 +23,8 @@ $nz-widget-target-border-size: 2px;
   pointer-events: all;
   display: flex;
   box-shadow: var(--iui-shadow-3);
+  animation: nz-grow var(--iui-duration-1) ease-in-out,
+    nz-pulse 3s ease-in-out 2s infinite;
 
   @include uicore-z-index(drop-target);
 
@@ -51,9 +53,6 @@ $nz-widget-target-border-size: 2px;
       }
     }
   }
-
-  animation: nz-grow var(--iui-duration-1) ease-in-out,
-    nz-pulse 3s ease-in-out 2s infinite;
 }
 
 @mixin nz-targeted-widget-target {

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
@@ -15,12 +15,12 @@
     min-height: 120px;
     transition: opacity var(--iui-duration-2) ease;
 
+    @include uicore-z-index(dragged-widget);
+    @include nz-widget-opacity;
+
     &.nz-floating-toolSettings {
       min-height: 60px;
     }
-
-    @include uicore-z-index(dragged-widget);
-    @include nz-widget-opacity;
 
     &.nz-minimized {
       flex-grow: 0;

--- a/ui/appui-react/src/appui-react/layout/widget/NavigationArea.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/NavigationArea.scss
@@ -8,12 +8,6 @@
 .nz-widget-navigationArea {
   transition: visibility var(--iui-duration-2) ease,
     opacity var(--iui-duration-2) ease;
-
-  &.nz-hidden {
-    opacity: 0;
-    visibility: hidden;
-  }
-
   display: grid;
   box-sizing: border-box;
   height: 100%;
@@ -23,11 +17,17 @@
   justify-items: end;
   grid-template-areas: "htools button" ". vtools";
 
+  &.nz-hidden {
+    opacity: 0;
+    visibility: hidden;
+  }
+
   > .nz-navigation-aid-container {
     margin-bottom: 6px;
     pointer-events: auto;
-    @include nz-widget-opacity;
     grid-area: button;
+
+    @include nz-widget-opacity;
   }
 
   > .nz-vertical-toolbar-container {
@@ -47,11 +47,11 @@
     justify-content: flex-end;
     min-width: 0;
 
+    @include nz-widget-opacity;
+
     > .components-toolbar-overflow-sizer {
       display: flex;
       justify-content: flex-end;
     }
-
-    @include nz-widget-opacity;
   }
 }

--- a/ui/appui-react/src/appui-react/layout/widget/ToolsArea.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/ToolsArea.scss
@@ -8,12 +8,6 @@
 .nz-tools-widget {
   transition: visibility var(--iui-duration-2) ease,
     opacity var(--iui-duration-2) ease;
-
-  &.nz-hidden {
-    opacity: 0;
-    visibility: hidden;
-  }
-
   display: grid;
   box-sizing: border-box;
   height: 100%;
@@ -22,6 +16,11 @@
   align-items: start;
   justify-items: start;
   grid-template-columns: auto 1fr;
+
+  &.nz-hidden {
+    opacity: 0;
+    visibility: hidden;
+  }
 
   > .nz-vertical-tool-area {
     display: inline-flex;

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/Button.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/Button.scss
@@ -8,26 +8,23 @@
   box-sizing: border-box;
   width: $mls-button-width;
   height: $mls-button-height;
-
-  &.nz-toolbar-button-icon-small {
-    width: $mls-small-button-width;
-    height: $mls-small-button-height;
-  }
-
   cursor: pointer;
   position: relative;
   overflow: hidden;
   background: var(--iui-color-background);
   border-radius: var(--iui-border-radius-1);
-
   border: {
     width: 1px;
     color: var(--iui-color-border-foreground);
     radius: var(--iui-border-radius-1);
     style: solid;
   }
-
   pointer-events: auto;
+
+  &.nz-toolbar-button-icon-small {
+    width: $mls-small-button-width;
+    height: $mls-small-button-height;
+  }
 
   > .nz-gradient {
     background: linear-gradient(

--- a/ui/appui-react/src/appui-react/pickers/ListPicker.scss
+++ b/ui/appui-react/src/appui-react/pickers/ListPicker.scss
@@ -22,10 +22,11 @@ $item-height: 32px;
 }
 
 .ListPicker-column {
-  @include uicore-scrollbar();
   overflow: auto;
   height: 40vh;
   width: 30vh;
+
+  @include uicore-scrollbar();
 }
 
 .ListPickerInnerContainer {

--- a/ui/appui-react/src/appui-react/preview/new-toolbars/ToolGroup.scss
+++ b/ui/appui-react/src/appui-react/preview/new-toolbars/ToolGroup.scss
@@ -22,15 +22,15 @@
   height: fit-content;
   border-color: var(--iui-color-border-foreground);
   transition: border-color var(--iui-duration-1) ease;
+  // TODO: needed due to opacity on toolbar container (since pointer events are disabled for center content).
+  pointer-events: all;
+
   @supports (backdrop-filter: blur(5px)) {
     background-color: hsl(
       var(--iui-color-background-hsl) / var(--iui-opacity-2)
     );
     backdrop-filter: blur(5px);
   }
-
-  // TODO: needed due to opacity on toolbar container (since pointer events are disabled for center content).
-  pointer-events: all;
 
   &.uifw-vertical {
     flex-direction: column;

--- a/ui/components-react/src/components-react/editors/PopupButton.scss
+++ b/ui/components-react/src/components-react/editors/PopupButton.scss
@@ -45,14 +45,13 @@
 
     > .components-popup-button-arrow-icon {
       transition: transform 0.2s;
+      text-align: center;
+      font-size: var(--iui-font-size-0);
+      line-height: var(--iui-size-l);
 
       &:hover {
         color: var(--iui-color-text-accent);
       }
-
-      text-align: center;
-      font-size: var(--iui-font-size-0);
-      line-height: var(--iui-size-l);
     }
   }
 

--- a/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
+++ b/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
@@ -50,7 +50,6 @@
 }
 
 .components-nonprimitive-property-label-renderer {
-  @include specific-property-label-renderer;
   align-items: center;
   border: none;
   background: transparent;
@@ -61,6 +60,8 @@
   width: 100%;
   transition: transform var(--iui-duration-1) ease-in-out,
     -webkit-transform var(--iui-duration-1) ease-in-out;
+
+  @include specific-property-label-renderer;
 
   > .components-property-label-renderer {
     flex: 1;

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGrid.scss
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGrid.scss
@@ -43,14 +43,13 @@
 }
 
 .components-property-list--horizontal {
-  @include components-property-list;
-
   display: grid;
-  grid-row-gap: 1px; // A gap of 10px is too wasteful
+  grid-row-gap: 1px;
   overflow: hidden;
+
+  @include components-property-list;
 }
 
 .components-property-list--vertical {
   @include components-property-list;
-  // margin-top: -13px;
 }

--- a/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
+++ b/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
@@ -24,17 +24,16 @@ $uicore-menu-top-bottom-padding: calc(#{$uicore-menu-padding} * 0.6667);
 
 .core-context-menu {
   color: var(--iui-color-text);
-
-  &:hover {
-    color: var(--iui-color-text-hover);
-    cursor: auto;
-  }
-
   width: 0px;
   height: 0px;
   position: relative;
 
   @include uicore-z-index(context-menu-z);
+
+  &:hover {
+    color: var(--iui-color-text-hover);
+    cursor: auto;
+  }
 
   .core-context-menu-container {
     position: absolute;

--- a/ui/core-react/src/core-react/radialmenu/RadialMenu.scss
+++ b/ui/core-react/src/core-react/radialmenu/RadialMenu.scss
@@ -8,13 +8,13 @@
 
 .core-radial-menu {
   visibility: hidden;
+  position: fixed;
+
+  @include uicore-z-index(dialog);
 
   &.opened {
     visibility: inherit;
   }
-
-  position: fixed;
-  @include uicore-z-index(dialog);
 
   > .core-radial-menu-container {
     margin-left: -50%;

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.scss
@@ -88,15 +88,6 @@
       background-color: $buic-background-control;
       opacity: 0.5;
       color: var(--iui-color-text);
-
-      &.checked {
-        color: var(--iui-color-text-accent);
-      }
-
-      &:hover {
-        opacity: 1;
-      }
-
       border-radius: var(--iui-border-radius-1);
       bottom: 10px;
       left: 10px;
@@ -105,6 +96,14 @@
       font-size: 12px;
       line-height: 16px;
       text-align: center;
+
+      &.checked {
+        color: var(--iui-color-text-accent);
+      }
+
+      &:hover {
+        opacity: 1;
+      }
     }
 
     .zoom {


### PR DESCRIPTION
## Changes

This PR fixes #911 to resolve [mixed-decls warnings](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) by moving CSS declarations to the beginning of the rule.
Additionally:
- The `sass` version is bumped to the latest since `mixed-decls` is only reproducible from `1.77.7`
- CI will run `vite build` for the standalone test app to catch SASS warnings in the future

## Testing

N/A
