### PR TITLE
Fix new toolbars to handle event ids as case insensitive

### DIFF
--- a/common/changes/@itwin/appui-react/fix-events-in-new-toolbars_2024-08-23-06-28.json
+++ b/common/changes/@itwin/appui-react/fix-events-in-new-toolbars_2024-08-23-06-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix new toolbars to handle event ids as case insensitive.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/appui-react](#itwinappui-react)
+  - [Fixes](#fixes)
+
+## @itwin/appui-react
+
+### Fixes
+
+- Fixed new toolbars to handle event ids as case insensitive. [#980](https://github.com/iTwin/appui/pull/980)

--- a/ui/appui-react/src/appui-react/hooks/useConditionalProp.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useConditionalProp.tsx
@@ -40,7 +40,12 @@ export function useConditionalProp<T>(conditionalProp: ConditionalProp<T>) {
       if (isConditionalValue(conditionalProp)) {
         return SyncUiEventDispatcher.onSyncUiEvent.addListener(
           ({ eventIds }) => {
-            if (!conditionalProp.syncEventIds.some((id) => eventIds.has(id)))
+            if (
+              !SyncUiEventDispatcher.hasEventOfInterest(
+                eventIds,
+                conditionalProp.syncEventIds
+              )
+            )
               return;
             if (!conditionalProp.refresh()) return;
 

--- a/ui/appui-react/src/test/hooks/useConditionalProp.test.tsx
+++ b/ui/appui-react/src/test/hooks/useConditionalProp.test.tsx
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { SyncUiEventDispatcher } from "../../appui-react";
+import { useConditionalProp } from "../../appui-react/hooks/useConditionalProp";
+import { act, renderHook } from "@testing-library/react";
+import { ConditionalStringValue } from "../../appui-react/shared/ConditionalValue";
+
+const timeToWaitForUiSyncCallback = 10;
+
+describe("useConditionalProp", () => {
+  beforeEach(() => {
+    SyncUiEventDispatcher.setTimeoutPeriod(timeToWaitForUiSyncCallback);
+  });
+
+  it("should sync with case insensitive event ids", async () => {
+    vi.useFakeTimers();
+
+    let counter = 0;
+    const label = new ConditionalStringValue(() => {
+      counter++;
+      return `Counter: ${counter}`;
+    }, ["myEvent1"]);
+    const { result } = renderHook(() => useConditionalProp(label));
+    expect(result.current).toEqual("Counter: 1");
+
+    act(() => {
+      SyncUiEventDispatcher.dispatchSyncUiEvent("myEvent1");
+      vi.advanceTimersByTime(timeToWaitForUiSyncCallback);
+    });
+    expect(result.current).toEqual("Counter: 2");
+
+    act(() => {
+      SyncUiEventDispatcher.dispatchSyncUiEvent("myevent1");
+      vi.advanceTimersByTime(timeToWaitForUiSyncCallback);
+    });
+    expect(result.current).toEqual("Counter: 3");
+  });
+});


### PR DESCRIPTION
## Changes
Same problem as in #967. Noticed when debugging booster code. Studio recently enabled new toolbars so the problem now occured.

## Testing
Added test for `useConditionalProp`.
