### PR TITLE
Fix `useConditionalValue` to handle event ids as case insensitive

### DIFF
--- a/common/changes/@itwin/appui-react/fix-useConditionalValue_2024-08-14-09-18.json
+++ b/common/changes/@itwin/appui-react/fix-useConditionalValue_2024-08-14-09-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `useConditionalValue` to handle event ids as case insensitive.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/hooks/useConditionalValue.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useConditionalValue.tsx
@@ -28,7 +28,13 @@ export function useConditionalValue<T>(getValue: () => T, eventIds: string[]) {
 
   React.useEffect(() => {
     return SyncUiEventDispatcher.onSyncUiEvent.addListener((args) => {
-      if (!eventIdsRef.current.some((id) => args.eventIds.has(id))) return;
+      if (
+        !SyncUiEventDispatcher.hasEventOfInterest(
+          args.eventIds,
+          eventIdsRef.current
+        )
+      )
+        return;
       setValue(getValueRef.current());
     });
   }, []);

--- a/ui/appui-react/src/test/hooks/useConditionalValue.test.tsx
+++ b/ui/appui-react/src/test/hooks/useConditionalValue.test.tsx
@@ -1,0 +1,38 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { SyncUiEventDispatcher, useConditionalValue } from "../../appui-react";
+import { act, renderHook } from "@testing-library/react";
+
+const timeToWaitForUiSyncCallback = 10;
+
+describe("useConditionalValue", () => {
+  beforeEach(() => {
+    SyncUiEventDispatcher.setTimeoutPeriod(timeToWaitForUiSyncCallback);
+  });
+
+  it("should sync case insensitive", async () => {
+    vi.useFakeTimers();
+
+    let counter = 0;
+    const { result } = renderHook(() =>
+      useConditionalValue(() => {
+        return counter++;
+      }, ["myEvent1"])
+    );
+    expect(result.current).toEqual(0);
+
+    act(() => {
+      SyncUiEventDispatcher.dispatchSyncUiEvent("myEvent1");
+      vi.advanceTimersByTime(timeToWaitForUiSyncCallback);
+    });
+    expect(result.current).toEqual(1);
+
+    act(() => {
+      SyncUiEventDispatcher.dispatchSyncUiEvent("myevent1");
+      vi.advanceTimersByTime(timeToWaitForUiSyncCallback);
+    });
+    expect(result.current).toEqual(2);
+  });
+});


### PR DESCRIPTION
## Changes

This PR fixes an issue where `useConditionalValue` would not handle the sync event ids correctly due to casing.

## Testing

Added additional unit test.
