### PR TITLE
Increase `SelectionCountField` margins

### DIFF
--- a/common/changes/@itwin/appui-react/increase-selection-count-padding_2024-08-20-12-21.json
+++ b/common/changes/@itwin/appui-react/increase-selection-count-padding_2024-08-20-12-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Increased margins of `SelectionCountField` component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,12 +1,1 @@
 # NextVersion <!-- omit from toc -->
-
-Table of contents:
-
-- [@itwin/appui-react](#itwinappui-react)
-  - [Changes](#changes)
-
-## @itwin/appui-react
-
-### Changes
-
-- Increased margins of `SelectionCountField` component. [#979](https://github.com/iTwin/appui/pull/979)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/appui-react](#itwinappui-react)
+  - [Changes](#changes)
+
+## @itwin/appui-react
+
+### Changes
+
+- Increased margins of `SelectionCountField` component. [#]()

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -9,4 +9,4 @@ Table of contents:
 
 ### Changes
 
-- Increased margins of `SelectionCountField` component. [#]()
+- Increased margins of `SelectionCountField` component. [#979](https://github.com/iTwin/appui/pull/979)

--- a/ui/appui-react/src/appui-react/statusfields/SelectionCount.scss
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionCount.scss
@@ -7,7 +7,7 @@
   display: flex;
   align-items: center;
   min-width: 3.75rem;
-  margin: 0 var(--iui-size-xs) 0 var(--iui-size-xs);
+  margin: 0 var(--iui-size-xs);
 
   .icon {
     color: var(--iui-color-icon);

--- a/ui/appui-react/src/appui-react/statusfields/SelectionCount.scss
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionCount.scss
@@ -6,8 +6,8 @@
   gap: var(--iui-size-2xs);
   display: flex;
   align-items: center;
-  min-width: var(--iui-size-2xl);
-  padding-left: var(--iui-size-2xs);
+  min-width: 3.75rem;
+  margin: 0 var(--iui-size-xs) 0 var(--iui-size-xs);
 
   .icon {
     color: var(--iui-color-icon);


### PR DESCRIPTION
## Changes
We had no padding on the right side of the `SelectionCountField` and it looked weird when there was a separator after it (the separator removes padding between different status bar fields). Changes:

- I added margins (`--iui-size-xs`) from both left and right sides now. I chose margins instead of paddings because padding is considered a part of the width so it basically decreased the `min-width` that we set (more specifically it would decrease the space reserved for more digits).
- Changed the `min-width` from `--iui-size-2xl` (equivalent to `4rem`) to `3.75rem`. This slightly decreases the min width of the component and is perfect to fit 5 digits without shifting other status bar content. I made this change because we previously had `padding-left` which is now switched to `margin-left` (again, the padding eats into the width and margin does not) so the freed up space was not needed anymore.

Adding some screenshots for comparison. Note that the first two images have separators.

### **Before:**
![image](https://github.com/user-attachments/assets/c010d3e3-e5b1-4b81-83d8-faf582b9b29d)
![image](https://github.com/user-attachments/assets/7e2dd453-d202-4f22-88f7-7bd632adceb1)
![image](https://github.com/user-attachments/assets/72f4c168-7289-4212-8c16-27d20a2586cf)

### **After:**
![image](https://github.com/user-attachments/assets/425c6b5a-55a0-4f64-8727-e34d72b61c53)
![image](https://github.com/user-attachments/assets/466b0062-44fc-473c-a445-ffc0d4c50ecb)
![image](https://github.com/user-attachments/assets/3461c500-7a5f-4c64-a520-f5a9d7459f4b)


Fixes #978.

## Testing
Tested in test-app.
