### PR TITLE
Fix `Toolbar` to avoid rendering of borders when there are no items

### DIFF
--- a/common/changes/@itwin/appui-react/fix-1002_2024-09-06-13-04.json
+++ b/common/changes/@itwin/appui-react/fix-1002_2024-09-06-13-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `Toolbar` to avoid rendering of borders artifact",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -54,6 +54,12 @@ type Story = StoryObj<typeof meta>;
 
 const items = createItems();
 
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};
+
 export const ActionItem: Story = {
   args: {
     items: [items.action1, items.action2, items.action3],

--- a/ui/appui-react/src/appui-react/preview/new-toolbars/ToolGroup.scss
+++ b/ui/appui-react/src/appui-react/preview/new-toolbars/ToolGroup.scss
@@ -40,4 +40,8 @@
   &:focus-within {
     border-color: var(--iui-color-border-foreground-hover);
   }
+
+  &:empty {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Changes

This PR fixes #1002 to avoid rendering a dot artifact when the toolbar is empty (with `newToolbars` preview feature enabled).

## Testing

Added additional story.
