### PR TITLE
Update release tags of frequently used APIs

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -184,7 +184,7 @@ export interface AccuDrawDialogProps extends CommonProps {
 export class AccuDrawGrabInputFocusEvent extends BeUiEvent<{}> {
 }
 
-// @beta
+// @public
 export class AccuDrawKeyboardShortcuts {
     static getDefaultShortcuts(): KeyboardShortcutProps[];
 }
@@ -531,7 +531,7 @@ export interface BackstageComposerStageLauncherProps {
 // @public
 export type BackstageItem = BackstageActionItem | BackstageStageLauncher;
 
-// @beta
+// @public
 export namespace BackstageItemUtilities {
     export function createActionItem(args: CreateActionItemArgs): BackstageActionItem;
     // @deprecated
@@ -739,9 +739,9 @@ export enum CalculatorOperator {
 
 // @alpha @deprecated
 export class CalculatorPopup extends React_2.PureComponent<CalculatorPopupProps, CalculatorPopupState> {
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: {
         size: Size;
     };
@@ -786,7 +786,7 @@ export interface CanFloatWidgetOptions {
 // @alpha
 export class CardContainer extends React_2.Component<CardContainerProps> {
     static get onCardSelectedEvent(): CardSelectedEvent;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
 }
 
@@ -1449,7 +1449,6 @@ export interface CursorMenuPayload {
 
 // @public
 export class CursorPopup extends React_2.Component<CursorPopupProps, CursorPopupState> {
-    // @internal
     constructor(props: CursorPopupProps);
     // (undocumented)
     componentDidMount(): void;
@@ -1459,7 +1458,7 @@ export class CursorPopup extends React_2.Component<CursorPopupProps, CursorPopup
     static fadeOutTime: number;
     // @internal (undocumented)
     static getPopupRect(pt: XAndY, offset: XAndY, popupSize: SizeProps | undefined, relativePosition: RelativePosition | Placement): RectangleProps;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
 }
 
@@ -1499,7 +1498,7 @@ CursorPopupMenuState> {
     componentWillUnmount(): void;
     // (undocumented)
     render(): React_2.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: CursorPopupMenuState;
 }
 
@@ -1776,7 +1775,7 @@ export interface DialogRendererProps {
 // @internal
 export function DockedStatusBarItem(props: StatusBarItemProps): React_2.JSX.Element;
 
-// @beta @deprecated
+// @public @deprecated
 export class DrawingNavigationAidControl extends NavigationAidControl {
     constructor(info: ConfigurableCreateInfo, options: any);
     // (undocumented)
@@ -1900,9 +1899,7 @@ export class FrameworkAccuDraw extends AccuDraw implements UserSettingsProvider 
     static get displayNotifications(): boolean;
     static set displayNotifications(v: boolean);
     static getFieldDisplayValue(index: ItemField): string;
-    // @internal
     grabInputFocus(): void;
-    // @internal
     get hasInputFocus(): boolean;
     static readonly isACSRotationConditional: ConditionalBooleanValue;
     static readonly isContextRotationConditional: ConditionalBooleanValue;
@@ -1921,20 +1918,19 @@ export class FrameworkAccuDraw extends AccuDraw implements UserSettingsProvider 
     static readonly onAccuDrawSetFieldValueFromUiEvent: AccuDrawSetFieldValueFromUiEvent;
     static readonly onAccuDrawSetFieldValueToUiEvent: AccuDrawSetFieldValueToUiEvent;
     static readonly onAccuDrawUiSettingsChangedEvent: AccuDrawUiSettingsChangedEvent;
-    // @internal (undocumented)
+    // (undocumented)
     onCompassModeChange(): void;
-    // @internal (undocumented)
+    // (undocumented)
     onFieldLockChange(index: ItemField): void;
-    // @internal (undocumented)
+    // (undocumented)
     onFieldValueChange(index: ItemField): void;
-    // @internal
     onMotion(_ev: BeButtonEvent): void;
-    // @internal (undocumented)
+    // (undocumented)
     onRotationModeChange(): void;
     // (undocumented)
     readonly providerId = "FrameworkAccuDraw";
     static setFieldValueFromUi(field: ItemField, stringValue: string): void;
-    // @internal (undocumented)
+    // (undocumented)
     setFocusItem(index: ItemField): void;
     static get uiStateStorage(): AccuDrawUiSettings | undefined;
     static set uiStateStorage(v: AccuDrawUiSettings | undefined);
@@ -2656,7 +2652,7 @@ export class HideIsolateEmphasizeManager extends HideIsolateEmphasizeActionHandl
 export class HTMLElementPopup extends React_2.PureComponent<HTMLElementPopupProps, HTMLElementPopupState> {
     // (undocumented)
     render(): React_2.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: {
         size: Size;
     };
@@ -2759,9 +2755,9 @@ export class InputEditorCommitHandler {
 
 // @alpha
 export class InputEditorPopup extends React_2.PureComponent<InputEditorPopupProps, InputEditorPopupState> {
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: {
         size: Size;
     };
@@ -2975,7 +2971,7 @@ export class KeyboardShortcutMenu extends React_2.PureComponent<CommonProps, Key
     static readonly onKeyboardShortcutMenuEvent: KeyboardShortcutMenuEvent;
     // (undocumented)
     render(): React_2.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: KeyboardShortcutMenuState;
 }
 
@@ -3184,9 +3180,9 @@ export class MenuButton extends React_2.PureComponent<MenuButtonProps, MenuButto
 
 // @alpha
 export class MenuButtonPopup extends React_2.PureComponent<MenuButtonPopupProps, MenuButtonPopupState> {
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: {
         size: Size;
     };
@@ -3820,7 +3816,7 @@ export type ReducerActions<R> = R extends Reducer<any, infer X> ? X extends Acti
 // @public @deprecated
 export type ReducerMapActions<R> = ReducerActions<R[keyof R]>;
 
-// @beta @deprecated
+// @public @deprecated
 export class ReducerRegistry {
     constructor();
     // @internal
@@ -4126,13 +4122,13 @@ export class SheetNavigationAid extends React_2.Component<SheetNavigationProps, 
     constructor(props: SheetNavigationProps);
     componentDidMount(): Promise<void>;
     componentWillUnmount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<SheetNavigationState>;
 }
 
-// @alpha @deprecated
+// @public @deprecated
 export class SheetNavigationAidControl extends NavigationAidControl {
     constructor(info: ConfigurableCreateInfo, options: any);
     // (undocumented)
@@ -4278,7 +4274,7 @@ export class StagePanelDef extends WidgetHost {
     set size(size: number | undefined);
     get sizeSpec(): StagePanelSizeSpec | undefined;
     set sizeSpec(size: StagePanelSizeSpec | undefined);
-    // @internal (undocumented)
+    // (undocumented)
     updateDynamicWidgetDefs(stageId: string, stageUsage: string, location: StagePanelLocation, _section: StagePanelSection | undefined, allStageWidgetDefs: WidgetDef[]): void;
     get widgetDefs(): ReadonlyArray<WidgetDef>;
 }
@@ -4451,11 +4447,11 @@ StandardRotationNavigationAidState> {
     constructor(props: any);
     // (undocumented)
     render(): React_2.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<StandardRotationNavigationAidState>;
 }
 
-// @alpha @deprecated
+// @public @deprecated
 export class StandardRotationNavigationAidControl extends NavigationAidControl {
     constructor(info: ConfigurableCreateInfo, options: any);
     // (undocumented)
@@ -4821,11 +4817,10 @@ export interface ToolAssistanceChangedEventArgs {
 
 // @public
 export class ToolAssistanceField extends React_2.Component<ToolAssistanceFieldProps, ToolAssistanceFieldState> {
-    // @internal
     constructor(p: ToolAssistanceFieldProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): Promise<void>;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // @internal (undocumented)
     context: React_2.ContextType<typeof UiStateStorageContext>;
@@ -4835,7 +4830,7 @@ export class ToolAssistanceField extends React_2.Component<ToolAssistanceFieldPr
     static readonly defaultProps: ToolAssistanceFieldDefaultProps;
     // @internal (undocumented)
     static getInstructionImage(instruction: ToolAssistanceInstruction): React_2.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.ReactNode;
 }
 
@@ -4961,7 +4956,7 @@ export namespace ToolbarItems {
     export function createZoomView(overrides?: Partial<ToolbarActionItem>): ToolbarActionItem;
 }
 
-// @beta
+// @public
 export namespace ToolbarItemUtilities {
     export function createActionItem(args: CreateActionItemArgs): ToolbarActionItem;
     // @deprecated
@@ -5032,7 +5027,7 @@ export class ToolbarPopup extends React_2.PureComponent<ToolbarPopupProps, Toolb
     static contextType: React_2.Context<HTMLElement>;
     // (undocumented)
     render(): React_2.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: {
         size: Size;
     };
@@ -5577,7 +5572,7 @@ export function useStatusBarEntry(): DockedStatusBarEntryContextArg;
 // @internal (undocumented)
 export function useToolSettingsNode(): string | number | boolean | React_2.ReactElement<any, string | React_2.JSXElementConstructor<any>> | Iterable<React_2.ReactNode> | React_2.ReactPortal | null | undefined;
 
-// @beta
+// @public
 export function useTransientState(onSave?: () => void, onRestore?: () => void): void;
 
 // @public
@@ -5614,7 +5609,7 @@ export function useWidgetDirection(): "horizontal" | "vertical";
 // @alpha
 export class ValidationTextbox extends React_2.PureComponent<ValidationTextboxProps, ValidationTextboxState> {
     constructor(props: ValidationTextboxProps);
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.ReactNode;
 }
 

--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -65,7 +65,7 @@ export abstract class AbstractTreeNodeLoaderWithProvider<TDataProvider extends T
 
 // @public
 export class ActionButtonList extends React_3.PureComponent<ActionButtonListProps> {
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
@@ -150,11 +150,11 @@ export class BasicPropertyEditor extends PropertyEditorBase {
 
 // @public
 export class BooleanEditor extends React_3.PureComponent<PropertyEditorProps, BooleanEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -162,9 +162,9 @@ export class BooleanEditor extends React_3.PureComponent<PropertyEditorProps, Bo
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<BooleanEditorState>;
 }
 
@@ -382,11 +382,11 @@ export function CustomizablePropertyRenderer(props: CustomizablePropertyRenderer
 
 // @alpha
 export class CustomNumberEditor extends React_3.PureComponent<PropertyEditorProps, CustomNumberEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -394,9 +394,9 @@ export class CustomNumberEditor extends React_3.PureComponent<PropertyEditorProp
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<CustomNumberEditorState>;
 }
 
@@ -638,9 +638,9 @@ export interface EditorContainerProps extends CommonProps {
 
 // @public
 export class EnumButtonGroupEditor extends React_3.Component<PropertyEditorProps, EnumButtonGroupEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -648,19 +648,19 @@ export class EnumButtonGroupEditor extends React_3.Component<PropertyEditorProps
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<EnumButtonGroupEditorState>;
 }
 
 // @public
 export class EnumEditor extends React_3.PureComponent<PropertyEditorProps, EnumEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -668,9 +668,9 @@ export class EnumEditor extends React_3.PureComponent<PropertyEditorProps, EnumE
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<EnumEditorState>;
 }
 
@@ -749,7 +749,7 @@ export enum FilteredType {
 // @public
 export class FilteringInput extends React_3.PureComponent<FilteringInputProps, FilteringInputState> {
     constructor(props: FilteringInputProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: FilteringInputProps): void;
     // (undocumented)
     render(): React_3.JSX.Element;
@@ -984,11 +984,11 @@ export class HighlightingEngine {
 // @alpha
 export class IconEditor extends React_3.PureComponent<PropertyEditorProps, IconEditorState> implements TypeEditor {
     constructor(props: PropertyEditorProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -996,7 +996,7 @@ export class IconEditor extends React_3.PureComponent<PropertyEditorProps, IconE
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
@@ -1017,11 +1017,11 @@ export { Image_2 as Image }
 
 // @public
 export class ImageCheckBoxEditor extends React_3.PureComponent<PropertyEditorProps, ImageCheckBoxEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -1031,7 +1031,7 @@ export class ImageCheckBoxEditor extends React_3.PureComponent<PropertyEditorPro
     get htmlElement(): HTMLElement | null;
     // (undocumented)
     render(): React_3.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<ImageCheckBoxEditorState>;
 }
 
@@ -1661,9 +1661,9 @@ export interface NonPrimitivePropertyLabelRendererProps extends PrimitivePropert
 // @public
 export class NonPrimitivePropertyRenderer extends React_3.Component<NonPrimitivePropertyRendererProps, NonPrimitivePropertyRendererState> {
     constructor(props: NonPrimitivePropertyRendererProps);
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: NonPrimitivePropertyRendererState;
 }
 
@@ -1680,11 +1680,11 @@ export interface NullableOperatorProcessor {
 
 // @public
 export class NumericInputEditor extends React_3.PureComponent<PropertyEditorProps, NumericInputEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -1692,9 +1692,9 @@ export class NumericInputEditor extends React_3.PureComponent<PropertyEditorProp
     hasFocus: boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<NumericInputEditorState>;
 }
 
@@ -1862,7 +1862,7 @@ export interface PrimitivePropertyLabelRendererProps extends PropertyLabelRender
 // @public
 export class PrimitivePropertyRenderer extends React_2.Component<PrimitiveRendererProps> {
     constructor(props: PrimitiveRendererProps);
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
 }
 
@@ -1902,7 +1902,7 @@ export interface PropertyCategory {
 // @public
 export class PropertyCategoryBlock extends React_3.Component<PropertyCategoryBlockProps> {
     constructor(props: PropertyCategoryBlockProps);
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
@@ -2342,7 +2342,7 @@ export interface PropertyLabelRendererProps {
 // @public
 export class PropertyList extends React_3.Component<PropertyListProps> {
     constructor(props: PropertyListProps);
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
@@ -2408,15 +2408,15 @@ export abstract class PropertyRecordDataFiltererBase extends PropertyDataFiltere
 // @public
 export class PropertyRenderer extends React_3.Component<PropertyRendererProps, PropertyRendererState> {
     constructor(props: PropertyRendererProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyRendererProps): void;
     // (undocumented)
     static getLabelOffset(indentation?: number, orientation?: Orientation, width?: number, columnRatio?: number, minColumnLabelWidth?: number): number;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<PropertyRendererState>;
     updateDisplayValueAsEditor(props: PropertyRendererProps): void;
 }
@@ -2475,7 +2475,7 @@ export class PropertyValueRendererManager {
 // @public
 export class PropertyView extends React_3.Component<PropertyViewProps, PropertyViewState> {
     constructor(props: PropertyViewProps);
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
@@ -2503,13 +2503,12 @@ export const renderLinks: (text: string, links: LinkElementsInfo, highlight?: ((
 
 // @public
 export class ResultSelector extends React_3.PureComponent<ResultSelectorProps, ResultSelectorState> {
-    // @internal
     constructor(props: ResultSelectorProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: ResultSelectorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
@@ -2678,11 +2677,11 @@ export interface SingleSelectionHandler<TItem> {
 
 // @public
 export class SliderEditor extends React_3.PureComponent<PropertyEditorProps, SliderEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -2690,9 +2689,9 @@ export class SliderEditor extends React_3.PureComponent<PropertyEditorProps, Sli
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<SliderEditorState>;
 }
 
@@ -2822,13 +2821,13 @@ export interface Subscription extends Unsubscribable {
 
 // @public
 export class TableArrayValueRenderer extends React_3.PureComponent<TableSpecificValueRendererProps> {
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
 // @public
 export class TableNonPrimitiveValueRenderer extends React_3.PureComponent<TableNonPrimitiveValueRendererProps> {
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
@@ -2852,17 +2851,17 @@ export interface TableSpecificValueRendererProps extends SharedTableNonPrimitive
 
 // @public
 export class TableStructValueRenderer extends React_3.PureComponent<TableSpecificValueRendererProps> {
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 
 // @public
 export class TextareaEditor extends React_3.PureComponent<PropertyEditorProps, TextareaEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -2870,9 +2869,9 @@ export class TextareaEditor extends React_3.PureComponent<PropertyEditorProps, T
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<TextareaEditorState>;
 }
 
@@ -2890,11 +2889,11 @@ export class TextareaPropertyEditor extends PropertyEditorBase {
 
 // @public
 export class TextEditor extends React_3.PureComponent<PropertyEditorProps, TextEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -2902,9 +2901,9 @@ export class TextEditor extends React_3.PureComponent<PropertyEditorProps, TextE
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<TextEditorState>;
 }
 
@@ -2952,11 +2951,11 @@ export const toDateString: (date: Date, timeZoneOffset?: number, formatOptions?:
 
 // @public
 export class ToggleEditor extends React_3.PureComponent<PropertyEditorProps, ToggleEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -2964,9 +2963,9 @@ export class ToggleEditor extends React_3.PureComponent<PropertyEditorProps, Tog
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<ToggleEditorState>;
 }
 
@@ -3694,13 +3693,12 @@ export function useVirtualizedPropertyGridLayoutStorage<T extends Element>(): {
 
 // @public
 export class VirtualizedPropertyGrid extends React_3.Component<VirtualizedPropertyGridProps, VirtualizedPropertyGridState> {
-    // @internal
     constructor(props: VirtualizedPropertyGridProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: VirtualizedPropertyGridProps): void;
     // @internal (undocumented)
     static getDerivedStateFromProps(props: VirtualizedPropertyGridProps, state: VirtualizedPropertyGridState): VirtualizedPropertyGridState | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_3.JSX.Element;
 }
 

--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -74,11 +74,11 @@ export type AsyncGetAutoSuggestDataFunc = (value: string) => Promise<AutoSuggest
 // @public @deprecated
 export class AutoSuggest extends React_2.PureComponent<AutoSuggestProps, AutoSuggestState> {
     constructor(props: AutoSuggestProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
     // (undocumented)
     componentDidUpdate(prevProps: AutoSuggestProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     render(): React_2.ReactElement;
@@ -242,11 +242,11 @@ export class ContextMenu extends React_2.PureComponent<ContextMenuProps, Context
     static autoFlip: (dir: ContextMenuDirection, rect: DOMRectReadOnly, windowWidth: number, windowHeight: number) => ContextMenuDirection;
     // (undocumented)
     blur: () => void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
     // (undocumented)
     componentDidUpdate(prevProps: ContextMenuProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: Partial<ContextMenuProps>;
@@ -258,7 +258,7 @@ export class ContextMenu extends React_2.PureComponent<ContextMenuProps, Context
     getRect: () => DOMRect;
     // (undocumented)
     render(): React_2.ReactElement;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<ContextMenuState>;
 }
 
@@ -305,7 +305,7 @@ export class ContextMenuItem extends React_2.PureComponent<ContextMenuItemProps,
     render(): React_2.ReactElement;
     // (undocumented)
     select: () => void;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<ContextMenuItemState>;
 }
 
@@ -369,7 +369,7 @@ export class ContextSubMenu extends React_2.Component<ContextSubMenuProps, Conte
     render(): React_2.ReactElement;
     // (undocumented)
     select: () => void;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<ContextSubMenuState>;
 }
 
@@ -777,7 +777,7 @@ export type IconSpec = string | ConditionalStringValue | React_2.ReactNode | Con
 
 // @public @deprecated
 export class ImageCheckBox extends React_2.PureComponent<ImageCheckBoxProps> {
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
 }
 
@@ -1292,7 +1292,7 @@ export class RadialButton extends React_2.Component<RadialButtonProps, RadialBut
     // (undocumented)
     render(): React_2.ReactElement;
     select: () => void;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<RadialButtonState>;
 }
 
@@ -1321,7 +1321,7 @@ export class RadialMenu extends React_2.Component<RadialMenuProps, RadialMenuSta
     // (undocumented)
     render(): React_2.ReactElement;
     select: () => void;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<RadialMenuState>;
 }
 
@@ -1455,9 +1455,9 @@ export class SearchBox extends React_2.Component<SearchBoxProps, SearchBoxState>
     componentWillUnmount(): void;
     // (undocumented)
     focus(): void;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<SearchBoxState>;
 }
 
@@ -1618,11 +1618,11 @@ export interface TabLabel {
 // @public @deprecated
 export class Tabs extends React_2.PureComponent<MainTabsProps, TabsState> {
     constructor(props: MainTabsProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: MainTabsProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.ReactElement;
 }
 

--- a/common/api/imodel-components-react.api.md
+++ b/common/api/imodel-components-react.api.md
@@ -39,9 +39,9 @@ import type { ViewState } from '@itwin/core-frontend';
 export class AlphaSlider extends React_2.PureComponent<AlphaSliderProps> {
     // @internal
     constructor(props: AlphaSliderProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.ReactNode;
 }
 
@@ -148,9 +148,9 @@ export class BaseTimelineDataProvider implements TimelineDataProvider {
 
 // @beta
 export class ColorEditor extends React_2.PureComponent<PropertyEditorProps, ColorEditorState> implements TypeEditor {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -158,9 +158,9 @@ export class ColorEditor extends React_2.PureComponent<PropertyEditorProps, Colo
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<ColorEditorState>;
 }
 
@@ -265,13 +265,13 @@ export enum CubeHover {
 
 // @public
 export class CubeNavigationAid extends React_2.Component<CubeNavigationAidProps, CubeNavigationAidState> {
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     render(): React_2.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<CubeNavigationAidState>;
 }
 
@@ -359,9 +359,9 @@ export class DrawingNavigationAid extends React_2.Component<DrawingNavigationAid
     static getDefaultClosedMapSize: () => Vector3d;
     // @internal (undocumented)
     static getDefaultOpenedMapSize: (paddingX?: number, paddingY?: number) => Vector3d;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.ReactNode;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<DrawingNavigationAidState>;
 }
 
@@ -596,7 +596,6 @@ export class InlineEdit extends React_2.Component<InlineEditProps, InlineEditSta
 
 // @public
 export class LineWeightSwatch extends React_2.PureComponent<LineWeightSwatchProps> {
-    // @internal
     constructor(props: LineWeightSwatchProps);
     // (undocumented)
     componentDidMount(): void;
@@ -1036,11 +1035,11 @@ export type ViewStateProp = ViewState | (() => ViewState);
 // @public
 export class WeightEditor extends React_2.PureComponent<PropertyEditorProps, WeightEditorState> implements TypeEditor {
     constructor(props: PropertyEditorProps);
-    // @internal (undocumented)
+    // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentDidUpdate(prevProps: PropertyEditorProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     getPropertyValue(): Promise<PropertyValue | undefined>;
@@ -1048,15 +1047,14 @@ export class WeightEditor extends React_2.PureComponent<PropertyEditorProps, Wei
     get hasFocus(): boolean;
     // (undocumented)
     get htmlElement(): HTMLElement | null;
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
-    // @internal (undocumented)
+    // (undocumented)
     readonly state: Readonly<WeightEditorState>;
 }
 
 // @public
 export class WeightPickerButton extends React_2.PureComponent<WeightPickerProps, WeightPickerState> {
-    // @internal
     constructor(props: WeightPickerProps);
     // (undocumented)
     componentDidMount(): void;
@@ -1064,7 +1062,7 @@ export class WeightPickerButton extends React_2.PureComponent<WeightPickerProps,
     static defaultProps: {
         weights: number[];
     };
-    // @internal (undocumented)
+    // (undocumented)
     render(): React_2.JSX.Element;
     // (undocumented)
     setFocus(): void;

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -6,7 +6,7 @@ beta;AccuDrawDialog(props: AccuDrawDialogProps): React_2.JSX.Element
 beta;AccuDrawDialogProps 
 beta;AccuDrawGrabInputFocusEvent 
 deprecated;AccuDrawGrabInputFocusEvent 
-beta;AccuDrawKeyboardShortcuts
+public;AccuDrawKeyboardShortcuts
 alpha;AccuDrawPopupManager
 beta;AccuDrawSetCompassModeEvent 
 deprecated;AccuDrawSetCompassModeEvent 
@@ -82,7 +82,7 @@ public;BackstageComposerProps
 internal;BackstageComposerStageLauncher({ item, }: BackstageComposerStageLauncherProps): React_2.JSX.Element
 internal;BackstageComposerStageLauncherProps
 public;BackstageItem = BackstageActionItem | BackstageStageLauncher
-beta;BackstageItemUtilities
+public;BackstageItemUtilities
 public;BackstageManager
 deprecated;BackstageManager
 public;BackstageStageLauncher 
@@ -245,7 +245,7 @@ internal;DialogManagerBase
 internal;DialogRendererBase 
 internal;DialogRendererProps
 internal;DockedStatusBarItem(props: StatusBarItemProps): React_2.JSX.Element
-beta;DrawingNavigationAidControl 
+public;DrawingNavigationAidControl 
 deprecated;DrawingNavigationAidControl 
 public;ElementTooltipChangedEvent 
 deprecated;ElementTooltipChangedEvent 
@@ -538,7 +538,7 @@ public;ReducerActions
 deprecated;ReducerActions
 public;ReducerMapActions
 deprecated;ReducerMapActions
-beta;ReducerRegistry
+public;ReducerRegistry
 deprecated;ReducerRegistry
 beta;ReducerRegistryInstance: ReducerRegistry
 deprecated;ReducerRegistryInstance: ReducerRegistry
@@ -584,7 +584,7 @@ alpha;SheetCard
 alpha;SheetCardProps
 alpha;SheetData
 public;SheetNavigationAid 
-alpha;SheetNavigationAidControl 
+public;SheetNavigationAidControl 
 deprecated;SheetNavigationAidControl 
 public;SheetNavigationProps 
 alpha;SheetsModalFrontstage 
@@ -620,7 +620,7 @@ public;StandardMessageBoxProps
 deprecated;StandardMessageBoxProps 
 public;StandardNavigationToolsProvider 
 beta;StandardNavigationToolsUiItemsProvider 
-alpha;StandardRotationNavigationAidControl 
+public;StandardRotationNavigationAidControl 
 deprecated;StandardRotationNavigationAidControl 
 public;StandardStatusbarItemsProvider 
 beta;StandardStatusbarUiItemsProvider 
@@ -707,7 +707,7 @@ deprecated;ToolbarHelper
 public;ToolbarItem = ToolbarActionItem | ToolbarGroupItem | ToolbarCustomItem
 public;ToolbarItemLayouts
 beta;ToolbarItems
-beta;ToolbarItemUtilities
+public;ToolbarItemUtilities
 public;ToolbarOrientation
 beta;ToolbarPopup 
 beta;ToolbarPopupProps = Omit
@@ -800,7 +800,7 @@ beta;useSolarDataProvider(viewport: ScreenViewport | undefined): SolarDataProvid
 public;useSpecificWidgetDef(widgetId: string): WidgetDef | undefined
 internal;useStatusBarEntry(): DockedStatusBarEntryContextArg
 internal;useToolSettingsNode(): string | number | boolean | React_2.ReactElement
-beta;useTransientState(onSave?: () => void, onRestore?: () => void): void
+public;useTransientState(onSave?: () => void, onRestore?: () => void): void
 public;useUiItemsProviderBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[]
 public;useUiItemsProviderStatusBarItems: (manager: StatusBarItemsManager) => readonly StatusBarItem[]
 public;useUiItemsProviderToolbarItems: (manager: ToolbarItemsManager, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation) => readonly ToolbarItem[]

--- a/common/changes/@itwin/appui-react/issue-891_2024-08-01-09-26.json
+++ b/common/changes/@itwin/appui-react/issue-891_2024-08-01-09-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Update release tags of frequently used APIs.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/issue-891_2024-08-01-09-26.json
+++ b/common/changes/@itwin/components-react/issue-891_2024-08-01-09-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/issue-891_2024-08-01-09-26.json
+++ b/common/changes/@itwin/core-react/issue-891_2024-08-01-09-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/issue-891_2024-08-01-09-26.json
+++ b/common/changes/@itwin/imodel-components-react/issue-891_2024-08-01-09-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -16,9 +16,6 @@ Table of contents:
   - [Deprecations](#deprecations-2)
   - [Additions](#additions-2)
   - [Changes](#changes-2)
-  - [Fixes](#fixes-2)
-- [@itwin/imodel-components-react](#itwinimodel-components-react)
-  - [Fixes](#fixes-3)
 
 ## @itwin/appui-react
 
@@ -220,6 +217,9 @@ Table of contents:
 - No more transitions when toggling themes. [#905](https://github.com/iTwin/appui/pull/905)
 - Updated `ToolSettingsPopup` to not rely on event propagation for cancellation. [#928](https://github.com/iTwin/appui/pull/928)
 - Adjusted `SelectionCount` styling to improve its visuals in various scenarios. [#936](https://github.com/iTwin/appui/pull/936)
+- Bumped `AccuDrawKeyboardShortcuts`, `BackstageItemUtilities`, `DrawingNavigationAidControl`, `ReducerRegistry`, `SheetNavigationAidControl`, `StandardRotationNavigationAidControl`, `ToolbarItemUtilities`, `useTransientState` APIs to `@public`. [#943](https://github.com/iTwin/appui/pull/943)
+- Removed `@internal` tags from React lifecycle methods and properties. Consumers should avoid calling class methods directly, since class components can be converted to functional components in the future. [#943](https://github.com/iTwin/appui/pull/943)
+- Removed `@internal` tags from overriden class methods. [#943](https://github.com/iTwin/appui/pull/943)
 
 ### Fixes
 
@@ -251,7 +251,6 @@ Table of contents:
 
 - Fixed `activeMatchIndex` not working correctly on adjacent matches in `HighlightedText`. [#898](https://github.com/iTwin/appui/pull/898)
 - Fixed widget tab styling to match the SVG and CSS icon size. [#901](https://github.com/iTwin/appui/pull/901)
-- Fixed [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) Sass warnings. [#939](https://github.com/iTwin/appui/pull/939)
 - Fixed `EditorContainer` trying to commit updated value twice when tab is pressed. [#942](https://github.com/iTwin/appui/pull/942)
 
 ## @itwin/core-react
@@ -356,13 +355,3 @@ Table of contents:
 ### Changes
 
 - Removed styling for the `theme-transition` class. [#890](https://github.com/iTwin/appui/pull/890)
-
-### Fixes
-
-- Fixed [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) Sass warnings. [#939](https://github.com/iTwin/appui/pull/939)
-
-## @itwin/imodel-components-react
-
-### Fixes
-
-- Fixed [mixed-decls](https://sass-lang.com/documentation/breaking-changes/mixed-decls/) Sass warnings. [#939](https://github.com/iTwin/appui/pull/939)

--- a/test-apps/appui-test-app/connected/src/frontend/appui/oidc/SignIn.tsx
+++ b/test-apps/appui-test-app/connected/src/frontend/appui/oidc/SignIn.tsx
@@ -28,7 +28,6 @@ export interface SignInProps extends CommonProps {
   onRegister?: () => void;
 }
 
-/** @internal */
 interface SignInState {
   isSigningIn: boolean;
   prompt: string;

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawKeyboardShortcuts.ts
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawKeyboardShortcuts.ts
@@ -37,7 +37,7 @@ import { KeyboardShortcutUtilities } from "../keyboardshortcut/KeyboardShortcutU
  *   AccuDrawKeyboardShortcuts.getDefaultShortcuts()
  * );
  * ```
- * @beta
+ * @public
  */
 export class AccuDrawKeyboardShortcuts {
   /** Get default AccuDraw Keyboard Shortcuts list.

--- a/ui/appui-react/src/appui-react/accudraw/CalculatorPopup.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/CalculatorPopup.tsx
@@ -50,7 +50,6 @@ export class CalculatorPopup extends React.PureComponent<
       this.setState({ size: Size.create(newSize) });
   };
 
-  /** @internal */
   public override render() {
     const point = PopupManager.getPopupPosition(
       this.props.el,

--- a/ui/appui-react/src/appui-react/accudraw/CalculatorPopup.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/CalculatorPopup.tsx
@@ -40,7 +40,6 @@ export class CalculatorPopup extends React.PureComponent<
   CalculatorPopupProps,
   CalculatorPopupState
 > {
-  /** @internal */
   public override readonly state = {
     size: new Size(-1, -1),
   };

--- a/ui/appui-react/src/appui-react/accudraw/FrameworkAccuDraw.ts
+++ b/ui/appui-react/src/appui-react/accudraw/FrameworkAccuDraw.ts
@@ -272,7 +272,6 @@ export class FrameworkAccuDraw
     return this.processFieldInput(args.field, args.stringValue, false);
   };
 
-  /** @internal */
   public override onCompassModeChange(): void {
     FrameworkAccuDraw.onAccuDrawSetCompassModeEvent.emit({
       mode: this.compassMode,
@@ -284,7 +283,6 @@ export class FrameworkAccuDraw
     this.outputCompassModeMessage();
   }
 
-  /** @internal */
   public override onRotationModeChange(): void {
     SyncUiEventDispatcher.dispatchSyncUiEvent(
       SyncUiEventId.AccuDrawRotationChanged
@@ -293,7 +291,6 @@ export class FrameworkAccuDraw
     this.outputRotationMessage();
   }
 
-  /** @internal */
   public override onFieldLockChange(index: ItemField): void {
     FrameworkAccuDraw.onAccuDrawSetFieldLockEvent.emit({
       field: index,
@@ -301,7 +298,6 @@ export class FrameworkAccuDraw
     });
   }
 
-  /** @internal */
   public override onFieldValueChange(index: ItemField): void {
     const value = this.getValueByIndex(index);
     const formattedValue = FrameworkAccuDraw.getFieldDisplayValue(index);
@@ -320,7 +316,6 @@ export class FrameworkAccuDraw
     this.onFieldValueChange(ItemField.DIST_Item);
   }
 
-  /** @internal */
   public override setFocusItem(index: ItemField): void {
     FrameworkAccuDraw.onAccuDrawSetFieldFocusEvent.emit({ field: index });
   }
@@ -328,7 +323,6 @@ export class FrameworkAccuDraw
   /** Implemented by sub-classes to update ui fields to show current deltas or coordinates when inactive.
    * Should also choose active x or y input field in rectangular mode based on cursor position when
    * axis isn't locked to support "smart lock".
-   * @internal
    */
   public override onMotion(_ev: BeButtonEvent): void {
     if (!this.isEnabled || this.isDeactivated || UiFramework.isContextMenuOpen)
@@ -339,9 +333,7 @@ export class FrameworkAccuDraw
     if (!this.dontMoveFocus) this.setFocusItem(this.newFocus);
   }
 
-  /** Determine if the AccuDraw UI has focus
-   * @internal
-   */
+  /** Determine if the AccuDraw UI has focus. */
   public override get hasInputFocus(): boolean {
     let hasFocus = false;
     const el = document.querySelector("div.uifw-accudraw-field-container");
@@ -349,9 +341,7 @@ export class FrameworkAccuDraw
     return hasFocus;
   }
 
-  /** Implement this method to set focus to the AccuDraw UI.
-   * @internal
-   */
+  /** Implement this method to set focus to the AccuDraw UI. */
   public override grabInputFocus(): void {
     FrameworkAccuDraw.onAccuDrawGrabInputFocusEvent.emit({});
   }

--- a/ui/appui-react/src/appui-react/accudraw/MenuButton.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/MenuButton.tsx
@@ -23,7 +23,6 @@ export interface MenuButtonProps extends SquareButtonProps {
   onSizeKnown?: (size: SizeProps) => void;
 }
 
-/** @internal */
 interface MenuButtonState {
   expanded: boolean;
 }

--- a/ui/appui-react/src/appui-react/accudraw/MenuButtonPopup.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/MenuButtonPopup.tsx
@@ -40,7 +40,6 @@ export class MenuButtonPopup extends React.PureComponent<
       this.setState({ size: Size.create(newSize) });
   };
 
-  /** @internal */
   public override render() {
     const point = PopupManager.getPopupPosition(
       this.props.el,

--- a/ui/appui-react/src/appui-react/accudraw/MenuButtonPopup.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/MenuButtonPopup.tsx
@@ -18,7 +18,6 @@ export interface MenuButtonPopupProps extends PopupPropsBase {
   content: React.ReactNode;
 }
 
-/** @internal */
 interface MenuButtonPopupState {
   size: Size;
 }
@@ -30,7 +29,6 @@ export class MenuButtonPopup extends React.PureComponent<
   MenuButtonPopupProps,
   MenuButtonPopupState
 > {
-  /** @internal */
   public override readonly state = {
     size: new Size(-1, -1),
   };

--- a/ui/appui-react/src/appui-react/backstage/BackstageItemUtilities.tsx
+++ b/ui/appui-react/src/appui-react/backstage/BackstageItemUtilities.tsx
@@ -14,7 +14,7 @@ import type {
 } from "./BackstageItem";
 
 /** Utilities for creating and maintaining backstage items
- * @beta
+ * @public
  */
 export namespace BackstageItemUtilities {
   interface CreateStageLauncherArgs

--- a/ui/appui-react/src/appui-react/cursor/cursormenu/CursorMenu.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursormenu/CursorMenu.tsx
@@ -36,7 +36,6 @@ export class CursorPopupMenu extends React.PureComponent<
   private _isMounted = false; // used to ensure _handleSyncUiEvent callback is not processed after componentWillUnmount is called
   private _hostChildWindowId?: string;
 
-  /** @internal */
   public override readonly state: CursorPopupMenuState = {
     menuX: 0,
     menuY: 0,

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.tsx
@@ -232,7 +232,6 @@ export class CursorPopup extends React.Component<
     }
   }
 
-  /** @internal */
   public override render() {
     const popupRect = CursorPopup.getPopupRect(
       this.props.pt,

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.tsx
@@ -71,7 +71,6 @@ export class CursorPopup extends React.Component<
   /** @internal */
   public static fadeOutTime = 500;
 
-  /** @internal */
   constructor(props: CursorPopupProps) {
     super(props);
 

--- a/ui/appui-react/src/appui-react/dialog/DialogManagerBase.tsx
+++ b/ui/appui-react/src/appui-react/dialog/DialogManagerBase.tsx
@@ -183,7 +183,6 @@ export class DialogRendererBase extends React.PureComponent<
   DialogRendererProps,
   DialogRendererState
 > {
-  /** @internal */
   public override readonly state: DialogRendererState = {
     parentDocument: undefined,
     renderer: undefined,

--- a/ui/appui-react/src/appui-react/feedback/ValidationTextbox.tsx
+++ b/ui/appui-react/src/appui-react/feedback/ValidationTextbox.tsx
@@ -66,7 +66,6 @@ export class ValidationTextbox extends React.PureComponent<
     this.state = { isValid: true };
   }
 
-  /** @internal */
   public override render(): React.ReactNode {
     const sizeStyle: React.CSSProperties = {
       width: this.props.size ? `${this.props.size.toString()}em` : "12em",

--- a/ui/appui-react/src/appui-react/keyboardshortcut/KeyboardShortcutMenu.tsx
+++ b/ui/appui-react/src/appui-react/keyboardshortcut/KeyboardShortcutMenu.tsx
@@ -43,7 +43,6 @@ export class KeyboardShortcutMenu extends React.PureComponent<
   CommonProps,
   KeyboardShortcutMenuState
 > {
-  /** @internal */
   public override readonly state: KeyboardShortcutMenuState = {
     menuVisible: false,
     menuX: 0,

--- a/ui/appui-react/src/appui-react/navigationaids/DrawingNavigationAidControl.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/DrawingNavigationAidControl.tsx
@@ -12,7 +12,7 @@ import type { ConfigurableCreateInfo } from "../configurableui/ConfigurableUiCon
 import { NavigationAidControl } from "./NavigationAidControl";
 
 /** Navigation Aid that displays an interactive mini-map for Drawing views that synchronizes with the iModel Viewport.
- * @beta
+ * @public
  * @deprecated in 4.16.0. Use {@link @itwin/imodel-components-react#DrawingNavigationAid} component instead.
  */
 // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.tsx
@@ -75,7 +75,6 @@ export class SheetNavigationAid extends React.Component<
 > {
   private _isMounted = false;
 
-  /** @internal */
   public override readonly state: Readonly<SheetNavigationState> = {
     index: 0,
     sheetData: [],

--- a/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.tsx
@@ -27,7 +27,7 @@ import { IconButton, ProgressRadial } from "@itwin/itwinui-react";
 import { SvgChevronLeft, SvgChevronRight } from "@itwin/itwinui-icons-react";
 
 /** A Sheet Navigation Aid control.
- * @alpha
+ * @public
  * @deprecated in 4.16.0. Use {@link SheetNavigationAid} component instead.
  */
 // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.tsx
@@ -150,7 +150,6 @@ export class SheetNavigationAid extends React.Component<
     return stateData;
   }
 
-  /** @internal */
   public override render(): React.ReactNode {
     const name =
       this.state.sheetData.length > 0

--- a/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.tsx
@@ -149,7 +149,6 @@ export class CardContainer extends React.Component<CardContainerProps> {
     return CardContainer._cardSelectedEvent;
   }
 
-  /** @internal */
   public override render() {
     return (
       // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/navigationaids/StandardRotationNavigationAid.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/StandardRotationNavigationAid.tsx
@@ -69,7 +69,6 @@ export class StandardRotationNavigationAid extends React.Component<
   CommonProps, // eslint-disable-line deprecation/deprecation
   StandardRotationNavigationAidState
 > {
-  /** @internal */
   public override readonly state: Readonly<StandardRotationNavigationAidState>;
 
   constructor(props: any) {

--- a/ui/appui-react/src/appui-react/navigationaids/StandardRotationNavigationAid.tsx
+++ b/ui/appui-react/src/appui-react/navigationaids/StandardRotationNavigationAid.tsx
@@ -35,7 +35,7 @@ import { NavigationAidControl } from "./NavigationAidControl";
 import "./StandardRotationNavigationAid.scss";
 
 /** A 3D Standard Rotation Navigation Aid control.
- * @alpha
+ * @public
  * @deprecated in 4.16.0. Use {@link StandardRotationNavigationAid} component instead.
  */
 // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/popup/CardPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/CardPopup.tsx
@@ -67,9 +67,7 @@ export class CardPopup extends React.PureComponent<
   CardPopupProps,
   CardPopupState
 > {
-  /** @internal */
   public static override contextType = WrapperContext;
-  /** @internal */
   public declare context: React.ContextType<typeof WrapperContext>;
   public override readonly state = {
     size: new Size(-1, -1),

--- a/ui/appui-react/src/appui-react/popup/CardPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/CardPopup.tsx
@@ -67,7 +67,9 @@ export class CardPopup extends React.PureComponent<
   CardPopupProps,
   CardPopupState
 > {
+  /** @internal */
   public static override contextType = WrapperContext;
+  /** @internal */
   public declare context: React.ContextType<typeof WrapperContext>;
   public override readonly state = {
     size: new Size(-1, -1),

--- a/ui/appui-react/src/appui-react/popup/CardPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/CardPopup.tsx
@@ -71,7 +71,6 @@ export class CardPopup extends React.PureComponent<
   public static override contextType = WrapperContext;
   /** @internal */
   public declare context: React.ContextType<typeof WrapperContext>;
-  /** @internal */
   public override readonly state = {
     size: new Size(-1, -1),
   };

--- a/ui/appui-react/src/appui-react/popup/HTMLElementPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/HTMLElementPopup.tsx
@@ -45,7 +45,6 @@ export class HTMLElementPopup extends React.PureComponent<
   HTMLElementPopupProps,
   HTMLElementPopupState
 > {
-  /** @internal */
   public override readonly state = {
     size: new Size(-1, -1),
   };

--- a/ui/appui-react/src/appui-react/popup/InputEditorPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/InputEditorPopup.tsx
@@ -41,7 +41,6 @@ export interface InputEditorPopupProps extends PopupPropsBase {
   commitHandler: InputEditorCommitHandler;
 }
 
-/** @internal */
 interface InputEditorPopupState {
   size: Size;
 }
@@ -53,7 +52,6 @@ export class InputEditorPopup extends React.PureComponent<
   InputEditorPopupProps,
   InputEditorPopupState
 > {
-  /** @internal */
   public override readonly state = {
     size: new Size(-1, -1),
   };

--- a/ui/appui-react/src/appui-react/popup/InputEditorPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/InputEditorPopup.tsx
@@ -63,7 +63,6 @@ export class InputEditorPopup extends React.PureComponent<
       this.setState({ size: Size.create(newSize) });
   };
 
-  /** @internal */
   public override render() {
     const point = PopupManager.getPopupPosition(
       this.props.el,

--- a/ui/appui-react/src/appui-react/popup/PopupManager.tsx
+++ b/ui/appui-react/src/appui-react/popup/PopupManager.tsx
@@ -586,11 +586,13 @@ interface PopupRendererState {
   popups: ReadonlyArray<PopupInfo>;
 }
 
-/**  Popup Renderer
+/** Popup Renderer.
  * @public
  */
 export class PopupRenderer extends React.Component<{}, PopupRendererState> {
+  /** @internal */
   public static override contextType = WrapperContext;
+  /** @internal */
   public declare context: React.ContextType<typeof WrapperContext>;
 
   public override readonly state: PopupRendererState = {

--- a/ui/appui-react/src/appui-react/popup/PopupManager.tsx
+++ b/ui/appui-react/src/appui-react/popup/PopupManager.tsx
@@ -581,7 +581,6 @@ export class PopupManager {
   }
 }
 
-/** @internal */
 interface PopupRendererState {
   parentDocument: Document | null;
   popups: ReadonlyArray<PopupInfo>;

--- a/ui/appui-react/src/appui-react/popup/PopupManager.tsx
+++ b/ui/appui-react/src/appui-react/popup/PopupManager.tsx
@@ -590,9 +590,7 @@ interface PopupRendererState {
  * @public
  */
 export class PopupRenderer extends React.Component<{}, PopupRendererState> {
-  /** @internal */
   public static override contextType = WrapperContext;
-  /** @internal */
   public declare context: React.ContextType<typeof WrapperContext>;
 
   public override readonly state: PopupRendererState = {

--- a/ui/appui-react/src/appui-react/popup/ToolSettingsPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/ToolSettingsPopup.tsx
@@ -32,7 +32,6 @@ export interface ToolSettingsPopupProps extends PopupPropsBase {
   onCancel: OnCancelFunc;
 }
 
-/** @internal */
 interface ToolSettingsPopupState {
   size: Size;
 }
@@ -44,7 +43,6 @@ export class ToolSettingsPopup extends React.PureComponent<
   ToolSettingsPopupProps,
   ToolSettingsPopupState
 > {
-  /** @internal */
   public override readonly state = {
     size: new Size(-1, -1),
   };

--- a/ui/appui-react/src/appui-react/popup/ToolbarPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/ToolbarPopup.tsx
@@ -42,7 +42,6 @@ export type ToolbarPopupProps = Omit<PopupPropsBase, "el"> & {
     placement: Placement;
   }>;
 
-/** @internal */
 interface ToolbarPopupState {
   size: Size;
 }
@@ -59,7 +58,6 @@ export class ToolbarPopup extends React.PureComponent<
   /** @internal */
   public declare context: React.ContextType<typeof WrapperContext>;
 
-  /** @internal */
   public override readonly state = {
     size: new Size(-1, -1),
   };

--- a/ui/appui-react/src/appui-react/popup/ToolbarPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/ToolbarPopup.tsx
@@ -53,9 +53,7 @@ export class ToolbarPopup extends React.PureComponent<
   ToolbarPopupProps,
   ToolbarPopupState
 > {
-  /** @internal */
   public static override contextType = WrapperContext;
-  /** @internal */
   public declare context: React.ContextType<typeof WrapperContext>;
 
   public override readonly state = {

--- a/ui/appui-react/src/appui-react/popup/ToolbarPopup.tsx
+++ b/ui/appui-react/src/appui-react/popup/ToolbarPopup.tsx
@@ -53,7 +53,9 @@ export class ToolbarPopup extends React.PureComponent<
   ToolbarPopupProps,
   ToolbarPopupState
 > {
+  /** @internal */
   public static override contextType = WrapperContext;
+  /** @internal */
   public declare context: React.ContextType<typeof WrapperContext>;
 
   public override readonly state = {

--- a/ui/appui-react/src/appui-react/redux/ReducerRegistry.ts
+++ b/ui/appui-react/src/appui-react/redux/ReducerRegistry.ts
@@ -22,7 +22,7 @@ export interface NameToReducerMap {
 /** Redux Reducer Registry.
  * Follows the example at http://nicolasgallagher.com/redux-modules-and-code-splitting/
  * Allows for small modules to provide their own reducers so that the they can manage their own state
- * @beta
+ * @public
  * @deprecated in 4.15.0. Use your preferred state management library instead.
  */
 export class ReducerRegistry {

--- a/ui/appui-react/src/appui-react/stagepanels/StagePanelDef.tsx
+++ b/ui/appui-react/src/appui-react/stagepanels/StagePanelDef.tsx
@@ -246,7 +246,6 @@ export class StagePanelDef extends WidgetHost {
     ];
   }
 
-  /** @internal */
   public override updateDynamicWidgetDefs(
     stageId: string,
     stageUsage: string,

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -139,7 +139,6 @@ export class ToolAssistanceField extends React.Component<
     defaultPromptAtCursor: false,
   };
 
-  /** @internal */
   constructor(p: ToolAssistanceFieldProps) {
     super(p);
 

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -361,7 +361,6 @@ export class ToolAssistanceField extends React.Component<
       );
   };
 
-  /** @internal */
   public override render(): React.ReactNode {
     const { instructions } = this.state;
     const dialogTitle = IModelApp.toolAdmin.activeTool

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -114,9 +114,7 @@ export class ToolAssistanceField extends React.Component<
   ToolAssistanceFieldProps,
   ToolAssistanceFieldState
 > {
-  /** @internal */
   public static override contextType = UiStateStorageContext;
-  /** @internal */
   public declare context: React.ContextType<typeof UiStateStorageContext>;
 
   private static _toolAssistanceKey = "ToolAssistance";

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -114,7 +114,9 @@ export class ToolAssistanceField extends React.Component<
   ToolAssistanceFieldProps,
   ToolAssistanceFieldState
 > {
+  /** @internal */
   public static override contextType = UiStateStorageContext;
+  /** @internal */
   public declare context: React.ContextType<typeof UiStateStorageContext>;
 
   private static _toolAssistanceKey = "ToolAssistance";

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -175,7 +175,6 @@ export class ToolAssistanceField extends React.Component<
     );
   }
 
-  /** @internal */
   public override async componentDidMount() {
     this._isMounted = true;
     MessageManager.onToolAssistanceChangedEvent.addListener(
@@ -192,7 +191,6 @@ export class ToolAssistanceField extends React.Component<
     await this.restoreSettings();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
     MessageManager.onToolAssistanceChangedEvent.removeListener(

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItemUtilities.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItemUtilities.tsx
@@ -16,7 +16,7 @@ import type {
 import { isArgsUtil } from "../backstage/BackstageItemUtilities";
 
 /** Helper namespace to create toolbar items.
- * @beta
+ * @public
  */
 export namespace ToolbarItemUtilities {
   interface CreateActionItemArgs

--- a/ui/appui-react/src/appui-react/widget-panels/useTransientState.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/useTransientState.tsx
@@ -14,7 +14,7 @@ import {
 } from "../layout/widget/ContentRenderer";
 
 /** Hook that allows to save and restore transient DOM state (i.e. scroll offset) of a widget.
- * @beta
+ * @public
  */
 export function useTransientState(onSave?: () => void, onRestore?: () => void) {
   const tabId = React.useContext(TabIdContext);

--- a/ui/components-react/src/components-react/editors/BooleanEditor.tsx
+++ b/ui/components-react/src/components-react/editors/BooleanEditor.tsx
@@ -34,7 +34,6 @@ export class BooleanEditor
   private _isMounted = false;
   private _inputElement = React.createRef<HTMLInputElement>();
 
-  /** @internal */
   public override readonly state: Readonly<BooleanEditorState> = {
     checkboxValue: false,
     isDisabled: false,
@@ -90,18 +89,15 @@ export class BooleanEditor
     }
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/BooleanEditor.tsx
+++ b/ui/components-react/src/components-react/editors/BooleanEditor.tsx
@@ -127,7 +127,6 @@ export class BooleanEditor
     if (this._isMounted) this.setState({ checkboxValue, isDisabled });
   }
 
-  /** @internal */
   public override render() {
     const className = classnames(
       "components-cell-editor",

--- a/ui/components-react/src/components-react/editors/CustomNumberEditor.tsx
+++ b/ui/components-react/src/components-react/editors/CustomNumberEditor.tsx
@@ -314,7 +314,6 @@ export class CustomNumberEditor
     e.target.select();
   };
 
-  /** @internal */
   public override render(): React.ReactNode {
     const minSize = this.state.size ? this.state.size : 8;
     const minWidthStyle: React.CSSProperties = {

--- a/ui/components-react/src/components-react/editors/CustomNumberEditor.tsx
+++ b/ui/components-react/src/components-react/editors/CustomNumberEditor.tsx
@@ -62,7 +62,6 @@ export class CustomNumberEditor
   private _inputElement = React.createRef<HTMLInputElement>();
   private _lastValidValue: PropertyValue | undefined;
 
-  /** @internal */
   public override readonly state: Readonly<CustomNumberEditorState> = {
     inputValue: "",
   };
@@ -170,18 +169,15 @@ export class CustomNumberEditor
     this._applyUpdatedValue(e.target.value);
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
+++ b/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
@@ -283,7 +283,6 @@ export class DateTimeEditor
     }
   };
 
-  /** @internal */
   public override render(): React.ReactNode {
     const date = this.state.editInUtc
       ? adjustDateToTimezone(this.state.value, 0)

--- a/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
+++ b/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
@@ -59,7 +59,6 @@ export class DateTimeEditor
   private _enterKey = false;
   private _divElement = React.createRef<HTMLDivElement>();
 
-  /** @internal */
   public override readonly state: Readonly<DateTimeEditorState> = {
     value: new Date(),
     editInUtc: false,
@@ -133,18 +132,15 @@ export class DateTimeEditor
     }
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/EnumButtonGroupEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumButtonGroupEditor.tsx
@@ -50,7 +50,6 @@ export class EnumButtonGroupEditor
   private _btnRefs = new Map<string | number, HTMLButtonElement>();
   private _divElement = React.createRef<HTMLDivElement>();
 
-  /** @internal */
   public override readonly state: Readonly<EnumButtonGroupEditorState> = {
     selectValue: "",
     enumIcons: [],
@@ -83,12 +82,10 @@ export class EnumButtonGroupEditor
     return containsFocus;
   }
 
-  /** @internal */
   public override componentDidMount() {
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/EnumButtonGroupEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumButtonGroupEditor.tsx
@@ -209,7 +209,6 @@ export class EnumButtonGroupEditor
     );
   }
 
-  /** @internal */
   public override render() {
     return (
       <div

--- a/ui/components-react/src/components-react/editors/EnumEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumEditor.tsx
@@ -161,7 +161,6 @@ export class EnumEditor
       });
   }
 
-  /** @internal */
   public override render() {
     const className = classnames(
       "components-cell-editor",

--- a/ui/components-react/src/components-react/editors/EnumEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumEditor.tsx
@@ -38,7 +38,6 @@ export class EnumEditor
   private _isMounted = false;
   private _divElement = React.createRef<HTMLDivElement>();
 
-  /** @internal */
   public override readonly state: Readonly<EnumEditorState> = {
     selectValue: "",
     valueIsNumber: false,
@@ -98,18 +97,15 @@ export class EnumEditor
     }
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/IconEditor.tsx
+++ b/ui/components-react/src/components-react/editors/IconEditor.tsx
@@ -131,18 +131,15 @@ export class IconEditor
     );
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/IconEditor.tsx
+++ b/ui/components-react/src/components-react/editors/IconEditor.tsx
@@ -169,7 +169,6 @@ export class IconEditor
       });
   }
 
-  /** @internal */
   public override render() {
     const { icon, icons, numColumns } = this.state;
     return (

--- a/ui/components-react/src/components-react/editors/ImageCheckBoxEditor.tsx
+++ b/ui/components-react/src/components-react/editors/ImageCheckBoxEditor.tsx
@@ -49,7 +49,6 @@ export class ImageCheckBoxEditor
   private _isMounted = false;
   private _inputElement: React.RefObject<HTMLInputElement> = React.createRef();
 
-  /** @internal */
   public override readonly state: Readonly<ImageCheckBoxEditorState> = {
     imageOff: "",
     imageOn: "",
@@ -80,18 +79,15 @@ export class ImageCheckBoxEditor
     return document.activeElement === this._inputElement.current;
   }
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
+++ b/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
@@ -53,7 +53,6 @@ export class NumericInputEditor
   private _inputElement: React.RefObject<HTMLInputElement> = React.createRef();
   public hasFocus = false; // hot used since containerHandlesEnter is false
 
-  /** @internal */
   public override readonly state: Readonly<NumericInputEditorState> = {
     value: 0,
     readonly: false,
@@ -107,18 +106,15 @@ export class NumericInputEditor
       );
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
+++ b/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
@@ -185,7 +185,6 @@ export class NumericInputEditor
       });
   }
 
-  /** @internal */
   public override render(): React.ReactNode {
     const className = classnames(
       "components-cell-editor",

--- a/ui/components-react/src/components-react/editors/PopupButton.tsx
+++ b/ui/components-react/src/components-react/editors/PopupButton.tsx
@@ -114,7 +114,6 @@ export class PopupButton extends React.PureComponent<
     }
   };
 
-  /** @internal */
   public override render(): React.ReactNode {
     const showArrow = this.props.showArrow ?? false;
     const showShadow = this.props.showShadow ?? false;

--- a/ui/components-react/src/components-react/editors/PopupButton.tsx
+++ b/ui/components-react/src/components-react/editors/PopupButton.tsx
@@ -71,12 +71,10 @@ export class PopupButton extends React.PureComponent<
 > {
   private _buttonRef = React.createRef<HTMLDivElement>();
 
-  /** @internal */
   public override readonly state: Readonly<PopupButtonState> = {
     showPopup: false,
   };
 
-  /** @internal */
   public override componentDidMount() {
     if (this.props.setFocus && this._buttonRef.current)
       this._buttonRef.current.focus();

--- a/ui/components-react/src/components-react/editors/SliderEditor.tsx
+++ b/ui/components-react/src/components-react/editors/SliderEditor.tsx
@@ -61,7 +61,6 @@ export class SliderEditor
   private _enterKey = false;
   private _divElement = React.createRef<HTMLDivElement>();
 
-  /** @internal */
   public override readonly state: Readonly<SliderEditorState> = {
     value: 0,
     min: 0,
@@ -103,18 +102,15 @@ export class SliderEditor
       });
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/SliderEditor.tsx
+++ b/ui/components-react/src/components-react/editors/SliderEditor.tsx
@@ -289,7 +289,6 @@ export class SliderEditor
     } as Partial<Omit<TooltipProps, "children">>;
   };
 
-  /** @internal */
   public override render(): React.ReactNode {
     const className = classnames(
       "components-cell-editor",

--- a/ui/components-react/src/components-react/editors/TextEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextEditor.tsx
@@ -173,7 +173,6 @@ export class TextEditor
       });
   }
 
-  /** @internal */
   public override render(): React.ReactNode {
     const className = classnames(
       "components-cell-editor",

--- a/ui/components-react/src/components-react/editors/TextEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextEditor.tsx
@@ -48,7 +48,6 @@ export class TextEditor
   private _isMounted = false;
   private _inputElement = React.createRef<HTMLInputElement>();
 
-  /** @internal */
   public override readonly state: Readonly<TextEditorState> = {
     inputValue: "",
     readonly: false,
@@ -100,18 +99,15 @@ export class TextEditor
       );
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/TextareaEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextareaEditor.tsx
@@ -188,7 +188,6 @@ export class TextareaEditor
     }
   };
 
-  /** @internal */
   public override render(): React.ReactNode {
     const className = classnames(
       "components-cell-editor",

--- a/ui/components-react/src/components-react/editors/TextareaEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextareaEditor.tsx
@@ -57,7 +57,6 @@ export class TextareaEditor
   private _divElement = React.createRef<HTMLDivElement>();
   private _textAreaElement = React.createRef<HTMLTextAreaElement>();
 
-  /** @internal */
   public override readonly state: Readonly<TextareaEditorState> = {
     inputValue: "",
     readonly: false,
@@ -98,18 +97,15 @@ export class TextareaEditor
       });
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/editors/ToggleEditor.tsx
+++ b/ui/components-react/src/components-react/editors/ToggleEditor.tsx
@@ -130,7 +130,6 @@ export class ToggleEditor
     if (this._isMounted) this.setState({ toggleValue, isDisabled });
   }
 
-  /** @internal */
   public override render() {
     const className = classnames(
       "components-cell-editor",

--- a/ui/components-react/src/components-react/editors/ToggleEditor.tsx
+++ b/ui/components-react/src/components-react/editors/ToggleEditor.tsx
@@ -38,7 +38,6 @@ export class ToggleEditor
   private _isMounted = false;
   private _inputElement = React.createRef<HTMLInputElement>();
 
-  /** @internal */
   public override readonly state: Readonly<ToggleEditorState> = {
     toggleValue: false,
     isDisabled: false,
@@ -93,18 +92,15 @@ export class ToggleEditor
     }
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/components-react/src/components-react/filtering/FilteringInput.tsx
+++ b/ui/components-react/src/components-react/filtering/FilteringInput.tsx
@@ -135,7 +135,6 @@ export class FilteringInput extends React.PureComponent<
     this.setState({ searchText: e.target.value, searchStarted: false });
   };
 
-  /** @internal */
   public override componentDidUpdate(prevProps: FilteringInputProps) {
     if (this.props.resultSelectorProps !== prevProps.resultSelectorProps) {
       this.setState((state) => ({

--- a/ui/components-react/src/components-react/filtering/ResultSelector.tsx
+++ b/ui/components-react/src/components-react/filtering/ResultSelector.tsx
@@ -127,7 +127,6 @@ export class ResultSelector extends React.PureComponent<
     }
   }
 
-  /** @internal */
   public override render() {
     return (
       <span

--- a/ui/components-react/src/components-react/filtering/ResultSelector.tsx
+++ b/ui/components-react/src/components-react/filtering/ResultSelector.tsx
@@ -45,7 +45,6 @@ export class ResultSelector extends React.PureComponent<
   ResultSelectorProps,
   ResultSelectorState
 > {
-  /** @internal */
   constructor(props: ResultSelectorProps) {
     super(props);
     this.state = {

--- a/ui/components-react/src/components-react/filtering/ResultSelector.tsx
+++ b/ui/components-react/src/components-react/filtering/ResultSelector.tsx
@@ -115,12 +115,10 @@ export class ResultSelector extends React.PureComponent<
     if (event.key === Key.Enter.valueOf()) this._onSelectedResultConfirmed();
   };
 
-  /** @internal */
   public override componentDidMount() {
     this.props.onSelectedChanged(this.props.resultCount ? 1 : 0);
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: ResultSelectorProps) {
     if (this.props.resultCount !== prevProps.resultCount) {
       this.props.onSelectedChanged(this.props.resultCount ? 1 : 0);

--- a/ui/components-react/src/components-react/iconpicker/IconPickerButton.tsx
+++ b/ui/components-react/src/components-react/iconpicker/IconPickerButton.tsx
@@ -31,7 +31,6 @@ interface IconItemProps
  * @internal
  */
 class IconItem extends React.PureComponent<IconItemProps> {
-  /** @internal */
   constructor(props: IconItemProps) {
     super(props);
   }
@@ -106,7 +105,6 @@ export class IconPickerButton extends React.PureComponent<
     numColumns: 4,
   };
 
-  /** @internal */
   constructor(props: IconPickerProps) {
     super(props);
 

--- a/ui/components-react/src/components-react/iconpicker/IconPickerButton.tsx
+++ b/ui/components-react/src/components-react/iconpicker/IconPickerButton.tsx
@@ -151,7 +151,6 @@ export class IconPickerButton extends React.PureComponent<
     );
   }
 
-  /** @internal */
   public override render() {
     const buttonStyle = { ...this.props.style } as React.CSSProperties;
     const buttonClassNames = classnames(

--- a/ui/components-react/src/components-react/properties/renderers/ActionButtonList.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/ActionButtonList.tsx
@@ -39,7 +39,6 @@ export class ActionButtonList extends React.PureComponent<ActionButtonListProps>
       : "components-property-action-button-list--vertical";
   }
 
-  /** @internal */
   public override render() {
     return (
       <div className={this.getClassName(this.props.orientation)}>

--- a/ui/components-react/src/components-react/properties/renderers/NonPrimitivePropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/NonPrimitivePropertyRenderer.tsx
@@ -24,9 +24,7 @@ export interface NonPrimitivePropertyRendererProps
   isCollapsible?: boolean;
 }
 
-/** State of [[NonPrimitivePropertyRenderer]] React component
- * @internal
- */
+/** State of [[NonPrimitivePropertyRenderer]] React component. */
 interface NonPrimitivePropertyRendererState {
   /** Is struct/array property expanded */
   isExpanded?: boolean;
@@ -39,7 +37,6 @@ export class NonPrimitivePropertyRenderer extends React.Component<
   NonPrimitivePropertyRendererProps,
   NonPrimitivePropertyRendererState
 > {
-  /** @internal */
   public override readonly state: NonPrimitivePropertyRendererState = {
     /** If it's not collapsible, that means it's expanded by default and can't be collapsed */
     isExpanded:

--- a/ui/components-react/src/components-react/properties/renderers/NonPrimitivePropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/NonPrimitivePropertyRenderer.tsx
@@ -129,7 +129,6 @@ export class NonPrimitivePropertyRenderer extends React.Component<
     );
   };
 
-  /** @internal */
   public override render() {
     let items: PropertyRecord[] =
       this.props.propertyRecord.getChildrenRecords();

--- a/ui/components-react/src/components-react/properties/renderers/PrimitivePropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/PrimitivePropertyRenderer.tsx
@@ -33,7 +33,6 @@ export class PrimitivePropertyRenderer extends React.Component<PrimitiveRenderer
     super(props);
   }
 
-  /** @internal */
   public override render() {
     return <CustomizablePropertyRenderer {...this.props} />;
   }

--- a/ui/components-react/src/components-react/properties/renderers/PropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/PropertyRenderer.tsx
@@ -99,7 +99,6 @@ export class PropertyRenderer extends React.Component<
   PropertyRendererProps,
   PropertyRendererState
 > {
-  /** @internal */
   public override readonly state: Readonly<PropertyRendererState> = {
     displayValue: UiComponents.translate("general.loading"),
   };
@@ -161,7 +160,6 @@ export class PropertyRenderer extends React.Component<
     });
   }
 
-  /** @internal */
   public override componentDidMount() {
     this.updateDisplayValue(this.props);
   }

--- a/ui/components-react/src/components-react/properties/renderers/PropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/PropertyRenderer.tsx
@@ -166,7 +166,6 @@ export class PropertyRenderer extends React.Component<
     this.updateDisplayValue(this.props);
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyRendererProps) {
     if (
       prevProps.propertyRecord !== this.props.propertyRecord ||
@@ -176,7 +175,6 @@ export class PropertyRenderer extends React.Component<
       this.updateDisplayValue(this.props);
   }
 
-  /** @internal */
   public override render() {
     const {
       propertyValueRendererManager,

--- a/ui/components-react/src/components-react/properties/renderers/PropertyView.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/PropertyView.tsx
@@ -82,7 +82,6 @@ export class PropertyView extends React.Component<
     return propertyRecordClassName;
   }
 
-  /** @internal */
   public override render() {
     const ratio = this.props.columnRatio ? this.props.columnRatio : 0.25;
     const needElementSeparator =

--- a/ui/components-react/src/components-react/properties/renderers/value/table/ArrayValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/table/ArrayValueRenderer.tsx
@@ -33,7 +33,6 @@ export class TableArrayValueRenderer extends React.PureComponent<TableSpecificVa
     );
   }
 
-  /** @internal */
   public override render() {
     const typeName = (this.props.propertyRecord.value as ArrayValue)
       .itemsTypeName;

--- a/ui/components-react/src/components-react/properties/renderers/value/table/NonPrimitiveValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/table/NonPrimitiveValueRenderer.tsx
@@ -100,7 +100,6 @@ export class TableNonPrimitiveValueRenderer extends React.PureComponent<TableNon
   //     this.props.onPopupHide();
   // }
 
-  /** @internal */
   public override render() {
     return (
       // eslint-disable-next-line deprecation/deprecation

--- a/ui/components-react/src/components-react/properties/renderers/value/table/StructValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/table/StructValueRenderer.tsx
@@ -29,7 +29,6 @@ export class TableStructValueRenderer extends React.PureComponent<TableSpecificV
     );
   }
 
-  /** @internal */
   public override render() {
     return (
       <TableValueRenderer

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyCategoryBlock.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyCategoryBlock.tsx
@@ -47,7 +47,6 @@ export class PropertyCategoryBlock extends React.Component<PropertyCategoryBlock
     this.toggleExpansion();
   };
 
-  /** @internal */
   public override render() {
     const { highlight, category, children, onExpansionToggled, ...other } =
       this.props;

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
@@ -74,7 +74,6 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
   PropertyGridEventsRelatedPropsSupplierProps,
   PropertyGridEventsRelatedPropsSupplierState
 > {
-  /** @internal */
   constructor(props: PropertyGridEventsRelatedPropsSupplierProps) {
     super(props);
     this.state = {};

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
@@ -172,7 +172,6 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
     this.setState({ selectedPropertyKey, editingPropertyKey });
   }
 
-  /** @internal */
   public override render() {
     const renderContext: PropertyGridEventsRelatedProps = {
       isPropertyHoverEnabled: this.props.isPropertyHoverEnabled,

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyList.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyList.tsx
@@ -93,7 +93,6 @@ export class PropertyList extends React.Component<PropertyListProps> {
       this.props.onEditCommit(args, this.props.category);
   };
 
-  /** @internal */
   public override render() {
     const propertyListClassName = classnames(
       this.props.orientation === Orientation.Horizontal

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -331,7 +331,6 @@ export class VirtualizedPropertyGrid extends React.Component<
     return depth + 1;
   };
 
-  /** @internal */
   public override render() {
     const defaultActionButtonWidth =
       (this.props.actionButtonRenderers?.length ?? 0) > 0

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -167,7 +167,6 @@ export class VirtualizedPropertyGrid extends React.Component<
 > {
   private _listRef = React.createRef<VariableSizeList>();
 
-  /** @internal */
   constructor(props: VirtualizedPropertyGridProps) {
     super(props);
     this.state = {

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -183,7 +183,6 @@ export class VirtualizedPropertyGrid extends React.Component<
     };
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: VirtualizedPropertyGridProps) {
     if (
       this.props.orientation !== prevProps.orientation ||

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-properties/FlatNonPrimitivePropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-properties/FlatNonPrimitivePropertyRenderer.tsx
@@ -67,7 +67,6 @@ export class FlatNonPrimitivePropertyRenderer extends React.Component<FlatNonPri
     );
   }
 
-  /** @internal */
   public override render() {
     const { indentation, ...props } = this.props;
     return <PropertyView labelElement={this.getLabel(this.props)} {...props} />;

--- a/ui/core-react/src/core-react/autosuggest/AutoSuggest.tsx
+++ b/ui/core-react/src/core-react/autosuggest/AutoSuggest.tsx
@@ -114,12 +114,10 @@ export class AutoSuggest extends React.PureComponent<
     };
   }
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }

--- a/ui/core-react/src/core-react/contextmenu/ContextMenu.tsx
+++ b/ui/core-react/src/core-react/contextmenu/ContextMenu.tsx
@@ -94,7 +94,6 @@ export class ContextMenu extends React.PureComponent<
     floating: true,
   };
 
-  /** @internal */
   public override readonly state: Readonly<ContextMenuState>;
   constructor(props: ContextMenuProps) {
     super(props);
@@ -349,7 +348,6 @@ export class ContextMenu extends React.PureComponent<
     return parentDocument.defaultView ?? window;
   }
 
-  /** @internal */
   public override componentDidMount() {
     const parentWindow = this.getWindow();
     parentWindow.addEventListener("focus", this._handleFocusChange);
@@ -360,7 +358,6 @@ export class ContextMenu extends React.PureComponent<
     if (this.props.opened) this.focus();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     const parentWindow = this.getWindow();
     parentWindow.removeEventListener("focus", this._handleFocusChange);

--- a/ui/core-react/src/core-react/contextmenu/ContextMenuItem.tsx
+++ b/ui/core-react/src/core-react/contextmenu/ContextMenuItem.tsx
@@ -79,7 +79,6 @@ export class ContextMenuItem extends React.PureComponent<
   constructor(props: ContextMenuItemProps) {
     super(props);
   }
-  /** @internal */
   public override readonly state: Readonly<ContextMenuItemState> = {};
   public override render(): React.ReactElement {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/ui/core-react/src/core-react/contextmenu/ContextSubMenu.tsx
+++ b/ui/core-react/src/core-react/contextmenu/ContextSubMenu.tsx
@@ -65,7 +65,6 @@ export class ContextSubMenu extends React.Component<
     selectedIndex: 0,
   };
 
-  /** @internal */
   public override readonly state: Readonly<ContextSubMenuState>;
   constructor(props: ContextSubMenuProps) {
     super(props);

--- a/ui/core-react/src/core-react/hocs/withOnOutsideClick.tsx
+++ b/ui/core-react/src/core-react/hocs/withOnOutsideClick.tsx
@@ -134,7 +134,6 @@ export const withOnOutsideClick = <ComponentProps extends {}>(
         );
     }
 
-    /** @internal */
     public override componentWillUnmount() {
       const outsideClickParentDocument = this.getParentDocument();
       if (usePointerEvents) {

--- a/ui/core-react/src/core-react/imagecheckbox/ImageCheckBox.tsx
+++ b/ui/core-react/src/core-react/imagecheckbox/ImageCheckBox.tsx
@@ -62,7 +62,6 @@ export class ImageCheckBox extends React.PureComponent<ImageCheckBoxProps> {
     if (e && e.stopPropagation) e.stopPropagation();
   };
 
-  /** @internal */
   public override render() {
     const checkBoxClass = classnames(
       "core-image-checkbox",

--- a/ui/core-react/src/core-react/popup/Popup.tsx
+++ b/ui/core-react/src/core-react/popup/Popup.tsx
@@ -121,7 +121,9 @@ interface PopupState {
 // eslint-disable-next-line deprecation/deprecation
 export class Popup extends React.Component<PopupProps, PopupState> {
   private _popup: HTMLElement | null = null;
+  /** @internal */
   public static override contextType = PopupContext;
+  /** @internal */
   public declare context: React.ContextType<typeof PopupContext>;
 
   // eslint-disable-next-line deprecation/deprecation

--- a/ui/core-react/src/core-react/popup/Popup.tsx
+++ b/ui/core-react/src/core-react/popup/Popup.tsx
@@ -121,9 +121,7 @@ interface PopupState {
 // eslint-disable-next-line deprecation/deprecation
 export class Popup extends React.Component<PopupProps, PopupState> {
   private _popup: HTMLElement | null = null;
-  /** @internal */
   public static override contextType = PopupContext;
-  /** @internal */
   public declare context: React.ContextType<typeof PopupContext>;
 
   // eslint-disable-next-line deprecation/deprecation

--- a/ui/core-react/src/core-react/radialmenu/RadialMenu.tsx
+++ b/ui/core-react/src/core-react/radialmenu/RadialMenu.tsx
@@ -67,7 +67,6 @@ export class RadialMenu extends React.Component<
     selected: -1,
   };
 
-  /** @internal */
   public override readonly state: Readonly<RadialMenuState> = {
     sectors: [],
   };
@@ -239,7 +238,6 @@ export class RadialButton extends React.Component<
   RadialButtonProps,
   RadialButtonState
 > {
-  /** @internal */
   public override readonly state: Readonly<RadialButtonState> = {
     hover: this.props.selected || false,
   };

--- a/ui/core-react/src/core-react/searchbox/SearchBox.tsx
+++ b/ui/core-react/src/core-react/searchbox/SearchBox.tsx
@@ -53,7 +53,6 @@ export class SearchBox extends React.Component<SearchBoxProps, SearchBoxState> {
   private _inputElement: HTMLInputElement | null = null;
   private _timeoutId: number = 0;
 
-  /** @internal */
   public override readonly state: Readonly<SearchBoxState> = {
     value: this.props.initialValue || "",
   };

--- a/ui/core-react/src/core-react/searchbox/SearchBox.tsx
+++ b/ui/core-react/src/core-react/searchbox/SearchBox.tsx
@@ -62,7 +62,6 @@ export class SearchBox extends React.Component<SearchBoxProps, SearchBoxState> {
     super(props);
   }
 
-  /** @internal */
   public override render(): React.ReactNode {
     const searchClassName = classnames("core-searchbox", this.props.className);
     const emptyString = this.state.value === "";

--- a/ui/core-react/src/core-react/tabs/Tabs.tsx
+++ b/ui/core-react/src/core-react/tabs/Tabs.tsx
@@ -101,13 +101,11 @@ export class Tabs extends React.PureComponent<MainTabsProps, TabsState> {
     return activeIndex;
   }
 
-  /** @internal */
   public override componentDidMount() {
     this._itemKeyboardNavigator.itemCount = this.props.labels.length;
     this._itemKeyboardNavigator.orientation = this.props.orientation;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: MainTabsProps) {
     if (prevProps.labels !== this.props.labels)
       this._itemKeyboardNavigator.itemCount = this.props.labels.length;

--- a/ui/core-react/src/core-react/tabs/Tabs.tsx
+++ b/ui/core-react/src/core-react/tabs/Tabs.tsx
@@ -157,7 +157,6 @@ export class Tabs extends React.PureComponent<MainTabsProps, TabsState> {
     this.setState({ activeIndex: index });
   };
 
-  /** @internal */
   public override render(): React.ReactElement {
     const ulClassNames = classnames(
       this.props.mainClassName,

--- a/ui/imodel-components-react/src/imodel-components-react/color/AlphaSlider.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/AlphaSlider.tsx
@@ -100,7 +100,6 @@ export class AlphaSlider extends React.PureComponent<AlphaSliderProps> {
     return alpha !== t ? t : undefined;
   };
 
-  /** @internal */
   public override componentWillUnmount() {
     this._unbindEventListeners();
   }

--- a/ui/imodel-components-react/src/imodel-components-react/color/AlphaSlider.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/color/AlphaSlider.tsx
@@ -168,7 +168,6 @@ export class AlphaSlider extends React.PureComponent<AlphaSliderProps> {
     window.removeEventListener("mouseup", this._onMouseUp);
   }
 
-  /** @internal */
   public override render(): React.ReactNode {
     const containerClasses = classnames(
       this.props.isHorizontal

--- a/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.tsx
@@ -153,7 +153,6 @@ export class ColorEditor
     }
   }
 
-  /** @internal */
   public override render() {
     const colorDef = ColorDef.create(this.state.colorValue);
     return (

--- a/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.tsx
@@ -48,7 +48,6 @@ export class ColorEditor
   private _buttonElement: React.RefObject<HTMLButtonElement> =
     React.createRef();
 
-  /** @internal */
   public override readonly state: Readonly<ColorEditorState> = {
     colorValue: 0,
     readonly: false,
@@ -107,12 +106,10 @@ export class ColorEditor
     );
   };
 
-  /** @internal */
   public override componentDidMount() {
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.tsx
@@ -43,7 +43,6 @@ export class WeightEditor
   private _availableWeights: number[] = [];
   private _divElement = React.createRef<HTMLDivElement>();
 
-  /** @internal */
   public override readonly state: Readonly<WeightEditorState> = {
     weightValue: 0,
     readonly: false,
@@ -114,18 +113,15 @@ export class WeightEditor
     );
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._isMounted = true;
     void this.setStateFromProps();
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     this._isMounted = false;
   }
 
-  /** @internal */
   public override componentDidUpdate(prevProps: PropertyEditorProps) {
     if (this.props.propertyRecord !== prevProps.propertyRecord) {
       void this.setStateFromProps();

--- a/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.tsx
@@ -152,7 +152,6 @@ export class WeightEditor
       });
   }
 
-  /** @internal */
   public override render() {
     return (
       <div

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/Swatch.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/Swatch.tsx
@@ -38,7 +38,6 @@ export interface LineWeightSwatchProps
  * @public
  */
 export class LineWeightSwatch extends React.PureComponent<LineWeightSwatchProps> {
-  /** @internal */
   constructor(props: LineWeightSwatchProps) {
     super(props);
   }

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.tsx
@@ -200,7 +200,6 @@ export class WeightPickerButton extends React.PureComponent<
     );
   }
 
-  /** @internal */
   public override render() {
     const buttonClassNames = classnames(
       "components-weightpicker-button",

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.tsx
@@ -60,7 +60,6 @@ export class WeightPickerButton extends React.PureComponent<
   private _weightsContainer: HTMLDivElement | null = null;
   private _focusTarget = React.createRef<HTMLButtonElement>(); // weight button that should receive focus after popup is open
 
-  /** @internal */
   constructor(props: WeightPickerProps) {
     super(props);
 

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.tsx
@@ -189,7 +189,6 @@ export class CubeNavigationAid extends React.Component<
   CubeNavigationAidState
 > {
   private _start: Vector2d = Vector2d.createZero();
-  /** @internal */
   public override readonly state: Readonly<CubeNavigationAidState> = {
     dragging: false,
     startRotMatrix: Matrix3d.createIdentity(),
@@ -211,7 +210,6 @@ export class CubeNavigationAid extends React.Component<
     [Face.Bottom]: UiIModelComponents.translate("cube.bottom"),
   };
 
-  /** @internal */
   public override componentDidMount() {
     this._mounted = true;
     ViewportComponentEvents.onViewRotationChangeEvent.addListener(
@@ -229,7 +227,6 @@ export class CubeNavigationAid extends React.Component<
     }
   }
 
-  /** @internal */
   public override componentWillUnmount() {
     ViewportComponentEvents.onViewRotationChangeEvent.removeListener(
       this._handleViewRotationChangeEvent

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.tsx
@@ -174,7 +174,6 @@ export class DrawingNavigationAid extends React.Component<
     };
   }
 
-  /** @internal */
   public override render(): React.ReactNode {
     const {
       startOrigin,

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.tsx
@@ -130,7 +130,6 @@ export class DrawingNavigationAid extends React.Component<
   private _animationFrame: any;
   private _mounted: boolean = false;
 
-  /** @internal */
   public override readonly state: Readonly<DrawingNavigationAidState>;
 
   constructor(props: DrawingNavigationAidProps) {

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/InlineEdit.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/InlineEdit.tsx
@@ -38,7 +38,6 @@ export class InlineEdit extends React.Component<
     };
   }
 
-  /** @internal */
   public override componentDidUpdate(
     prevProps: InlineEditProps,
     _prevState: InlineEditState


### PR DESCRIPTION
## Changes

Fixes #891 by updating release tags of frequently used APIs.
Fixes #671 by removing `@internal` tags from React lifecycle methods and properties.
Additionally `@internal` tags are removed from methods tagged with the `override` keyword.

## Testing

N/A
