### PR TITLE
Export `AccuDrawFieldContainer` from a barrel file

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -21,7 +21,7 @@ import type { BeButtonEvent } from '@itwin/core-frontend';
 import type { BeDuration } from '@itwin/core-bentley';
 import { BeEvent } from '@itwin/core-bentley';
 import { BeUiEvent } from '@itwin/core-bentley';
-import { Button } from '@itwin/itwinui-react';
+import type { Button } from '@itwin/itwinui-react';
 import { ColorDef } from '@itwin/core-common';
 import { CombinedState } from 'redux';
 import type { CommandHandler as CommandHandler_2 } from '@itwin/appui-abstract';
@@ -128,7 +128,7 @@ import type { ViewStateProp } from '@itwin/imodel-components-react';
 import type { ViewStateProps } from '@itwin/core-common';
 import type { XAndY } from '@itwin/core-geometry';
 
-// @beta @deprecated
+// @public @deprecated
 export class AccuDrawCommandItems {
     // (undocumented)
     static get bumpToolSetting(): ToolItemDef;
@@ -168,10 +168,10 @@ export class AccuDrawCommandItems {
     static get setOrigin(): ToolItemDef;
 }
 
-// @beta
+// @public
 export function AccuDrawDialog(props: AccuDrawDialogProps): React_2.JSX.Element;
 
-// @beta
+// @public
 export interface AccuDrawDialogProps extends CommonProps {
     // @deprecated
     dialogId?: string;
@@ -180,8 +180,41 @@ export interface AccuDrawDialogProps extends CommonProps {
     orientation?: Orientation;
 }
 
-// @beta @deprecated
+// @public
+export function AccuDrawFieldContainer(props: AccuDrawFieldContainerProps): React_2.JSX.Element;
+
+// @public
+export interface AccuDrawFieldContainerProps extends CommonProps {
+    orientation: Orientation;
+    // @internal (undocumented)
+    showZOverride?: boolean;
+    uiSettingsStorage?: UiStateStorage;
+}
+
+// @public @deprecated
 export class AccuDrawGrabInputFocusEvent extends BeUiEvent<{}> {
+}
+
+// @public
+export const AccuDrawInputField: (props: AccuDrawInputFieldProps) => React_2.ReactNode;
+
+// @public
+export interface AccuDrawInputFieldProps extends CommonProps {
+    field: ItemField;
+    icon?: React_2.ReactNode;
+    // @deprecated
+    iconSpec?: IconSpec;
+    id: string;
+    isLocked?: boolean;
+    label?: string;
+    labelCentered?: boolean;
+    labelClassName?: string;
+    labelStyle?: React_2.CSSProperties;
+    onEnterPressed?: () => void;
+    onEscPressed?: () => void;
+    onValueChanged: (stringValue: string) => void;
+    ref?: React_2.Ref<HTMLInputElement>;
+    valueChangedDelay?: number;
 }
 
 // @public
@@ -189,7 +222,7 @@ export class AccuDrawKeyboardShortcuts {
     static getDefaultShortcuts(): KeyboardShortcutProps[];
 }
 
-// @alpha
+// @public
 export class AccuDrawPopupManager {
     // (undocumented)
     static hideCalculator(): boolean;
@@ -199,7 +232,7 @@ export class AccuDrawPopupManager {
     static showAngleEditor(el: HTMLElement, pt: XAndY, value: number, onCommit: (value: number) => void, onCancel: () => void): boolean;
     // (undocumented)
     static showCalculator(el: HTMLElement, pt: XAndY, initialValue: number, resultIcon: string, onOk: (value: number) => void, onCancel: () => void): boolean;
-    // (undocumented)
+    // @internal (undocumented)
     static showDimensionEditor(dimension: "height" | "length", el: HTMLElement, pt: XAndY, value: number, onCommit: (value: number) => void, onCancel: () => void): boolean;
     // (undocumented)
     static showHeightEditor(el: HTMLElement, pt: XAndY, value: number, onCommit: (value: number) => void, onCancel: () => void): boolean;
@@ -209,31 +242,31 @@ export class AccuDrawPopupManager {
     static showMenuButton(id: string, el: HTMLElement, pt: XAndY, menuItemsProps: CursorMenuItemProps[]): boolean;
 }
 
-// @beta @deprecated
+// @public @deprecated
 export class AccuDrawSetCompassModeEvent extends BeUiEvent<AccuDrawSetCompassModeEventArgs> {
 }
 
-// @beta @deprecated
+// @public @deprecated
 export interface AccuDrawSetCompassModeEventArgs {
     // (undocumented)
     mode: CompassMode;
 }
 
-// @beta @deprecated
+// @public @deprecated
 export class AccuDrawSetFieldFocusEvent extends BeUiEvent<AccuDrawSetFieldFocusEventArgs> {
 }
 
-// @beta @deprecated
+// @public @deprecated
 export interface AccuDrawSetFieldFocusEventArgs {
     // (undocumented)
     field: ItemField;
 }
 
-// @beta @deprecated
+// @public @deprecated
 export class AccuDrawSetFieldLockEvent extends BeUiEvent<AccuDrawSetFieldLockEventArgs> {
 }
 
-// @beta @deprecated
+// @public @deprecated
 export interface AccuDrawSetFieldLockEventArgs {
     // (undocumented)
     field: ItemField;
@@ -241,11 +274,11 @@ export interface AccuDrawSetFieldLockEventArgs {
     lock: boolean;
 }
 
-// @beta @deprecated
+// @public @deprecated
 export class AccuDrawSetFieldValueFromUiEvent extends BeUiEvent<AccuDrawSetFieldValueFromUiEventArgs> {
 }
 
-// @beta @deprecated
+// @public @deprecated
 export interface AccuDrawSetFieldValueFromUiEventArgs {
     // (undocumented)
     field: ItemField;
@@ -253,11 +286,11 @@ export interface AccuDrawSetFieldValueFromUiEventArgs {
     stringValue: string;
 }
 
-// @beta @deprecated
+// @public @deprecated
 export class AccuDrawSetFieldValueToUiEvent extends BeUiEvent<AccuDrawSetFieldValueToUiEventArgs> {
 }
 
-// @beta @deprecated
+// @public @deprecated
 export interface AccuDrawSetFieldValueToUiEventArgs {
     // (undocumented)
     field: ItemField;
@@ -267,7 +300,7 @@ export interface AccuDrawSetFieldValueToUiEventArgs {
     value: number;
 }
 
-// @beta
+// @public
 export interface AccuDrawUiSettings {
     angleBackgroundColor?: ColorDef | string;
     angleForegroundColor?: ColorDef | string;
@@ -306,14 +339,14 @@ export interface AccuDrawUiSettings {
     zStyle?: React.CSSProperties;
 }
 
-// @beta @deprecated
+// @public @deprecated
 export class AccuDrawUiSettingsChangedEvent extends BeUiEvent<{}> {
 }
 
 // @public
 export function AccuDrawWidget(): React_2.JSX.Element;
 
-// @beta @deprecated
+// @public @deprecated
 export class AccuDrawWidgetControl extends WidgetControl {
     constructor(info: ConfigurableCreateInfo, options: any);
     // (undocumented)
@@ -675,13 +708,13 @@ export class BumpToolSetting extends Tool {
     static toolId: string;
 }
 
-// @alpha (undocumented)
+// @public (undocumented)
 export class Calculator extends React_2.PureComponent<CalculatorProps, CalculatorState> {
     constructor(props: CalculatorProps);
     // (undocumented)
     componentDidMount(): void;
-    // @internal (undocumented)
-    static readonly defaultProps: CalculatorPropsProps;
+    // (undocumented)
+    static readonly defaultProps: Pick<CalculatorProps, "engine">;
     // (undocumented)
     render(): React_2.JSX.Element;
 }
@@ -737,7 +770,7 @@ export enum CalculatorOperator {
     Subtract = 5
 }
 
-// @alpha @deprecated
+// @public @deprecated
 export class CalculatorPopup extends React_2.PureComponent<CalculatorPopupProps, CalculatorPopupState> {
     // (undocumented)
     render(): React_2.JSX.Element;
@@ -747,7 +780,7 @@ export class CalculatorPopup extends React_2.PureComponent<CalculatorPopupProps,
     };
 }
 
-// @alpha @deprecated (undocumented)
+// @public @deprecated (undocumented)
 export interface CalculatorPopupProps extends PopupPropsBase {
     // (undocumented)
     initialValue: number;
@@ -759,7 +792,7 @@ export interface CalculatorPopupProps extends PopupPropsBase {
     resultIcon: string;
 }
 
-// @alpha (undocumented)
+// @public (undocumented)
 export interface CalculatorProps extends CommonProps {
     // @internal
     engine: CalculatorEngine;
@@ -768,9 +801,6 @@ export interface CalculatorProps extends CommonProps {
     onOk?: OnNumberCommitFunc;
     resultIcon?: React_2.ReactNode;
 }
-
-// @internal (undocumented)
-export type CalculatorPropsProps = Pick<CalculatorProps, "engine">;
 
 // @public
 export interface CanFloatWidgetOptions {
@@ -1893,7 +1923,7 @@ export class FocusToolSettings extends Tool {
     static toolId: string;
 }
 
-// @beta
+// @public
 export class FrameworkAccuDraw extends AccuDraw implements UserSettingsProvider {
     constructor();
     static get displayNotifications(): boolean;
@@ -3171,14 +3201,14 @@ export function mapToPlacement(input?: Placement | RelativePosition): Placement;
 // @internal
 export function mapToRelativePosition(input: Placement | RelativePosition): RelativePosition;
 
-// @alpha (undocumented)
+// @public (undocumented)
 export class MenuButton extends React_2.PureComponent<MenuButtonProps, MenuButtonState> {
     constructor(props: MenuButtonProps);
     // (undocumented)
     render(): React_2.JSX.Element;
 }
 
-// @alpha
+// @public
 export class MenuButtonPopup extends React_2.PureComponent<MenuButtonPopupProps, MenuButtonPopupState> {
     // (undocumented)
     render(): React_2.JSX.Element;
@@ -3188,14 +3218,14 @@ export class MenuButtonPopup extends React_2.PureComponent<MenuButtonPopupProps,
     };
 }
 
-// @alpha (undocumented)
+// @public (undocumented)
 export interface MenuButtonPopupProps extends PopupPropsBase {
     // (undocumented)
     content: React_2.ReactNode;
 }
 
-// @alpha (undocumented)
-export interface MenuButtonProps extends SquareButtonProps {
+// @public (undocumented)
+export interface MenuButtonProps extends Omit<ButtonProps, "size" | "styleType"> {
     onSizeKnown?: (size: SizeProps) => void;
     point: XAndY;
 }
@@ -4826,16 +4856,13 @@ export class ToolAssistanceField extends React_2.Component<ToolAssistanceFieldPr
     context: React_2.ContextType<typeof UiStateStorageContext>;
     // @internal (undocumented)
     static contextType: React_2.Context<UiStateStorage_2>;
-    // @internal (undocumented)
-    static readonly defaultProps: ToolAssistanceFieldDefaultProps;
+    // (undocumented)
+    static readonly defaultProps: Pick<ToolAssistanceFieldProps, "includePromptAtCursor" | "uiStateStorage" | "cursorPromptTimeout" | "fadeOutCursorPrompt" | "defaultPromptAtCursor">;
     // @internal (undocumented)
     static getInstructionImage(instruction: ToolAssistanceInstruction): React_2.ReactNode;
     // (undocumented)
     render(): React_2.ReactNode;
 }
-
-// @internal
-export type ToolAssistanceFieldDefaultProps = Pick<ToolAssistanceFieldProps, "includePromptAtCursor" | "uiStateStorage" | "cursorPromptTimeout" | "fadeOutCursorPrompt" | "defaultPromptAtCursor">;
 
 // @public
 export interface ToolAssistanceFieldProps extends CommonProps {

--- a/common/api/core-react.api.md
+++ b/common/api/core-react.api.md
@@ -299,7 +299,7 @@ export class ContextMenuItem extends React_2.PureComponent<ContextMenuItemProps,
     componentDidMount(): void;
     // (undocumented)
     componentDidUpdate(prevProps: ContextMenuItemProps): void;
-    // @internal (undocumented)
+    // (undocumented)
     static defaultProps: Partial<ContextMenuItemProps>;
     // (undocumented)
     render(): React_2.ReactElement;

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -1,38 +1,42 @@
 sep=;
 Release Tag;API Item
-beta;AccuDrawCommandItems
+public;AccuDrawCommandItems
 deprecated;AccuDrawCommandItems
-beta;AccuDrawDialog(props: AccuDrawDialogProps): React_2.JSX.Element
-beta;AccuDrawDialogProps 
-beta;AccuDrawGrabInputFocusEvent 
+public;AccuDrawDialog(props: AccuDrawDialogProps): React_2.JSX.Element
+public;AccuDrawDialogProps 
+public;AccuDrawFieldContainer(props: AccuDrawFieldContainerProps): React_2.JSX.Element
+public;AccuDrawFieldContainerProps 
+public;AccuDrawGrabInputFocusEvent 
 deprecated;AccuDrawGrabInputFocusEvent 
+public;AccuDrawInputField: (props: AccuDrawInputFieldProps) => React_2.ReactNode
+public;AccuDrawInputFieldProps 
 public;AccuDrawKeyboardShortcuts
-alpha;AccuDrawPopupManager
-beta;AccuDrawSetCompassModeEvent 
+public;AccuDrawPopupManager
+public;AccuDrawSetCompassModeEvent 
 deprecated;AccuDrawSetCompassModeEvent 
-beta;AccuDrawSetCompassModeEventArgs
+public;AccuDrawSetCompassModeEventArgs
 deprecated;AccuDrawSetCompassModeEventArgs
-beta;AccuDrawSetFieldFocusEvent 
+public;AccuDrawSetFieldFocusEvent 
 deprecated;AccuDrawSetFieldFocusEvent 
-beta;AccuDrawSetFieldFocusEventArgs
+public;AccuDrawSetFieldFocusEventArgs
 deprecated;AccuDrawSetFieldFocusEventArgs
-beta;AccuDrawSetFieldLockEvent 
+public;AccuDrawSetFieldLockEvent 
 deprecated;AccuDrawSetFieldLockEvent 
-beta;AccuDrawSetFieldLockEventArgs
+public;AccuDrawSetFieldLockEventArgs
 deprecated;AccuDrawSetFieldLockEventArgs
-beta;AccuDrawSetFieldValueFromUiEvent 
+public;AccuDrawSetFieldValueFromUiEvent 
 deprecated;AccuDrawSetFieldValueFromUiEvent 
-beta;AccuDrawSetFieldValueFromUiEventArgs
+public;AccuDrawSetFieldValueFromUiEventArgs
 deprecated;AccuDrawSetFieldValueFromUiEventArgs
-beta;AccuDrawSetFieldValueToUiEvent 
+public;AccuDrawSetFieldValueToUiEvent 
 deprecated;AccuDrawSetFieldValueToUiEvent 
-beta;AccuDrawSetFieldValueToUiEventArgs
+public;AccuDrawSetFieldValueToUiEventArgs
 deprecated;AccuDrawSetFieldValueToUiEventArgs
-beta;AccuDrawUiSettings
-beta;AccuDrawUiSettingsChangedEvent 
+public;AccuDrawUiSettings
+public;AccuDrawUiSettingsChangedEvent 
 deprecated;AccuDrawUiSettingsChangedEvent 
 public;AccuDrawWidget(): React_2.JSX.Element
-beta;AccuDrawWidgetControl 
+public;AccuDrawWidgetControl 
 deprecated;AccuDrawWidgetControl 
 public;Action
 deprecated;Action
@@ -95,16 +99,15 @@ public;BasicNavigationWidgetProps
 public;BasicToolWidget(props: BasicToolWidgetProps): React_2.JSX.Element
 public;BasicToolWidgetProps
 alpha;BumpToolSetting 
-alpha;Calculator 
+public;Calculator 
 internal;CalculatorEngine
 internal;CalculatorKeyType
 internal;CalculatorOperator
-alpha;CalculatorPopup 
+public;CalculatorPopup 
 deprecated;CalculatorPopup 
-alpha;CalculatorPopupProps 
+public;CalculatorPopupProps 
 deprecated;CalculatorPopupProps 
-alpha;CalculatorProps 
-internal;CalculatorPropsProps = Pick
+public;CalculatorProps 
 public;CanFloatWidgetOptions
 alpha;CardContainer 
 alpha;CardContainerProps 
@@ -270,7 +273,7 @@ deprecated;FloatingViewportContentWrapper({ children, }: FloatingViewportContent
 public;FloatingViewportContentWrapperProps
 deprecated;FloatingViewportContentWrapperProps
 alpha;FocusToolSettings 
-beta;FrameworkAccuDraw 
+public;FrameworkAccuDraw 
 public;FrameworkBackstage
 public;FrameworkChildWindows
 public;FrameworkContent
@@ -420,10 +423,10 @@ public;LocalStateStorage = LocalStateStorage_2
 public;LocalStateStorage: typeof LocalStateStorage_2
 internal;mapToPlacement(input?: Placement | RelativePosition): Placement
 internal;mapToRelativePosition(input: Placement | RelativePosition): RelativePosition
-alpha;MenuButton 
-alpha;MenuButtonPopup 
-alpha;MenuButtonPopupProps 
-alpha;MenuButtonProps 
+public;MenuButton 
+public;MenuButtonPopup 
+public;MenuButtonPopupProps 
+public;MenuButtonProps 
 alpha;MenuItem 
 deprecated;MenuItem 
 alpha;MenuItemHelpers
@@ -692,7 +695,6 @@ deprecated;ToolAssistanceChangedEvent
 public;ToolAssistanceChangedEventArgs
 deprecated;ToolAssistanceChangedEventArgs
 public;ToolAssistanceField 
-internal;ToolAssistanceFieldDefaultProps = Pick
 public;ToolAssistanceFieldProps 
 beta;Toolbar(props: ToolbarProps): React_2.JSX.Element
 public;TOOLBAR_OPACITY_DEFAULT = 0.5

--- a/common/changes/@itwin/appui-react/bump-accudraw_2024-08-01-13-15.json
+++ b/common/changes/@itwin/appui-react/bump-accudraw_2024-08-01-13-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Promote AccuDraw APIs to `@public`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/bump-accudraw_2024-08-01-13-15.json
+++ b/common/changes/@itwin/components-react/bump-accudraw_2024-08-01-13-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/bump-accudraw_2024-08-01-13-15.json
+++ b/common/changes/@itwin/core-react/bump-accudraw_2024-08-01-13-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -221,6 +221,7 @@ Table of contents:
 - Removed `@internal` tags from React lifecycle methods and properties. Consumers should avoid calling class methods directly, since class components can be converted to functional components in the future. [#943](https://github.com/iTwin/appui/pull/943)
 - Removed `@internal` tags from overriden class methods. [#943](https://github.com/iTwin/appui/pull/943)
 - Bumped `FrameworkDialog`, `FrameworkDialogs.modal`, `FrameworkDialogs.modeless`, `FrameworkStackedDialog`, `FrameworkToolAdmin`, `StandardNavigationToolsUiItemsProvider`, `StatusBarItemUtilities.createActionItem`, `StatusBarItemUtilities.createCustomItem`, `StatusBarItemUtilities.createLabelItem`, `SyncUiEventDispatcher.setTimeoutPeriod` APIs to `@public`. [#944](https://github.com/iTwin/appui/pull/944)
+- Promoted AccuDraw APIs to `@public` and exported `AccuDrawFieldContainer`, `AccuDrawInputField` components from the barrel file. [#945](https://github.com/iTwin/appui/pull/945)
 
 ### Fixes
 

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -10,6 +10,8 @@ export * from "./appui-react/UiFramework"; // Please ensure that this line comes
 
 export * from "./appui-react/accudraw/AccuDrawCommandItems";
 export * from "./appui-react/accudraw/AccuDrawDialog";
+export * from "./appui-react/accudraw/AccuDrawFieldContainer";
+export * from "./appui-react/accudraw/AccuDrawInputField";
 export * from "./appui-react/accudraw/AccuDrawKeyboardShortcuts";
 export * from "./appui-react/accudraw/AccuDrawPopupManager";
 export * from "./appui-react/accudraw/AccuDrawUiSettings";

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawCommandItems.ts
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawCommandItems.ts
@@ -32,7 +32,7 @@ import type { ToolbarItemUtilities } from "../toolbar/ToolbarItemUtilities";
 /* eslint-disable deprecation/deprecation */
 
 /** AccuDraw Command Items - useful in Keyboard Shortcuts
- * @beta
+ * @public
  * @deprecated in 4.15.0. Use {@link KeyboardShortcutUtilities} or {@link ToolbarItemUtilities} instead.
  */
 export class AccuDrawCommandItems {

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawDialog.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawDialog.tsx
@@ -16,7 +16,8 @@ import { useTranslation } from "../hooks/useTranslation";
 import { Dialog } from "@itwin/itwinui-react";
 
 /** Properties for [[AccuDrawDialog]]
- * @beta */
+ * @public
+ */
 // eslint-disable-next-line deprecation/deprecation
 export interface AccuDrawDialogProps extends CommonProps {
   /** Indicates whether the dialog is open */
@@ -32,7 +33,8 @@ export interface AccuDrawDialogProps extends CommonProps {
 }
 
 /** Dialog displays [[AccuDrawFieldContainer]] for AccuDraw Ui
- * @beta */
+ * @public
+ */
 export function AccuDrawDialog(props: AccuDrawDialogProps) {
   const { translate } = useTranslation();
   const [opened, setOpened] = React.useState(props.opened);

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawFieldContainer.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawFieldContainer.tsx
@@ -24,7 +24,7 @@ import { UiFramework } from "../UiFramework";
 import type { UiStateStorage } from "../uistate/UiStateStorage";
 
 /** Properties for [[AccuDrawFieldContainer]] component
- * @beta
+ * @public
  */
 // eslint-disable-next-line deprecation/deprecation
 export interface AccuDrawFieldContainerProps extends CommonProps {
@@ -48,7 +48,7 @@ const defaultYLabel = "Y";
 const defaultZLabel = "Z";
 
 /** AccuDraw Ui Field Container displays [[AccuDrawInputField]] for each field
- * @beta
+ * @public
  */
 export function AccuDrawFieldContainer(props: AccuDrawFieldContainerProps) {
   const {

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.tsx
@@ -23,7 +23,7 @@ function isLetter(char: string): boolean {
 }
 
 /** Properties for [[AccuDrawInputField]] component
- * @beta
+ * @public
  */
 // eslint-disable-next-line deprecation/deprecation
 export interface AccuDrawInputFieldProps extends CommonProps {
@@ -220,7 +220,7 @@ const ForwardRefAccuDrawInput = React.forwardRef<
 });
 
 /** Input field for AccuDraw UI.
- * @beta
+ * @public
  */
 export const AccuDrawInputField: (
   props: AccuDrawInputFieldProps

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawPopupManager.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawPopupManager.tsx
@@ -22,7 +22,7 @@ import lengthIcon from "./distance.svg";
 import heightIcon from "./height-2.svg";
 
 /** AccuDraw Popup Manager class
- * @alpha
+ * @public
  */
 export class AccuDrawPopupManager {
   private static _calculatorId = "Calculator";
@@ -125,7 +125,7 @@ export class AccuDrawPopupManager {
     );
   }
 
-  // @internal
+  /** @internal */
   public static showDimensionEditor(
     dimension: "height" | "length",
     el: HTMLElement,

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawUiSettings.ts
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawUiSettings.ts
@@ -10,7 +10,7 @@ import type { ColorDef } from "@itwin/core-common";
 import type { IconSpec } from "@itwin/core-react";
 
 /** AccuDraw User Interface Settings
- * @beta
+ * @public
  */
 export interface AccuDrawUiSettings {
   /** X field style */

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawWidget.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawWidget.tsx
@@ -15,7 +15,7 @@ import { WidgetControl } from "../widgets/WidgetControl";
 import { UiFramework } from "../UiFramework";
 
 /** AccuDraw Widget Control
- * @beta
+ * @public
  * @deprecated in 4.16.0. Use {@link AccuDrawWidget} component instead.
  */
 // eslint-disable-next-line deprecation/deprecation

--- a/ui/appui-react/src/appui-react/accudraw/Calculator.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/Calculator.tsx
@@ -15,14 +15,13 @@ import type { CommonProps } from "@itwin/core-react";
 import { Icon, IconInput } from "@itwin/core-react";
 import { Button, Input } from "@itwin/itwinui-react";
 import { CalculatorEngine, CalculatorOperator } from "./CalculatorEngine";
-import type { SquareButtonProps } from "./SquareButton";
 import { SquareButton } from "./SquareButton";
 import { SvgCheckmark, SvgRemove } from "@itwin/itwinui-icons-react";
 import backspaceIcon from "./backspace.svg";
 
-// cSpell:ignore plusmn
+type SquareButtonProps = React.ComponentProps<typeof SquareButton>;
 
-/** @alpha */
+/** @public */
 // eslint-disable-next-line deprecation/deprecation
 export interface CalculatorProps extends CommonProps {
   /** Initial value */
@@ -34,7 +33,7 @@ export interface CalculatorProps extends CommonProps {
   /** A function to be run when the Cancel button is clicked */
   onCancel?: OnCancelFunc;
 
-  /** @internal  Calculator state machine. */
+  /** @internal Calculator state machine. */
   engine: CalculatorEngine;
 }
 
@@ -42,10 +41,7 @@ interface CalculatorState {
   displayValue: string;
 }
 
-/** @internal */
-export type CalculatorPropsProps = Pick<CalculatorProps, "engine">;
-
-/** @alpha */
+/** @public */
 export class Calculator extends React.PureComponent<
   CalculatorProps,
   CalculatorState
@@ -53,8 +49,7 @@ export class Calculator extends React.PureComponent<
   private _mainDiv = React.createRef<HTMLDivElement>();
   private _equalsClicked = false;
 
-  /** @internal */
-  public static readonly defaultProps: CalculatorPropsProps = {
+  public static readonly defaultProps: Pick<CalculatorProps, "engine"> = {
     engine: new CalculatorEngine(),
   };
 

--- a/ui/appui-react/src/appui-react/accudraw/CalculatorPopup.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/CalculatorPopup.tsx
@@ -17,7 +17,7 @@ import type { SizeProps } from "../utils/SizeProps";
 import { AccuDrawPopupManager } from "./AccuDrawPopupManager";
 
 /**
- * @alpha
+ * @public
  * @deprecated in 4.16.0. Props of deprecated component {@link CalculatorPopup}.
  */
 export interface CalculatorPopupProps extends PopupPropsBase {
@@ -32,7 +32,7 @@ interface CalculatorPopupState {
 }
 
 /** Popup component for Calculator
- * @alpha
+ * @public
  * @deprecated in 4.16.0. Use {@link Calculator} component with {@link https://itwinui.bentley.com/docs/popover iTwinUI Popover} or {@link AccuDrawPopupManager.showCalculator} method instead.
  */
 export class CalculatorPopup extends React.PureComponent<

--- a/ui/appui-react/src/appui-react/accudraw/FrameworkAccuDraw.ts
+++ b/ui/appui-react/src/appui-react/accudraw/FrameworkAccuDraw.ts
@@ -46,7 +46,7 @@ const rotationModeToKeyMap = new Map<RotationMode, string>([
 ]);
 
 /** Arguments for [[AccuDrawSetFieldFocusEvent]]
- * @beta
+ * @public
  * @deprecated in 4.13.0. Event args are inferred from a listener. If explicit type is needed use a type helper.
  */
 export interface AccuDrawSetFieldFocusEventArgs {
@@ -54,14 +54,14 @@ export interface AccuDrawSetFieldFocusEventArgs {
 }
 
 /** AccuDraw Set Field Focus event
- * @beta
+ * @public
  * @deprecated in 4.13.0. This class should not be used by applications to instantiate objects.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class AccuDrawSetFieldFocusEvent extends BeUiEvent<AccuDrawSetFieldFocusEventArgs> {}
 
 /** Arguments for [[AccuDrawSetFieldValueToUiEvent]]
- * @beta
+ * @public
  * @deprecated in 4.13.0. Event args are inferred from a listener. If explicit type is needed use a type helper.
  */
 export interface AccuDrawSetFieldValueToUiEventArgs {
@@ -71,14 +71,14 @@ export interface AccuDrawSetFieldValueToUiEventArgs {
 }
 
 /** AccuDraw Set Field Value to Ui event
- * @beta
+ * @public
  * @deprecated in 4.13.0. This class should not be used by applications to instantiate objects.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class AccuDrawSetFieldValueToUiEvent extends BeUiEvent<AccuDrawSetFieldValueToUiEventArgs> {}
 
 /** Arguments for [[AccuDrawSetFieldValueFromUiEvent]]
- * @beta
+ * @public
  * @deprecated in 4.13.0. Event args are inferred from a listener. If explicit type is needed use a type helper.
  */
 export interface AccuDrawSetFieldValueFromUiEventArgs {
@@ -87,14 +87,14 @@ export interface AccuDrawSetFieldValueFromUiEventArgs {
 }
 
 /** AccuDraw Set Field Value from Ui event
- * @beta
+ * @public
  * @deprecated in 4.13.0. This class should not be used by applications to instantiate objects.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class AccuDrawSetFieldValueFromUiEvent extends BeUiEvent<AccuDrawSetFieldValueFromUiEventArgs> {}
 
 /** Arguments for [[AccuDrawSetFieldLockEvent]]
- * @beta
+ * @public
  * @deprecated in 4.13.0. Event args are inferred from a listener. If explicit type is needed use a type helper.
  */
 export interface AccuDrawSetFieldLockEventArgs {
@@ -103,14 +103,14 @@ export interface AccuDrawSetFieldLockEventArgs {
 }
 
 /** AccuDraw Set Field Lock event
- * @beta
+ * @public
  * @deprecated in 4.13.0. This class should not be used by applications to instantiate objects.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class AccuDrawSetFieldLockEvent extends BeUiEvent<AccuDrawSetFieldLockEventArgs> {}
 
 /** Arguments for [[AccuDrawSetCompassModeEvent]]
- * @beta
+ * @public
  * @deprecated in 4.13.0. Event args are inferred from a listener. If explicit type is needed use a type helper.
  */
 export interface AccuDrawSetCompassModeEventArgs {
@@ -118,20 +118,20 @@ export interface AccuDrawSetCompassModeEventArgs {
 }
 
 /** AccuDraw Set Compass Mode event
- * @beta
+ * @public
  * @deprecated in 4.13.0. This class should not be used by applications to instantiate objects.
  */
 // eslint-disable-next-line deprecation/deprecation
 export class AccuDrawSetCompassModeEvent extends BeUiEvent<AccuDrawSetCompassModeEventArgs> {}
 
 /** AccuDraw Grab Input Focus event
- * @beta
+ * @public
  * @deprecated in 4.13.0. This class should not be used by applications to instantiate objects.
  */
 export class AccuDrawGrabInputFocusEvent extends BeUiEvent<{}> {}
 
 /** AccuDraw Ui Settings Changed event
- * @beta
+ * @public
  * @deprecated in 4.13.0. This class should not be used by applications to instantiate objects.
  */
 export class AccuDrawUiSettingsChangedEvent extends BeUiEvent<{}> {}
@@ -145,7 +145,7 @@ export class AccuDrawUiSettingsChangedEvent extends BeUiEvent<{}> {}
  *   accuDraw: new FrameworkAccuDraw()
  * });
  * ```
- * @beta
+ * @public
  */
 export class FrameworkAccuDraw
   extends AccuDraw

--- a/ui/appui-react/src/appui-react/accudraw/MenuButton.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/MenuButton.tsx
@@ -10,13 +10,16 @@ import "./MenuButton.scss";
 import * as React from "react";
 import type { XAndY } from "@itwin/core-geometry";
 import { ContextMenu, Icon, Size } from "@itwin/core-react";
-import type { SquareButtonProps } from "./SquareButton";
 import { SquareButton } from "./SquareButton";
 import { SvgMore } from "@itwin/itwinui-icons-react";
 import type { SizeProps } from "../utils/SizeProps";
+import type { Button } from "@itwin/itwinui-react";
 
-/** @alpha */
-export interface MenuButtonProps extends SquareButtonProps {
+type ButtonProps = React.ComponentPropsWithoutRef<typeof Button>;
+
+/** @public */
+export interface MenuButtonProps
+  extends Omit<ButtonProps, "size" | "styleType"> {
   /** Center point */
   point: XAndY;
   /** Function called when size is known. */
@@ -27,7 +30,7 @@ interface MenuButtonState {
   expanded: boolean;
 }
 
-/** @alpha */
+/** @public */
 export class MenuButton extends React.PureComponent<
   MenuButtonProps,
   MenuButtonState

--- a/ui/appui-react/src/appui-react/accudraw/MenuButtonPopup.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/MenuButtonPopup.tsx
@@ -13,7 +13,7 @@ import { PopupManager } from "../popup/PopupManager";
 import { MenuButton } from "./MenuButton";
 import type { SizeProps } from "../utils/SizeProps";
 
-/** @alpha */
+/** @public */
 export interface MenuButtonPopupProps extends PopupPropsBase {
   content: React.ReactNode;
 }
@@ -23,7 +23,7 @@ interface MenuButtonPopupState {
 }
 
 /** Popup component for Menu Buttons
- * @alpha
+ * @public
  */
 export class MenuButtonPopup extends React.PureComponent<
   MenuButtonPopupProps,

--- a/ui/appui-react/src/appui-react/accudraw/SquareButton.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/SquareButton.tsx
@@ -13,11 +13,9 @@ import { Button } from "@itwin/itwinui-react";
 
 type ButtonProps = React.ComponentPropsWithoutRef<typeof Button>;
 
-/** @alpha */
-export interface SquareButtonProps // eslint-disable-line @typescript-eslint/no-empty-interface
-  extends Omit<ButtonProps, "size" | "styleType"> {}
+type SquareButtonProps = Omit<ButtonProps, "size" | "styleType">;
 
-/** @alpha */
+/** @internal */
 export class SquareButton extends React.PureComponent<SquareButtonProps> {
   public override render() {
     const { className, style, ...buttonProps } = this.props;

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -79,18 +79,6 @@ export interface ToolAssistanceFieldProps extends CommonProps {
   defaultPromptAtCursor: boolean;
 }
 
-/** Default properties of [[ToolAssistanceField]] component.
- * @internal
- */
-export type ToolAssistanceFieldDefaultProps = Pick<
-  ToolAssistanceFieldProps,
-  | "includePromptAtCursor"
-  | "uiStateStorage"
-  | "cursorPromptTimeout"
-  | "fadeOutCursorPrompt"
-  | "defaultPromptAtCursor"
->;
-
 /** @internal */
 interface ToolAssistanceFieldState {
   instructions: ToolAssistanceInstructions | undefined;
@@ -131,8 +119,14 @@ export class ToolAssistanceField extends React.Component<
   private _isMounted = false;
   private _uiSettingsStorage: UiStateStorage;
 
-  /** @internal */
-  public static readonly defaultProps: ToolAssistanceFieldDefaultProps = {
+  public static readonly defaultProps: Pick<
+    ToolAssistanceFieldProps,
+    | "includePromptAtCursor"
+    | "uiStateStorage"
+    | "cursorPromptTimeout"
+    | "fadeOutCursorPrompt"
+    | "defaultPromptAtCursor"
+  > = {
     includePromptAtCursor: true,
     cursorPromptTimeout: 5000,
     fadeOutCursorPrompt: true,

--- a/ui/components-react/src/components-react/iconpicker/IconPickerButton.tsx
+++ b/ui/components-react/src/components-react/iconpicker/IconPickerButton.tsx
@@ -100,7 +100,6 @@ export class IconPickerButton extends React.PureComponent<
 > {
   private _target = React.createRef<HTMLButtonElement>();
 
-  /** @internal */
   public static defaultProps: Partial<IconPickerProps> = {
     numColumns: 4,
   };

--- a/ui/core-react/src/core-react/contextmenu/ContextMenuItem.tsx
+++ b/ui/core-react/src/core-react/contextmenu/ContextMenuItem.tsx
@@ -70,7 +70,6 @@ export class ContextMenuItem extends React.PureComponent<
   private _root: HTMLElement | null = null;
   private _lastChildren: React.ReactNode;
   private _parsedChildren: React.ReactNode;
-  /** @internal */
   public static defaultProps: Partial<ContextMenuItemProps> = {
     disabled: false,
     hidden: false,


### PR DESCRIPTION
## Changes

Export `AccuDrawFieldContainer` and `AccuDrawInputField` modules from the barrel file.
Promote AccuDraw APIs to `@public`.

## Testing

N/A
