### PR TITLE
952 allow to enable multiple snaps

### DIFF
--- a/common/changes/@itwin/appui-react/952-allow-to-enable-multiple-snaps_2024-08-09-18-12.json
+++ b/common/changes/@itwin/appui-react/952-allow-to-enable-multiple-snaps_2024-08-09-18-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "We are now able to activate multiple snap modes at once. We can also choose what snap modes are available in the app via SnapModeField  snapModes props. ",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/test-apps/appui-test-app/standalone/src/frontend/index.tsx
+++ b/test-apps/appui-test-app/standalone/src/frontend/index.tsx
@@ -37,6 +37,7 @@ import {
   SafeAreaContext,
   SafeAreaInsets,
   SessionStateActionId,
+  SnapModeField,
   StageUsage,
   StandardContentToolsUiItemsProvider,
   StateManager,
@@ -379,6 +380,25 @@ export class SampleAppIModelApp {
             id: "language",
             section: StatusBarSection.Right,
             content: <AppLanguageSelect />,
+          }),
+          StatusBarItemUtilities.createCustomItem({
+            id: "booster.SnapMode2",
+            section: StatusBarSection.Center,
+            content: (
+              <SnapModeField
+                snapMode={SnapMode.NearestKeypoint}
+                snapModes={
+                  Object.values(SnapMode).filter(
+                    (snapMode) => snapMode !== SnapMode.Bisector
+                  ) as SnapMode[]
+                }
+              />
+            ),
+          }),
+          StatusBarItemUtilities.createCustomItem({
+            id: "booster.SnapMode3",
+            section: StatusBarSection.Center,
+            content: <SnapModeField snapModes={[SnapMode.Bisector]} />,
           }),
         ],
       },

--- a/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
@@ -69,12 +69,62 @@ describe("SnapModeField", () => {
         <SnapModeField />
       </Provider>
     );
+    const previousMode = UiFramework.getAccudrawSnapMode();
     await theUserTo.click(screen.getByRole("button"));
     await theUserTo.click(screen.getByText("snapModeField.bisector"));
 
-    expect(UiFramework.getAccudrawSnapMode()).to.equal(SnapMode.Bisector);
+    expect(UiFramework.getAccudrawSnapMode()).to.equal(
+      previousMode | SnapMode.Bisector
+    );
     expect(spy.mock.calls[0][0].eventIds.values()).toContain(
       "configurableui:set_snapmode"
     );
+  });
+
+  it("should not be able to disable all snapMode. at least one should be active at all time", async () => {
+    render(
+      <Provider store={TestUtils.store}>
+        <SnapModeField />
+      </Provider>
+    );
+    const previousMode = UiFramework.getAccudrawSnapMode();
+    expect(previousMode).toEqual(SnapMode.NearestKeypoint); // Make sure that only one mode is active.
+    await theUserTo.click(screen.getByRole("button"));
+    await theUserTo.click(screen.getByText("snapModeField.keypoint")); // Click to deactivate the mode.
+    expect(UiFramework.getAccudrawSnapMode()).to.equal(
+      SnapMode.NearestKeypoint
+    ); // Expect it to be still active.
+  });
+
+  it("Status Bar with filtered SnapModes Field should render", () => {
+    const { container } = render(
+      <Provider store={TestUtils.store}>
+        <SnapModeField
+          snapModes={
+            // Filter out the Bisector snap mode.
+            Object.values(SnapMode).filter(
+              (snapMode) => snapMode !== SnapMode.Bisector
+            ) as SnapMode[]
+          }
+        />
+      </Provider>
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    fireEvent.click(button!);
+
+    // Bisector snap mode should not be present.
+    expect(screen.getByText("snapModeField.bisector")).toBeFalsy();
+
+    const iconContainer = container.querySelector(".icon");
+    expect(iconContainer).toBeTruthy();
+
+    const snaps = container.parentElement!.querySelectorAll(
+      ".nz-footer-snapMode-snap"
+    );
+    expect(snaps.length).to.eql(6); // 7 modes total, minus Bisector = 6 modes
+
+    fireEvent.click(button!); // Closes popup
   });
 });


### PR DESCRIPTION
## Changes
### Multi snaps 
We are now able to activate multiple snap modes simultaneousely. 
We can see in the picture that, when multiple modes are active at the same time, we have multiple possible snaps location depending ont he cursor position. 
![image](https://github.com/user-attachments/assets/55c1d9f8-ab4b-49d7-98b9-fb73b9e936d8)

### Snap modes choices
The consuming app can now choose what snap modes are available in their app. 
Ex, Bisector option has been filtered out. 
![image](https://github.com/user-attachments/assets/20bf7d47-3215-40d4-9c3c-ca2a56dd7c6f)

## Testing
2 unit tests are added to check the functionnality. 
- Ensuring at least one snap mode active at all times.
- Validating if we are able to select what snap modes are available in the app.