### PR TITLE
Added `trackContainerProps` property to `TimelineComponent`

### DIFF
--- a/common/api/imodel-components-react.api.md
+++ b/common/api/imodel-components-react.api.md
@@ -24,6 +24,7 @@ import type { QuantityTypeArg } from '@itwin/core-frontend';
 import * as React_2 from 'react';
 import { RelativePosition } from '@itwin/appui-abstract';
 import { ScreenViewport } from '@itwin/core-frontend';
+import { Slider } from '@itwin/itwinui-react';
 import type { StandardViewId } from '@itwin/core-frontend';
 import type { TentativePoint } from '@itwin/core-frontend';
 import type { TypeEditor } from '@itwin/components-react';
@@ -765,6 +766,8 @@ export interface ScrubberProps extends CommonProps {
     timeZoneOffset?: number;
     // (undocumented)
     totalDuration: number;
+    // (undocumented)
+    trackContainerProps?: React_2.ComponentProps<typeof Slider>["trackContainerProps"];
 }
 
 // @alpha
@@ -843,6 +846,7 @@ export interface TimelineComponentProps {
     timeFormatOptions?: DateFormatOptions;
     timeZoneOffset?: number;
     totalDuration: number;
+    trackContainerProps?: React_2.ComponentProps<typeof Slider>["trackContainerProps"];
 }
 
 // @public

--- a/common/changes/@itwin/imodel-components-react/new-timeline-prop_2024-08-05-07-08.json
+++ b/common/changes/@itwin/imodel-components-react/new-timeline-prop_2024-08-05-07-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Added `trackContainerProps` property to `TimelineComponent`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -365,4 +365,4 @@ Table of contents:
 
 ### Additions
 
-- Added `trackContainerProps` property to `TimelineComponent`. []()
+- Added `trackContainerProps` property to `TimelineComponent`. [#948](https://github.com/iTwin/appui/pull/948)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -16,6 +16,8 @@ Table of contents:
   - [Deprecations](#deprecations-2)
   - [Additions](#additions-2)
   - [Changes](#changes-2)
+- [@itwin/components-react](#itwincomponents-react-1)
+  - [Additions](#additions-3)
 
 ## @itwin/appui-react
 
@@ -358,3 +360,9 @@ Table of contents:
 
 - Removed styling for the `theme-transition` class. [#890](https://github.com/iTwin/appui/pull/890)
 - Bumped `Listbox`, `ListboxContext`, `ListboxContextProps`, `ListboxItem`, `ListboxItemProps`, `ListboxProps`, `ListboxValue` APIs to `@public`. [#944](https://github.com/iTwin/appui/pull/944)
+
+## @itwin/components-react
+
+### Additions
+
+- Added `trackContainerProps` property to `TimelineComponent`. []()

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/Scrubber.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/Scrubber.tsx
@@ -202,6 +202,9 @@ export interface ScrubberProps extends CommonProps {
   onUpdate?: (values: ReadonlyArray<number>) => void;
   timeZoneOffset?: number;
   markDate?: TimelineDateMarkerProps;
+  trackContainerProps?: React.ComponentProps<
+    typeof Slider
+  >["trackContainerProps"];
 }
 
 /** Properties for marking current date in RailMarkers
@@ -226,6 +229,7 @@ export function Scrubber(props: ScrubberProps) {
     className,
     onChange,
     onUpdate,
+    trackContainerProps,
   } = props;
 
   const [sliderContainer, setSliderContainer] =
@@ -328,6 +332,7 @@ export function Scrubber(props: ScrubberProps) {
       onPointerEnter={handlePointerEnter}
       onPointerMove={handlePointerMove}
       onPointerLeave={handlePointerLeave}
+      trackContainerProps={trackContainerProps}
     />
   );
 }

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/TimelineComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/TimelineComponent.tsx
@@ -22,7 +22,6 @@ import { InlineEdit } from "./InlineEdit";
 import type { PlaybackSettings, TimelinePausePlayArgs } from "./interfaces";
 import { TimelinePausePlayAction } from "./interfaces";
 import { PlayButton } from "./PlayButton";
-import type { ScrubberProps } from "./Scrubber";
 import { Scrubber } from "./Scrubber";
 import { useTranslation } from "../useTranslation";
 

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/TimelineComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/TimelineComponent.tsx
@@ -11,6 +11,7 @@ import { UiAdmin } from "@itwin/appui-abstract";
 import type { DateFormatOptions } from "@itwin/components-react";
 import { toDateString, toTimeString } from "@itwin/components-react";
 import { SvgCheckmark, SvgMoreVertical } from "@itwin/itwinui-icons-react";
+import type { Slider } from "@itwin/itwinui-react";
 import {
   DropdownMenu,
   IconButton,
@@ -118,7 +119,9 @@ export interface TimelineComponentProps {
   /** Used to control the play/pause state of the Timeline.*/
   isPlaying?: boolean;
   /** Props for a container that holds the slider thumbs and tracks. */
-  trackContainerProps?: ScrubberProps["trackContainerProps"];
+  trackContainerProps?: React.ComponentProps<
+    typeof Slider
+  >["trackContainerProps"];
 }
 
 /** [[TimelineComponent]] is used to playback timeline data

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/TimelineComponent.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/TimelineComponent.tsx
@@ -21,6 +21,7 @@ import { InlineEdit } from "./InlineEdit";
 import type { PlaybackSettings, TimelinePausePlayArgs } from "./interfaces";
 import { TimelinePausePlayAction } from "./interfaces";
 import { PlayButton } from "./PlayButton";
+import type { ScrubberProps } from "./Scrubber";
 import { Scrubber } from "./Scrubber";
 import { useTranslation } from "../useTranslation";
 
@@ -116,6 +117,8 @@ export interface TimelineComponentProps {
   timeFormatOptions?: DateFormatOptions;
   /** Used to control the play/pause state of the Timeline.*/
   isPlaying?: boolean;
+  /** Props for a container that holds the slider thumbs and tracks. */
+  trackContainerProps?: ScrubberProps["trackContainerProps"];
 }
 
 /** [[TimelineComponent]] is used to playback timeline data
@@ -298,6 +301,7 @@ export function TimelineComponent(props: TimelineComponentProps) {
         onUpdate={onTimelineChange}
         timeZoneOffset={props.timeZoneOffset}
         markDate={props.markDate}
+        trackContainerProps={props.trackContainerProps}
       />
       <div className="time-container">
         {hasDates && (


### PR DESCRIPTION
## Changes
Added `trackContainerProps` property to `TimelineComponent`. This property is passed to iTwinUI `Slider` component.

Closes #947.

## Testing
Tested in storybook.
