### PR TITLE
Add new tab dragging logic

### DIFF
--- a/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
+++ b/test-apps/appui-test-app/appui-test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
@@ -50,6 +50,9 @@ const availableFeatures: AvailableFeatures = {
   controlWidgetVisibility: {
     label: "Control widget visibility",
   },
+  newDragging: {
+    label: "Enable new dragging logic",
+  },
 };
 
 function PreviewFeatureList() {

--- a/ui/appui-react/src/appui-react/layout/base/GlobalWindowDraggedOverTracker.tsx
+++ b/ui/appui-react/src/appui-react/layout/base/GlobalWindowDraggedOverTracker.tsx
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Base
+ */
+
+// TODO: Maybe look into alternative methods to handle this. Also needs ability to register new windows.
+class GlobalWindowDraggedOverTracker {
+  constructor() {
+    this.registerListeners();
+  }
+
+  private _isDraggedOver = false;
+
+  public get isDraggedOver() {
+    return this._isDraggedOver;
+  }
+
+  private registerListeners() {
+    window.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      this.markDraggedOver();
+    });
+    window.addEventListener("dragleave", (e) => {
+      e.preventDefault();
+      this.clearDraggedOver();
+    });
+  }
+
+  private markDraggedOver() {
+    if (!this._isDraggedOver) this._isDraggedOver = true;
+  }
+
+  private clearDraggedOver() {
+    if (this._isDraggedOver) this._isDraggedOver = false;
+  }
+}
+
+const globalWindowDraggedOverTracker = new GlobalWindowDraggedOverTracker();
+
+/** @internal */
+export function isWindowDraggedOver() {
+  return globalWindowDraggedOverTracker.isDraggedOver;
+}

--- a/ui/appui-react/src/appui-react/layout/base/NineZone.tsx
+++ b/ui/appui-react/src/appui-react/layout/base/NineZone.tsx
@@ -24,6 +24,7 @@ import { WidgetTab } from "../widget/Tab";
 import type { NineZoneAction } from "../state/NineZoneAction";
 import type { LayoutStore } from "./LayoutStore";
 import { LayoutStoreContext, useLayout } from "./LayoutStore";
+import { IsTabDraggedContext } from "../widget/IsTabDraggedContext";
 
 /** @internal */
 export type NineZoneDispatch = (action: NineZoneAction) => void;
@@ -83,6 +84,8 @@ const floatingWidget = <FloatingWidget />;
 
 /** @internal */
 export function NineZoneProvider(props: NineZoneProviderProps) {
+  const [isTabDragged, setIsTabDragged] = React.useState(false);
+
   return (
     <LayoutStoreContext.Provider value={props.layout}>
       <NineZoneDispatchContext.Provider value={props.dispatch}>
@@ -107,7 +110,14 @@ export function NineZoneProvider(props: NineZoneProviderProps) {
                             <CursorTypeProvider>
                               <WidgetContentManager>
                                 <MeasureContext.Provider value={props.measure}>
-                                  {props.children}
+                                  <IsTabDraggedContext.Provider
+                                    value={{
+                                      isDragged: isTabDragged,
+                                      setIsDragged: setIsTabDragged,
+                                    }}
+                                  >
+                                    {props.children}
+                                  </IsTabDraggedContext.Provider>
                                 </MeasureContext.Provider>
                               </WidgetContentManager>
                             </CursorTypeProvider>

--- a/ui/appui-react/src/appui-react/layout/outline/TabOutline.tsx
+++ b/ui/appui-react/src/appui-react/layout/outline/TabOutline.tsx
@@ -13,6 +13,7 @@ import { useTargeted } from "../base/DragManager";
 import { WidgetIdContext } from "../widget/Widget";
 import { isWidgetDropTargetState } from "../state/DropTargetState";
 import { useSendBackHomeState } from "../widget/SendBack";
+import { WidgetDraggedOverContext } from "../widget/WidgetDraggedOverContext";
 
 /** @internal */
 export function TabOutline() {
@@ -25,8 +26,10 @@ function useHidden() {
   const widgetId = React.useContext(WidgetIdContext);
   const targeted = useTargeted();
   const activeHomeState = useSendBackHomeState();
+  const draggedOver = React.useContext(WidgetDraggedOverContext);
 
   return React.useMemo(() => {
+    if (draggedOver?.target === "widget") return false;
     if (activeHomeState?.widgetId === widgetId) return false;
 
     if (!targeted) return true;
@@ -36,5 +39,5 @@ function useHidden() {
     if (targeted.widgetId !== widgetId) return true;
 
     return false;
-  }, [targeted, widgetId, activeHomeState]);
+  }, [targeted, widgetId, activeHomeState, draggedOver]);
 }

--- a/ui/appui-react/src/appui-react/layout/outline/WidgetOutline.tsx
+++ b/ui/appui-react/src/appui-react/layout/outline/WidgetOutline.tsx
@@ -16,6 +16,7 @@ import {
   isWidgetDropTargetState,
 } from "../state/DropTargetState";
 import { useSendBackHomeState } from "../widget/SendBack";
+import { WidgetDraggedOverContext } from "../widget/WidgetDraggedOverContext";
 
 /** @internal */
 export function WidgetOutline() {
@@ -32,8 +33,10 @@ function useHidden() {
   const widgetId = React.useContext(WidgetIdContext);
   const targeted = useTargeted();
   const activeHomeState = useSendBackHomeState();
+  const draggedOver = React.useContext(WidgetDraggedOverContext);
 
   return React.useMemo(() => {
+    if (draggedOver?.target !== undefined) return false;
     if (activeHomeState?.widgetId === widgetId) return false;
 
     if (!targeted) return true;
@@ -45,5 +48,5 @@ function useHidden() {
       return false;
 
     return true;
-  }, [targeted, widgetId, activeHomeState]);
+  }, [targeted, widgetId, activeHomeState, draggedOver]);
 }

--- a/ui/appui-react/src/appui-react/layout/state/DropTargetState.ts
+++ b/ui/appui-react/src/appui-react/layout/state/DropTargetState.ts
@@ -6,6 +6,7 @@
  * @module Base
  */
 
+import type { XAndY } from "@itwin/core-geometry";
 import type { SizeProps } from "../../utils/SizeProps";
 import type { PanelSide } from "../widget-panels/PanelTypes";
 import type { FloatingWidgetState, WidgetState } from "./WidgetState";
@@ -43,6 +44,7 @@ export interface FloatingWidgetDropTargetState {
   readonly type: "floatingWidget";
   readonly newFloatingWidgetId: FloatingWidgetState["id"];
   readonly size: SizeProps;
+  readonly position?: XAndY;
 }
 
 /** Drop target of a tab drag action.
@@ -126,4 +128,11 @@ export function isTabDragDropTargetState(
 ): state is TabDragDropTargetState {
   if (state.type === "window") return false;
   return true;
+}
+
+/** @internal */
+export function isFloatingWidgetDragDropTargetState(
+  state: DropTargetState
+): state is FloatingWidgetDropTargetState {
+  return state.type === "floatingWidget";
 }

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
@@ -224,6 +224,13 @@ export interface WidgetTabDragEndAction {
 }
 
 /** @internal */
+export interface WidgetTabDragEndNewAction {
+  readonly type: "WIDGET_TAB_DRAG_END_NEW";
+  readonly id: TabState["id"];
+  readonly target: TabDragDropTargetState;
+}
+
+/** @internal */
 export interface WidgetTabCloseAction {
   readonly type: "WIDGET_TAB_CLOSE";
   readonly id: TabState["id"];
@@ -368,6 +375,7 @@ export type NineZoneAction =
   | WidgetTabDragStartAction
   | WidgetTabDragAction
   | WidgetTabDragEndAction
+  | WidgetTabDragEndNewAction
   | WidgetTabExpandAction
   | WidgetTabFloatAction
   | WidgetTabHideAction

--- a/ui/appui-react/src/appui-react/layout/state/TabLocation.ts
+++ b/ui/appui-react/src/appui-react/layout/state/TabLocation.ts
@@ -19,6 +19,7 @@ import {
   isFloatingWidgetLocation,
   isPopoutWidgetLocation,
 } from "./WidgetLocation";
+import { getWidgetState } from "./internal/WidgetStateHelpers";
 
 /** @internal */
 export interface PanelTabLocation {
@@ -97,4 +98,23 @@ export function getTabLocation(
     side: location.side,
     widgetId,
   };
+}
+
+/** Checks if the given tab is the only one in the widget.
+ * @internal
+ */
+export function isWidgetOnlyOneTab(
+  state: NineZoneState,
+  tabId: TabState["id"],
+  targetWidgetId: WidgetState["id"]
+): boolean {
+  const location = getTabLocation(state, tabId);
+  if (!location) return false;
+
+  const widgetId = location.widgetId;
+  if (widgetId !== targetWidgetId) return false;
+  const widget = getWidgetState(state, widgetId);
+  const tabs = widget.tabs;
+
+  return tabs.length === 1 && tabs[0] === tabId;
 }

--- a/ui/appui-react/src/appui-react/layout/target/MergeTarget.tsx
+++ b/ui/appui-react/src/appui-react/layout/target/MergeTarget.tsx
@@ -10,12 +10,14 @@ import "./MergeTarget.scss";
 import classnames from "classnames";
 import * as React from "react";
 import { DraggedWidgetIdContext, useTarget } from "../base/DragManager";
-import { CursorTypeContext } from "../base/NineZone";
+import { CursorTypeContext, NineZoneDispatchContext } from "../base/NineZone";
 import { getCursorClassName } from "../widget-panels/CursorOverlay";
 import type { WidgetState } from "../state/WidgetState";
 import type { WidgetDropTargetState } from "../state/DropTargetState";
 import { useAllowedWidgetTarget } from "./useAllowedWidgetTarget";
 import { useLayout } from "../base/LayoutStore";
+import { WidgetDraggedOverContext } from "../widget/WidgetDraggedOverContext";
+import { IsTabDraggedContext } from "../widget/IsTabDraggedContext";
 
 /** @internal */
 export interface MergeTargetProps {
@@ -27,20 +29,55 @@ export function MergeTarget(props: MergeTargetProps) {
   const { widgetId } = props;
   const cursorType = React.useContext(CursorTypeContext);
   const draggedWidgetId = React.useContext(DraggedWidgetIdContext);
+  const dispatch = React.useContext(NineZoneDispatchContext);
+  const draggedOver = React.useContext(WidgetDraggedOverContext);
   const draggedTab = useLayout((state) => !!state.draggedTab);
   const [ref, targeted] = useTarget<HTMLDivElement>(useTargetArgs(widgetId));
   const allowedTarget = useAllowedWidgetTarget(widgetId);
+  // This state is used instead of the draggedOver context because tab bar or tab and merge
+  // target are mutually exclusive but they set the same context value.
+  const [isDraggedOver, setIsDraggedOver] = React.useState(false);
+  const isTabDragged = React.useContext(IsTabDraggedContext);
+
   const hidden =
-    !allowedTarget ||
-    (!draggedTab && !draggedWidgetId) ||
-    draggedWidgetId === widgetId;
+    !isTabDragged?.isDragged &&
+    (!allowedTarget ||
+      (!draggedTab && !draggedWidgetId) ||
+      draggedWidgetId === widgetId);
   const className = classnames(
     "nz-target-mergeTarget",
-    targeted && "nz-targeted",
+    (targeted || isDraggedOver) && "nz-targeted",
     hidden && "nz-hidden",
     cursorType && getCursorClassName(cursorType)
   );
-  return <div className={className} ref={ref} />;
+  return (
+    <div
+      className={className}
+      ref={ref}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setIsDraggedOver(true);
+        draggedOver?.setTarget("widget");
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault();
+        setIsDraggedOver(false);
+        draggedOver?.setTarget(undefined);
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        isTabDragged?.setIsDragged(false);
+        setIsDraggedOver(false);
+        draggedOver?.setTarget(undefined);
+        const id = e.dataTransfer.getData("text/plain");
+        dispatch({
+          type: "WIDGET_TAB_DRAG_END_NEW",
+          id,
+          target: { widgetId, type: "widget" },
+        });
+      }}
+    />
+  );
 }
 
 function useTargetArgs(widgetId: WidgetState["id"]) {

--- a/ui/appui-react/src/appui-react/layout/target/TabTarget.tsx
+++ b/ui/appui-react/src/appui-react/layout/target/TabTarget.tsx
@@ -11,7 +11,7 @@ import classnames from "classnames";
 import * as React from "react";
 import { assert } from "@itwin/core-bentley";
 import { DraggedWidgetIdContext, useTarget } from "../base/DragManager";
-import { CursorTypeContext } from "../base/NineZone";
+import { CursorTypeContext, NineZoneDispatchContext } from "../base/NineZone";
 import { getCursorClassName } from "../widget-panels/CursorOverlay";
 import type { WidgetState } from "../state/WidgetState";
 import { WidgetIdContext } from "../widget/Widget";
@@ -20,6 +20,8 @@ import { useAllowedWidgetTarget } from "./useAllowedWidgetTarget";
 import type { TabDropTargetState } from "../state/DropTargetState";
 import { useLayout } from "../base/LayoutStore";
 import { getWidgetState } from "../state/internal/WidgetStateHelpers";
+import { WidgetDraggedOverContext } from "../widget/WidgetDraggedOverContext";
+import { IsTabDraggedContext } from "../widget/IsTabDraggedContext";
 
 /** @internal */
 export function TabTarget() {
@@ -27,23 +29,57 @@ export function TabTarget() {
   const draggedTab = useLayout((state) => !!state.draggedTab);
   const draggedWidgetId = React.useContext(DraggedWidgetIdContext);
   const widgetId = React.useContext(WidgetIdContext);
+  const draggedOver = React.useContext(WidgetDraggedOverContext);
+  const dispatch = React.useContext(NineZoneDispatchContext);
   assert(!!widgetId);
   const tabIndex = useTabIndex();
+  // This state is used instead of the draggedOver context because tab and merge
+  // target are mutually exclusive but they set the same context value.
+  const [isDraggedOver, setIsDraggedOver] = React.useState(false);
+  const isTabDragged = React.useContext(IsTabDraggedContext);
   const [ref, targeted] = useTarget<HTMLDivElement>(
     useTargetArgs(widgetId, tabIndex)
   );
   const allowedTarget = useAllowedWidgetTarget(widgetId);
   const hidden =
-    !allowedTarget ||
-    (!draggedTab && !draggedWidgetId) ||
-    draggedWidgetId === widgetId;
+    !isTabDragged?.isDragged &&
+    (!allowedTarget ||
+      (!draggedTab && !draggedWidgetId) ||
+      draggedWidgetId === widgetId);
   const className = classnames(
     "nz-target-tabTarget",
     hidden && "nz-hidden",
-    targeted && "nz-targeted",
+    (targeted || isDraggedOver) && "nz-targeted",
     cursorType && getCursorClassName(cursorType)
   );
-  return <div className={className} ref={ref} />;
+  return (
+    <div
+      className={className}
+      ref={ref}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setIsDraggedOver(true);
+        draggedOver?.setTarget("tab");
+      }}
+      onDragLeave={(e) => {
+        e.preventDefault();
+        setIsDraggedOver(false);
+        draggedOver?.setTarget(undefined);
+      }}
+      onDrop={(e) => {
+        e.preventDefault();
+        isTabDragged?.setIsDragged(false);
+        setIsDraggedOver(false);
+        draggedOver?.setTarget(undefined);
+        const id = e.dataTransfer.getData("text/plain");
+        dispatch({
+          type: "WIDGET_TAB_DRAG_END_NEW",
+          id,
+          target: { type: "tab", widgetId, tabIndex },
+        });
+      }}
+    />
+  );
 }
 
 function useTabIndex() {

--- a/ui/appui-react/src/appui-react/layout/widget/IsTabDraggedContext.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/IsTabDraggedContext.tsx
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Utilities
+ */
+
+import * as React from "react";
+
+interface IsTabDraggedContextType {
+  isDragged: boolean;
+  setIsDragged: (isDragged: boolean) => void;
+}
+
+/** @internal */
+export const IsTabDraggedContext = React.createContext<
+  IsTabDraggedContextType | undefined
+>(undefined);

--- a/ui/appui-react/src/appui-react/layout/widget/Widget.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Widget.tsx
@@ -25,6 +25,8 @@ import { useLayout } from "../base/LayoutStore";
 import { getWidgetState } from "../state/internal/WidgetStateHelpers";
 import { useFloatingWidgetId } from "./FloatingWidget";
 import type { SizeProps } from "../../utils/SizeProps";
+import type { DraggedOverTargets } from "./WidgetDraggedOverContext";
+import { WidgetDraggedOverContext } from "./WidgetDraggedOverContext";
 
 /** @internal */
 export interface WidgetProviderProps {
@@ -157,22 +159,29 @@ export const Widget = React.forwardRef<HTMLDivElement, WidgetProps>(
       }),
       [measure]
     );
+    const [draggedOverTarget, setDraggedOverTarget] = React.useState<
+      DraggedOverTargets | undefined
+    >(undefined);
 
     const ref = useRefs(forwardedRef, elementRef);
     const className = classnames("nz-widget-widget", props.className);
     return (
       <WidgetContext.Provider value={widgetContextValue}>
-        <div
-          className={className}
-          onMouseEnter={props.onMouseEnter}
-          onMouseLeave={props.onMouseLeave}
-          onTransitionEnd={props.onTransitionEnd}
-          ref={ref}
-          style={props.style}
-          data-widget-id={props.widgetId}
+        <WidgetDraggedOverContext.Provider
+          value={{ target: draggedOverTarget, setTarget: setDraggedOverTarget }}
         >
-          {props.children}
-        </div>
+          <div
+            className={className}
+            onMouseEnter={props.onMouseEnter}
+            onMouseLeave={props.onMouseLeave}
+            onTransitionEnd={props.onTransitionEnd}
+            ref={ref}
+            style={props.style}
+            data-widget-id={props.widgetId}
+          >
+            {props.children}
+          </div>
+        </WidgetDraggedOverContext.Provider>
       </WidgetContext.Provider>
     );
   }

--- a/ui/appui-react/src/appui-react/layout/widget/WidgetDraggedOverContext.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/WidgetDraggedOverContext.tsx
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Utilities
+ */
+
+import * as React from "react";
+
+// TODO: add support for panels and sections
+/** @internal */
+export type DraggedOverTargets = "widget" | "tab";
+
+interface WidgetDraggedOverContextType {
+  target: DraggedOverTargets | undefined;
+  setTarget: (target: DraggedOverTargets | undefined) => void;
+}
+
+/** @internal */
+export const WidgetDraggedOverContext = React.createContext<
+  WidgetDraggedOverContextType | undefined
+>(undefined);

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -67,6 +67,9 @@ interface KnownPreviewFeatures {
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/859
    */
   controlWidgetVisibility: boolean | WidgetDef["id"][];
+  /** If `true`, tab dragging is handled by the Drag and Drop API.
+   */
+  newDragging: boolean;
 }
 
 /** Object used trim to only known features at runtime.
@@ -82,6 +85,7 @@ const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
   newToolbars: undefined,
   reparentPopoutWidgets: undefined,
   controlWidgetVisibility: undefined,
+  newDragging: undefined,
 };
 
 /** List of preview features that can be enabled/disabled.


### PR DESCRIPTION
WIP

Know issues to resolve:
```[tasklist]
### Tasks
- [ ] Docked tool settings dragging is buggy with the new API. Probably need to make the docked tool settings draggable with drag and drop API instead of instantly switching it to a floating widget. 
- [ ] Missing implementation for dragging tabs to panels and sections.
- [ ] Esc press while dragging makes the widget pop out.
``` 
