### PR TITLE
Fixed tool setting editor not updating state after value change

### DIFF
--- a/common/changes/@itwin/appui-react/fix_tool_settings_2024-08-26-13-14.json
+++ b/common/changes/@itwin/appui-react/fix_tool_settings_2024-08-26-13-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fixed tool setting editor not updating after value change.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/appui-react](#itwinappui-react)
+  - [Fixes](#fixes)
+
+## @itwin/appui-react
+
+### Fixes
+
+- Fixed tool setting editor not updating state after value is changed. [#982](https://github.com/iTwin/appui/pull/982)

--- a/test-apps/appui-test-app/appui-test-providers/src/tools/SampleTool.ts
+++ b/test-apps/appui-test-app/appui-test-providers/src/tools/SampleTool.ts
@@ -150,19 +150,19 @@ export class SampleTool extends PrimitiveTool {
   private _colorValue: DialogItemValue = { value: ColorByName.blue };
 
   public get colorValue(): number {
-    return this._optionsValue.value as number;
+    return this._colorValue.value as number;
   }
 
   public set colorValue(colorVal: number) {
-    this._optionsValue.value = colorVal;
+    this._colorValue.value = colorVal;
   }
 
   public get colorDef(): ColorDef {
-    return ColorDef.create(this._optionsValue.value as number);
+    return ColorDef.create(this._colorValue.value as number);
   }
 
   public set colorDef(colorVal: ColorDef) {
-    this._optionsValue.value = colorVal.tbgr;
+    this._colorValue.value = colorVal.tbgr;
   }
 
   // ------------- Weight ---------------

--- a/test-apps/appui-test-app/appui-test-providers/src/tools/ToolWithDynamicSettings.ts
+++ b/test-apps/appui-test-app/appui-test-providers/src/tools/ToolWithDynamicSettings.ts
@@ -206,7 +206,6 @@ export class ToolWithDynamicSettings extends PrimitiveTool {
       editorPosition: { rowPriority: 1, columnIndex: 1 },
     });
     if (this.state.valueOf() > 0 && this.state.valueOf() < cities.length) {
-      this.city = cities[this.state].cities[0];
       toolSettings.push({
         value: this._cityValue,
         property: ToolWithDynamicSettings.getCityDescription(this.state),
@@ -226,8 +225,18 @@ export class ToolWithDynamicSettings extends PrimitiveTool {
       const newStateValue = updatedValue.value.value as number;
       if (this.state.valueOf() !== newStateValue) {
         this.state = newStateValue;
+        this.city = cities[this.state].cities[0];
         // update the UI to show/remove city option any time state value changes.
         this.reloadToolSettingsProperties();
+      }
+    }
+
+    if (
+      updatedValue.propertyName === ToolWithDynamicSettings._cityPropertyName
+    ) {
+      const newCityValue = updatedValue.value.value as string;
+      if (this.city.valueOf() !== newCityValue) {
+        this.city = newCityValue;
       }
     }
 

--- a/ui/appui-react/src/test/frontstage/ModalSettingsStage.test.tsx
+++ b/ui/appui-react/src/test/frontstage/ModalSettingsStage.test.tsx
@@ -174,28 +174,32 @@ describe("ModalSettingsStage", () => {
     SettingsModalFrontstage.showSettingsStage(); // set the stage using static
 
     const wrapper = render(renderModalFrontstage(true));
-    await TestUtils.flushAsyncOperations();
 
-    expect(
-      wrapper.container.querySelectorAll("div.uifw-modal-frontstage").length
-    ).toEqual(1);
-    const liPage1 = wrapper.container.querySelector(
-      `li[data-for='page1']`
-    ) as HTMLLIElement;
-    expect(liPage1.classList.contains("core-active")).toEqual(true);
+    await waitFor(() => {
+      expect(
+        wrapper.container.querySelectorAll("div.uifw-modal-frontstage").length
+      ).toEqual(1);
+    });
+    await waitFor(() => {
+      const liPage1 = wrapper.container.querySelector(
+        `li[data-for='page1']`
+      ) as HTMLLIElement;
+      expect(liPage1.classList.contains("core-active")).toEqual(true);
+    });
 
     SettingsModalFrontstage.showSettingsStage("page2");
-    await TestUtils.flushAsyncOperations();
-    const liPage2 = wrapper.container.querySelector(
-      `li[data-for='page-2']`
-    ) as HTMLLIElement;
-    expect(liPage2.classList.contains("core-active")).toEqual(true);
+    await waitFor(() => {
+      const liPage2 = wrapper.container.querySelector(
+        `li[data-for='page-2']`
+      ) as HTMLLIElement;
+      expect(liPage2.classList.contains("core-active")).toEqual(true);
+    });
 
     SettingsModalFrontstage.showSettingsStage("page-3");
-    const liPage3 = wrapper.container.querySelector(
-      `li[data-for='page-3']`
-    ) as HTMLLIElement;
     await waitFor(() => {
+      const liPage3 = wrapper.container.querySelector(
+        `li[data-for='page-3']`
+      ) as HTMLLIElement;
       expect(liPage3.classList.contains("core-active")).toEqual(true);
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes. 
-->
Fixed tool setting property editor not updating state after value is changed. This resulted in editor component always having only initial value and not the current value. 

Fixes https://github.com/iTwin/appui/issues/981

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Did manual testing with various tools in standalone test-app. Fixed some tools to correctly update settings values as some of them were changing only in UI.
