### PR TITLE
Allow to set the available snap modes in SnapModeField.

### DIFF
--- a/common/changes/@itwin/appui-react/allow-set-available-snap-modes_2024-08-14-16-33.json
+++ b/common/changes/@itwin/appui-react/allow-set-available-snap-modes_2024-08-14-16-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Allow to set the available snap modes in SnapModeField.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/storybook/src/components/StatusBarComposer.stories.tsx
+++ b/docs/storybook/src/components/StatusBarComposer.stories.tsx
@@ -25,6 +25,7 @@ import {
 } from "@itwin/itwinui-icons-react";
 import { withResizer } from "../../.storybook/addons/Resizer";
 import { StatusBarComposerStory } from "./StatusBarComposer";
+import { SnapMode } from "@itwin/core-frontend";
 
 const PageLayout: Decorator = (Story) => {
   return (
@@ -79,7 +80,7 @@ export const LabelItem: Story = {
 
 export const CustomItem: Story = {
   args: {
-    items: [items.custom1, items.custom2, items.custom3],
+    items: [items.custom1, items.custom2, items.custom4],
   },
 };
 
@@ -194,6 +195,18 @@ function createItems() {
     <SnapModeField />
   );
 
+  const availableSnapModes = [
+    SnapMode.NearestKeypoint,
+    SnapMode.Center,
+    SnapMode.Nearest,
+  ];
+  const custom4 = StatusBarItemUtilities.createCustomItem(
+    "item10",
+    StatusBarSection.Right,
+    10,
+    <SnapModeField availableSnapModes={availableSnapModes} />
+  );
+
   return {
     action1,
     action2,
@@ -204,6 +217,7 @@ function createItems() {
     custom1,
     custom2,
     custom3,
+    custom4,
   };
 }
 

--- a/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { Provider } from "react-redux";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { SnapMode } from "@itwin/core-frontend";
 import type { ListenerType } from "@itwin/core-react";
 import {
@@ -20,16 +20,15 @@ describe("SnapModeField", () => {
     theUserTo = userEvent.setup();
   });
 
-  it("Status Bar with SnapModes Field should render", () => {
+  it("Status Bar with SnapModes Field should render", async () => {
     const { container } = render(
       <Provider store={TestUtils.store}>
         <SnapModeField />
       </Provider>
     );
 
-    const button = container.querySelector("button");
-    expect(button).toBeTruthy();
-    fireEvent.click(button!);
+    const snapModeButton = screen.getByText("snapModeField.snapMode");
+    await theUserTo.click(snapModeButton);
 
     const iconContainer = container.querySelector(".icon");
     expect(iconContainer).toBeTruthy();
@@ -39,7 +38,7 @@ describe("SnapModeField", () => {
     );
     expect(snaps.length).to.eql(7);
 
-    fireEvent.click(button!); // Closes popup
+    await theUserTo.click(snapModeButton); // Closes popup
   });
 
   it("Validate multiple snaps mode", () => {
@@ -69,12 +68,31 @@ describe("SnapModeField", () => {
         <SnapModeField />
       </Provider>
     );
-    await theUserTo.click(screen.getByRole("button"));
+    await theUserTo.click(screen.getByText("snapModeField.snapMode"));
     await theUserTo.click(screen.getByText("snapModeField.bisector"));
 
     expect(UiFramework.getAccudrawSnapMode()).to.equal(SnapMode.Bisector);
     expect(spy.mock.calls[0][0].eventIds.values()).toContain(
       "configurableui:set_snapmode"
     );
+  });
+
+  it("Display only the available SnapMode(s).", async () => {
+    const { container } = render(
+      <Provider store={TestUtils.store}>
+        <SnapModeField availableSnapModes={[SnapMode.Center]} />
+      </Provider>
+    );
+
+    await theUserTo.click(screen.getByText("snapModeField.snapMode"));
+    // Bisector snap mode should not be present.
+    expect(screen.queryByText("snapModeField.bisector")).toBeFalsy();
+    // Center snap mode be present.
+    expect(screen.queryByText("snapModeField.center")).toBeTruthy();
+
+    const snaps = container.parentElement!.querySelectorAll(
+      ".nz-footer-snapMode-snap"
+    );
+    expect(snaps.length).to.eql(1); // Only the center snap mode is displayed.
   });
 });


### PR DESCRIPTION
## Snap modes choices
The consuming app can now choose what snap modes are available in their app.
Ex, Bisector option has been filtered out.
![image](https://github.com/user-attachments/assets/f3fe5f78-af20-44dd-b753-ce05b81f14c1)
