### PR TITLE
Fix tool conditionals that depend on active viewport when content control APIs are not used

### DIFF
--- a/apps/test-app/src/frontend/appui/frontstages/MainFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/MainFrontstage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@itwin/appui-react";
 import {
   ComponentExamplesModalFrontstage,
+  getCustomViewSelectorPopupItem,
   ViewportContent,
 } from "@itwin/appui-test-providers";
 import { SvgImodel } from "@itwin/itwinui-icons-react";
@@ -45,6 +46,7 @@ createMainFrontstage.stageId = "main";
 export function createMainFrontstageProvider() {
   return {
     id: "appui-test-app:backstageItemsProvider",
+    getToolbarItems: () => [getCustomViewSelectorPopupItem()],
     getBackstageItems: () => [
       BackstageItemUtilities.createStageLauncher({
         stageId: createMainFrontstage.stageId,

--- a/apps/test-app/src/frontend/registerFrontstages.tsx
+++ b/apps/test-app/src/frontend/registerFrontstages.tsx
@@ -116,7 +116,12 @@ export function registerFrontstages({
   });
   UiItemsManager.register(
     new AbstractUiItemsProvider(AppUiTestProviders.localizationNamespace),
-    { stageIds: [createMainFrontstage.stageId] }
+    {
+      stageIds: [
+        createMainFrontstage.stageId,
+        createWidgetApiFrontstage.stageId,
+      ],
+    }
   );
   UiItemsManager.register(new MessageUiItemsProvider(), {
     stageIds: [createMainFrontstage.stageId, createWidgetApiFrontstage.stageId],

--- a/apps/test-app/src/frontend/registerFrontstages.tsx
+++ b/apps/test-app/src/frontend/registerFrontstages.tsx
@@ -115,11 +115,17 @@ export function registerFrontstages({
     stageIds: [createWidgetApiFrontstage.stageId],
   });
   UiItemsManager.register(
-    new AbstractUiItemsProvider(AppUiTestProviders.localizationNamespace)
+    new AbstractUiItemsProvider(AppUiTestProviders.localizationNamespace),
+    { stageIds: [createMainFrontstage.stageId] }
   );
-  UiItemsManager.register(new MessageUiItemsProvider());
+  UiItemsManager.register(new MessageUiItemsProvider(), {
+    stageIds: [createMainFrontstage.stageId, createWidgetApiFrontstage.stageId],
+  });
   UiItemsManager.register(
-    new InspectUiItemInfoToolProvider(AppUiTestProviders.localizationNamespace)
+    new InspectUiItemInfoToolProvider(AppUiTestProviders.localizationNamespace),
+    {
+      stageIds: [createWidgetApiFrontstage.stageId],
+    }
   );
   UiItemsManager.register(createPreviewFeaturesProvider(), {
     stageUsages: [StageUsage.General],

--- a/apps/test-providers/src/appui-test-providers.ts
+++ b/apps/test-providers/src/appui-test-providers.ts
@@ -15,9 +15,19 @@ export * from "./tools/SampleTool";
 export * from "./tools/ToolWithDynamicSettings";
 export * from "./tools/UiLayoutTools";
 
+export * from "./ui/buttons/ViewSelectorPanel";
+
 export * from "./ui/components/LanguageSelect";
 
 export * from "./ui/dialogs/SampleModalDialog";
+
+export * from "./ui/frontstages/ComponentExamples";
+export * from "./ui/frontstages/ContentLayoutFrontstage";
+export * from "./ui/frontstages/CustomContentFrontstage";
+export * from "./ui/frontstages/CustomFrontstageProvider";
+export * from "./ui/frontstages/PopoutWindowsFrontstage";
+export * from "./ui/frontstages/registerCustomFrontstage";
+export * from "./ui/frontstages/SynchronizedViewportFrontstage";
 
 export * from "./ui/providers/AbstractUiItemsProvider";
 export * from "./ui/providers/ContentLayoutStageUiItemsProvider";
@@ -30,14 +40,6 @@ export * from "./ui/providers/PreviewFeaturesToggleProvider";
 export * from "./ui/providers/SynchronizedViewportProvider";
 export * from "./ui/providers/UpdatedUiItemsProvider";
 export * from "./ui/providers/WidgetContentProvider";
-
-export * from "./ui/frontstages/ComponentExamples";
-export * from "./ui/frontstages/ContentLayoutFrontstage";
-export * from "./ui/frontstages/CustomContentFrontstage";
-export * from "./ui/frontstages/CustomFrontstageProvider";
-export * from "./ui/frontstages/PopoutWindowsFrontstage";
-export * from "./ui/frontstages/registerCustomFrontstage";
-export * from "./ui/frontstages/SynchronizedViewportFrontstage";
 
 export * from "./ui/widgets/ITwinUIv2Widget";
 export * from "./ui/widgets/LayoutWidget";

--- a/apps/test-providers/src/ui/buttons/ViewSelectorPanel.tsx
+++ b/apps/test-providers/src/ui/buttons/ViewSelectorPanel.tsx
@@ -7,6 +7,8 @@ import * as React from "react";
 import {
   ToolbarCustomItem,
   ToolbarItemUtilities,
+  ToolbarOrientation,
+  ToolbarUsage,
   useActiveIModelConnection,
   useActiveViewport,
   ViewSelector,
@@ -23,6 +25,12 @@ export function getCustomViewSelectorPopupItem(
     panelContent: <ViewSelectorPanel />,
     itemPriority: 20,
     groupPriority: 3000,
+    layouts: {
+      standard: {
+        orientation: ToolbarOrientation.Vertical,
+        usage: ToolbarUsage.ViewNavigation,
+      },
+    },
     ...overrides,
   });
 }

--- a/apps/test-providers/src/ui/providers/PopoutWindowsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/PopoutWindowsProvider.tsx
@@ -67,14 +67,7 @@ export function createPopoutWindowsProvider() {
           },
         },
       }),
-      getCustomViewSelectorPopupItem({
-        layouts: {
-          standard: {
-            orientation: ToolbarOrientation.Vertical,
-            usage: ToolbarUsage.ViewNavigation,
-          },
-        },
-      }),
+      getCustomViewSelectorPopupItem(),
     ],
     getStatusBarItems: () => [
       StatusBarItemUtilities.createCustomItem({

--- a/common/changes/@itwin/appui-react/fix-1001_2024-09-09-16-11.json
+++ b/common/changes/@itwin/appui-react/fix-1001_2024-09-09-16-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix tool conditionals that depend on active viewport when content control APIs are not used.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/selection/SelectionContextItemDef.ts
+++ b/ui/appui-react/src/appui-react/selection/SelectionContextItemDef.ts
@@ -7,7 +7,6 @@
  */
 
 import { ConditionalBooleanValue } from "@itwin/appui-abstract";
-import { IModelApp } from "@itwin/core-frontend";
 import { SessionStateActionId } from "../redux/SessionState";
 import { CommandItemDef } from "../shared/CommandItemDef";
 import type { BaseItemState } from "../shared/ItemDefBase";
@@ -25,6 +24,7 @@ import svgVisibilitySemiTransparent from "@bentley/icons-generic/icons/visibilit
 import svgVisibilityHide from "@bentley/icons-generic/icons/visibility-hide_2.svg";
 import svgVisibility from "@bentley/icons-generic/icons/visibility.svg";
 import type { ToolbarItems } from "../tools/ToolbarItems";
+import { getActiveViewport } from "../utils/getActiveViewport";
 
 /* eslint-disable deprecation/deprecation */
 
@@ -62,10 +62,7 @@ export function getSelectionContextSyncEventIds(): string[] {
  * @deprecated in 4.15.0. Use {@link ToolbarItems} or a custom conditional value instead.
  */
 export function isNoSelectionActive(): boolean {
-  const activeContentControl = UiFramework.content.getActiveContentControl();
-  const viewport = activeContentControl
-    ? activeContentControl.viewport
-    : IModelApp.viewManager.selectedView;
+  const viewport = getActiveViewport();
   if (!viewport) {
     return true;
   }
@@ -88,10 +85,7 @@ export function isNoSelectionActive(): boolean {
  * @deprecated in 4.15.0. Use {@link ToolbarItems} or a custom conditional value instead.
  */
 export function areNoFeatureOverridesActive(): boolean {
-  const activeContentControl = UiFramework.content.getActiveContentControl();
-  const viewport = activeContentControl
-    ? activeContentControl.viewport
-    : IModelApp.viewManager.selectedView;
+  const viewport = getActiveViewport();
   if (!viewport) {
     return true;
   }
@@ -130,10 +124,7 @@ export function getIsHiddenIfSelectionNotActive(): ConditionalBooleanValue {
 export function featureOverridesActiveStateFunc(
   state: Readonly<BaseItemState>
 ): BaseItemState {
-  const activeContentControl = UiFramework.content.getActiveContentControl();
-  const viewport = activeContentControl
-    ? activeContentControl.viewport
-    : IModelApp.viewManager.selectedView;
+  const viewport = getActiveViewport();
   if (!viewport) {
     return { ...state, isVisible: false };
   }
@@ -152,10 +143,7 @@ export function featureOverridesActiveStateFunc(
 export function selectionContextStateFunc(
   state: Readonly<BaseItemState>
 ): BaseItemState {
-  const activeContentControl = UiFramework.content.getActiveContentControl();
-  const viewport = activeContentControl
-    ? activeContentControl.viewport
-    : IModelApp.viewManager.selectedView;
+  const viewport = getActiveViewport();
   if (!viewport) {
     return { ...state, isVisible: false };
   }

--- a/ui/appui-react/src/appui-react/selection/SelectionContextItemDef.ts
+++ b/ui/appui-react/src/appui-react/selection/SelectionContextItemDef.ts
@@ -67,13 +67,12 @@ export function isNoSelectionActive(): boolean {
     return true;
   }
 
-  const hiddenElementsSet = viewport.neverDrawn;
-  const selectedElementsSet = viewport.view.iModel.selectionSet.elements;
-
   const selectionCount = UiFramework.getNumItemsSelected();
   if (selectionCount > 0) return false;
 
   // TODO: add check for categories, subcategories and models
+  const hiddenElementsSet = viewport.neverDrawn;
+  const selectedElementsSet = viewport.view.iModel.selectionSet.elements;
   if (![...selectedElementsSet].every((value) => hiddenElementsSet?.has(value)))
     return false;
 

--- a/ui/appui-react/src/appui-react/selection/SelectionContextItemDef.ts
+++ b/ui/appui-react/src/appui-react/selection/SelectionContextItemDef.ts
@@ -63,13 +63,12 @@ export function getSelectionContextSyncEventIds(): string[] {
  */
 export function isNoSelectionActive(): boolean {
   const activeContentControl = UiFramework.content.getActiveContentControl();
-  if (activeContentControl && !activeContentControl.viewport) {
+  const viewport = activeContentControl
+    ? activeContentControl.viewport
+    : IModelApp.viewManager.selectedView;
+  if (!viewport) {
     return true;
   }
-
-  const viewport =
-    activeContentControl?.viewport ?? IModelApp.viewManager.selectedView;
-  if (!viewport) return true;
 
   const hiddenElementsSet = viewport.neverDrawn;
   const selectedElementsSet = viewport.view.iModel.selectionSet.elements;
@@ -90,12 +89,9 @@ export function isNoSelectionActive(): boolean {
  */
 export function areNoFeatureOverridesActive(): boolean {
   const activeContentControl = UiFramework.content.getActiveContentControl();
-  if (activeContentControl && !activeContentControl.viewport) {
-    return true;
-  }
-
-  const viewport =
-    activeContentControl?.viewport ?? IModelApp.viewManager.selectedView;
+  const viewport = activeContentControl
+    ? activeContentControl.viewport
+    : IModelApp.viewManager.selectedView;
   if (!viewport) {
     return true;
   }
@@ -135,12 +131,9 @@ export function featureOverridesActiveStateFunc(
   state: Readonly<BaseItemState>
 ): BaseItemState {
   const activeContentControl = UiFramework.content.getActiveContentControl();
-  if (activeContentControl && !activeContentControl.viewport) {
-    return { ...state, isVisible: false };
-  }
-
-  const viewport =
-    activeContentControl?.viewport ?? IModelApp.viewManager.selectedView;
+  const viewport = activeContentControl
+    ? activeContentControl.viewport
+    : IModelApp.viewManager.selectedView;
   if (!viewport) {
     return { ...state, isVisible: false };
   }
@@ -160,12 +153,9 @@ export function selectionContextStateFunc(
   state: Readonly<BaseItemState>
 ): BaseItemState {
   const activeContentControl = UiFramework.content.getActiveContentControl();
-  if (activeContentControl && !activeContentControl.viewport) {
-    return { ...state, isVisible: false };
-  }
-
-  const viewport =
-    activeContentControl?.viewport ?? IModelApp.viewManager.selectedView;
+  const viewport = activeContentControl
+    ? activeContentControl.viewport
+    : IModelApp.viewManager.selectedView;
   if (!viewport) {
     return { ...state, isVisible: false };
   }

--- a/ui/appui-react/src/appui-react/tools/CoreToolDefinitions.tsx
+++ b/ui/appui-react/src/appui-react/tools/CoreToolDefinitions.tsx
@@ -51,6 +51,7 @@ import svgSelectionClear from "@bentley/icons-generic/icons/selection-clear.svg"
 import { SvgMeasure, SvgProcess } from "@itwin/itwinui-icons-react";
 import { ConditionalIconItem } from "@itwin/core-react";
 import type { ToolbarItems } from "./ToolbarItems";
+import { getActiveViewport } from "../utils/getActiveViewport";
 
 /* eslint-disable deprecation/deprecation */
 
@@ -133,12 +134,7 @@ export class CoreTools {
     return new ToolItemDef({
       toolId: RotateViewTool.toolId,
       iconSpec: new ConditionalStringValue(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
-
+        const viewport = getActiveViewport();
         if (viewport?.view.is2d()) return svgRotateLeft;
         return svgGyroscope;
       }, [
@@ -163,11 +159,7 @@ export class CoreTools {
       label: WalkViewTool.flyover,
       description: WalkViewTool.description,
       isHidden: new ConditionalBooleanValue(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
+        const viewport = getActiveViewport();
         return !!viewport?.view.is2d();
       }, [
         SyncUiEventId.ActiveContentChanged,
@@ -206,11 +198,7 @@ export class CoreTools {
     return new ToolItemDef({
       toolId: ViewToggleCameraTool.toolId,
       iconSpec: new ConditionalIconItem(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
+        const viewport = getActiveViewport();
         if (viewport?.view.is3d() && viewport?.isCameraOn) {
           return <SvgCameraAnimation />;
         }
@@ -222,11 +210,7 @@ export class CoreTools {
         SyncUiEventId.ViewStateChanged,
       ]),
       label: new ConditionalStringValue(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
+        const viewport = getActiveViewport();
         if (viewport?.view.is3d() && viewport?.isCameraOn) {
           return UiFramework.translate(
             "tools.View.ToggleCamera.turnOffFlyover"
@@ -240,11 +224,7 @@ export class CoreTools {
       ]),
       description: ViewToggleCameraTool.description,
       isHidden: new ConditionalBooleanValue(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
+        const viewport = getActiveViewport();
         return !(viewport?.view.is3d() && viewport?.view.supportsCamera());
       }, [
         SyncUiEventId.ActiveContentChanged,
@@ -279,11 +259,7 @@ export class CoreTools {
     return new ToolItemDef({
       toolId: ViewUndoTool.toolId,
       isDisabled: new ConditionalBooleanValue(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
+        const viewport = getActiveViewport();
         if (!viewport) return false;
         return !viewport.isUndoPossible;
       }, [
@@ -314,11 +290,7 @@ export class CoreTools {
           IModelApp.viewManager.selectedView
         ),
       isDisabled: new ConditionalBooleanValue(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
+        const viewport = getActiveViewport();
         if (!viewport) return false;
         return !viewport.isRedoPossible;
       }, [
@@ -416,11 +388,7 @@ export class CoreTools {
       labelKey: "UiFramework:tools.sectionTools",
       iconSpec: svgSectionTool,
       isHidden: new ConditionalBooleanValue(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
+        const viewport = getActiveViewport();
         return !!viewport?.view.is2d();
       }, [
         SyncUiEventId.ActiveContentChanged,
@@ -449,11 +417,7 @@ export class CoreTools {
       panelLabelKey: "UiFramework:tools.sectionPanelLabel",
       iconSpec: svgSectionTool,
       isHidden: new ConditionalBooleanValue(() => {
-        const activeContentControl =
-          UiFramework.content.getActiveContentControl();
-        const viewport = activeContentControl
-          ? activeContentControl.viewport
-          : IModelApp.viewManager.selectedView;
+        const viewport = getActiveViewport();
         return !!viewport?.view.is2d();
       }, [
         SyncUiEventId.ActiveContentChanged,

--- a/ui/appui-react/src/appui-react/tools/CoreToolDefinitions.tsx
+++ b/ui/appui-react/src/appui-react/tools/CoreToolDefinitions.tsx
@@ -135,7 +135,11 @@ export class CoreTools {
       iconSpec: new ConditionalStringValue(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        if (activeContentControl?.viewport?.view.is2d()) return svgRotateLeft;
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+
+        if (viewport?.view.is2d()) return svgRotateLeft;
         return svgGyroscope;
       }, [
         SyncUiEventId.ActiveContentChanged,
@@ -161,7 +165,10 @@ export class CoreTools {
       isHidden: new ConditionalBooleanValue(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        return !!activeContentControl?.viewport?.view.is2d();
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+        return !!viewport?.view.is2d();
       }, [
         SyncUiEventId.ActiveContentChanged,
         SyncUiEventId.ActiveViewportChanged,
@@ -201,12 +208,13 @@ export class CoreTools {
       iconSpec: new ConditionalIconItem(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        if (
-          activeContentControl?.viewport?.view.is3d() &&
-          activeContentControl?.viewport?.isCameraOn
-        ) {
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+        if (viewport?.view.is3d() && viewport?.isCameraOn) {
           return <SvgCameraAnimation />;
         }
+
         return <SvgCameraAnimationDisabled />;
       }, [
         SyncUiEventId.ActiveContentChanged,
@@ -216,10 +224,10 @@ export class CoreTools {
       label: new ConditionalStringValue(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        if (
-          activeContentControl?.viewport?.view.is3d() &&
-          activeContentControl?.viewport?.isCameraOn
-        ) {
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+        if (viewport?.view.is3d() && viewport?.isCameraOn) {
           return UiFramework.translate(
             "tools.View.ToggleCamera.turnOffFlyover"
           );
@@ -234,10 +242,10 @@ export class CoreTools {
       isHidden: new ConditionalBooleanValue(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        return !(
-          activeContentControl?.viewport?.view.is3d() &&
-          activeContentControl?.viewport?.view.supportsCamera()
-        );
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+        return !(viewport?.view.is3d() && viewport?.view.supportsCamera());
       }, [
         SyncUiEventId.ActiveContentChanged,
         SyncUiEventId.ActiveViewportChanged,
@@ -273,9 +281,11 @@ export class CoreTools {
       isDisabled: new ConditionalBooleanValue(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        if (activeContentControl && activeContentControl.viewport)
-          return !activeContentControl.viewport.isUndoPossible;
-        return false;
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+        if (!viewport) return false;
+        return !viewport.isUndoPossible;
       }, [
         SyncUiEventId.ActiveContentChanged,
         SyncUiEventId.ActiveViewportChanged,
@@ -306,9 +316,11 @@ export class CoreTools {
       isDisabled: new ConditionalBooleanValue(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        if (activeContentControl && activeContentControl.viewport)
-          return !activeContentControl.viewport.isRedoPossible;
-        return false;
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+        if (!viewport) return false;
+        return !viewport.isRedoPossible;
       }, [
         SyncUiEventId.ActiveContentChanged,
         SyncUiEventId.ActiveViewportChanged,
@@ -406,7 +418,10 @@ export class CoreTools {
       isHidden: new ConditionalBooleanValue(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        return !!activeContentControl?.viewport?.view.is2d();
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+        return !!viewport?.view.is2d();
       }, [
         SyncUiEventId.ActiveContentChanged,
         SyncUiEventId.ActiveViewportChanged,
@@ -436,7 +451,10 @@ export class CoreTools {
       isHidden: new ConditionalBooleanValue(() => {
         const activeContentControl =
           UiFramework.content.getActiveContentControl();
-        return !!activeContentControl?.viewport?.view.is2d();
+        const viewport = activeContentControl
+          ? activeContentControl.viewport
+          : IModelApp.viewManager.selectedView;
+        return !!viewport?.view.is2d();
       }, [
         SyncUiEventId.ActiveContentChanged,
         SyncUiEventId.ActiveViewportChanged,

--- a/ui/appui-react/src/appui-react/utils/getActiveViewport.ts
+++ b/ui/appui-react/src/appui-react/utils/getActiveViewport.ts
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Utilities
+ */
+
+import { IModelApp } from "@itwin/core-frontend";
+import { UiFramework } from "../UiFramework";
+
+/** A helper function used to get the active viewport in conditional definitions.
+ * Uses the deprecated active content control APIs to get the active viewport or the selected view of the view manager as a fallback.
+ * @note Might need a better strategy for a use case where selected view fallback behavior is not desired (i.e. a map of active content id to a viewport).
+ * @internal
+ */
+export function getActiveViewport() {
+  // eslint-disable-next-line deprecation/deprecation
+  const activeContentControl = UiFramework.content.getActiveContentControl();
+  return activeContentControl
+    ? activeContentControl.viewport
+    : IModelApp.viewManager.selectedView;
+}


### PR DESCRIPTION
## Changes

This PR fixes #1001 by falling back to `IModelApp.viewManager.selectedView` in conditional value getters when deprecated content control APIs are not used.

## Testing

Tested manually via the `test-app`.
