### PR TITLE
Fix `useActiveViewport` to correctly return the active viewport

### DIFF
--- a/common/changes/@itwin/appui-react/issue-963_2024-08-14-08-42.json
+++ b/common/changes/@itwin/appui-react/issue-963_2024-08-14-08-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `useActiveViewport` to correctly return the active viewport.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/hooks/useActiveViewport.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useActiveViewport.tsx
@@ -6,24 +6,24 @@
  * @module Hooks
  */
 
-import { useEffect, useState } from "react";
 import type { ScreenViewport } from "@itwin/core-frontend";
 import { IModelApp } from "@itwin/core-frontend";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
+
+const subscribe = (onStoreChange: () => void) => {
+  return IModelApp.viewManager.onSelectedViewportChanged.addListener(
+    onStoreChange
+  );
+};
+
+const getSnapshot = () => {
+  return IModelApp.viewManager.selectedView;
+};
 
 /** React hook that maintains the active viewport.
  * @public
  */
 export function useActiveViewport(): ScreenViewport | undefined {
-  const [activeViewport, setActiveViewport] = useState(
-    IModelApp.viewManager.selectedView
-  );
-  useEffect(() => {
-    return IModelApp.viewManager.onSelectedViewportChanged.addListener(
-      (args) => {
-        setActiveViewport(args.current);
-      }
-    );
-  }, []);
-
+  const activeViewport = useSyncExternalStore(subscribe, getSnapshot);
   return activeViewport;
 }


### PR DESCRIPTION
## Changes

This PR fixes #963 by correctly syncing with the static view manager store.

## Testing

Added additional unit test
