### PR TITLE
Active content

### DIFF
--- a/apps/test-app/src/frontend/logger.ts
+++ b/apps/test-app/src/frontend/logger.ts
@@ -24,5 +24,4 @@ export function initializeLogger() {
 
   Logger.setLevelDefault(LogLevel.Warning);
   Logger.setLevel(loggerCategory, LogLevel.Info);
-  Logger.setLevel("ViewportComponent", LogLevel.Info);
 }

--- a/apps/test-providers/src/appui-test-providers.ts
+++ b/apps/test-providers/src/appui-test-providers.ts
@@ -46,6 +46,7 @@ export * from "./ui/widgets/LayoutWidget";
 export * from "./ui/widgets/LogLifecycleWidget";
 export * from "./ui/widgets/UseWidgetHookWidget";
 
+export * from "./ui/useActiveContentId";
 export * from "./ui/ViewportContent";
 
 export * from "./AppUiTestProviders";

--- a/apps/test-providers/src/tools/ContentLayoutTools.tsx
+++ b/apps/test-providers/src/tools/ContentLayoutTools.tsx
@@ -233,6 +233,7 @@ export function createSplitSingleViewportToolbarItem(
         classId: "",
         content: (
           <ViewportContent
+            contentId="imodel-view-0"
             viewState={viewState1}
             imodel={viewport.view.iModel}
           />
@@ -246,6 +247,7 @@ export function createSplitSingleViewportToolbarItem(
         classId: "",
         content: (
           <ViewportContent
+            contentId="imodel-view-1"
             viewState={viewState2}
             imodel={viewport.view.iModel}
           />
@@ -275,6 +277,7 @@ export function createSplitSingleViewportToolbarItem(
         classId: "",
         content: (
           <ViewportContent
+            contentId="imodel-view-0"
             viewState={viewState}
             imodel={viewport.view.iModel}
             renderViewOverlay={() => undefined}

--- a/apps/test-providers/src/tools/ContentLayoutTools.tsx
+++ b/apps/test-providers/src/tools/ContentLayoutTools.tsx
@@ -268,12 +268,14 @@ export function createSplitSingleViewportToolbarItem(
       await UiFramework.content.layouts.setActiveContentGroup(newContentGroup);
     } else if (2 === contentGroup.contentPropsList.length) {
       const contentPropsArray: ContentProps[] = [];
+      const viewState = viewport.view.clone();
+      viewState.description = "imodel-view-0";
       contentPropsArray.push({
         id: "imodel-view-0",
         classId: "",
         content: (
           <ViewportContent
-            viewState={viewport.view.clone()}
+            viewState={viewState}
             imodel={viewport.view.iModel}
             renderViewOverlay={() => undefined}
           />

--- a/apps/test-providers/src/tools/OpenSynchronizedViewTool.tsx
+++ b/apps/test-providers/src/tools/OpenSynchronizedViewTool.tsx
@@ -35,6 +35,7 @@ export class OpenSynchronizedViewTool extends Tool {
     let y: number | undefined;
     const stage = UiFramework.frontstages.activeFrontstageDef;
     if (stage && stage.nineZoneState) {
+      // eslint-disable-next-line deprecation/deprecation
       const floatingContentCount = stage.floatingContentControls?.length ?? 0;
       // we should not really every support more than 8 floating views
       if (

--- a/apps/test-providers/src/ui/frontstages/ContentLayoutFrontstage.tsx
+++ b/apps/test-providers/src/ui/frontstages/ContentLayoutFrontstage.tsx
@@ -89,5 +89,4 @@ export function createContentLayoutFrontstage() {
     usage: StageUsage.General,
   });
 }
-createContentLayoutFrontstage.stageId =
-  "appui-test-providers:ContentLayoutExample";
+createContentLayoutFrontstage.stageId = "content-layout";

--- a/apps/test-providers/src/ui/frontstages/ContentLayoutFrontstage.tsx
+++ b/apps/test-providers/src/ui/frontstages/ContentLayoutFrontstage.tsx
@@ -32,15 +32,17 @@ class ContentLayoutStageContentGroupProvider extends ContentGroupProvider {
     if (primaryViewState) {
       primaryViewState.description = "imodel-view-primary";
     }
+    const id = "primaryContent";
     const defaultContent = new ContentGroup({
       id: "content-layout-stage-frontstage-main-content-group",
       layout: StandardContentLayouts.singleView,
       contents: [
         {
-          id: "primaryContent",
+          id,
           classId: "",
           content: (
             <ViewportContent
+              contentId={id}
               renderViewOverlay={() => undefined}
               viewState={primaryViewState}
             />

--- a/apps/test-providers/src/ui/frontstages/ContentLayoutFrontstage.tsx
+++ b/apps/test-providers/src/ui/frontstages/ContentLayoutFrontstage.tsx
@@ -28,6 +28,10 @@ class ContentLayoutStageContentGroupProvider extends ContentGroupProvider {
   public override async contentGroup(
     config: Frontstage
   ): Promise<ContentGroup> {
+    const primaryViewState = UiFramework.getDefaultViewState()?.clone();
+    if (primaryViewState) {
+      primaryViewState.description = "imodel-view-primary";
+    }
     const defaultContent = new ContentGroup({
       id: "content-layout-stage-frontstage-main-content-group",
       layout: StandardContentLayouts.singleView,
@@ -35,7 +39,12 @@ class ContentLayoutStageContentGroupProvider extends ContentGroupProvider {
         {
           id: "primaryContent",
           classId: "",
-          content: <ViewportContent renderViewOverlay={() => undefined} />,
+          content: (
+            <ViewportContent
+              renderViewOverlay={() => undefined}
+              viewState={primaryViewState}
+            />
+          ),
         },
       ],
     });

--- a/apps/test-providers/src/ui/frontstages/CustomContentFrontstage.tsx
+++ b/apps/test-providers/src/ui/frontstages/CustomContentFrontstage.tsx
@@ -14,20 +14,7 @@ import {
 } from "@itwin/appui-react";
 import { StandardContentLayouts } from "@itwin/appui-abstract";
 import { SampleContentControl } from "../content/SampleContentControl";
-
-function useActiveContentId() {
-  const [activeId, setActiveId] = React.useState(
-    UiFramework.content.getActiveId()
-  );
-  React.useEffect(() => {
-    return UiFramework.content.onActiveContentChangedEvent.addListener(
-      (args) => {
-        setActiveId(args.id);
-      }
-    );
-  }, []);
-  return activeId;
-}
+import { useActiveContentId } from "../useActiveContentId";
 
 function CustomViewToolWidgetComposer() {
   const activeId = useActiveContentId();

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -216,35 +216,47 @@ function ViewportWidget({ contentId }: ViewportWidgetProps) {
 function ContentInfo() {
   const activeViewport = useActiveViewport();
   const contentId = useActiveContentId();
+  const columns = React.useMemo(
+    () => [
+      {
+        id: "name",
+        Header: "Name",
+        accessor: "name" as const,
+      },
+      {
+        id: "value",
+        Header: "Value",
+        accessor: "value" as const,
+      },
+    ],
+    []
+  );
+
+  const viewId = activeViewport?.view.id;
+  const description = activeViewport?.view.description;
+  const data = React.useMemo(
+    () => [
+      {
+        name: "View id",
+        value: viewId,
+      },
+      {
+        name: "View description",
+        value: description,
+      },
+      {
+        name: "Content id",
+        value: contentId,
+      },
+    ],
+    [viewId, description, contentId]
+  );
   return (
     <Table
-      columns={[
-        {
-          id: "name",
-          Header: "Name",
-          accessor: "name",
-        },
-        {
-          id: "value",
-          Header: "Value",
-          accessor: "value",
-        },
-      ]}
-      data={[
-        {
-          name: "View id",
-          value: activeViewport?.view.id,
-        },
-        {
-          name: "View description",
-          value: activeViewport?.view.description,
-        },
-        {
-          name: "Content id",
-          value: contentId,
-        },
-      ]}
+      columns={columns}
+      data={data}
       emptyTableContent=""
+      autoResetPage={false}
     />
   );
 }

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -19,6 +19,7 @@ import {
   Widget,
   WidgetState,
 } from "@itwin/appui-react";
+import { Table } from "@itwin/itwinui-react";
 import {
   createSplitSingleViewportToolbarItem,
   RestoreSavedContentLayoutTool,
@@ -32,6 +33,7 @@ import { ControlViewportWidget } from "../widgets/ControlViewportWidget";
 import { ViewportWidget as ViewportWidgetBase } from "../widgets/ViewportWidget";
 import { WidgetContentContext } from "./WidgetContentProvider";
 import { createContentLayoutFrontstage } from "../frontstages/ContentLayoutFrontstage";
+import { useActiveContentId } from "../useActiveContentId";
 
 /** The ContentLayoutStageUiItemsProvider provides additional items only to the `ContentLayoutStage` frontstage.
  * This provider provides four tool buttons to:
@@ -147,9 +149,9 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
         },
       },
       {
-        id: "active-view",
-        label: "Active view",
-        content: <ActiveView />,
+        id: "content-info",
+        label: "Content info",
+        content: <ContentInfo />,
         layouts: {
           standard: {
             location: StagePanelLocation.Right,
@@ -201,14 +203,38 @@ function ViewportWidget({ contentId }: ViewportWidgetProps) {
   );
 }
 
-function ActiveView() {
-  const viewport = useActiveViewport();
-  if (!viewport) return <span>No active viewport</span>;
+function ContentInfo() {
+  const activeViewport = useActiveViewport();
+  const contentId = useActiveContentId();
   return (
-    <span>
-      <b>id:</b> {viewport.view.id}
-      <br />
-      <b>description:</b> {viewport.view.description}
-    </span>
+    <Table
+      columns={[
+        {
+          id: "name",
+          Header: "Name",
+          accessor: "name",
+        },
+        {
+          id: "value",
+          Header: "Value",
+          accessor: "value",
+        },
+      ]}
+      data={[
+        {
+          name: "View id",
+          value: activeViewport?.view.id,
+        },
+        {
+          name: "View description",
+          value: activeViewport?.view.description,
+        },
+        {
+          name: "Content id",
+          value: contentId,
+        },
+      ]}
+      emptyTableContent=""
+    />
   );
 }

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -14,6 +14,7 @@ import {
   ToolbarItemUtilities,
   ToolbarOrientation,
   ToolbarUsage,
+  UiFramework,
   UiItemsProvider,
   useActiveViewport,
   Widget,
@@ -193,12 +194,21 @@ interface ViewportWidgetProps {
 function ViewportWidget({ contentId }: ViewportWidgetProps) {
   // We could have used `IModelApp.viewManager` instead to track active viewport.
   const context = React.useContext(WidgetContentContext);
+  const [viewState] = React.useState(() => {
+    const initialViewState = UiFramework.getDefaultViewState()?.clone();
+    if (initialViewState) {
+      initialViewState.description = contentId;
+    }
+
+    return initialViewState;
+  });
   return (
     <ViewportWidgetBase
       active={contentId === context.activeId}
       onActivate={() => {
         context.setActiveId(contentId);
       }}
+      viewState={viewState}
     />
   );
 }

--- a/apps/test-providers/src/ui/useActiveContentId.ts
+++ b/apps/test-providers/src/ui/useActiveContentId.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import { UiFramework } from "@itwin/appui-react";
+
+export function useActiveContentId() {
+  const [activeId, setActiveId] = React.useState(
+    UiFramework.content.getActiveId()
+  );
+  React.useEffect(() => {
+    return UiFramework.content.onActiveContentChangedEvent.addListener(
+      (args) => {
+        setActiveId(args.id);
+      }
+    );
+  }, []);
+  return activeId;
+}

--- a/apps/test-providers/src/ui/widgets/ViewportWidget.tsx
+++ b/apps/test-providers/src/ui/widgets/ViewportWidget.tsx
@@ -5,16 +5,24 @@
 import * as React from "react";
 import { ContentOverlay, UiFramework } from "@itwin/appui-react";
 import { ViewportComponent } from "@itwin/imodel-components-react";
+import { ViewState } from "@itwin/core-frontend";
 
 interface ViewportWidgetProps {
   active: boolean;
   onActivate?: () => void;
+  viewState?: ViewState;
 }
 
-export function ViewportWidget({ active, onActivate }: ViewportWidgetProps) {
-  const [viewState] = React.useState(() => {
+export function ViewportWidget({
+  active,
+  onActivate,
+  viewState,
+}: ViewportWidgetProps) {
+  const [defaultViewState] = React.useState(() => {
     return UiFramework.getDefaultViewState();
   });
+  viewState = viewState ?? defaultViewState;
+
   if (!viewState) return null;
   return (
     <ContentOverlay

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -97,7 +97,7 @@ import { SnapMode } from '@itwin/core-frontend';
 import type { SolarDataProvider } from '@itwin/imodel-components-react';
 import { StandardViewId } from '@itwin/core-frontend';
 import type { Store } from 'redux';
-import type { StoreApi } from 'zustand';
+import { StoreApi } from 'zustand';
 import type { StringGetter } from '@itwin/appui-abstract';
 import { ToasterSettings } from '@itwin/itwinui-react/cjs/core/Toast/Toaster';
 import { Tool } from '@itwin/core-frontend';
@@ -119,6 +119,7 @@ import { UiStateStorage as UiStateStorage_2 } from '@itwin/core-react';
 import type { UiStateStorageResult as UiStateStorageResult_2 } from '@itwin/core-react';
 import { UiStateStorageStatus as UiStateStorageStatus_2 } from '@itwin/core-react';
 import type { UnitSystemKey } from '@itwin/core-quantity';
+import { UseBoundStore } from 'zustand';
 import type { useToaster } from '@itwin/itwinui-react';
 import type { ViewFlagProps } from '@itwin/core-common';
 import type { Viewport } from '@itwin/core-frontend';
@@ -1294,7 +1295,6 @@ export interface ContentProps {
     applicationData?: any;
     // @deprecated
     classId: string | ConfigurableUiControlConstructor;
-    // @beta
     content?: React_2.ReactNode;
     id: string;
 }
@@ -2403,7 +2403,7 @@ export class FrontstageDef {
     // @deprecated (undocumented)
     dropFloatingContentControl(contentControl?: ContentControl): void;
     findWidgetDef(id: string): WidgetDef | undefined;
-    // (undocumented)
+    // @deprecated (undocumented)
     get floatingContentControls(): ContentControl[] | undefined;
     // @beta
     floatWidget(widgetId: string, position?: XAndY, size?: SizeProps): void;
@@ -2549,7 +2549,7 @@ export function getSelectionContextSyncEventIds(): string[];
 export function getUiSettingsManagerEntry(itemPriority: number): SettingsTabEntry_2;
 
 // @internal (undocumented)
-export function getWidgetState(widgetDef: WidgetDef, nineZone: NineZoneState): WidgetState;
+export function getWidgetState(widgetId: WidgetDef["id"], nineZone: NineZoneState): WidgetState;
 
 // @internal (undocumented)
 export type GroupedItems = ReadonlyArray<ReadonlyArray<BackstageItem>>;
@@ -5524,6 +5524,9 @@ export const useBackstageManager: () => FrameworkBackstage;
 
 // @alpha
 export function useConditionalValue<T>(getValue: () => T, eventIds: string[]): T;
+
+// @internal
+export const useContentOverlayStore: UseBoundStore<StoreApi<number>>;
 
 // @internal
 export const useDefaultBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[];

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -336,7 +336,7 @@ beta;getQuantityFormatsSettingsManagerEntry(itemPriority: number, opts?: Partial
 beta;getSelectionContextSyncEventIds(): string[]
 deprecated;getSelectionContextSyncEventIds(): string[]
 beta;getUiSettingsManagerEntry(itemPriority: number): SettingsTabEntry_2
-internal;getWidgetState(widgetDef: WidgetDef, nineZone: NineZoneState): WidgetState
+internal;getWidgetState(widgetId: WidgetDef["id"], nineZone: NineZoneState): WidgetState
 internal;GroupedItems = ReadonlyArray
 public;GroupItemDef 
 deprecated;GroupItemDef 
@@ -779,6 +779,7 @@ public;useAnalysisAnimationDataProvider(viewport: ScreenViewport | undefined): A
 internal;useAvailableUiItemsProviders(): readonly string[]
 public;useBackstageManager: () => FrameworkBackstage
 alpha;useConditionalValue
+internal;useContentOverlayStore: UseBoundStore
 internal;useDefaultBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[]
 public;useDefaultStatusBarItems: (manager: StatusBarItemsManager) => readonly StatusBarItem[]
 public;useDefaultToolbarItems: (manager: ToolbarItemsManager) => readonly ToolbarItem[]

--- a/common/changes/@itwin/appui-react/active-content_2024-09-16-12-16.json
+++ b/common/changes/@itwin/appui-react/active-content_2024-09-16-12-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Track `ContentOverlay` components to determine if the active strip should be rendered by the content layout.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -107,11 +107,14 @@ Table of contents:
 - Deprecated `BaseUiItemsProvider`, `StandardContentToolsProvider`, `StandardNavigationToolsProvider`, `StandardStatusbarItemsProvider` classes. Use `UiItemsProviderOverrides` to specify supported frontstages when registering the provider. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead. [#1024](https://github.com/iTwin/appui/pull/1024)
+- Deprecated `floatingContentControls` getter of `FrontstageDef` class that used a deprecated `ContentControl` class. Use floating widgets instead.
 
 ### Changes
 
 - Allow to set the available snap modes in `SnapModeField` component. [#974](https://github.com/iTwin/appui/pull/974)
 - Bump `StandardContentToolsUiItemsProvider`, `StandardStatusbarUiItemsProvider` classes to `@public`. [#1024](https://github.com/iTwin/appui/pull/1024)
+- Bump `content` property of `ContentProps` interface to `@public`.
+- Content layout will now track `ContentOverlay` components to determine if the active strip should be rendered for the active content.
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/content/ContentGroup.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentGroup.tsx
@@ -36,7 +36,7 @@ export interface ContentProps {
    */
   applicationData?: any;
   /** Content to be displayed in the content view.
-   * @beta
+   * @public
    */
   content?: React.ReactNode;
 }

--- a/ui/appui-react/src/appui-react/content/ContentLayout.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.tsx
@@ -59,6 +59,7 @@ export function ContentWrapper(props: ContentWrapperProps) {
   const [hasMultipleContents, setHasMultipleContents] = React.useState(
     () =>
       (activeFrontstageDef &&
+        // eslint-disable-next-line deprecation/deprecation
         !!activeFrontstageDef.floatingContentControls?.length) ||
       // eslint-disable-next-line deprecation/deprecation
       (activeFrontstageDef?.contentGroup?.getContentControls().length ?? 0) > 1
@@ -85,8 +86,8 @@ export function ContentWrapper(props: ContentWrapperProps) {
 
         setHasMultipleContents(
           (activeFrontstageDef &&
-            !!activeFrontstageDef.floatingContentControls?.length) ||
             // eslint-disable-next-line deprecation/deprecation
+            !!activeFrontstageDef.floatingContentControls?.length) ||
             (activeFrontstageDef?.contentGroup?.contentPropsList.length ?? 0) >
               1
         );
@@ -105,6 +106,7 @@ export function ContentWrapper(props: ContentWrapperProps) {
       () => {
         setHasMultipleContents(
           (activeFrontstageDef &&
+            // eslint-disable-next-line deprecation/deprecation
             !!activeFrontstageDef.floatingContentControls?.length) ||
             // eslint-disable-next-line deprecation/deprecation
             (activeFrontstageDef?.contentGroup?.getContentControls().length ??

--- a/ui/appui-react/src/appui-react/content/ContentLayout.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.tsx
@@ -25,7 +25,7 @@ import type { CommonProps } from "@itwin/core-react";
 import type { ContentGroup } from "./ContentGroup";
 import { useActiveFrontstageDef } from "../frontstage/FrontstageDef";
 import { UiFramework } from "../UiFramework";
-import { ContentOverlay } from "./ContentOverlay";
+import { ContentOverlay, useContentOverlayStore } from "./ContentOverlay";
 
 /** Properties for [[ContentWrapper]] */
 // eslint-disable-next-line deprecation/deprecation
@@ -116,7 +116,8 @@ export function ContentWrapper(props: ContentWrapperProps) {
     );
   }, [activeFrontstageDef]);
 
-  const active = isActive && hasMultipleContents;
+  const contentOverlays = useContentOverlayStore();
+  const active = isActive && (hasMultipleContents || contentOverlays > 1);
   return (
     <ContentOverlay
       className={classnames("uifw-contentlayout-wrapper", props.className)}

--- a/ui/appui-react/src/appui-react/content/ContentOverlay.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentOverlay.tsx
@@ -9,8 +9,11 @@
 import "./ContentOverlay.scss";
 import classnames from "classnames";
 import * as React from "react";
+import { create } from "zustand";
 
-// eslint-disable-next-line deprecation/deprecation
+/** @internal */
+export const useContentOverlayStore = create<number>(() => 0);
+
 interface ContentOverlayProps extends React.ComponentProps<"div"> {
   /** Describes if the content is active. */
   active?: boolean;
@@ -25,6 +28,12 @@ export function ContentOverlay({
   active,
   ...other
 }: ContentOverlayProps) {
+  React.useEffect(() => {
+    useContentOverlayStore.setState((prev) => prev + 1);
+    return () => {
+      useContentOverlayStore.setState((prev) => prev - 1);
+    };
+  }, []);
   return (
     <div
       className={classnames("uifw-content-contentOverlay", className)}

--- a/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
+++ b/ui/appui-react/src/appui-react/content/InternalContentViewManager.ts
@@ -117,6 +117,7 @@ export class InternalContentViewManager {
       activeContentControl = this.getControlFromElement(
         this._activeContent,
         activeContentGroup,
+        // eslint-disable-next-line deprecation/deprecation
         activeFrontstageDef.floatingContentControls
       );
     }
@@ -170,11 +171,13 @@ export class InternalContentViewManager {
       const oldContentControl = this.getControlFromElement(
         oldContent,
         contentGroup,
+        // eslint-disable-next-line deprecation/deprecation
         frontstageDef.floatingContentControls
       );
       const activeContentControl = this.getControlFromElement(
         activeContent,
         contentGroup,
+        // eslint-disable-next-line deprecation/deprecation
         frontstageDef.floatingContentControls,
         true
       );

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -105,6 +105,7 @@ export class FrontstageDef {
   public get contentGroupProvider(): ContentGroupProvider | undefined {
     return this._contentGroupProvider;
   }
+  /** @deprecated in 4.17.0. Returns instances of a deprecated {@link ContentControl} type. */
   public get floatingContentControls() {
     return this._floatingContentControls;
   }

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -172,7 +172,7 @@ export class FrontstageDef {
     }
 
     for (const widgetDef of this.widgetDefs) {
-      const widgetState = getWidgetState(widgetDef, nineZone);
+      const widgetState = getWidgetState(widgetDef.id, nineZone);
       widgetMap.set(widgetDef, widgetState);
     }
     return { panelMap, widgetMap };

--- a/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
+++ b/ui/appui-react/src/appui-react/widgets/WidgetDef.tsx
@@ -106,7 +106,7 @@ export class WidgetDef {
     const nineZone = frontstageDef?.nineZoneState;
     if (!nineZone) return this.defaultState;
     if (!frontstageDef.findWidgetDef(this.id)) return this.defaultState;
-    return getWidgetState(this, nineZone);
+    return getWidgetState(this.id, nineZone);
   }
 
   public get id(): string {
@@ -602,25 +602,28 @@ export class WidgetDef {
 }
 
 /** @internal */
-export function getWidgetState(widgetDef: WidgetDef, nineZone: NineZoneState) {
-  const tab = nineZone.tabs[widgetDef.id];
+export function getWidgetState(
+  widgetId: WidgetDef["id"],
+  nineZone: NineZoneState
+) {
+  const tab = nineZone.tabs[widgetId];
   if (tab && tab.unloaded) {
     return WidgetState.Unloaded;
   }
 
-  if (nineZone.draggedTab?.tabId === widgetDef.id) {
+  if (nineZone.draggedTab?.tabId === widgetId) {
     return WidgetState.Closed;
   }
 
   const toolSettingsTabId = nineZone.toolSettings?.tabId;
   if (
-    toolSettingsTabId === widgetDef.id &&
+    toolSettingsTabId === widgetId &&
     nineZone.toolSettings?.type === "docked"
   ) {
     return nineZone.toolSettings.hidden ? WidgetState.Hidden : WidgetState.Open;
   }
 
-  const location = getTabLocation(nineZone, widgetDef.id);
+  const location = getTabLocation(nineZone, widgetId);
   if (!location) {
     return WidgetState.Hidden;
   }
@@ -636,7 +639,7 @@ export function getWidgetState(widgetDef: WidgetDef, nineZone: NineZoneState) {
   }
 
   const widget = nineZone.widgets[location.widgetId];
-  if (widget.minimized || widgetDef.id !== widget.activeTabId)
+  if (widget.minimized || widgetId !== widget.activeTabId)
     return WidgetState.Closed;
 
   return WidgetState.Open;

--- a/ui/appui-react/src/test/widgets/WidgetDef.test.tsx
+++ b/ui/appui-react/src/test/widgets/WidgetDef.test.tsx
@@ -232,7 +232,7 @@ describe("getWidgetState", () => {
     vi.spyOn(frontstageDef, "getStagePanelDef").mockReturnValue(leftPanel);
     vi.spyOn(frontstageDef, "findWidgetDef").mockReturnValue(widgetDef);
 
-    expect(getWidgetState(widgetDef, frontstageDef.nineZoneState)).to.be.eql(
+    expect(getWidgetState(widgetDef.id, frontstageDef.nineZoneState)).to.be.eql(
       WidgetState.Closed
     );
   });
@@ -274,7 +274,7 @@ describe("getWidgetState", () => {
     vi.spyOn(frontstageDef, "getStagePanelDef").mockReturnValue(leftPanel);
     vi.spyOn(frontstageDef, "findWidgetDef").mockReturnValue(widgetDef);
 
-    expect(getWidgetState(widgetDef, frontstageDef.nineZoneState)).to.be.eql(
+    expect(getWidgetState(widgetDef.id, frontstageDef.nineZoneState)).to.be.eql(
       WidgetState.Closed
     );
   });
@@ -303,7 +303,7 @@ describe("getWidgetState", () => {
     });
 
     vi.spyOn(frontstageDef, "findWidgetDef").mockReturnValue(widgetDef);
-    expect(getWidgetState(widgetDef, frontstageDef.nineZoneState)).to.be.eql(
+    expect(getWidgetState(widgetDef.id, frontstageDef.nineZoneState)).to.be.eql(
       WidgetState.Closed
     );
   });
@@ -320,7 +320,7 @@ describe("getWidgetState", () => {
     });
 
     vi.spyOn(frontstageDef, "findWidgetDef").mockReturnValue(widgetDef);
-    expect(getWidgetState(widgetDef, frontstageDef.nineZoneState)).to.be.eql(
+    expect(getWidgetState(widgetDef.id, frontstageDef.nineZoneState)).to.be.eql(
       WidgetState.Unloaded
     );
   });


### PR DESCRIPTION
## Changes

This PR fixes #1028 by tracking the `ContentOverlay` components to determine if the content layout should render the active strip (used to check for multiple content controls only).
The capability to customize/override this default legacy behavior will be provided in https://github.com/iTwin/appui/issues/1026

## Testing

Tested via test-app
