### PR TITLE
Update deprecation message of `ToolbarActionItem["icon"]`

### DIFF
--- a/common/changes/@itwin/appui-react/fix-1006_2024-09-09-10-54.json
+++ b/common/changes/@itwin/appui-react/fix-1006_2024-09-09-10-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
@@ -74,7 +74,7 @@ export interface CommonToolbarItem {
  */
 export interface ToolbarActionItem extends CommonToolbarItem {
   /** Name of icon WebFont entry or if specifying an imported SVG symbol use "webSvg:" prefix  to imported symbol Id.
-   * @deprecated in 4.16.0. Use {@link CommonToolbarItem.iconNode} instead.
+   * @deprecated in 4.16.0. Use {@link CommonToolbarItem.iconNode} instead and specify `undefined` for this property. This will be made optional in 5.0.0.
    */
   // eslint-disable-next-line deprecation/deprecation
   readonly icon: IconSpec;

--- a/ui/appui-react/src/test/toolbar/Toolbar.test.tsx
+++ b/ui/appui-react/src/test/toolbar/Toolbar.test.tsx
@@ -163,6 +163,24 @@ describe("<Toolbar />", () => {
         childStructure(".components-badge .core-badge-deprecatedBadge")
       );
     });
+
+    it("should prefer `iconNode` property over `icon`", () => {
+      const toolbarItems = [
+        ToolbarItemUtilities.createActionItem(
+          "item1",
+          0,
+          <>test-icon</>,
+          "",
+          () => {},
+          {
+            iconNode: <>test-icon-node</>,
+          }
+        ),
+      ];
+
+      const { getByRole } = render(<Toolbar items={toolbarItems} />);
+      getByRole("button", { name: "test-icon-node" });
+    });
   });
 
   describe('New toolbars ("newToolbars" preview feature on)', () => {
@@ -339,6 +357,28 @@ describe("<Toolbar />", () => {
       expect(screen.getByRole("menuitem", { name: "Item 2" })).to.satisfy(
         childStructure(".uifw-toolbar-group-badge .core-badge-deprecatedBadge")
       );
+    });
+
+    it("should prefer `iconNode` property over `icon`", () => {
+      const toolbarItems = [
+        ToolbarItemUtilities.createActionItem(
+          "item1",
+          0,
+          <>test-icon</>,
+          "",
+          () => {},
+          {
+            iconNode: <>test-icon-node</>,
+          }
+        ),
+      ];
+
+      const { getByText } = render(
+        <PreviewFeaturesProvider features={{ newToolbars: true }}>
+          <Toolbar items={toolbarItems} />
+        </PreviewFeaturesProvider>
+      );
+      getByText("test-icon-node");
     });
   });
 });


### PR DESCRIPTION
## Changes

This PR fixes #1006 by updating the deprecation message.

## Testing

Added additional unit tests to ensure that `iconNode` is preferred over the deprecated `icon` property.
