### PR TITLE
Fix `copyStyles` to ignore errors on external resource links

### DIFF
--- a/common/changes/@itwin/appui-react/copy-styles-fix_2024-09-06-15-19.json
+++ b/common/changes/@itwin/appui-react/copy-styles-fix_2024-09-06-15-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix copyStyles to ignore errors on external resource links.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/childwindow/CopyStyles.ts
+++ b/ui/appui-react/src/appui-react/childwindow/CopyStyles.ts
@@ -2,6 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { Logger } from "@itwin/core-bentley";
+import { UiFramework } from "../UiFramework";
 
 /** Copies the CSS style sheets from source document into the target document.
  * @internal
@@ -22,12 +24,19 @@ export async function copyStyles(
       clonedNode.href
     ) {
       promises.push(
-        new Promise((resolve, reject) => {
+        new Promise((resolve) => {
           clonedNode.onload = () => {
             resolve();
           };
-          clonedNode.onerror = (error) => {
-            reject(error);
+          clonedNode.onerror = () => {
+            Logger.logWarning(
+              UiFramework.loggerCategory(copyStyles),
+              `Failed to load external resource`,
+              {
+                href: clonedNode.href,
+              }
+            );
+            resolve();
           };
         })
       );

--- a/ui/appui-react/src/appui-react/childwindow/CopyStyles.ts
+++ b/ui/appui-react/src/appui-react/childwindow/CopyStyles.ts
@@ -29,7 +29,7 @@ export async function copyStyles(
             resolve();
           };
           clonedNode.onerror = () => {
-            Logger.logWarning(
+            Logger.logError(
               UiFramework.loggerCategory(copyStyles),
               `Failed to load external resource`,
               {


### PR DESCRIPTION
## Changes

This PR fixes a potential issue where a popout widget is never rendered if there's an error with one of the external resource links (stylesheets).

This was reported by one of the AppUI consumers, who managed to get around this issue by fixing the resource.

## Testing

Tested manually via the `test-app`.
