### PR TITLE
Bump more APIs to `@public`

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -2024,7 +2024,7 @@ export interface FrameworkControls {
     unregister(classId: string): void;
 }
 
-// @beta
+// @public
 export interface FrameworkDialog {
     readonly active: React.ReactNode | undefined;
     close(dialog?: React.ReactNode): void;
@@ -2036,11 +2036,9 @@ export interface FrameworkDialog {
 
 // @public
 export interface FrameworkDialogs {
-    // @beta
     readonly modal: FrameworkDialog & {
         readonly onModalDialogChangedEvent: ModalDialogChangedEvent;
     };
-    // @beta
     readonly modeless: FrameworkStackedDialog<ModelessDialogInfo> & {
         readonly onModelessDialogChangedEvent: ModelessDialogChangedEvent;
     };
@@ -2191,7 +2189,7 @@ export interface FrameworkRootState {
     frameworkState: FrameworkState;
 }
 
-// @beta
+// @public
 export interface FrameworkStackedDialog<DialogInfoType> extends FrameworkDialog {
     // (undocumented)
     getInfo(id: string): DialogInfoType | undefined;
@@ -2207,7 +2205,7 @@ export interface FrameworkState {
     sessionState: SessionState;
 }
 
-// @beta
+// @public
 export class FrameworkToolAdmin extends ToolAdmin {
     // (undocumented)
     processShortcutKey(e: KeyboardEvent, wentDown: boolean): Promise<boolean>;
@@ -4432,7 +4430,7 @@ export class StandardNavigationToolsProvider extends BaseUiItemsProvider {
     static register(providerId: string, defaultNavigationTools?: DefaultNavigationTools, isSupportedStage?: (stageId: string, stageUsage: string, stageAppData?: any) => boolean): StandardNavigationToolsProvider;
 }
 
-// @beta
+// @public
 export class StandardNavigationToolsUiItemsProvider implements UiItemsProvider {
     constructor(defaultNavigationTools?: DefaultNavigationTools | undefined);
     // (undocumented)
@@ -4578,7 +4576,6 @@ export interface StatusBarItemProps extends CommonProps {
 
 // @public
 export namespace StatusBarItemUtilities {
-    // @beta
     export function createActionItem(args: CreateActionItemArgs): StatusBarActionItem;
     // @deprecated
     export function createActionItem(...args: DeprecatedCreateActionItemArgs): StatusBarActionItem;
@@ -4587,14 +4584,12 @@ export namespace StatusBarItemUtilities {
         // (undocumented)
         icon?: StatusBarActionItem["iconNode"];
     }
-    // @beta
     export function createCustomItem(args: CreateCustomItemArgs): StatusBarCustomItem;
     // @deprecated
     export function createCustomItem(...args: DeprecatedCreateCustomItemArgs): StatusBarCustomItem;
     // (undocumented)
     export interface CreateCustomItemArgs extends Partial<Omit<StatusBarCustomItem, "id">>, Pick<StatusBarCustomItem, "id"> {
     }
-    // @beta
     export function createLabelItem(args: CreateLabelItemArgs): StatusBarLabelItem;
     // @deprecated
     export function createLabelItem(...args: DeprecatedCreateLabelItemArgs): StatusBarLabelItem;
@@ -4743,7 +4738,7 @@ export class SyncUiEventDispatcher {
     static initialize(): void;
     static initializeConnectionEvents(iModelConnection: IModelConnection): void;
     static get onSyncUiEvent(): UiSyncEvent;
-    // @internal
+    // (undocumented)
     static setTimeoutPeriod(period: number): void;
     static get syncEventIds(): Set<string>;
 }

--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -869,13 +869,13 @@ export class Line {
     p2: Point;
 }
 
-// @alpha @deprecated
+// @public @deprecated
 export function Listbox(props: ListboxProps): React_2.JSX.Element;
 
-// @alpha @deprecated
+// @public @deprecated
 export const ListboxContext: React_2.Context<ListboxContextProps>;
 
-// @alpha @deprecated
+// @public @deprecated
 export interface ListboxContextProps {
     // (undocumented)
     focusValue?: ListboxValue;
@@ -889,16 +889,16 @@ export interface ListboxContextProps {
     onListboxValueChange: (newValue: ListboxValue, isControlOrCommandPressed?: boolean) => void;
 }
 
-// @alpha @deprecated
+// @public @deprecated
 export function ListboxItem(props: ListboxItemProps): React_2.JSX.Element;
 
-// @alpha @deprecated
+// @public @deprecated
 export interface ListboxItemProps extends React_2.DetailedHTMLProps<React_2.LiHTMLAttributes<HTMLLIElement>, HTMLLIElement> {
     disabled?: boolean;
     value: ListboxValue;
 }
 
-// @alpha @deprecated
+// @public @deprecated
 export interface ListboxProps extends React_2.DetailedHTMLProps<React_2.HTMLAttributes<HTMLUListElement>, HTMLUListElement> {
     // (undocumented)
     ariaLabel?: any;
@@ -912,7 +912,7 @@ export interface ListboxProps extends React_2.DetailedHTMLProps<React_2.HTMLAttr
     selectedValue?: ListboxValue;
 }
 
-// @alpha @deprecated
+// @public @deprecated
 export type ListboxValue = string;
 
 // @internal

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -276,7 +276,7 @@ public;FrameworkChildWindows
 public;FrameworkContent
 public;FrameworkControls
 deprecated;FrameworkControls
-beta;FrameworkDialog
+public;FrameworkDialog
 public;FrameworkDialogs
 public;FrameworkFrontstages
 public;FrameworkKeyboardShortcut
@@ -286,10 +286,10 @@ public;FrameworkReducer: Reducer_2
 deprecated;FrameworkReducer: Reducer_2
 beta;FrameworkRootState
 deprecated;FrameworkRootState
-beta;FrameworkStackedDialog
+public;FrameworkStackedDialog
 public;FrameworkState
 deprecated;FrameworkState
-beta;FrameworkToolAdmin 
+public;FrameworkToolAdmin 
 public;FrameworkToolSettings
 public;FrameworkUiAdmin 
 public;FrameworkVisibility
@@ -619,7 +619,7 @@ deprecated;StandardMessageBox(props: StandardMessageBoxProps): React_2.JSX.Eleme
 public;StandardMessageBoxProps 
 deprecated;StandardMessageBoxProps 
 public;StandardNavigationToolsProvider 
-beta;StandardNavigationToolsUiItemsProvider 
+public;StandardNavigationToolsUiItemsProvider 
 public;StandardRotationNavigationAidControl 
 deprecated;StandardRotationNavigationAidControl 
 public;StandardStatusbarItemsProvider 
@@ -650,9 +650,6 @@ deprecated;StatusBarIndicatorProps
 public;StatusBarItem = StatusBarActionItem | StatusBarLabelItem | StatusBarCustomItem
 internal;StatusBarItemProps 
 public;StatusBarItemUtilities
-beta;createActionItem(args: CreateActionItemArgs): StatusBarActionItem
-beta;createCustomItem(args: CreateCustomItemArgs): StatusBarCustomItem
-beta;createLabelItem(args: CreateLabelItemArgs): StatusBarLabelItem
 beta;StatusBarLabelIndicator(props: StatusBarLabelIndicatorProps): React_2.JSX.Element
 deprecated;StatusBarLabelIndicator(props: StatusBarLabelIndicatorProps): React_2.JSX.Element
 beta;StatusBarLabelIndicatorProps 

--- a/common/api/summary/core-react.exports.csv
+++ b/common/api/summary/core-react.exports.csv
@@ -173,19 +173,19 @@ internal;ItemKeyboardNavigator
 public;LabeledComponentProps
 deprecated;LabeledComponentProps
 internal;Line
-alpha;Listbox(props: ListboxProps): React_2.JSX.Element
+public;Listbox(props: ListboxProps): React_2.JSX.Element
 deprecated;Listbox(props: ListboxProps): React_2.JSX.Element
-alpha;ListboxContext: React_2.Context
+public;ListboxContext: React_2.Context
 deprecated;ListboxContext: React_2.Context
-alpha;ListboxContextProps
+public;ListboxContextProps
 deprecated;ListboxContextProps
-alpha;ListboxItem(props: ListboxItemProps): React_2.JSX.Element
+public;ListboxItem(props: ListboxItemProps): React_2.JSX.Element
 deprecated;ListboxItem(props: ListboxItemProps): React_2.JSX.Element
-alpha;ListboxItemProps 
+public;ListboxItemProps 
 deprecated;ListboxItemProps 
-alpha;ListboxProps 
+public;ListboxProps 
 deprecated;ListboxProps 
-alpha;ListboxValue = string
+public;ListboxValue = string
 deprecated;ListboxValue = string
 internal;ListenerType
 public;LoadingBar 

--- a/common/changes/@itwin/appui-react/more-public-apis_2024-08-01-11-03.json
+++ b/common/changes/@itwin/appui-react/more-public-apis_2024-08-01-11-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/core-react/more-public-apis_2024-08-01-11-03.json
+++ b/common/changes/@itwin/core-react/more-public-apis_2024-08-01-11-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -220,6 +220,7 @@ Table of contents:
 - Bumped `AccuDrawKeyboardShortcuts`, `BackstageItemUtilities`, `DrawingNavigationAidControl`, `ReducerRegistry`, `SheetNavigationAidControl`, `StandardRotationNavigationAidControl`, `ToolbarItemUtilities`, `useTransientState` APIs to `@public`. [#943](https://github.com/iTwin/appui/pull/943)
 - Removed `@internal` tags from React lifecycle methods and properties. Consumers should avoid calling class methods directly, since class components can be converted to functional components in the future. [#943](https://github.com/iTwin/appui/pull/943)
 - Removed `@internal` tags from overriden class methods. [#943](https://github.com/iTwin/appui/pull/943)
+- Bumped `FrameworkDialog`, `FrameworkDialogs.modal`, `FrameworkDialogs.modeless`, `FrameworkStackedDialog`, `FrameworkToolAdmin`, `StandardNavigationToolsUiItemsProvider`, `StatusBarItemUtilities.createActionItem`, `StatusBarItemUtilities.createCustomItem`, `StatusBarItemUtilities.createLabelItem`, `SyncUiEventDispatcher.setTimeoutPeriod` APIs to `@public`. [#944](https://github.com/iTwin/appui/pull/944)
 
 ### Fixes
 
@@ -355,3 +356,4 @@ Table of contents:
 ### Changes
 
 - Removed styling for the `theme-transition` class. [#890](https://github.com/iTwin/appui/pull/890)
+- Bumped `Listbox`, `ListboxContext`, `ListboxContextProps`, `ListboxItem`, `ListboxItemProps`, `ListboxProps`, `ListboxValue` APIs to `@public`. [#944](https://github.com/iTwin/appui/pull/944)

--- a/ui/appui-react/src/appui-react/framework/FrameworkDialogs.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkDialogs.ts
@@ -31,7 +31,7 @@ export interface ModelessDialogInfo {
 
 /**
  * Manages dialog access
- * @beta
+ * @public
  */
 export interface FrameworkDialog {
   /** Get the array of modal dialogs */
@@ -61,7 +61,7 @@ export interface FrameworkDialog {
 
 /**
  * FrameworkDialog that manages the top most content.
- * @beta
+ * @public
  */
 export interface FrameworkStackedDialog<DialogInfoType>
   extends FrameworkDialog {
@@ -83,20 +83,14 @@ export interface FrameworkStackedDialog<DialogInfoType>
  * @public
  */
 export interface FrameworkDialogs {
-  /**
-   * Manage modal dialogs.
-   * @beta
-   */
+  /** Manage modal dialogs. */
   readonly modal: FrameworkDialog & {
     /** Modal Dialog Changed Event */
     // eslint-disable-next-line deprecation/deprecation
     readonly onModalDialogChangedEvent: ModalDialogChangedEvent;
   };
 
-  /**
-   * Manage modeless dialogs.
-   * @beta
-   */
+  /** Manage modeless dialogs. */
   readonly modeless: FrameworkStackedDialog<ModelessDialogInfo> & {
     /** Modeless Dialog Changed Event */
     // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/statusbar/StatusBarItemUtilities.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBarItemUtilities.tsx
@@ -60,24 +60,18 @@ export namespace StatusBarItemUtilities {
     };
   }
 
-  /** Creates a StatusBar item to perform an action.
-   * @beta
-   */
+  /** Creates a StatusBar item to perform an action. */
   export function createActionItem(
     args: CreateActionItemArgs
   ): StatusBarActionItem;
-  /** Creates a StatusBar item to perform an action.
-   * @beta
-   */
+  /** Creates a StatusBar item to perform an action. */
   /** Creates a StatusBar item to perform an action.
    * @deprecated in 4.16.0. Uses a deprecated {@link @itwin/core-react#IconSpec} type. Use an overload instead.
    */
   export function createActionItem(
     ...args: DeprecatedCreateActionItemArgs
   ): StatusBarActionItem;
-  /** Creates a StatusBar item to perform an action.
-   * @beta
-   */
+  /** Creates a StatusBar item to perform an action. */
   export function createActionItem(
     ...args: DeprecatedCreateActionItemArgs | [CreateActionItemArgs]
   ): StatusBarActionItem {
@@ -140,9 +134,7 @@ export namespace StatusBarItemUtilities {
     };
   }
 
-  /** Creates a StatusBar item to display a label.
-   * @beta
-   */
+  /** Creates a StatusBar item to display a label. */
   export function createLabelItem(
     args: CreateLabelItemArgs
   ): StatusBarLabelItem;
@@ -152,9 +144,7 @@ export namespace StatusBarItemUtilities {
   export function createLabelItem(
     ...args: DeprecatedCreateLabelItemArgs
   ): StatusBarLabelItem;
-  /** Creates a StatusBar item to display a label.
-   * @beta
-   */
+  /** Creates a StatusBar item to display a label. */
   export function createLabelItem(
     ...args: DeprecatedCreateLabelItemArgs | [CreateLabelItemArgs]
   ): StatusBarLabelItem {
@@ -208,9 +198,7 @@ export namespace StatusBarItemUtilities {
     };
   }
 
-  /** Creates a StatusBar item to display a custom content.
-   * @beta
-   */
+  /** Creates a StatusBar item to display a custom content. */
   export function createCustomItem(
     args: CreateCustomItemArgs
   ): StatusBarCustomItem;
@@ -220,9 +208,7 @@ export namespace StatusBarItemUtilities {
   export function createCustomItem(
     ...args: DeprecatedCreateCustomItemArgs
   ): StatusBarCustomItem;
-  /** Creates a StatusBar item to display a custom content.
-   * @beta
-   */
+  /** Creates a StatusBar item to display a custom content. */
   export function createCustomItem(
     ...args: DeprecatedCreateCustomItemArgs | [CreateCustomItemArgs]
   ): StatusBarCustomItem {

--- a/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
+++ b/ui/appui-react/src/appui-react/syncui/SyncUiEventDispatcher.ts
@@ -77,8 +77,6 @@ export class SyncUiEventDispatcher {
   private static _connectionUnregisterFuncs = new Array<() => void>();
   private static _iModelConnection?: IModelConnection;
 
-  /** @internal - used for testing only */
-
   public static setTimeoutPeriod(period: number): void {
     SyncUiEventDispatcher._uiEventDispatcher.setTimeoutPeriod(period);
   }

--- a/ui/appui-react/src/appui-react/tools/FrameworkToolAdmin.ts
+++ b/ui/appui-react/src/appui-react/tools/FrameworkToolAdmin.ts
@@ -20,7 +20,7 @@ import { UiFramework } from "../UiFramework";
  *   toolAdmin: new FrameworkToolAdmin()
  * });
  * ```
- * @beta
+ * @public
  */
 export class FrameworkToolAdmin extends ToolAdmin {
   public override async processShortcutKey(

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsUiItemsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsUiItemsProvider.ts
@@ -33,7 +33,7 @@ export interface DefaultNavigationTools {
 
 /**
  * Provide standard tools for the ViewNavigationWidgetComposer.
- * @beta
+ * @public
  */
 export class StandardNavigationToolsUiItemsProvider implements UiItemsProvider {
   public get id(): string {

--- a/ui/core-react/src/core-react.ts
+++ b/ui/core-react/src/core-react.ts
@@ -216,6 +216,10 @@ registerIconWebComponent();
  * Components for working with input controls, such as Input, IconInput and NumberInput.
  */
 /**
+ * @docs-group-description Listbox
+ * Components for working with a Listbox.
+ */
+/**
  * @docs-group-description Loading
  * Components for working with Loading spinners and progress indicators and bars.
  */

--- a/ui/core-react/src/core-react/listbox/Listbox.tsx
+++ b/ui/core-react/src/core-react/listbox/Listbox.tsx
@@ -14,13 +14,13 @@ import { Guid } from "@itwin/core-bentley";
 /* eslint-disable deprecation/deprecation */
 
 /** `Listbox` value.
- * @alpha
+ * @public
  * @deprecated in 4.12.0. Value used in a deprecated component {@link Listbox}.
  */
 export type ListboxValue = string;
 
 /** `Listbox` Props.
- * @alpha
+ * @public
  * @deprecated in 4.12.0. Props of deprecated component {@link Listbox}.
  */
 export interface ListboxProps
@@ -39,7 +39,7 @@ export interface ListboxProps
 }
 
 /** `ListboxItem` Props.
- * @alpha
+ * @public
  * @deprecated in 4.12.0. Props of deprecated component {@link ListboxItem}.
  */
 export interface ListboxItemProps
@@ -54,7 +54,7 @@ export interface ListboxItemProps
 }
 
 /** `Listbox` Context.
- * @alpha
+ * @public
  * @deprecated in 4.12.0. Props of deprecated context {@link ListboxContext}.
  */
 export interface ListboxContextProps {
@@ -69,7 +69,7 @@ export interface ListboxContextProps {
 }
 
 /** Context set up by listbox for use by `ListboxItems` .
- * @alpha
+ * @public
  * @deprecated in 4.12.0. Context of deprecated component {@link Listbox}.
  */
 export const ListboxContext = React.createContext<ListboxContextProps>({
@@ -135,7 +135,7 @@ function processKeyboardNavigation(
 }
 
 /** Single select `Listbox` component
- * @alpha
+ * @public
  * @deprecated in 4.12.0. Use {@link https://itwinui.bentley.com/docs/list iTwinUI list} instead.
  */
 export function Listbox(props: ListboxProps) {
@@ -337,7 +337,7 @@ export function Listbox(props: ListboxProps) {
 }
 
 /** `ListboxItem` component.
- * @alpha
+ * @public
  * @deprecated in 4.12.0. Use {@link https://itwinui.bentley.com/docs/list iTwinUI list} instead.
  */
 export function ListboxItem(props: ListboxItemProps) {

--- a/ui/core-react/src/core-react/listbox/Listbox.tsx
+++ b/ui/core-react/src/core-react/listbox/Listbox.tsx
@@ -2,6 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Listbox
+ */
 import * as React from "react";
 import classnames from "classnames";
 import { Key } from "ts-key-enum";


### PR DESCRIPTION
## Changes

Bump more APIs to `@public` in addition to https://github.com/iTwin/appui/pull/943

## Testing

N/A
