### PR TITLE
Deprecate `UiItemsProvider` APIs that depend on `provide*` variants

### DIFF
--- a/apps/test-app/src/frontend/appui/providers/StatusbarUiItemsProvider.tsx
+++ b/apps/test-app/src/frontend/appui/providers/StatusbarUiItemsProvider.tsx
@@ -27,8 +27,7 @@ export function createStatusBarUiItemsProvider() {
     id: "statusbar",
     getStatusBarItems: () => {
       return [
-        // eslint-disable-next-line deprecation/deprecation
-        ...standardProvider.provideStatusBarItems("", ""),
+        ...standardProvider.getStatusBarItems(),
         StatusBarItemUtilities.createCustomItem({
           id: "selection-scope",
           section: StatusBarSection.Right,

--- a/apps/test-providers/src/tools/ContentLayoutTools.tsx
+++ b/apps/test-providers/src/tools/ContentLayoutTools.tsx
@@ -16,6 +16,7 @@ import {
   StageContentLayout,
   StageContentLayoutProps,
   SyncUiEventId,
+  ToolbarActionItem,
   ToolbarItemUtilities,
   UiFramework,
   useConditionalValue,
@@ -196,7 +197,9 @@ function SplitWindowIcon() {
 }
 
 export function createSplitSingleViewportToolbarItem(
-  getViewport: (content: ContentProps) => ScreenViewport | undefined
+  getViewport: (content: ContentProps) => ScreenViewport | undefined,
+  // eslint-disable-next-line deprecation/deprecation
+  overrides?: Omit<Partial<ToolbarActionItem>, "icon">
 ) {
   const id = "splitSingleViewportCommandDef";
   const label = new ConditionalStringValue(
@@ -297,5 +300,6 @@ export function createSplitSingleViewportToolbarItem(
     icon: <SplitWindowIcon />,
     label,
     execute,
+    ...overrides,
   });
 }

--- a/apps/test-providers/src/tools/InspectUiItemInfoTool.ts
+++ b/apps/test-providers/src/tools/InspectUiItemInfoTool.ts
@@ -14,8 +14,6 @@ import {
   IModelApp,
   PrimitiveTool,
 } from "@itwin/core-frontend";
-
-import { ToolbarItemUtilities } from "@itwin/appui-abstract";
 import inspectIconSvg from "@bentley/icons-generic/icons/search.svg";
 
 export class InspectUiItemInfoTool extends PrimitiveTool {
@@ -155,24 +153,5 @@ export class InspectUiItemInfoTool extends PrimitiveTool {
 
   protected setupAndPromptForNextAction(): void {
     IModelApp.notifications.outputPrompt("click over UI item");
-  }
-
-  public static getActionButtonDef(
-    itemPriority: number,
-    groupPriority?: number
-  ) {
-    const overrides = {
-      groupPriority,
-    };
-    return ToolbarItemUtilities.createActionButton(
-      InspectUiItemInfoTool.toolId,
-      itemPriority,
-      InspectUiItemInfoTool.iconSpec,
-      InspectUiItemInfoTool.flyover,
-      async () => {
-        await IModelApp.tools.run(InspectUiItemInfoTool.toolId);
-      },
-      overrides
-    );
   }
 }

--- a/apps/test-providers/src/tools/OpenAbstractModalDialogTool.ts
+++ b/apps/test-providers/src/tools/OpenAbstractModalDialogTool.ts
@@ -6,9 +6,8 @@
  * @module Tools
  */
 
-import { IModelApp, Tool } from "@itwin/core-frontend";
+import { Tool } from "@itwin/core-frontend";
 import { AbstractDialogDataProvider } from "../ui/dialogs/TestUiProviderDialog";
-import { ToolbarItemUtilities } from "@itwin/appui-abstract";
 import { AppUiTestProviders } from "../AppUiTestProviders";
 import { UiFramework } from "@itwin/appui-react";
 
@@ -55,25 +54,5 @@ export class OpenAbstractDialogTool extends Tool {
 
   public static override get englishKeyin(): string {
     return "open abstract dialog";
-  }
-
-  public static getActionButtonDef(
-    itemPriority: number,
-    groupPriority?: number
-  ) {
-    const overrides = {
-      groupPriority,
-    };
-
-    return ToolbarItemUtilities.createActionButton(
-      OpenAbstractDialogTool.toolId,
-      itemPriority,
-      OpenAbstractDialogTool.iconSpec,
-      OpenAbstractDialogTool.flyover,
-      async () => {
-        await IModelApp.tools.run(OpenAbstractDialogTool.toolId);
-      },
-      overrides
-    );
   }
 }

--- a/apps/test-providers/src/tools/OpenCustomDialogTool.tsx
+++ b/apps/test-providers/src/tools/OpenCustomDialogTool.tsx
@@ -7,12 +7,8 @@
  */
 
 import * as React from "react";
-import { IModelApp, Tool } from "@itwin/core-frontend";
+import { Tool } from "@itwin/core-frontend";
 import { SampleModalDialog } from "../ui/dialogs/SampleModalDialog";
-import {
-  ConditionalBooleanValue,
-  ToolbarItemUtilities,
-} from "@itwin/appui-abstract";
 import { AppUiTestProviders } from "../AppUiTestProviders";
 import connectedQuerySvg from "../ui/icons/connected-query.svg";
 import { UiFramework } from "@itwin/appui-react";
@@ -49,27 +45,5 @@ export class OpenCustomDialogTool extends Tool {
 
   public static override get englishKeyin(): string {
     return "open custom dialog";
-  }
-
-  public static getActionButtonDef(
-    itemPriority: number,
-    groupPriority?: number,
-    isHidden?: ConditionalBooleanValue
-  ) {
-    const overrides = {
-      groupPriority,
-      isHidden,
-    };
-
-    return ToolbarItemUtilities.createActionButton(
-      OpenCustomDialogTool.toolId,
-      itemPriority,
-      this.iconSpec,
-      OpenCustomDialogTool.flyover,
-      async () => {
-        await IModelApp.tools.run(OpenCustomDialogTool.toolId);
-      },
-      overrides
-    );
   }
 }

--- a/apps/test-providers/src/tools/SampleTool.ts
+++ b/apps/test-providers/src/tools/SampleTool.ts
@@ -28,7 +28,6 @@ import {
   PropertyEditorParamTypes,
   StandardEditorNames,
   SuppressLabelEditorParams,
-  ToolbarItemUtilities,
 } from "@itwin/appui-abstract";
 
 import { Logger } from "@itwin/core-bentley";
@@ -716,23 +715,5 @@ export class SampleTool extends PrimitiveTool {
 
     // return true is change is valid
     return true;
-  }
-
-  public static getActionButtonDef(
-    itemPriority: number,
-    groupPriority?: number
-  ) {
-    const overrides = undefined !== groupPriority ? { groupPriority } : {};
-
-    return ToolbarItemUtilities.createActionButton(
-      SampleTool.toolId,
-      itemPriority,
-      this.iconSpec,
-      SampleTool.flyover,
-      async () => {
-        await IModelApp.tools.run(SampleTool.toolId);
-      },
-      overrides
-    );
   }
 }

--- a/apps/test-providers/src/tools/ToolWithDynamicSettings.ts
+++ b/apps/test-providers/src/tools/ToolWithDynamicSettings.ts
@@ -19,7 +19,6 @@ import {
   DialogPropertySyncItem,
   EnumerationChoice,
   PropertyDescription,
-  ToolbarItemUtilities,
 } from "@itwin/appui-abstract";
 import dynamicToolSvg from "./DynamicTool.svg";
 import { AppUiTestProviders } from "../AppUiTestProviders";
@@ -242,23 +241,5 @@ export class ToolWithDynamicSettings extends PrimitiveTool {
 
     // return true is change is valid
     return true;
-  }
-
-  public static getActionButtonDef(
-    itemPriority: number,
-    groupPriority?: number
-  ) {
-    const overrides = undefined !== groupPriority ? { groupPriority } : {};
-
-    return ToolbarItemUtilities.createActionButton(
-      ToolWithDynamicSettings.toolId,
-      itemPriority,
-      this.iconSpec,
-      ToolWithDynamicSettings.flyover,
-      async () => {
-        await IModelApp.tools.run(ToolWithDynamicSettings.toolId);
-      },
-      overrides
-    );
   }
 }

--- a/apps/test-providers/src/ui/providers/AbstractUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/AbstractUiItemsProvider.tsx
@@ -86,46 +86,39 @@ export class AbstractUiItemsProvider implements UiItemsProvider {
     return [];
   }
 
-  public provideStatusBarItems(
-    _stageId: string,
-    stageUsage: string
-  ): StatusBarItem[] {
-    const statusBarItems: StatusBarItem[] = [];
-    if (stageUsage === StageUsage.General.valueOf()) {
-      statusBarItems.push(
-        /** Add a status bar item that will open a dialog allow the user to set the active unit system used to display quantity values.  */
-        StatusBarItemUtilities.createCustomItem({
-          id: "AppUiTestProviders:UnitsStatusBarItem",
-          section:
-            this.props?.unitsStatusBarItem?.section ?? StatusBarSection.Center,
-          itemPriority: this.props?.unitsStatusBarItem?.itemPriority ?? 100,
-          content: (
-            <UnitsField
-              label={AppUiTestProviders.translate("StatusBar.UnitsFlyover")}
-              title={AppUiTestProviders.translate("StatusBar.Units")}
-              options={[
-                {
-                  label: AppUiTestProviders.translate("StatusBar.Metric"),
-                  value: "metric",
-                },
-                {
-                  label: AppUiTestProviders.translate("StatusBar.Imperial"),
-                  value: "imperial",
-                },
-                {
-                  label: AppUiTestProviders.translate("StatusBar.UsSurvey"),
-                  value: "usSurvey",
-                },
-                {
-                  label: AppUiTestProviders.translate("StatusBar.UsCustomary"),
-                  value: "usCustomary",
-                },
-              ]}
-            />
-          ),
-        })
-      );
-    }
-    return statusBarItems;
+  public getStatusBarItems(): StatusBarItem[] {
+    return [
+      /** Add a status bar item that will open a dialog allowing the user to set the active unit system used to display quantity values. */
+      StatusBarItemUtilities.createCustomItem({
+        id: "AppUiTestProviders:UnitsStatusBarItem",
+        section:
+          this.props?.unitsStatusBarItem?.section ?? StatusBarSection.Center,
+        itemPriority: this.props?.unitsStatusBarItem?.itemPriority ?? 100,
+        content: (
+          <UnitsField
+            label={AppUiTestProviders.translate("StatusBar.UnitsFlyover")}
+            title={AppUiTestProviders.translate("StatusBar.Units")}
+            options={[
+              {
+                label: AppUiTestProviders.translate("StatusBar.Metric"),
+                value: "metric",
+              },
+              {
+                label: AppUiTestProviders.translate("StatusBar.Imperial"),
+                value: "imperial",
+              },
+              {
+                label: AppUiTestProviders.translate("StatusBar.UsSurvey"),
+                value: "usSurvey",
+              },
+              {
+                label: AppUiTestProviders.translate("StatusBar.UsCustomary"),
+                value: "usCustomary",
+              },
+            ]}
+          />
+        ),
+      }),
+    ];
   }
 }

--- a/apps/test-providers/src/ui/providers/AbstractUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/AbstractUiItemsProvider.tsx
@@ -5,11 +5,11 @@
 
 import * as React from "react";
 import {
-  StageUsage,
   StatusBarItem,
   StatusBarItemUtilities,
   StatusBarSection,
   ToolbarItem,
+  ToolbarItemUtilities,
   ToolbarOrientation,
   ToolbarUsage,
   UiItemsProvider,
@@ -20,15 +20,7 @@ import { OpenAbstractDialogTool } from "../../tools/OpenAbstractModalDialogTool"
 import { ToolWithDynamicSettings } from "../../tools/ToolWithDynamicSettings";
 import { UnitsField } from "../statusfields/unitsfield/UnitsField";
 
-export interface AbstractUiItemsProviderProps {
-  sampleTool?: { itemPriority?: number; groupPriority?: number };
-  dynamicTool?: { itemPriority?: number; groupPriority?: number };
-  openAbstractDialogTool?: { itemPriority?: number; groupPriority?: number };
-  unitsStatusBarItem?: { itemPriority?: number; section?: StatusBarSection };
-}
-
-/**
- * The AbstractUiItemsProvider provides additional items to any frontstage that has a usage value of StageUsage.General.
+/** The AbstractUiItemsProvider provides additional items to any frontstage that has a usage value of StageUsage.General.
  * The unique thing about the items provided with this provider is that the toolbar and and statusbar items provider simply
  * provide abstract item data and the UI packages generate the necessary React components. This means that the package that
  * supplies the abstract definitions only need to take a dependency on appui-abstract and not on react or any of the other appui packages.
@@ -36,64 +28,48 @@ export interface AbstractUiItemsProviderProps {
 export class AbstractUiItemsProvider implements UiItemsProvider {
   public readonly id = "appui-test-providers:AbstractUiItemsProvider";
 
-  constructor(
-    localizationNamespace: string,
-    public props?: AbstractUiItemsProviderProps
-  ) {
+  constructor(localizationNamespace: string) {
     // register tools that will be returned via this provider
     OpenAbstractDialogTool.register(localizationNamespace);
     SampleTool.register(localizationNamespace);
     ToolWithDynamicSettings.register(localizationNamespace);
   }
 
-  public provideToolbarItems(
-    _stageId: string,
-    stageUsage: string,
-    toolbarUsage: ToolbarUsage,
-    toolbarOrientation: ToolbarOrientation
-  ): ToolbarItem[] {
-    /** Add a tool that displays tool settings  */
-    if (
-      stageUsage === StageUsage.General.valueOf() &&
-      toolbarUsage === ToolbarUsage.ContentManipulation &&
-      toolbarOrientation === ToolbarOrientation.Horizontal
-    ) {
-      return [
-        SampleTool.getActionButtonDef(
-          this.props?.sampleTool?.itemPriority ?? 1000,
-          this.props?.sampleTool?.groupPriority
-        ),
-        ToolWithDynamicSettings.getActionButtonDef(
-          this.props?.dynamicTool?.itemPriority ?? 1001,
-          this.props?.dynamicTool?.groupPriority
-        ),
-      ];
-    }
-    /** Add a tool that opens a dialog box  */
-    if (
-      stageUsage === StageUsage.General.valueOf() &&
-      toolbarUsage === ToolbarUsage.ContentManipulation &&
-      toolbarOrientation === ToolbarOrientation.Vertical
-    ) {
-      return [
-        OpenAbstractDialogTool.getActionButtonDef(
-          this.props?.openAbstractDialogTool?.itemPriority ?? 10.1,
-          this.props?.openAbstractDialogTool?.groupPriority
-        ),
-      ];
-    }
-
-    return [];
+  public getToolbarItems(): readonly ToolbarItem[] {
+    const horizontal = {
+      standard: {
+        usage: ToolbarUsage.ContentManipulation,
+        orientation: ToolbarOrientation.Horizontal,
+      },
+    };
+    return [
+      ToolbarItemUtilities.createForTool(SampleTool, {
+        itemPriority: 1000,
+        layouts: horizontal,
+      }),
+      ToolbarItemUtilities.createForTool(ToolWithDynamicSettings, {
+        itemPriority: 1001,
+        layouts: horizontal,
+      }),
+      ToolbarItemUtilities.createForTool(OpenAbstractDialogTool, {
+        itemPriority: 10.1,
+        layouts: {
+          standard: {
+            usage: ToolbarUsage.ContentManipulation,
+            orientation: ToolbarOrientation.Vertical,
+          },
+        },
+      }),
+    ];
   }
 
-  public getStatusBarItems(): StatusBarItem[] {
+  public getStatusBarItems(): readonly StatusBarItem[] {
     return [
       /** Add a status bar item that will open a dialog allowing the user to set the active unit system used to display quantity values. */
       StatusBarItemUtilities.createCustomItem({
         id: "AppUiTestProviders:UnitsStatusBarItem",
-        section:
-          this.props?.unitsStatusBarItem?.section ?? StatusBarSection.Center,
-        itemPriority: this.props?.unitsStatusBarItem?.itemPriority ?? 100,
+        section: StatusBarSection.Center,
+        itemPriority: 100,
         content: (
           <UnitsField
             label={AppUiTestProviders.translate("StatusBar.UnitsFlyover")}

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -167,21 +167,14 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
     ];
   }
 
-  public provideStatusBarItems(
-    _stageId: string,
-    stageUsage: string
-  ): StatusBarItem[] {
-    const statusBarItems: StatusBarItem[] = [];
-    if (stageUsage === StageUsage.General.valueOf()) {
-      statusBarItems.push(
-        StatusBarItemUtilities.createCustomItem({
-          id: "DisplayStyle",
-          itemPriority: 400,
-          content: <DisplayStyleField />,
-        })
-      );
-    }
-    return statusBarItems;
+  public getStatusBarItems(): StatusBarItem[] {
+    return [
+      StatusBarItemUtilities.createCustomItem({
+        id: "DisplayStyle",
+        itemPriority: 400,
+        content: <DisplayStyleField />,
+      }),
+    ];
   }
 
   public getBackstageItems(): BackstageItem[] {

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -99,19 +99,9 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
     return [];
   }
 
-  public provideWidgets(
-    _stageId: string,
-    stageUsage: string,
-    location: StagePanelLocation,
-    section?: StagePanelSection
-  ): ReadonlyArray<Widget> {
-    const widgets: Widget[] = [];
-    if (
-      stageUsage === StageUsage.General.valueOf() &&
-      location === StagePanelLocation.Bottom &&
-      section === StagePanelSection.Start
-    ) {
-      widgets.push({
+  public getWidgets(): ReadonlyArray<Widget> {
+    return [
+      {
         id: "appui-test-providers:viewport-old",
         label: "Viewport (old)",
         icon: "icon-bentley-systems",
@@ -121,8 +111,14 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
         },
         canPopout: true,
         content: <ControlViewportWidget />,
-      });
-      widgets.push({
+        layouts: {
+          standard: {
+            location: StagePanelLocation.Bottom,
+            section: StagePanelSection.Start,
+          },
+        },
+      },
+      {
         id: "appui-test-providers:viewport-widget1",
         label: "Viewport 1",
         icon: "icon-bentley-systems",
@@ -132,8 +128,14 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
         },
         canPopout: true,
         content: <ViewportWidget contentId="viewport-widget1" />,
-      });
-      widgets.push({
+        layouts: {
+          standard: {
+            location: StagePanelLocation.Bottom,
+            section: StagePanelSection.Start,
+          },
+        },
+      },
+      {
         id: "appui-test-providers:viewport-widget2",
         label: "Viewport 2",
         icon: "icon-bentley-systems",
@@ -144,19 +146,25 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
         },
         canPopout: true,
         content: <ViewportWidget contentId="viewport-widget2" />,
-      });
-    }
-    if (
-      location === StagePanelLocation.Right &&
-      section === StagePanelSection.End
-    ) {
-      widgets.push({
+        layouts: {
+          standard: {
+            location: StagePanelLocation.Bottom,
+            section: StagePanelSection.Start,
+          },
+        },
+      },
+      {
         id: "active-view",
         label: "Active view",
         content: <ActiveView />,
-      });
-    }
-    return widgets;
+        layouts: {
+          standard: {
+            location: StagePanelLocation.Right,
+            section: StagePanelSection.End,
+          },
+        },
+      },
+    ];
   }
 
   public provideStatusBarItems(

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -2,14 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 import * as React from "react";
 import {
   BackstageItem,
   BackstageItemUtilities,
   StagePanelLocation,
   StagePanelSection,
-  StageUsage,
   StatusBarItem,
   StatusBarItemUtilities,
   ToolbarItem,
@@ -35,8 +33,7 @@ import { ViewportWidget as ViewportWidgetBase } from "../widgets/ViewportWidget"
 import { WidgetContentContext } from "./WidgetContentProvider";
 import { createContentLayoutFrontstage } from "../frontstages/ContentLayoutFrontstage";
 
-/**
- * The ContentLayoutStageUiItemsProvider provides additional items only to the `ContentLayoutStage` frontstage.
+/** The ContentLayoutStageUiItemsProvider provides additional items only to the `ContentLayoutStage` frontstage.
  * This provider provides four tool buttons to:
  *  - toggle between a single view and two side-by-side views.
  *  - activate a tool to save the current view layout and viewstate shown in each view.
@@ -58,48 +55,44 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
     SaveContentLayoutTool.register(localizationNamespace);
   }
 
-  public provideToolbarItems(
-    stageId: string,
-    _stageUsage: string,
-    toolbarUsage: ToolbarUsage,
-    toolbarOrientation: ToolbarOrientation
-  ): ToolbarItem[] {
-    const allowedStages = [createContentLayoutFrontstage.stageId];
-    if (allowedStages.includes(stageId)) {
-      if (
-        toolbarUsage === ToolbarUsage.ContentManipulation &&
-        toolbarOrientation === ToolbarOrientation.Horizontal
-      ) {
-        return [
-          {
-            ...createSplitSingleViewportToolbarItem(() => {
-              return IModelApp.viewManager.selectedView;
-            }),
-            itemPriority: 15,
-            groupPriority: 3000,
+  public getToolbarItems(): readonly ToolbarItem[] {
+    const layouts = {
+      standard: {
+        usage: ToolbarUsage.ViewNavigation,
+        orientation: ToolbarOrientation.Vertical,
+      },
+    };
+    return [
+      createSplitSingleViewportToolbarItem(
+        () => {
+          return IModelApp.viewManager.selectedView;
+        },
+        {
+          itemPriority: 15,
+          groupPriority: 3000,
+          layouts: {
+            standard: {
+              usage: ToolbarUsage.ContentManipulation,
+              orientation: ToolbarOrientation.Horizontal,
+            },
           },
-        ];
-      } else if (
-        toolbarUsage === ToolbarUsage.ViewNavigation &&
-        toolbarOrientation === ToolbarOrientation.Vertical
-      ) {
-        return [
-          ToolbarItemUtilities.createForTool(SaveContentLayoutTool, {
-            itemPriority: 10,
-            groupPriority: 3000,
-          }),
-          ToolbarItemUtilities.createForTool(RestoreSavedContentLayoutTool, {
-            itemPriority: 15,
-            groupPriority: 3000,
-          }),
-          getCustomViewSelectorPopupItem(),
-        ];
-      }
-    }
-    return [];
+        }
+      ),
+      ToolbarItemUtilities.createForTool(SaveContentLayoutTool, {
+        itemPriority: 10,
+        groupPriority: 3000,
+        layouts,
+      }),
+      ToolbarItemUtilities.createForTool(RestoreSavedContentLayoutTool, {
+        itemPriority: 15,
+        groupPriority: 3000,
+        layouts,
+      }),
+      getCustomViewSelectorPopupItem({ layouts }),
+    ];
   }
 
-  public getWidgets(): ReadonlyArray<Widget> {
+  public getWidgets(): readonly Widget[] {
     return [
       {
         id: "appui-test-providers:viewport-old",
@@ -167,7 +160,7 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
     ];
   }
 
-  public getStatusBarItems(): StatusBarItem[] {
+  public getStatusBarItems(): readonly StatusBarItem[] {
     return [
       StatusBarItemUtilities.createCustomItem({
         id: "DisplayStyle",
@@ -177,7 +170,7 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
     ];
   }
 
-  public getBackstageItems(): BackstageItem[] {
+  public getBackstageItems(): readonly BackstageItem[] {
     return [
       BackstageItemUtilities.createStageLauncher({
         stageId: createContentLayoutFrontstage.stageId,

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -176,7 +176,7 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
     return statusBarItems;
   }
 
-  public provideBackstageItems(): BackstageItem[] {
+  public getBackstageItems(): BackstageItem[] {
     return [
       BackstageItemUtilities.createStageLauncher({
         stageId: createContentLayoutFrontstage.stageId,

--- a/apps/test-providers/src/ui/providers/CustomContentStageUiProvider.tsx
+++ b/apps/test-providers/src/ui/providers/CustomContentStageUiProvider.tsx
@@ -49,16 +49,6 @@ export class CustomContentStageUiProvider implements UiItemsProvider {
     "appui-test-providers:CustomContentStageUiProvider";
   public readonly id = CustomContentStageUiProvider.providerId;
 
-  /** method that updates the value in redux store and dispatches a sync event so items are refreshed. */
-  public toggleCustomDialogTool = () => {
-    store.setHideCustomDialogButton(!store.state.hideCustomDialogButton);
-
-    // tell the toolbar to reevaluate state of any item with this event Id
-    SyncUiEventDispatcher.dispatchImmediateSyncUiEvent(
-      AppUiTestProviders.syncEventIdHideCustomDialogButton
-    );
-  };
-
   constructor(localizationNamespace: string) {
     // register tools that will be returned via this provider
     OpenCustomDialogTool.register(localizationNamespace);
@@ -81,7 +71,7 @@ export class CustomContentStageUiProvider implements UiItemsProvider {
         -1,
         visibilitySemiTransparentSvg,
         "Custom Action Button",
-        (): void => {
+        () => {
           IModelApp.notifications.outputMessage(
             new NotifyMessageDetails(
               OutputMessagePriority.Info,
@@ -115,7 +105,12 @@ export class CustomContentStageUiProvider implements UiItemsProvider {
         icon: <SvgActivity />,
         label: "Toggle CustomDialog Button Visibility",
         execute: () => {
-          this.toggleCustomDialogTool();
+          store.setHideCustomDialogButton(!store.state.hideCustomDialogButton);
+
+          // tell the toolbar to reevaluate state of any item with this event Id
+          SyncUiEventDispatcher.dispatchImmediateSyncUiEvent(
+            AppUiTestProviders.syncEventIdHideCustomDialogButton
+          );
         },
       });
 
@@ -191,9 +186,8 @@ export class CustomContentStageUiProvider implements UiItemsProvider {
     return widgets;
   }
 
-  public provideBackstageItems(): BackstageItem[] {
+  public getBackstageItems(): BackstageItem[] {
     return [
-      // use 200 to group it with secondary stages in ui-test-app
       BackstageItemUtilities.createStageLauncher({
         stageId: createCustomContentFrontstage.stageId,
         groupPriority: 200,

--- a/apps/test-providers/src/ui/providers/CustomContentStageUiProvider.tsx
+++ b/apps/test-providers/src/ui/providers/CustomContentStageUiProvider.tsx
@@ -9,7 +9,6 @@ import {
   BackstageItemUtilities,
   StagePanelLocation,
   StagePanelSection,
-  StageUsage,
   SyncUiEventDispatcher,
   ToolbarItem,
   ToolbarItemUtilities,
@@ -41,16 +40,12 @@ import { SampleNonModalDialog } from "../dialogs/SampleNonModalDialog";
 import { createCustomContentFrontstage } from "../frontstages/CustomContentFrontstage";
 import { store } from "../../store";
 
-/**
- * Test UiItemsProvider that provide buttons, and backstage item to stage.
- */
 export class CustomContentStageUiProvider implements UiItemsProvider {
   public static providerId =
     "appui-test-providers:CustomContentStageUiProvider";
   public readonly id = CustomContentStageUiProvider.providerId;
 
   constructor(localizationNamespace: string) {
-    // register tools that will be returned via this provider
     OpenCustomDialogTool.register(localizationNamespace);
   }
 
@@ -160,19 +155,9 @@ export class CustomContentStageUiProvider implements UiItemsProvider {
     return [];
   }
 
-  public provideWidgets(
-    _stageId: string,
-    stageUsage: string,
-    location: StagePanelLocation,
-    section?: StagePanelSection
-  ): ReadonlyArray<Widget> {
-    const widgets: Widget[] = [];
-    if (
-      stageUsage === StageUsage.General.valueOf() &&
-      location === StagePanelLocation.Right &&
-      section === StagePanelSection.Start
-    ) {
-      widgets.push({
+  public getWidgets(): ReadonlyArray<Widget> {
+    return [
+      {
         id: "appui-test-providers:elementDataListWidget",
         label: "Data",
         icon: "icon-flag-2",
@@ -181,9 +166,14 @@ export class CustomContentStageUiProvider implements UiItemsProvider {
           containerId: "ui-item-provider-test:ViewAttributesWidget",
         },
         content: <SelectedElementDataWidgetComponent />,
-      });
-    }
-    return widgets;
+        layouts: {
+          standard: {
+            location: StagePanelLocation.Right,
+            section: StagePanelSection.Start,
+          },
+        },
+      },
+    ];
   }
 
   public getBackstageItems(): BackstageItem[] {

--- a/apps/test-providers/src/ui/providers/FloatingWidgetsUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/FloatingWidgetsUiItemsProvider.tsx
@@ -7,7 +7,6 @@ import { ViewAttributesWidgetComponent } from "../widgets/ViewAttributesWidget";
 import {
   StagePanelLocation,
   StagePanelSection,
-  StageUsage,
   UiItemsProvider,
   Widget,
   WidgetState,
@@ -19,19 +18,15 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
   public static providerId = "appui-test-providers:FloatingWidgetsUiProvider";
   public readonly id = FloatingWidgetsUiItemsProvider.providerId;
 
-  public provideWidgets(
-    _stageId: string,
-    stageUsage: string,
-    location: StagePanelLocation,
-    section?: StagePanelSection
-  ): ReadonlyArray<Widget> {
-    const widgets: Widget[] = [];
-    if (
-      stageUsage === StageUsage.General.valueOf() &&
-      location === StagePanelLocation.Left &&
-      section === StagePanelSection.Start
-    ) {
-      widgets.push({
+  public getWidgets(): ReadonlyArray<Widget> {
+    const layouts = {
+      standard: {
+        location: StagePanelLocation.Left,
+        section: StagePanelSection.Start,
+      },
+    };
+    return [
+      {
         id: "appui-test-providers:ViewAttributesWidget",
         label: "View Attributes",
         icon: "icon-window-settings",
@@ -42,9 +37,9 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
         content: <ViewAttributesWidgetComponent />,
         canPopout: true,
         allowedPanels: [StagePanelLocation.Left, StagePanelLocation.Right],
-      });
-
-      widgets.push({
+        layouts,
+      },
+      {
         id: "FW-1",
         label: "FW-1",
         icon: "icon-app-1",
@@ -54,8 +49,9 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
           defaultPosition: { x: 600, y: 385 },
         },
         content: <div>Floating widget 1</div>,
-      });
-      widgets.push({
+        layouts,
+      },
+      {
         id: "FW-2",
         label: "FW-2",
         icon: "icon-app-2",
@@ -65,8 +61,9 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
         },
         content: <div>Floating widget 2</div>,
         allowedPanels: [],
-      });
-      widgets.push({
+        layouts,
+      },
+      {
         id: "FW-3",
         label: "FW-3",
         icon: "icon-app-1",
@@ -75,9 +72,9 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
           containerId: "appui-test-providers:floating-widget",
         },
         content: <div>Floating widget 3</div>,
-      });
-
-      widgets.push({
+        layouts,
+      },
+      {
         id: "FW-H1",
         label: "FW-H1",
         icon: "icon-visibility-hide",
@@ -86,8 +83,9 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
           containerId: "appui-test-providers:hidden-floating-widget",
         },
         content: <div>Hidden floating widget 1</div>,
-      });
-      widgets.push({
+        layouts,
+      },
+      {
         id: "appui-test-providers:PopoutMountUnmountWidget",
         label: "Mount/Unmount",
         icon: "icon-window-settings",
@@ -101,8 +99,8 @@ export class FloatingWidgetsUiItemsProvider implements UiItemsProvider {
         ),
         canPopout: true,
         allowedPanels: [StagePanelLocation.Left],
-      });
-    }
-    return widgets;
+        layouts,
+      },
+    ];
   }
 }

--- a/apps/test-providers/src/ui/providers/InspectUiItemInfoToolProvider.tsx
+++ b/apps/test-providers/src/ui/providers/InspectUiItemInfoToolProvider.tsx
@@ -2,56 +2,38 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
 import {
-  StageUsage,
   ToolbarItem,
+  ToolbarItemUtilities,
   ToolbarOrientation,
   ToolbarUsage,
   UiItemsProvider,
 } from "@itwin/appui-react";
 import { InspectUiItemInfoTool } from "../../tools/InspectUiItemInfoTool";
 
-export interface InspectUiItemInfoToolProviderProps {
-  inspectTool?: { itemPriority?: number; groupPriority?: number };
-}
-
-/**
- * The InspectUiItemInfoToolProvider registers and provides the InspectUiItemInfoTool to any stage that has a usage value of StageUsage.General.
+/** The InspectUiItemInfoToolProvider registers and provides the InspectUiItemInfoTool to any stage that has a usage value of StageUsage.General.
  * This tool can be used to display info about dynamically provided toolbuttons, status bar items, and widget by hovering over them
  * with mouse.
  */
 export class InspectUiItemInfoToolProvider implements UiItemsProvider {
   public readonly id = "appui-test-providers:InspectUiItemInfoToolProvider";
 
-  constructor(
-    localizationNamespace: string,
-    public props?: InspectUiItemInfoToolProviderProps
-  ) {
+  constructor(localizationNamespace: string) {
     // register tools that will be returned via this provider
     InspectUiItemInfoTool.register(localizationNamespace);
   }
 
-  public provideToolbarItems(
-    _stageId: string,
-    stageUsage: string,
-    toolbarUsage: ToolbarUsage,
-    toolbarOrientation: ToolbarOrientation
-  ): ToolbarItem[] {
-    /** Add a tool that starts inspect tool  */
-    if (
-      stageUsage === StageUsage.General.valueOf() &&
-      toolbarUsage === ToolbarUsage.ContentManipulation &&
-      toolbarOrientation === ToolbarOrientation.Horizontal
-    ) {
-      return [
-        InspectUiItemInfoTool.getActionButtonDef(
-          this.props?.inspectTool?.itemPriority ?? 2000,
-          this.props?.inspectTool?.groupPriority
-        ),
-      ];
-    }
-
-    return [];
+  public getToolbarItems(): readonly ToolbarItem[] {
+    return [
+      ToolbarItemUtilities.createForTool(InspectUiItemInfoTool, {
+        itemPriority: 2000,
+        layouts: {
+          standard: {
+            usage: ToolbarUsage.ContentManipulation,
+            orientation: ToolbarOrientation.Horizontal,
+          },
+        },
+      }),
+    ];
   }
 }

--- a/apps/test-providers/src/ui/providers/MessageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/MessageUiItemsProvider.tsx
@@ -119,7 +119,7 @@ export class MessageUiItemsProvider implements UiItemsProvider {
         layouts: {
           standard: {
             usage: ToolbarUsage.ContentManipulation,
-            orientation: ToolbarOrientation.Horizontal,
+            orientation: ToolbarOrientation.Vertical,
           },
         },
       }),

--- a/apps/test-providers/src/ui/providers/MessageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/MessageUiItemsProvider.tsx
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import {
-  StageUsage,
   ToolbarItem,
   ToolbarItemUtilities,
   ToolbarOrientation,
@@ -27,111 +26,104 @@ export class MessageUiItemsProvider implements UiItemsProvider {
   public static providerId = "appui-test-providers:MessageUiItemsProvider";
   public readonly id = MessageUiItemsProvider.providerId;
 
-  public provideToolbarItems(
-    _stageId: string,
-    stageUsage: string,
-    usage: ToolbarUsage,
-    orientation: ToolbarOrientation
-  ): ToolbarItem[] {
-    if (
-      stageUsage === StageUsage.General.valueOf() &&
-      usage === ToolbarUsage.ContentManipulation &&
-      orientation === ToolbarOrientation.Vertical
-    ) {
-      return [
-        ToolbarItemUtilities.createGroupItem({
-          id: `${this.id}:group`,
-          itemPriority: 10,
-          icon: <SvgPlaceholder />,
-          label: "Messages",
-          items: [
-            ToolbarItemUtilities.createActionItem({
-              id: `${this.id}:activity`,
-              itemPriority: 1,
-              icon: <SvgPlaceholder />,
-              label: "Activity message",
-              execute: async () => {
-                let isCancelled = false;
-                let progress = 0;
+  public getToolbarItems(): readonly ToolbarItem[] {
+    return [
+      ToolbarItemUtilities.createGroupItem({
+        id: `${this.id}:group`,
+        itemPriority: 10,
+        icon: <SvgPlaceholder />,
+        label: "Messages",
+        items: [
+          ToolbarItemUtilities.createActionItem({
+            id: `${this.id}:activity`,
+            itemPriority: 1,
+            icon: <SvgPlaceholder />,
+            label: "Activity message",
+            execute: async () => {
+              let isCancelled = false;
+              let progress = 0;
 
-                if (details) return;
+              if (details) return;
 
-                details = new ActivityMessageDetails(true, true, true, true);
-                details.onActivityCancelled = () => {
-                  isCancelled = true;
-                };
-                IModelApp.notifications.setupActivityMessage(details);
+              details = new ActivityMessageDetails(true, true, true, true);
+              details.onActivityCancelled = () => {
+                isCancelled = true;
+              };
+              IModelApp.notifications.setupActivityMessage(details);
 
-                while (!isCancelled && progress <= 100) {
-                  IModelApp.notifications.outputActivityMessage(
-                    "Sample activity message",
-                    progress
-                  );
-                  await BeDuration.wait(100);
-                  progress++;
-                }
-
-                IModelApp.notifications.endActivityMessage(
-                  ActivityMessageEndReason.Completed
+              while (!isCancelled && progress <= 100) {
+                IModelApp.notifications.outputActivityMessage(
+                  "Sample activity message",
+                  progress
                 );
-                details = undefined;
-              },
-            }),
-            ToolbarItemUtilities.createActionItem({
-              id: `${this.id}:toast`,
-              itemPriority: 1,
-              icon: <SvgPlaceholder />,
-              label: "Toast message",
-              execute: () => {
-                IModelApp.notifications.outputMessage(
-                  new NotifyMessageDetails(
-                    OutputMessagePriority.Info,
-                    "Toast message",
-                    undefined,
-                    OutputMessageType.Toast
-                  )
-                );
-              },
-            }),
-            ToolbarItemUtilities.createActionItem({
-              id: `${this.id}:sticky`,
-              itemPriority: 1,
-              icon: <SvgPlaceholder />,
-              label: "Sticky message",
-              execute: () => {
-                IModelApp.notifications.outputMessage(
-                  new NotifyMessageDetails(
-                    OutputMessagePriority.Info,
-                    "Sticky message",
-                    "Additional message details",
-                    OutputMessageType.Sticky
-                  )
-                );
-              },
-            }),
-            ToolbarItemUtilities.createActionItem({
-              id: `${this.id}:alert`,
-              itemPriority: 1,
-              icon: <SvgPlaceholder />,
-              label: "Alert message",
-              execute: () => {
-                IModelApp.notifications.outputMessage(
-                  new NotifyMessageDetails(
-                    OutputMessagePriority.Fatal,
-                    "Alert message",
-                    undefined,
-                    OutputMessageType.Alert
-                  )
-                );
-              },
-              badgeKind: "new",
-            }),
-          ],
-        }),
-      ];
-    }
+                await BeDuration.wait(100);
+                progress++;
+              }
 
-    return [];
+              IModelApp.notifications.endActivityMessage(
+                ActivityMessageEndReason.Completed
+              );
+              details = undefined;
+            },
+          }),
+          ToolbarItemUtilities.createActionItem({
+            id: `${this.id}:toast`,
+            itemPriority: 1,
+            icon: <SvgPlaceholder />,
+            label: "Toast message",
+            execute: () => {
+              IModelApp.notifications.outputMessage(
+                new NotifyMessageDetails(
+                  OutputMessagePriority.Info,
+                  "Toast message",
+                  undefined,
+                  OutputMessageType.Toast
+                )
+              );
+            },
+          }),
+          ToolbarItemUtilities.createActionItem({
+            id: `${this.id}:sticky`,
+            itemPriority: 1,
+            icon: <SvgPlaceholder />,
+            label: "Sticky message",
+            execute: () => {
+              IModelApp.notifications.outputMessage(
+                new NotifyMessageDetails(
+                  OutputMessagePriority.Info,
+                  "Sticky message",
+                  "Additional message details",
+                  OutputMessageType.Sticky
+                )
+              );
+            },
+          }),
+          ToolbarItemUtilities.createActionItem({
+            id: `${this.id}:alert`,
+            itemPriority: 1,
+            icon: <SvgPlaceholder />,
+            label: "Alert message",
+            execute: () => {
+              IModelApp.notifications.outputMessage(
+                new NotifyMessageDetails(
+                  OutputMessagePriority.Fatal,
+                  "Alert message",
+                  undefined,
+                  OutputMessageType.Alert
+                )
+              );
+            },
+            badgeKind: "new",
+          }),
+        ],
+        layouts: {
+          standard: {
+            usage: ToolbarUsage.ContentManipulation,
+            orientation: ToolbarOrientation.Horizontal,
+          },
+        },
+      }),
+    ];
   }
 }
 

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -649,7 +649,7 @@ export interface BaseItemState {
     isVisible?: boolean;
 }
 
-// @public
+// @public @deprecated
 export class BaseUiItemsProvider implements UiItemsProvider {
     constructor(_providerId: string, isSupportedStage?: ((stageId: string, stageUsage: string, stageAppData?: any, provider?: UiItemsProvider) => boolean) | undefined);
     // (undocumented)
@@ -1646,7 +1646,7 @@ export interface DefaultContentTools {
     };
 }
 
-// @public
+// @public @deprecated
 export interface DefaultContentToolsAppData {
     // (undocumented)
     defaultContentTools?: {
@@ -4380,7 +4380,7 @@ export enum StageUsage {
     ViewOnly = "ViewOnly"
 }
 
-// @public
+// @public @deprecated
 export class StandardContentToolsProvider extends BaseUiItemsProvider {
     constructor(providerId: string, defaultContentTools?: DefaultContentTools | undefined, isSupportedStage?: (stageId: string, stageUsage: string, stageAppData?: any) => boolean);
     // (undocumented)
@@ -4390,14 +4390,18 @@ export class StandardContentToolsProvider extends BaseUiItemsProvider {
     static register(providerId: string, defaultContentTools?: DefaultContentTools, isSupportedStage?: (stageId: string, stageUsage: string, stageAppData?: any) => boolean): StandardContentToolsProvider;
 }
 
-// @beta (undocumented)
+// @public
 export class StandardContentToolsUiItemsProvider implements UiItemsProvider {
     constructor(defaultContextTools?: DefaultContentTools | undefined);
     // (undocumented)
+    getStatusBarItems(): readonly StatusBarItem[];
+    // (undocumented)
+    getToolbarItems(): readonly ToolbarItem[];
+    // (undocumented)
     get id(): string;
-    // (undocumented)
+    // @deprecated (undocumented)
     provideStatusBarItems(_stageId: string, _stageUsage: string, _stageAppData?: any): StatusBarItem[];
-    // (undocumented)
+    // @deprecated (undocumented)
     provideToolbarItems(_stageId: string, _stageUsage: string, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation, stageAppData?: any): ToolbarItem[];
 }
 
@@ -4452,7 +4456,7 @@ export interface StandardMessageBoxProps extends CommonProps {
     title: string;
 }
 
-// @public
+// @public @deprecated
 export class StandardNavigationToolsProvider extends BaseUiItemsProvider {
     constructor(providerId: string, defaultNavigationTools?: DefaultNavigationTools | undefined, isSupportedStage?: (stageId: string, stageUsage: string, stageAppData?: any) => boolean);
     // (undocumented)
@@ -4464,8 +4468,10 @@ export class StandardNavigationToolsProvider extends BaseUiItemsProvider {
 export class StandardNavigationToolsUiItemsProvider implements UiItemsProvider {
     constructor(defaultNavigationTools?: DefaultNavigationTools | undefined);
     // (undocumented)
-    get id(): string;
+    getToolbarItems(): readonly ToolbarItem[];
     // (undocumented)
+    get id(): string;
+    // @deprecated (undocumented)
     provideToolbarItems(_stageId: string, _stageUsage: string, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation, _stageAppData?: any): ToolbarItem[];
 }
 
@@ -4486,7 +4492,7 @@ export class StandardRotationNavigationAidControl extends NavigationAidControl {
     static navigationAidId: string;
 }
 
-// @public
+// @public @deprecated
 export class StandardStatusbarItemsProvider extends BaseUiItemsProvider {
     constructor(providerId: string, _defaultItems?: DefaultStatusbarItems | undefined, isSupportedStage?: (stageId: string, stageUsage: string, stageAppData?: any) => boolean);
     // (undocumented)
@@ -4494,12 +4500,14 @@ export class StandardStatusbarItemsProvider extends BaseUiItemsProvider {
     static register(providerId: string, defaultItems?: DefaultStatusbarItems, isSupportedStage?: (stageId: string, stageUsage: string, stageAppData?: any) => boolean): StandardStatusbarItemsProvider;
 }
 
-// @beta
+// @public
 export class StandardStatusbarUiItemsProvider implements UiItemsProvider {
     constructor(_defaultItems?: DefaultStatusbarItems | undefined);
     // (undocumented)
-    get id(): string;
+    getStatusBarItems(): readonly StatusBarItem[];
     // (undocumented)
+    get id(): string;
+    // @deprecated (undocumented)
     provideStatusBarItems(_stageId: string, _stageUsage: string, _stageAppData?: any): StatusBarItem[];
 }
 

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -94,6 +94,7 @@ public;BackstageToggledArgs
 public;BaseItemState
 deprecated;BaseItemState
 public;BaseUiItemsProvider 
+deprecated;BaseUiItemsProvider 
 public;BasicNavigationWidget(props: BasicNavigationWidgetProps): React_2.JSX.Element
 public;BasicNavigationWidgetProps
 public;BasicToolWidget(props: BasicToolWidgetProps): React_2.JSX.Element
@@ -233,6 +234,7 @@ public;DeepReadonlyObject
 deprecated;DeepReadonlyObject
 public;DefaultContentTools
 public;DefaultContentToolsAppData
+deprecated;DefaultContentToolsAppData
 public;DefaultDialogGridContainer({ componentGenerator, isToolSettings, }:
 public;DefaultNavigationTools
 public;DefaultStatusbarItems
@@ -611,7 +613,8 @@ public;StagePanelSizeSpec = number |
 public;StagePanelState
 public;StageUsage
 public;StandardContentToolsProvider 
-beta;StandardContentToolsUiItemsProvider 
+deprecated;StandardContentToolsProvider 
+public;StandardContentToolsUiItemsProvider 
 public;StandardFrontstageProps
 public;StandardFrontstageProvider 
 deprecated;StandardFrontstageProvider 
@@ -622,11 +625,13 @@ deprecated;StandardMessageBox(props: StandardMessageBoxProps): React_2.JSX.Eleme
 public;StandardMessageBoxProps 
 deprecated;StandardMessageBoxProps 
 public;StandardNavigationToolsProvider 
+deprecated;StandardNavigationToolsProvider 
 public;StandardNavigationToolsUiItemsProvider 
 public;StandardRotationNavigationAidControl 
 deprecated;StandardRotationNavigationAidControl 
 public;StandardStatusbarItemsProvider 
-beta;StandardStatusbarUiItemsProvider 
+deprecated;StandardStatusbarItemsProvider 
+public;StandardStatusbarUiItemsProvider 
 public;StateManager
 deprecated;StateManager
 public;StateType

--- a/common/changes/@itwin/appui-react/deprecate-ui-providers_2024-09-11-16-43.json
+++ b/common/changes/@itwin/appui-react/deprecate-ui-providers_2024-09-11-16-43.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Deprecate remnant APIs related to `provide*` variants of `UiItemsProvider`.",
+      "type": "none"
+    },
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Deprecate APIs related to `BaseUiItemsProvider`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -3,16 +3,24 @@
 Table of contents:
 
 - [@itwin/appui-react](#itwinappui-react)
+  - [Deprecations](#deprecations)
   - [Changes](#changes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Additions](#additions)
-  - [Deprecations](#deprecations)
+  - [Deprecations](#deprecations-1)
 
 ## @itwin/appui-react
+
+### Deprecations
+
+- Deprecated `BaseUiItemsProvider`, `StandardContentToolsProvider`, `StandardNavigationToolsProvider`, `StandardStatusbarItemsProvider` classes. Use `UiItemsProviderOverrides` to specify supported frontstages when registering the provider.
+- Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs.
+- Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead.
 
 ### Changes
 
 - Allow to set the available snap modes in `SnapModeField` component. [#974](https://github.com/iTwin/appui/pull/974)
+- Bump `StandardContentToolsUiItemsProvider`, `StandardStatusbarUiItemsProvider` classes to `@public`.
 
 ## @itwin/components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -13,14 +13,14 @@ Table of contents:
 
 ### Deprecations
 
-- Deprecated `BaseUiItemsProvider`, `StandardContentToolsProvider`, `StandardNavigationToolsProvider`, `StandardStatusbarItemsProvider` classes. Use `UiItemsProviderOverrides` to specify supported frontstages when registering the provider.
-- Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs.
-- Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead.
+- Deprecated `BaseUiItemsProvider`, `StandardContentToolsProvider`, `StandardNavigationToolsProvider`, `StandardStatusbarItemsProvider` classes. Use `UiItemsProviderOverrides` to specify supported frontstages when registering the provider. [#1024](https://github.com/iTwin/appui/pull/1024)
+- Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs. [#1024](https://github.com/iTwin/appui/pull/1024)
+- Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead. [#1024](https://github.com/iTwin/appui/pull/1024)
 
 ### Changes
 
 - Allow to set the available snap modes in `SnapModeField` component. [#974](https://github.com/iTwin/appui/pull/974)
-- Bump `StandardContentToolsUiItemsProvider`, `StandardStatusbarUiItemsProvider` classes to `@public`.
+- Bump `StandardContentToolsUiItemsProvider`, `StandardStatusbarUiItemsProvider` classes to `@public`. [#1024](https://github.com/iTwin/appui/pull/1024)
 
 ## @itwin/components-react
 

--- a/docs/storybook/src/AppUiStory.tsx
+++ b/docs/storybook/src/AppUiStory.tsx
@@ -170,7 +170,7 @@ function Initialized(props: AppUiStoryProps) {
 function Initializer() {
   return (
     <ThemeProvider>
-      <ProgressLinear indeterminate labels={["Getting things ready!"]} />;
+      <ProgressLinear indeterminate labels={["Getting things ready!"]} />
     </ThemeProvider>
   );
 }

--- a/docs/storybook/src/frontstage/Frontstage.stories.tsx
+++ b/docs/storybook/src/frontstage/Frontstage.stories.tsx
@@ -13,7 +13,7 @@ import {
 import { AppUiDecorator } from "../Decorators";
 import { Page } from "../AppUiStory";
 import { FrontstageStory } from "./Frontstage";
-import { removeProperty } from "../Utils";
+import { createWidget, removeProperty } from "../Utils";
 import { VirtualCursorElement, createCursorEvents } from "../VirtualCursor";
 
 const meta = {
@@ -45,26 +45,26 @@ export const Overview: Story = {
     itemProviders: [
       {
         id: "widgets",
-        provideWidgets: (_stageId, _stageUsage, location) => {
-          if (location === StagePanelLocation.Right)
-            return [
-              {
-                id: "w2",
-                label: "Widget 2",
-                content: <>Widget content</>,
+        getWidgets: () => {
+          const layouts = {
+            standard: {
+              location: StagePanelLocation.Right,
+              section: StagePanelSection.Start,
+            },
+          };
+          return [
+            createWidget(1, {
+              defaultState: WidgetState.Floating,
+              canFloat: {
+                defaultPosition: { x: 20, y: 50 },
+                isResizable: true,
               },
-              {
-                id: "w1",
-                label: "Widget 1",
-                content: <>Widget content</>,
-                defaultState: WidgetState.Floating,
-                canFloat: {
-                  defaultPosition: { x: 20, y: 50 },
-                  isResizable: true,
-                },
-              },
-            ];
-          return [];
+              layouts,
+            }),
+            createWidget(2, {
+              layouts,
+            }),
+          ];
         },
       },
     ],
@@ -98,41 +98,44 @@ export const Panels: Story = {
     itemProviders: [
       {
         id: "widgets",
-        provideWidgets: (_stageId, _stageUsage, location) => {
-          if (location === StagePanelLocation.Top)
-            return [
-              {
-                id: "w1",
-                label: "Widget 1",
-                content: <b>Top panel</b>,
+        getWidgets: () => [
+          createWidget(1, {
+            content: <b>Top panel</b>,
+            layouts: {
+              standard: {
+                location: StagePanelLocation.Top,
+                section: StagePanelSection.Start,
               },
-            ];
-          if (location === StagePanelLocation.Left)
-            return [
-              {
-                id: "w2",
-                label: "Widget 2",
-                content: <b>Left panel</b>,
+            },
+          }),
+          createWidget(2, {
+            content: <b>Left panel</b>,
+            layouts: {
+              standard: {
+                location: StagePanelLocation.Left,
+                section: StagePanelSection.Start,
               },
-            ];
-          if (location === StagePanelLocation.Bottom)
-            return [
-              {
-                id: "w3",
-                label: "Widget 3",
-                content: <b>Bottom panel</b>,
+            },
+          }),
+          createWidget(3, {
+            content: <b>Bottom panel</b>,
+            layouts: {
+              standard: {
+                location: StagePanelLocation.Bottom,
+                section: StagePanelSection.Start,
               },
-            ];
-          if (location === StagePanelLocation.Right)
-            return [
-              {
-                id: "w4",
-                label: "Widget 4",
-                content: <b>Right panel</b>,
+            },
+          }),
+          createWidget(4, {
+            content: <b>Right panel</b>,
+            layouts: {
+              standard: {
+                location: StagePanelLocation.Right,
+                section: StagePanelSection.Start,
               },
-            ];
-          return [];
-        },
+            },
+          }),
+        ],
       },
     ],
   },
@@ -153,53 +156,44 @@ export const PanelSections: Story = {
     itemProviders: [
       {
         id: "widgets",
-        provideWidgets: (_stageId, _stageUsage, location, section) => {
-          if (
-            location === StagePanelLocation.Right &&
-            section === StagePanelSection.Start
-          )
-            return [
-              {
-                id: "w3",
-                label: "Widget 3",
-                content: <b>Start section</b>,
+        getWidgets: () => [
+          createWidget(1, {
+            content: <b>Start section</b>,
+            layouts: {
+              standard: {
+                location: StagePanelLocation.Bottom,
+                section: StagePanelSection.Start,
               },
-            ];
-          if (
-            location === StagePanelLocation.Right &&
-            section === StagePanelSection.End
-          )
-            return [
-              {
-                id: "w4",
-                label: "Widget 4",
-                content: <b>End section</b>,
+            },
+          }),
+          createWidget(2, {
+            content: <b>End section</b>,
+            layouts: {
+              standard: {
+                location: StagePanelLocation.Bottom,
+                section: StagePanelSection.End,
               },
-            ];
-          if (
-            location === StagePanelLocation.Bottom &&
-            section === StagePanelSection.Start
-          )
-            return [
-              {
-                id: "w1",
-                label: "Widget 1",
-                content: <b>Start section</b>,
+            },
+          }),
+          createWidget(3, {
+            content: <b>Start section</b>,
+            layouts: {
+              standard: {
+                location: StagePanelLocation.Right,
+                section: StagePanelSection.Start,
               },
-            ];
-          if (
-            location === StagePanelLocation.Bottom &&
-            section === StagePanelSection.End
-          )
-            return [
-              {
-                id: "w2",
-                label: "Widget 2",
-                content: <b>End section</b>,
+            },
+          }),
+          createWidget(4, {
+            content: <b>End section</b>,
+            layouts: {
+              standard: {
+                location: StagePanelLocation.Right,
+                section: StagePanelSection.End,
               },
-            ];
-          return [];
-        },
+            },
+          }),
+        ],
       },
     ],
   },
@@ -210,34 +204,28 @@ export const FloatingWidgets: Story = {
     itemProviders: [
       {
         id: "widgets",
-        provideWidgets: () => {
-          return [
-            {
-              id: "w1",
-              label: "Widget 1",
-              content: <b>Floating widget</b>,
-              defaultState: WidgetState.Floating,
-              canFloat: {
-                defaultPosition: {
-                  x: 20,
-                  y: 20,
-                },
+        getWidgets: () => [
+          createWidget(1, {
+            content: <b>Floating widget</b>,
+            defaultState: WidgetState.Floating,
+            canFloat: {
+              defaultPosition: {
+                x: 20,
+                y: 20,
               },
             },
-            {
-              id: "w2",
-              label: "Widget 2",
-              content: <b>Floating widget</b>,
-              defaultState: WidgetState.Floating,
-              canFloat: {
-                defaultPosition: {
-                  x: 20,
-                  y: 200,
-                },
+          }),
+          createWidget(2, {
+            content: <b>Floating widget</b>,
+            defaultState: WidgetState.Floating,
+            canFloat: {
+              defaultPosition: {
+                x: 20,
+                y: 200,
               },
             },
-          ];
-        },
+          }),
+        ],
       },
     ],
   },
@@ -253,13 +241,15 @@ export const WidgetContainer: Story = {
     itemProviders: [
       {
         id: "widgets",
-        provideWidgets: (_stageId, _stageUsage, location) => {
-          if (location !== StagePanelLocation.Right) return [];
+        getWidgets: () => {
+          const layouts = {
+            standard: {
+              location: StagePanelLocation.Right,
+              section: StagePanelSection.Start,
+            },
+          };
           return [
-            {
-              id: "w1",
-              label: "Widget 1",
-              content: <b>Widget content</b>,
+            createWidget(1, {
               defaultState: WidgetState.Floating,
               canFloat: {
                 defaultPosition: {
@@ -268,40 +258,33 @@ export const WidgetContainer: Story = {
                 },
                 containerId: "fw1",
               },
-            },
-            {
-              id: "w2",
-              label: "Widget 2",
-              content: <b>Widget content</b>,
+              layouts,
+            }),
+            createWidget(2, {
               defaultState: WidgetState.Floating,
               canFloat: {
                 containerId: "fw1",
               },
-            },
-            {
-              id: "w3",
-              label: "Widget 3",
-              content: <b>Widget content</b>,
+              layouts,
+            }),
+            createWidget(3, {
               canFloat: {
                 containerId: "fw1",
               },
-            },
-            {
-              id: "w4",
-              label: "Widget 4",
-              content: <b>Widget content</b>,
+              layouts,
+            }),
+            createWidget(4, {
               canFloat: {
                 containerId: "fw1",
               },
-            },
-            {
-              id: "w5",
-              label: "Widget 5",
-              content: <b>Widget content</b>,
+              layouts,
+            }),
+            createWidget(5, {
               canFloat: {
                 containerId: "fw1",
               },
-            },
+              layouts,
+            }),
           ];
         },
       },
@@ -314,21 +297,14 @@ export const Interaction: Story = {
     itemProviders: [
       {
         id: "widgets",
-        provideWidgets: (_stageId, _stageUsage, location) => {
-          if (location === StagePanelLocation.Right)
-            return [
-              {
-                id: "w1",
-                label: "Widget 1",
-                content: <>Widget content</>,
-              },
-              {
-                id: "w2",
-                label: "Widget 2",
-                content: <>Widget content</>,
-              },
-            ];
-          return [];
+        getWidgets: () => {
+          const layouts = {
+            standard: {
+              location: StagePanelLocation.Right,
+              section: StagePanelSection.Start,
+            },
+          };
+          return [createWidget(1, { layouts }), createWidget(2, { layouts })];
         },
       },
     ],

--- a/docs/storybook/src/frontstage/SplitViewport.stories.tsx
+++ b/docs/storybook/src/frontstage/SplitViewport.stories.tsx
@@ -13,6 +13,8 @@ import {
   IModelViewportControl,
   SyncUiEventId,
   ToolbarItemUtilities,
+  ToolbarOrientation,
+  ToolbarUsage,
   UiFramework,
 } from "@itwin/appui-react";
 import { ConditionalIconItem } from "@itwin/core-react";
@@ -88,57 +90,85 @@ export const Default: Story = {
     itemProviders: [
       {
         id: "toolbar",
-        provideToolbarItems: () => [
-          ToolbarItemUtilities.createActionItem(
-            `Test1and2`,
-            0,
-            new ConditionalIconItem(testIcon1, [
-              SyncUiEventId.ActiveContentChanged,
-            ]),
-            new ConditionalStringValue(
-              () => (leftViewportActive ? "Test 1" : "Test 2"),
-              [SyncUiEventId.ActiveContentChanged]
+        getToolbarItems: () => {
+          return [
+            ...getToolbarItems(
+              ToolbarUsage.ContentManipulation,
+              ToolbarOrientation.Horizontal
             ),
-            () => undefined
-          ),
-          ToolbarItemUtilities.createActionItem(
-            `Test3and4`,
-            1,
-            new ConditionalIconItem(testIcon2, [
-              SyncUiEventId.ActiveContentChanged,
-            ]),
-            new ConditionalStringValue(
-              () => (leftViewportActive ? "Test 3" : "Test 4"),
-              [SyncUiEventId.ActiveContentChanged]
+            ...getToolbarItems(
+              ToolbarUsage.ContentManipulation,
+              ToolbarOrientation.Vertical
             ),
-            () => undefined,
-            {
-              isDisabled: new ConditionalBooleanValue(
-                () => (leftViewportActive ? true : false),
-                [SyncUiEventId.ActiveContentChanged]
-              ),
-            }
-          ),
-          ToolbarItemUtilities.createActionItem(
-            `Test5and6`,
-            2,
-            new ConditionalIconItem(testIcon3, [
-              SyncUiEventId.ActiveContentChanged,
-            ]),
-            new ConditionalStringValue(
-              () => (leftViewportActive ? "Test 5" : "Test 6"),
-              [SyncUiEventId.ActiveContentChanged]
+            ...getToolbarItems(
+              ToolbarUsage.ViewNavigation,
+              ToolbarOrientation.Horizontal
             ),
-            () => undefined,
-            {
-              isHidden: new ConditionalBooleanValue(
-                () => (leftViewportActive ? true : false),
-                [SyncUiEventId.ActiveContentChanged]
-              ),
-            }
-          ),
-        ],
+            ...getToolbarItems(
+              ToolbarUsage.ViewNavigation,
+              ToolbarOrientation.Vertical
+            ),
+          ];
+        },
       },
     ],
   },
 };
+
+function getToolbarItems(usage: ToolbarUsage, orientation: ToolbarOrientation) {
+  const layouts = {
+    standard: {
+      usage,
+      orientation,
+    },
+  };
+  return [
+    ToolbarItemUtilities.createActionItem(
+      `Test1and2`,
+      0,
+      new ConditionalIconItem(testIcon1, [SyncUiEventId.ActiveContentChanged]),
+      new ConditionalStringValue(
+        () => (leftViewportActive ? "Test 1" : "Test 2"),
+        [SyncUiEventId.ActiveContentChanged]
+      ),
+      () => undefined,
+      {
+        layouts,
+      }
+    ),
+    ToolbarItemUtilities.createActionItem(
+      `Test3and4`,
+      1,
+      new ConditionalIconItem(testIcon2, [SyncUiEventId.ActiveContentChanged]),
+      new ConditionalStringValue(
+        () => (leftViewportActive ? "Test 3" : "Test 4"),
+        [SyncUiEventId.ActiveContentChanged]
+      ),
+      () => undefined,
+      {
+        isDisabled: new ConditionalBooleanValue(
+          () => (leftViewportActive ? true : false),
+          [SyncUiEventId.ActiveContentChanged]
+        ),
+        layouts,
+      }
+    ),
+    ToolbarItemUtilities.createActionItem(
+      `Test5and6`,
+      2,
+      new ConditionalIconItem(testIcon3, [SyncUiEventId.ActiveContentChanged]),
+      new ConditionalStringValue(
+        () => (leftViewportActive ? "Test 5" : "Test 6"),
+        [SyncUiEventId.ActiveContentChanged]
+      ),
+      () => undefined,
+      {
+        isHidden: new ConditionalBooleanValue(
+          () => (leftViewportActive ? true : false),
+          [SyncUiEventId.ActiveContentChanged]
+        ),
+        layouts,
+      }
+    ),
+  ];
+}

--- a/docs/storybook/src/keyboard/KeyboardShortcuts.tsx
+++ b/docs/storybook/src/keyboard/KeyboardShortcuts.tsx
@@ -16,7 +16,7 @@ import { createFrontstage, createWidget } from "../Utils";
 function createProvider(): UiItemsProvider {
   return {
     id: "widgets",
-    provideWidgets: () => {
+    getWidgets: () => {
       return [
         createWidget(1, {
           content: (

--- a/docs/storybook/src/widget/CanFloat.tsx
+++ b/docs/storybook/src/widget/CanFloat.tsx
@@ -5,34 +5,29 @@
 import {
   CanFloatWidgetOptions,
   UiItemsProvider,
-  Widget,
   WidgetState,
 } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
+import { createWidget } from "../Utils";
 
 function createProvider(props: CanFloatWidgetOptions): UiItemsProvider {
   return {
     id: "widgets",
-    provideWidgets: () => {
-      const widget1: Widget = {
-        id: "w1",
-        label: "Widget 1",
-        content: <>Widget 1 content</>,
-        defaultState: WidgetState.Floating,
-        canFloat: props,
-      };
-      const widget2: Widget = {
-        id: "w2",
-        label: "Widget 2",
-        content: <>Widget 2 content </>,
-        defaultState: props.containerId ? WidgetState.Floating : undefined,
-        canFloat: props.containerId
-          ? {
-              containerId: props.containerId,
-            }
-          : undefined,
-      };
-      return [widget1, widget2];
+    getWidgets: () => {
+      return [
+        createWidget(1, {
+          defaultState: WidgetState.Floating,
+          canFloat: props,
+        }),
+        createWidget(2, {
+          defaultState: props.containerId ? WidgetState.Floating : undefined,
+          canFloat: props.containerId
+            ? {
+                containerId: props.containerId,
+              }
+            : undefined,
+        }),
+      ];
     },
   };
 }

--- a/docs/storybook/src/widget/CanPopout.tsx
+++ b/docs/storybook/src/widget/CanPopout.tsx
@@ -4,17 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 import { StagePanelState, UiItemsProvider, Widget } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
+import { createWidget } from "../Utils";
 
 function createProvider(props: CanPopoutStoryProps): UiItemsProvider {
   return {
     id: "widgets",
-    provideWidgets: () => [
-      {
-        id: "w1",
-        label: "Widget 1",
-        content: <>Widget 1 content</>,
+    getWidgets: () => [
+      createWidget(1, {
         canPopout: props.canPopout,
-      },
+      }),
     ],
   };
 }

--- a/docs/storybook/src/widget/EmptyState.tsx
+++ b/docs/storybook/src/widget/EmptyState.tsx
@@ -11,7 +11,7 @@ import {
 } from "@itwin/appui-react";
 import { Button } from "@itwin/itwinui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstage } from "../Utils";
+import { createFrontstage, createWidget } from "../Utils";
 
 interface EmptyStateStoryProps {
   /** Toggle this on to hide the widget when there is no data to display. */
@@ -26,12 +26,10 @@ interface EmptyStateStoryProps {
 export function EmptyStateStory(props: EmptyStateStoryProps) {
   const provider = {
     id: "widgets",
-    provideWidgets: () => [
-      {
-        id: "w1",
-        label: "Widget 1",
+    getWidgets: () => [
+      createWidget(1, {
         content: <Widget hideOnEmptyState={props.hideOnEmptyState} />,
-      },
+      }),
     ],
   } satisfies UiItemsProvider;
   return (

--- a/docs/storybook/src/widget/Widget.tsx
+++ b/docs/storybook/src/widget/Widget.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { action } from "@storybook/addon-actions";
 import { StagePanelState, UiItemsProvider, Widget } from "@itwin/appui-react";
 import { AppUiStory } from "../AppUiStory";
-import { createFrontstage } from "../Utils";
+import { createFrontstage, createWidget } from "../Utils";
 
 export function StoryWidget({ id }: { id: string }) {
   React.useEffect(() => {
@@ -21,16 +21,14 @@ export function StoryWidget({ id }: { id: string }) {
 function createProvider(widgets: WidgetStoryProps["widgets"]): UiItemsProvider {
   return {
     id: "widgets",
-    provideWidgets: () => {
+    getWidgets: () => {
       return Array.from({ length: widgets.length }, (_, index) => {
         const widget = widgets[index];
-        const id = `w${index + 1}`;
-        return {
-          id,
-          label: `Widget ${index + 1}`,
-          content: <StoryWidget id={id} />,
+        const id = index + 1;
+        return createWidget(id, {
+          content: <StoryWidget id={`${id}`} />,
           ...widget,
-        } satisfies Widget;
+        });
       });
     },
   };

--- a/ui/appui-react/src/appui-react/ui-items-provider/BaseUiItemsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/BaseUiItemsProvider.ts
@@ -16,12 +16,13 @@ import type {
   ToolbarUsage,
 } from "../toolbar/ToolbarItem";
 import type { Widget } from "../widgets/Widget";
-import { UiItemsManager } from "./UiItemsManager";
+import { UiItemsManager, UiItemsProviderOverrides } from "./UiItemsManager";
 import type { UiItemsProvider } from "./UiItemsProvider";
 
 /** Base implementation of a UiItemsProvider. The base class allows the user to pass in a function that is used to determine if the
  * active stage should be provided items. Derived provider classes should override the `xxxInternal` methods to provide items.
  * @public
+ * @deprecated in 4.17.0. Use {@link UiItemsProviderOverrides} to specify supported frontstages when {@link UiItemsManager.register registering} the provider.
  */
 export class BaseUiItemsProvider implements UiItemsProvider {
   /*

--- a/ui/appui-react/src/appui-react/ui-items-provider/BaseUiItemsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/BaseUiItemsProvider.ts
@@ -22,7 +22,7 @@ import type { UiItemsProvider } from "./UiItemsProvider";
 /** Base implementation of a UiItemsProvider. The base class allows the user to pass in a function that is used to determine if the
  * active stage should be provided items. Derived provider classes should override the `xxxInternal` methods to provide items.
  * @public
- * @deprecated in 4.17.0. Use {@link UiItemsProviderOverrides} to specify supported frontstages when {@link UiItemsManager.register registering} the provider.
+ * @deprecated in 4.17.0. Use {@link UiItemsProviderOverrides} to specify supported frontstages when registering the provider.
  */
 export class BaseUiItemsProvider implements UiItemsProvider {
   /*

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsProvider.tsx
@@ -41,6 +41,7 @@ import type { StatusBarItem } from "../statusbar/StatusBarItem";
  *
  * ```
  * @public
+ * @deprecated in 4.17.0. Application data is not supported in frontstages. Instead configure the {@link UiItemsProvider} before registering for a specific frontstage.
  */
 export interface DefaultContentToolsAppData {
   defaultContentTools?: {

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsProvider.tsx
@@ -17,6 +17,7 @@ import type {
   ToolbarUsage,
 } from "../toolbar/ToolbarItem";
 import type { StatusBarItem } from "../statusbar/StatusBarItem";
+import { UiItemsProvider } from "./UiItemsProvider";
 
 /**
  * Defines options that may be set in frontstage app data to control what group priorities
@@ -57,10 +58,11 @@ export interface DefaultContentToolsAppData {
   };
 }
 
-/**
- * Provide standard tools for the ContentManipulationWidgetComposer.
+/** Provide standard tools for the ContentManipulationWidgetComposer.
  * @public
+ * @deprecated in 4.17.0. Use {@link StandardContentToolsUiItemsProvider} instead. Supported frontstages can be specified when registering the provider.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class StandardContentToolsProvider extends BaseUiItemsProvider {
   private uiItemsProvider: StandardContentToolsUiItemsProvider;
   /**
@@ -81,6 +83,7 @@ export class StandardContentToolsProvider extends BaseUiItemsProvider {
       stageAppData?: any
     ) => boolean
   ) {
+    // eslint-disable-next-line deprecation/deprecation
     const provider = new StandardContentToolsProvider(
       providerId,
       defaultContentTools,

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsUiItemsProvider.tsx
@@ -49,7 +49,9 @@ function getGroupPriority(potentialId: any, defaultValue: number) {
   return defaultValue;
 }
 
-/** @beta */
+/** Provides standard content manipulation items.
+ * @public
+ */
 export class StandardContentToolsUiItemsProvider implements UiItemsProvider {
   public get id(): string {
     return "appui-react:StandardContentToolsUiItemsProvider";

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsUiItemsProvider.tsx
@@ -57,6 +57,7 @@ export class StandardContentToolsUiItemsProvider implements UiItemsProvider {
 
   constructor(private defaultContextTools?: DefaultContentTools) {}
 
+  /** @deprecated in 4.17.0. Property of a deprecated interface {@link UiItemsProvider.provideToolbarItems}. */
   public provideToolbarItems(
     _stageId: string,
     _stageUsage: string,
@@ -64,155 +65,16 @@ export class StandardContentToolsUiItemsProvider implements UiItemsProvider {
     toolbarOrientation: ToolbarOrientation,
     stageAppData?: any
   ): ToolbarItem[] {
-    const items: ToolbarItem[] = [];
+    const allItems = getAllToolbarItems(this.defaultContextTools, stageAppData);
+    return allItems.filter(
+      (item) =>
+        item.layouts?.standard?.usage === toolbarUsage &&
+        item.layouts?.standard?.orientation === toolbarOrientation
+    );
+  }
 
-    if (
-      toolbarUsage === ToolbarUsage.ContentManipulation &&
-      toolbarOrientation === ToolbarOrientation.Horizontal
-    ) {
-      const clearSelectionGroupPriority = getGroupPriority(
-        stageAppData?.defaultContentTools?.horizontal
-          ?.clearSelectionGroupPriority,
-        10
-      );
-      const overridesGroupPriority = getGroupPriority(
-        stageAppData?.defaultContentTools?.horizontal?.overridesGroupPriority,
-        20
-      );
-
-      if (
-        !this.defaultContextTools ||
-        !this.defaultContextTools.horizontal ||
-        this.defaultContextTools.horizontal.clearSelection
-      )
-        items.push(
-          ToolbarItems.createClearSelection({
-            itemPriority: 10,
-            groupPriority: clearSelectionGroupPriority,
-          })
-        );
-
-      if (
-        !this.defaultContextTools ||
-        !this.defaultContextTools.horizontal ||
-        this.defaultContextTools.horizontal.clearDisplayOverrides
-      )
-        items.push(
-          ToolbarItems.createClearHideIsolateEmphasizeElements({
-            itemPriority: 20,
-            groupPriority: overridesGroupPriority,
-          })
-        );
-
-      if (
-        !this.defaultContextTools ||
-        !this.defaultContextTools.horizontal ||
-        this.defaultContextTools.horizontal.hide
-      ) {
-        if (this.defaultContextTools?.horizontal?.hide === "group")
-          items.push(
-            ToolbarItems.createHideSectionGroup({
-              itemPriority: 30,
-              groupPriority: overridesGroupPriority,
-            })
-          );
-        else
-          items.push(
-            ToolbarItems.createHideElements({
-              itemPriority: 30,
-              groupPriority: overridesGroupPriority,
-            })
-          );
-      }
-
-      if (
-        !this.defaultContextTools ||
-        !this.defaultContextTools.horizontal ||
-        this.defaultContextTools.horizontal.isolate
-      ) {
-        if (this.defaultContextTools?.horizontal?.isolate === "group")
-          items.push(
-            ToolbarItems.createIsolateSelectionGroup({
-              itemPriority: 40,
-              groupPriority: overridesGroupPriority,
-            })
-          );
-        else
-          items.push(
-            ToolbarItems.createIsolateElements({
-              itemPriority: 40,
-              groupPriority: overridesGroupPriority,
-            })
-          );
-      }
-
-      if (
-        !this.defaultContextTools ||
-        !this.defaultContextTools.horizontal ||
-        this.defaultContextTools.horizontal.emphasize
-      ) {
-        items.push(
-          ToolbarItems.createEmphasizeElements({
-            itemPriority: 50,
-            groupPriority: overridesGroupPriority,
-          })
-        );
-      }
-    } else if (
-      toolbarUsage === ToolbarUsage.ContentManipulation &&
-      toolbarOrientation === ToolbarOrientation.Vertical
-    ) {
-      const selectElementGroupPriority = getGroupPriority(
-        stageAppData?.defaultContentTools?.vertical?.selectElementGroupPriority,
-        10
-      );
-      const measureGroupPriority = getGroupPriority(
-        stageAppData?.defaultContentTools?.vertical?.measureGroupPriority,
-        10
-      );
-      const selectionGroupPriority = getGroupPriority(
-        stageAppData?.defaultContentTools?.vertical?.selectionGroupPriority,
-        10
-      );
-
-      if (
-        !this.defaultContextTools ||
-        !this.defaultContextTools.vertical ||
-        this.defaultContextTools.vertical.selectElement
-      )
-        items.push(
-          ToolbarItems.createSelectElement({
-            itemPriority: 10,
-            groupPriority: selectElementGroupPriority,
-          })
-        );
-
-      if (
-        !this.defaultContextTools ||
-        !this.defaultContextTools.vertical ||
-        this.defaultContextTools.vertical.measureGroup
-      )
-        items.push(
-          ToolbarItems.createMeasureGroup({
-            itemPriority: 20,
-            groupPriority: measureGroupPriority,
-          })
-        );
-
-      if (
-        !this.defaultContextTools ||
-        !this.defaultContextTools.vertical ||
-        this.defaultContextTools.vertical.sectionGroup
-      ) {
-        items.push(
-          ToolbarItems.createSectionGroup({
-            itemPriority: 30,
-            groupPriority: selectionGroupPriority,
-          })
-        );
-      }
-    }
-    return items;
+  public getToolbarItems(): readonly ToolbarItem[] {
+    return getAllToolbarItems(this.defaultContextTools, undefined);
   }
 
   /** @deprecated in 4.17.0. Property of a deprecated interface {@link UiItemsProvider.provideStatusBarItems}. */
@@ -241,4 +103,172 @@ export class StandardContentToolsUiItemsProvider implements UiItemsProvider {
 
     return statusBarItems;
   }
+}
+
+// Extracted due to discontinued `stageAppData` usage, until `provideToolbarItems` is removed.
+function getAllToolbarItems(
+  defaultContextTools?: DefaultContentTools,
+  stageAppData?: any
+): ToolbarItem[] {
+  const items: ToolbarItem[] = [];
+  const clearSelectionGroupPriority = getGroupPriority(
+    stageAppData?.defaultContentTools?.horizontal?.clearSelectionGroupPriority,
+    10
+  );
+  const overridesGroupPriority = getGroupPriority(
+    stageAppData?.defaultContentTools?.horizontal?.overridesGroupPriority,
+    20
+  );
+
+  const horizontal = {
+    standard: {
+      usage: ToolbarUsage.ContentManipulation,
+      orientation: ToolbarOrientation.Horizontal,
+    },
+  };
+  if (
+    !defaultContextTools ||
+    !defaultContextTools.horizontal ||
+    defaultContextTools.horizontal.clearSelection
+  )
+    items.push(
+      ToolbarItems.createClearSelection({
+        itemPriority: 10,
+        groupPriority: clearSelectionGroupPriority,
+        layouts: horizontal,
+      })
+    );
+
+  if (
+    !defaultContextTools ||
+    !defaultContextTools.horizontal ||
+    defaultContextTools.horizontal.clearDisplayOverrides
+  )
+    items.push(
+      ToolbarItems.createClearHideIsolateEmphasizeElements({
+        itemPriority: 20,
+        groupPriority: overridesGroupPriority,
+        layouts: horizontal,
+      })
+    );
+
+  if (
+    !defaultContextTools ||
+    !defaultContextTools.horizontal ||
+    defaultContextTools.horizontal.hide
+  ) {
+    if (defaultContextTools?.horizontal?.hide === "group")
+      items.push(
+        ToolbarItems.createHideSectionGroup({
+          itemPriority: 30,
+          groupPriority: overridesGroupPriority,
+          layouts: horizontal,
+        })
+      );
+    else
+      items.push(
+        ToolbarItems.createHideElements({
+          itemPriority: 30,
+          groupPriority: overridesGroupPriority,
+          layouts: horizontal,
+        })
+      );
+  }
+
+  if (
+    !defaultContextTools ||
+    !defaultContextTools.horizontal ||
+    defaultContextTools.horizontal.isolate
+  ) {
+    if (defaultContextTools?.horizontal?.isolate === "group")
+      items.push(
+        ToolbarItems.createIsolateSelectionGroup({
+          itemPriority: 40,
+          groupPriority: overridesGroupPriority,
+          layouts: horizontal,
+        })
+      );
+    else
+      items.push(
+        ToolbarItems.createIsolateElements({
+          itemPriority: 40,
+          groupPriority: overridesGroupPriority,
+          layouts: horizontal,
+        })
+      );
+  }
+
+  if (
+    !defaultContextTools ||
+    !defaultContextTools.horizontal ||
+    defaultContextTools.horizontal.emphasize
+  ) {
+    items.push(
+      ToolbarItems.createEmphasizeElements({
+        itemPriority: 50,
+        groupPriority: overridesGroupPriority,
+        layouts: horizontal,
+      })
+    );
+  }
+
+  const vertical = {
+    standard: {
+      usage: ToolbarUsage.ContentManipulation,
+      orientation: ToolbarOrientation.Vertical,
+    },
+  };
+  const selectElementGroupPriority = getGroupPriority(
+    stageAppData?.defaultContentTools?.vertical?.selectElementGroupPriority,
+    10
+  );
+  const measureGroupPriority = getGroupPriority(
+    stageAppData?.defaultContentTools?.vertical?.measureGroupPriority,
+    10
+  );
+  const selectionGroupPriority = getGroupPriority(
+    stageAppData?.defaultContentTools?.vertical?.selectionGroupPriority,
+    10
+  );
+
+  if (
+    !defaultContextTools ||
+    !defaultContextTools.vertical ||
+    defaultContextTools.vertical.selectElement
+  )
+    items.push(
+      ToolbarItems.createSelectElement({
+        itemPriority: 10,
+        groupPriority: selectElementGroupPriority,
+        layouts: vertical,
+      })
+    );
+
+  if (
+    !defaultContextTools ||
+    !defaultContextTools.vertical ||
+    defaultContextTools.vertical.measureGroup
+  )
+    items.push(
+      ToolbarItems.createMeasureGroup({
+        itemPriority: 20,
+        groupPriority: measureGroupPriority,
+        layouts: vertical,
+      })
+    );
+
+  if (
+    !defaultContextTools ||
+    !defaultContextTools.vertical ||
+    defaultContextTools.vertical.sectionGroup
+  ) {
+    items.push(
+      ToolbarItems.createSectionGroup({
+        itemPriority: 30,
+        groupPriority: selectionGroupPriority,
+        layouts: vertical,
+      })
+    );
+  }
+  return items;
 }

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardContentToolsUiItemsProvider.tsx
@@ -49,9 +49,7 @@ function getGroupPriority(potentialId: any, defaultValue: number) {
   return defaultValue;
 }
 
-/**
- * @beta
- */
+/** @beta */
 export class StandardContentToolsUiItemsProvider implements UiItemsProvider {
   public get id(): string {
     return "appui-react:StandardContentToolsUiItemsProvider";
@@ -217,11 +215,16 @@ export class StandardContentToolsUiItemsProvider implements UiItemsProvider {
     return items;
   }
 
+  /** @deprecated in 4.17.0. Property of a deprecated interface {@link UiItemsProvider.provideStatusBarItems}. */
   public provideStatusBarItems(
     _stageId: string,
     _stageUsage: string,
     _stageAppData?: any
   ): StatusBarItem[] {
+    return this.getStatusBarItems() as StatusBarItem[];
+  }
+
+  public getStatusBarItems(): readonly StatusBarItem[] {
     const statusBarItems: StatusBarItem[] = [];
 
     // if the sectionGroup tools are to be shown then we want the status field added to allow clearing or manipulation the section

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsProvider.ts
@@ -16,10 +16,11 @@ import type { DefaultNavigationTools } from "./StandardNavigationToolsUiItemsPro
 import { StandardNavigationToolsUiItemsProvider } from "./StandardNavigationToolsUiItemsProvider";
 import { UiItemsManager } from "./UiItemsManager";
 
-/**
- * Provide standard tools for the ViewNavigationWidgetComposer.
+/** Provide standard tools for the ViewNavigationWidgetComposer.
  * @public
+ * @deprecated in 4.17.0. Use {@link StandardNavigationToolsUiItemsProvider} instead. Supported frontstages can be specified when registering the provider.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class StandardNavigationToolsProvider extends BaseUiItemsProvider {
   private uiItemsProvider: StandardNavigationToolsUiItemsProvider;
   /**
@@ -40,6 +41,7 @@ export class StandardNavigationToolsProvider extends BaseUiItemsProvider {
       stageAppData?: any
     ) => boolean
   ) {
+    // eslint-disable-next-line deprecation/deprecation
     const provider = new StandardNavigationToolsProvider(
       providerId,
       defaultNavigationTools,

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsUiItemsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsUiItemsProvider.ts
@@ -31,8 +31,7 @@ export interface DefaultNavigationTools {
   };
 }
 
-/**
- * Provide standard tools for the ViewNavigationWidgetComposer.
+/** Provide standard tools for the ViewNavigationWidgetComposer.
  * @public
  */
 export class StandardNavigationToolsUiItemsProvider implements UiItemsProvider {

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsUiItemsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsUiItemsProvider.ts
@@ -31,7 +31,7 @@ export interface DefaultNavigationTools {
   };
 }
 
-/** Provide standard tools for the ViewNavigationWidgetComposer.
+/** Provide standard view navigation items.
  * @public
  */
 export class StandardNavigationToolsUiItemsProvider implements UiItemsProvider {

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsUiItemsProvider.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardNavigationToolsUiItemsProvider.ts
@@ -42,6 +42,7 @@ export class StandardNavigationToolsUiItemsProvider implements UiItemsProvider {
 
   constructor(private defaultNavigationTools?: DefaultNavigationTools) {}
 
+  /** @deprecated in 4.17.0. Property of a deprecated interface {@link UiItemsProvider.provideToolbarItems}. */
   public provideToolbarItems(
     _stageId: string,
     _stageUsage: string,
@@ -49,110 +50,131 @@ export class StandardNavigationToolsUiItemsProvider implements UiItemsProvider {
     toolbarOrientation: ToolbarOrientation,
     _stageAppData?: any
   ): ToolbarItem[] {
+    return this.getToolbarItems().filter(
+      (item) =>
+        item.layouts?.standard?.orientation === toolbarOrientation &&
+        item.layouts?.standard?.usage === toolbarUsage
+    );
+  }
+
+  public getToolbarItems(): readonly ToolbarItem[] {
     const items: ToolbarItem[] = [];
+    const horizontal = {
+      standard: {
+        orientation: ToolbarOrientation.Horizontal,
+        usage: ToolbarUsage.ViewNavigation,
+      },
+    };
     if (
-      toolbarUsage === ToolbarUsage.ViewNavigation &&
-      toolbarOrientation === ToolbarOrientation.Horizontal
+      !this.defaultNavigationTools ||
+      !this.defaultNavigationTools.horizontal ||
+      this.defaultNavigationTools.horizontal.rotateView
+    )
+      items.push(
+        ToolbarItems.createRotateView({
+          itemPriority: 10,
+          layouts: horizontal,
+        })
+      );
+
+    if (
+      !this.defaultNavigationTools ||
+      !this.defaultNavigationTools.horizontal ||
+      this.defaultNavigationTools.horizontal.panView
+    )
+      items.push(
+        ToolbarItems.createPanView({
+          itemPriority: 20,
+          layouts: horizontal,
+        })
+      );
+
+    if (
+      !this.defaultNavigationTools ||
+      !this.defaultNavigationTools.horizontal ||
+      this.defaultNavigationTools.horizontal.fitView
     ) {
-      if (
-        !this.defaultNavigationTools ||
-        !this.defaultNavigationTools.horizontal ||
-        this.defaultNavigationTools.horizontal.rotateView
-      )
-        items.push(
-          ToolbarItems.createRotateView({
-            itemPriority: 10,
-          })
-        );
-
-      if (
-        !this.defaultNavigationTools ||
-        !this.defaultNavigationTools.horizontal ||
-        this.defaultNavigationTools.horizontal.panView
-      )
-        items.push(
-          ToolbarItems.createPanView({
-            itemPriority: 20,
-          })
-        );
-
-      if (
-        !this.defaultNavigationTools ||
-        !this.defaultNavigationTools.horizontal ||
-        this.defaultNavigationTools.horizontal.fitView
-      ) {
-        items.push(
-          ToolbarItems.createFitView({
-            itemPriority: 30,
-          })
-        );
-      }
-
-      if (
-        !this.defaultNavigationTools ||
-        !this.defaultNavigationTools.horizontal ||
-        this.defaultNavigationTools.horizontal.windowArea
-      ) {
-        items.push(
-          ToolbarItems.createWindowArea({
-            itemPriority: 40,
-          })
-        );
-      }
-
-      if (
-        !this.defaultNavigationTools ||
-        !this.defaultNavigationTools.horizontal ||
-        this.defaultNavigationTools.horizontal.viewUndoRedo
-      ) {
-        items.push(
-          ToolbarItems.createViewUndo({
-            itemPriority: 50,
-          })
-        );
-        items.push(
-          ToolbarItems.createViewRedo({
-            itemPriority: 60,
-          })
-        );
-      }
-    } else if (
-      toolbarUsage === ToolbarUsage.ViewNavigation &&
-      toolbarOrientation === ToolbarOrientation.Vertical
-    ) {
-      if (
-        !this.defaultNavigationTools ||
-        !this.defaultNavigationTools.vertical ||
-        this.defaultNavigationTools.vertical.setupWalkCamera
-      )
-        items.push(
-          ToolbarItems.createSetupWalkCamera({
-            itemPriority: 5,
-          })
-        );
-
-      if (
-        !this.defaultNavigationTools ||
-        !this.defaultNavigationTools.vertical ||
-        this.defaultNavigationTools.vertical.walk
-      )
-        items.push(
-          ToolbarItems.createWalkView({
-            itemPriority: 10,
-          })
-        );
-
-      if (
-        !this.defaultNavigationTools ||
-        !this.defaultNavigationTools.vertical ||
-        this.defaultNavigationTools.vertical.toggleCamera
-      )
-        items.push(
-          ToolbarItems.createToggleCameraView({
-            itemPriority: 20,
-          })
-        );
+      items.push(
+        ToolbarItems.createFitView({
+          itemPriority: 30,
+          layouts: horizontal,
+        })
+      );
     }
+
+    if (
+      !this.defaultNavigationTools ||
+      !this.defaultNavigationTools.horizontal ||
+      this.defaultNavigationTools.horizontal.windowArea
+    ) {
+      items.push(
+        ToolbarItems.createWindowArea({
+          itemPriority: 40,
+          layouts: horizontal,
+        })
+      );
+    }
+
+    if (
+      !this.defaultNavigationTools ||
+      !this.defaultNavigationTools.horizontal ||
+      this.defaultNavigationTools.horizontal.viewUndoRedo
+    ) {
+      items.push(
+        ToolbarItems.createViewUndo({
+          itemPriority: 50,
+          layouts: horizontal,
+        })
+      );
+      items.push(
+        ToolbarItems.createViewRedo({
+          itemPriority: 60,
+          layouts: horizontal,
+        })
+      );
+    }
+
+    const vertical = {
+      standard: {
+        orientation: ToolbarOrientation.Vertical,
+        usage: ToolbarUsage.ViewNavigation,
+      },
+    };
+    if (
+      !this.defaultNavigationTools ||
+      !this.defaultNavigationTools.vertical ||
+      this.defaultNavigationTools.vertical.setupWalkCamera
+    )
+      items.push(
+        ToolbarItems.createSetupWalkCamera({
+          itemPriority: 5,
+          layouts: vertical,
+        })
+      );
+
+    if (
+      !this.defaultNavigationTools ||
+      !this.defaultNavigationTools.vertical ||
+      this.defaultNavigationTools.vertical.walk
+    )
+      items.push(
+        ToolbarItems.createWalkView({
+          itemPriority: 10,
+          layouts: vertical,
+        })
+      );
+
+    if (
+      !this.defaultNavigationTools ||
+      !this.defaultNavigationTools.vertical ||
+      this.defaultNavigationTools.vertical.toggleCamera
+    )
+      items.push(
+        ToolbarItems.createToggleCameraView({
+          itemPriority: 20,
+          layouts: vertical,
+        })
+      );
     return items;
   }
 }

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarItemsProvider.tsx
@@ -14,7 +14,9 @@ import { BaseUiItemsProvider } from "./BaseUiItemsProvider";
 
 /** Provide standard status bar fields.
  * @public
+ * @deprecated in 4.17.0. Use {@link StandardStatusbarUiItemsProvider} instead. Supported frontstages can be specified when registering the provider.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class StandardStatusbarItemsProvider extends BaseUiItemsProvider {
   private uiItemsProvider: StandardStatusbarUiItemsProvider;
   constructor(
@@ -48,6 +50,7 @@ export class StandardStatusbarItemsProvider extends BaseUiItemsProvider {
       stageAppData?: any
     ) => boolean
   ) {
+    // eslint-disable-next-line deprecation/deprecation
     const provider = new StandardStatusbarItemsProvider(
       providerId,
       defaultItems,

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
@@ -48,11 +48,16 @@ export class StandardStatusbarUiItemsProvider implements UiItemsProvider {
   /** Creates a provider. If the `defaultItems` argument is not set, all default fields are added. Otherwise, only the fields that are set to `true` are added. */
   constructor(private _defaultItems?: DefaultStatusbarItems) {}
 
+  /** @deprecated in 4.17.0. Property of a deprecated interface {@link UiItemsProvider.provideStatusBarItems}. */
   public provideStatusBarItems(
     _stageId: string,
     _stageUsage: string,
     _stageAppData?: any
   ): StatusBarItem[] {
+    return this.getStatusBarItems() as StatusBarItem[];
+  }
+
+  public getStatusBarItems(): readonly StatusBarItem[] {
     const statusBarItems: StatusBarItem[] = [];
     if (!this._defaultItems || this._defaultItems.messageCenter) {
       statusBarItems.push(

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
@@ -37,8 +37,8 @@ export interface DefaultStatusbarItems {
   selectionInfo?: boolean;
 }
 
-/** Provide standard status bar fields.
- * @beta
+/** Provides standard status bar items.
+ * @public
  */
 export class StandardStatusbarUiItemsProvider implements UiItemsProvider {
   public get id(): string {


### PR DESCRIPTION
## Changes

This PR deprecates APIs related to `BaseUiItemsProvider` since these are no longer possible to implement with the new `get*` methods. Additionally, `provide*` methods are deprecated explicitly, and new `get*` variants are added instead.

## Testing

N/A
