### PR TITLE
Correctly export conditional value classes from `@itwin/appui-abstract`

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -30,8 +30,8 @@ import type { CommonDivProps } from '@itwin/core-react';
 import { CommonProps } from '@itwin/core-react';
 import type { CommonToolbarItemWithBadgeKind } from '@itwin/components-react';
 import { CompassMode } from '@itwin/core-frontend';
-import { ConditionalBooleanValue } from '@itwin/appui-abstract';
-import { ConditionalStringValue } from '@itwin/appui-abstract';
+import { ConditionalBooleanValue as ConditionalBooleanValue_2 } from '@itwin/appui-abstract';
+import { ConditionalStringValue as ConditionalStringValue_2 } from '@itwin/appui-abstract';
 import type { ContentLayoutProps } from '@itwin/appui-abstract';
 import type { CustomButtonDefinition } from '@itwin/appui-abstract';
 import type { DialogItem } from '@itwin/appui-abstract';
@@ -928,13 +928,13 @@ export interface CommonBackstageItem {
     readonly icon?: IconSpec;
     readonly iconNode?: React.ReactNode;
     readonly id: string;
-    readonly isActive?: boolean | ConditionalBooleanValue;
-    readonly isDisabled?: boolean | ConditionalBooleanValue;
-    readonly isHidden?: boolean | ConditionalBooleanValue;
+    readonly isActive?: boolean | ConditionalBooleanValue_2;
+    readonly isDisabled?: boolean | ConditionalBooleanValue_2;
+    readonly isHidden?: boolean | ConditionalBooleanValue_2;
     readonly itemPriority: number;
-    readonly label: string | ConditionalStringValue;
-    readonly subtitle?: string | ConditionalStringValue;
-    readonly tooltip?: string | ConditionalStringValue;
+    readonly label: string | ConditionalStringValue_2;
+    readonly subtitle?: string | ConditionalStringValue_2;
+    readonly tooltip?: string | ConditionalStringValue_2;
 }
 
 // @public
@@ -943,8 +943,8 @@ export interface CommonStatusBarItem {
     readonly badge?: BadgeType;
     readonly badgeKind?: BadgeKind;
     readonly id: string;
-    readonly isDisabled?: boolean | ConditionalBooleanValue;
-    readonly isHidden?: boolean | ConditionalBooleanValue;
+    readonly isDisabled?: boolean | ConditionalBooleanValue_2;
+    readonly isHidden?: boolean | ConditionalBooleanValue_2;
     readonly itemPriority: number;
     readonly section: StatusBarSection;
 }
@@ -954,16 +954,28 @@ export interface CommonToolbarItem {
     // @deprecated
     readonly badge?: BadgeType;
     readonly badgeKind?: BadgeKind;
-    readonly description?: string | ConditionalStringValue;
+    readonly description?: string | ConditionalStringValue_2;
     readonly groupPriority?: number;
     readonly iconNode?: React.ReactNode;
     readonly id: string;
     readonly isActive?: boolean;
-    readonly isDisabled?: boolean | ConditionalBooleanValue;
-    readonly isHidden?: boolean | ConditionalBooleanValue;
+    readonly isDisabled?: boolean | ConditionalBooleanValue_2;
+    readonly isHidden?: boolean | ConditionalBooleanValue_2;
     readonly itemPriority: number;
     readonly layouts?: ToolbarItemLayouts;
 }
+
+// @public
+export type ConditionalBooleanValue = ConditionalBooleanValue_2;
+
+// @public (undocumented)
+export const ConditionalBooleanValue: typeof ConditionalBooleanValue_2;
+
+// @public
+export type ConditionalStringValue = ConditionalStringValue_2;
+
+// @public (undocumented)
+export const ConditionalStringValue: typeof ConditionalStringValue_2;
 
 // @public @deprecated
 export class ConfigurableBase implements ConfigurableUiElement {
@@ -1444,26 +1456,26 @@ export interface CursorMenuItemProps extends CommonProps {
     badgeKind?: BadgeKind;
     // @deprecated
     badgeType?: BadgeType;
-    description?: string | StringGetter | ConditionalStringValue_2;
+    description?: string | StringGetter | ConditionalStringValue;
     descriptionKey?: string;
     execute?: () => any;
     // @deprecated
     icon?: IconSpec;
     iconNode?: React_2.ReactNode;
-    iconRight?: string | ConditionalStringValue_2;
+    iconRight?: string | ConditionalStringValue;
     // @deprecated
     iconSpec?: IconSpec;
     id: string;
     isActive?: boolean;
-    isDisabled?: boolean | ConditionalBooleanValue;
-    isHidden?: boolean | ConditionalBooleanValue;
+    isDisabled?: boolean | ConditionalBooleanValue_2;
+    isHidden?: boolean | ConditionalBooleanValue_2;
     isPressed?: boolean;
     // @deprecated
     item?: CommandItemProps;
-    label?: string | StringGetter | ConditionalStringValue_2;
+    label?: string | StringGetter | ConditionalStringValue;
     labelKey?: string;
     submenu?: CursorMenuItemProps[];
-    tooltip?: string | StringGetter | ConditionalStringValue_2;
+    tooltip?: string | StringGetter | ConditionalStringValue;
     tooltipKey?: string;
 }
 
@@ -1931,14 +1943,14 @@ export class FrameworkAccuDraw extends AccuDraw implements UserSettingsProvider 
     static getFieldDisplayValue(index: ItemField): string;
     grabInputFocus(): void;
     get hasInputFocus(): boolean;
-    static readonly isACSRotationConditional: ConditionalBooleanValue;
-    static readonly isContextRotationConditional: ConditionalBooleanValue;
-    static readonly isFrontRotationConditional: ConditionalBooleanValue;
-    static readonly isPolarModeConditional: ConditionalBooleanValue;
-    static readonly isRectangularModeConditional: ConditionalBooleanValue;
-    static readonly isSideRotationConditional: ConditionalBooleanValue;
-    static readonly isTopRotationConditional: ConditionalBooleanValue;
-    static readonly isViewRotationConditional: ConditionalBooleanValue;
+    static readonly isACSRotationConditional: ConditionalBooleanValue_2;
+    static readonly isContextRotationConditional: ConditionalBooleanValue_2;
+    static readonly isFrontRotationConditional: ConditionalBooleanValue_2;
+    static readonly isPolarModeConditional: ConditionalBooleanValue_2;
+    static readonly isRectangularModeConditional: ConditionalBooleanValue_2;
+    static readonly isSideRotationConditional: ConditionalBooleanValue_2;
+    static readonly isTopRotationConditional: ConditionalBooleanValue_2;
+    static readonly isViewRotationConditional: ConditionalBooleanValue_2;
     // (undocumented)
     loadUserSettings(storage: UiStateStorage): Promise<void>;
     static readonly onAccuDrawGrabInputFocusEvent: AccuDrawGrabInputFocusEvent;
@@ -2151,10 +2163,10 @@ export interface FrameworkKeyboardShortcut {
     readonly isAltKeyRequired: boolean;
     readonly isCtrlKeyRequired: boolean;
     // (undocumented)
-    isDisabled?: boolean | ConditionalBooleanValue_2;
+    isDisabled?: boolean | ConditionalBooleanValue;
     readonly isFunctionKey: boolean;
     // (undocumented)
-    isHidden?: boolean | ConditionalBooleanValue_2;
+    isHidden?: boolean | ConditionalBooleanValue;
     // (undocumented)
     isPressed: boolean;
     readonly isShiftKeyRequired: boolean;
@@ -2167,13 +2179,13 @@ export interface FrameworkKeyboardShortcut {
     // (undocumented)
     readonly label: string;
     // (undocumented)
-    readonly rawLabel: string | StringGetter | ConditionalStringValue_2;
+    readonly rawLabel: string | StringGetter | ConditionalStringValue;
     // (undocumented)
-    setDescription(v: string | StringGetter | ConditionalStringValue_2): void;
+    setDescription(v: string | StringGetter | ConditionalStringValue): void;
     // (undocumented)
-    setLabel(v: string | StringGetter | ConditionalStringValue_2): void;
+    setLabel(v: string | StringGetter | ConditionalStringValue): void;
     // (undocumented)
-    setTooltip(v: string | StringGetter | ConditionalStringValue_2): void;
+    setTooltip(v: string | StringGetter | ConditionalStringValue): void;
     readonly shortcutContainer: FrameworkKeyboardShortcutContainer;
     // (undocumented)
     readonly tooltip: string;
@@ -2519,10 +2531,10 @@ export function getFeatureOverrideSyncEventIds(): string[];
 export function getFrontstageStateSettingName(frontstageId: WidgetPanelsFrontstageState["id"]): string;
 
 // @beta @deprecated
-export function getIsHiddenIfFeatureOverridesActive(): ConditionalBooleanValue;
+export function getIsHiddenIfFeatureOverridesActive(): ConditionalBooleanValue_2;
 
 // @beta @deprecated
-export function getIsHiddenIfSelectionNotActive(): ConditionalBooleanValue;
+export function getIsHiddenIfSelectionNotActive(): ConditionalBooleanValue_2;
 
 // @internal
 export function getKeyinsFromToolList(toolList: ToolList, localizedKeyinPreference?: KeyinFieldLocalization): KeyinEntry[];
@@ -2582,7 +2594,7 @@ export class GroupItemDef extends ActionButtonItemDef {
     get panelLabel(): string;
     // (undocumented)
     resolveItems(force?: boolean): void;
-    setPanelLabel(v: string | StringGetter | ConditionalStringValue): void;
+    setPanelLabel(v: string | StringGetter | ConditionalStringValue_2): void;
 }
 
 // @public @deprecated
@@ -2901,16 +2913,16 @@ export abstract class ItemDefBase {
     get isActive(): boolean;
     set isActive(v: boolean);
     // (undocumented)
-    isDisabled?: boolean | ConditionalBooleanValue;
+    isDisabled?: boolean | ConditionalBooleanValue_2;
     // (undocumented)
-    isHidden?: boolean | ConditionalBooleanValue;
+    isHidden?: boolean | ConditionalBooleanValue_2;
     // (undocumented)
     isPressed: boolean;
     get label(): string;
-    get rawLabel(): string | StringGetter | ConditionalStringValue;
-    setDescription(v: string | StringGetter | ConditionalStringValue): void;
-    setLabel(v: string | StringGetter | ConditionalStringValue): void;
-    setTooltip(v: string | StringGetter | ConditionalStringValue): void;
+    get rawLabel(): string | StringGetter | ConditionalStringValue_2;
+    setDescription(v: string | StringGetter | ConditionalStringValue_2): void;
+    setLabel(v: string | StringGetter | ConditionalStringValue_2): void;
+    setTooltip(v: string | StringGetter | ConditionalStringValue_2): void;
     get tooltip(): string;
     // (undocumented)
     get trayId(): undefined;
@@ -2948,16 +2960,16 @@ export interface ItemProps extends IconProps {
     badgeKind?: BadgeKind;
     // @deprecated
     badgeType?: BadgeType;
-    description?: string | StringGetter | ConditionalStringValue;
+    description?: string | StringGetter | ConditionalStringValue_2;
     descriptionKey?: string;
     icon?: IconSpec;
     isActive?: boolean;
-    isDisabled?: boolean | ConditionalBooleanValue;
-    isHidden?: boolean | ConditionalBooleanValue;
+    isDisabled?: boolean | ConditionalBooleanValue_2;
+    isHidden?: boolean | ConditionalBooleanValue_2;
     isPressed?: boolean;
-    label?: string | StringGetter | ConditionalStringValue;
+    label?: string | StringGetter | ConditionalStringValue_2;
     labelKey?: string;
-    tooltip?: string | StringGetter | ConditionalStringValue;
+    tooltip?: string | StringGetter | ConditionalStringValue_2;
     tooltipKey?: string;
 }
 
@@ -3025,7 +3037,7 @@ export interface KeyboardShortcutProps extends CommonProps {
     badgeKind?: BadgeKind;
     // @deprecated
     badgeType?: BadgeType;
-    description?: string | StringGetter | ConditionalStringValue_2;
+    description?: string | StringGetter | ConditionalStringValue;
     descriptionKey?: string;
     execute?: () => void;
     // @deprecated
@@ -3036,17 +3048,17 @@ export interface KeyboardShortcutProps extends CommonProps {
     isActive?: boolean;
     isAltKeyRequired?: boolean;
     isCtrlKeyRequired?: boolean;
-    isDisabled?: boolean | ConditionalBooleanValue_2;
-    isHidden?: boolean | ConditionalBooleanValue_2;
+    isDisabled?: boolean | ConditionalBooleanValue;
+    isHidden?: boolean | ConditionalBooleanValue;
     isPressed?: boolean;
     isShiftKeyRequired?: boolean;
     // @deprecated
     item?: ActionButtonItemDef;
     key: string | Key;
-    label?: string | StringGetter | ConditionalStringValue_2;
+    label?: string | StringGetter | ConditionalStringValue;
     labelKey?: string;
     shortcuts?: KeyboardShortcutProps[];
-    tooltip?: string | StringGetter | ConditionalStringValue_2;
+    tooltip?: string | StringGetter | ConditionalStringValue;
     tooltipKey?: string;
 }
 
@@ -3779,9 +3791,9 @@ export interface PreviewFeaturesProviderProps {
 export class PropsHelper {
     // @deprecated (undocumented)
     static getAbstractPropsForReactIcon(iconSpec: IconSpec, internalData?: Map<string, any>): Partial<AbstractWidgetProps> | Partial<CommonBackstageItem_2>;
-    static getIcon(iconSpec: string | ConditionalStringValue | React_2.ReactNode): React_2.ReactElement | undefined;
-    static getStringFromSpec(spec: string | StringGetter | ConditionalStringValue): string;
-    static getStringSpec(explicitValue: string | StringGetter | ConditionalStringValue | undefined, stringKey?: string): string | StringGetter | ConditionalStringValue;
+    static getIcon(iconSpec: string | ConditionalStringValue_2 | React_2.ReactNode): React_2.ReactElement | undefined;
+    static getStringFromSpec(spec: string | StringGetter | ConditionalStringValue_2): string;
+    static getStringSpec(explicitValue: string | StringGetter | ConditionalStringValue_2 | undefined, stringKey?: string): string | StringGetter | ConditionalStringValue_2;
     static isShallowEqual(newObj: any, prevObj: any): boolean;
 }
 
@@ -4544,8 +4556,8 @@ export interface StatusBarActionItem extends CommonStatusBarItem {
     // @deprecated
     readonly icon?: IconSpec;
     readonly iconNode?: React_2.ReactNode;
-    readonly label?: string | ConditionalStringValue;
-    readonly tooltip?: string | ConditionalStringValue;
+    readonly label?: string | ConditionalStringValue_2;
+    readonly tooltip?: string | ConditionalStringValue_2;
 }
 
 // @public
@@ -4642,7 +4654,7 @@ export namespace StatusBarItemUtilities {
     section: StatusBarSection,
     itemPriority: number,
     icon: IconSpec,
-    tooltip: string | ConditionalStringValue,
+    tooltip: string | ConditionalStringValue_2,
     execute: () => void,
     overrides?: Partial<StatusBarActionItem>
     ];
@@ -4660,7 +4672,7 @@ export namespace StatusBarItemUtilities {
     section: StatusBarSection,
     itemPriority: number,
     icon: IconSpec,
-    label: string | ConditionalStringValue,
+    label: string | ConditionalStringValue_2,
     labelSide?: StatusBarLabelSide,
     overrides?: Partial<StatusBarLabelItem>
     ];
@@ -4682,7 +4694,7 @@ export interface StatusBarLabelItem extends CommonStatusBarItem {
     // @deprecated
     readonly icon?: IconSpec;
     readonly iconNode?: React_2.ReactNode;
-    readonly label: string | ConditionalStringValue;
+    readonly label: string | ConditionalStringValue_2;
     readonly labelSide?: StatusBarLabelSide;
 }
 
@@ -4887,7 +4899,7 @@ export interface ToolbarActionItem extends CommonToolbarItem {
     readonly execute: () => void;
     // @deprecated
     readonly icon: IconSpec;
-    readonly label: string | ConditionalStringValue;
+    readonly label: string | ConditionalStringValue_2;
     readonly parentGroupItemId?: string;
 }
 
@@ -4908,7 +4920,7 @@ export function ToolbarComposer(props: ExtensibleToolbarProps): React_2.JSX.Elem
 export interface ToolbarCustomItem extends CommonToolbarItem {
     // @deprecated
     readonly icon?: IconSpec;
-    readonly label?: string | ConditionalStringValue;
+    readonly label?: string | ConditionalStringValue_2;
     readonly panelContent?: React.ReactNode;
 }
 
@@ -4920,8 +4932,8 @@ export interface ToolbarGroupItem extends CommonToolbarItem {
     // @deprecated
     readonly icon: IconSpec;
     readonly items: ReadonlyArray<ToolbarActionItem | ToolbarGroupItem>;
-    readonly label: string | ConditionalStringValue;
-    readonly panelLabel?: string | ConditionalStringValue;
+    readonly label: string | ConditionalStringValue_2;
+    readonly panelLabel?: string | ConditionalStringValue_2;
     readonly parentGroupItemId?: string;
 }
 
@@ -5815,12 +5827,12 @@ export interface Widget {
     // (undocumented)
     readonly id: string;
     // (undocumented)
-    readonly label?: string | ConditionalStringValue;
+    readonly label?: string | ConditionalStringValue_2;
     readonly layouts?: WidgetLayouts;
     // (undocumented)
     readonly priority?: number;
     // (undocumented)
-    readonly tooltip?: string | ConditionalStringValue;
+    readonly tooltip?: string | ConditionalStringValue_2;
 }
 
 // @public
@@ -5928,8 +5940,8 @@ export class WidgetDef {
     setCanPopout(value: boolean | undefined): void;
     // (undocumented)
     setFloatingContainerId(value: string | undefined): void;
-    setLabel(labelSpec: string | ConditionalStringValue | StringGetter): void;
-    setTooltip(v: string | ConditionalStringValue | StringGetter): void;
+    setLabel(labelSpec: string | ConditionalStringValue_2 | StringGetter): void;
+    setTooltip(v: string | ConditionalStringValue_2 | StringGetter): void;
     // (undocumented)
     setWidgetState(newState: WidgetState): void;
     show(): void;

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -135,6 +135,10 @@ deprecated;CommandItemProps
 public;CommonBackstageItem
 public;CommonStatusBarItem
 public;CommonToolbarItem
+public;ConditionalBooleanValue = ConditionalBooleanValue_2
+public;ConditionalBooleanValue: typeof ConditionalBooleanValue_2
+public;ConditionalStringValue = ConditionalStringValue_2
+public;ConditionalStringValue: typeof ConditionalStringValue_2
 public;ConfigurableBase 
 deprecated;ConfigurableBase 
 public;ConfigurableCreateInfo
@@ -323,10 +327,10 @@ deprecated;FunctionType = (...args: any[]) => any
 beta;getFeatureOverrideSyncEventIds(): string[]
 deprecated;getFeatureOverrideSyncEventIds(): string[]
 internal;getFrontstageStateSettingName(frontstageId: WidgetPanelsFrontstageState["id"]): string
-beta;getIsHiddenIfFeatureOverridesActive(): ConditionalBooleanValue
-deprecated;getIsHiddenIfFeatureOverridesActive(): ConditionalBooleanValue
-beta;getIsHiddenIfSelectionNotActive(): ConditionalBooleanValue
-deprecated;getIsHiddenIfSelectionNotActive(): ConditionalBooleanValue
+beta;getIsHiddenIfFeatureOverridesActive(): ConditionalBooleanValue_2
+deprecated;getIsHiddenIfFeatureOverridesActive(): ConditionalBooleanValue_2
+beta;getIsHiddenIfSelectionNotActive(): ConditionalBooleanValue_2
+deprecated;getIsHiddenIfSelectionNotActive(): ConditionalBooleanValue_2
 internal;getKeyinsFromToolList(toolList: ToolList, localizedKeyinPreference?: KeyinFieldLocalization): KeyinEntry[]
 beta;getListPanel(props: ListPickerProps): React_2.ReactNode
 internal;getPanelSectionId(location: StagePanelLocation, section: StagePanelSection): PanelSectionId

--- a/common/changes/@itwin/appui-react/export-conditional-value_2024-09-16-12-56.json
+++ b/common/changes/@itwin/appui-react/export-conditional-value_2024-09-16-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add `ConditionalBooleanValue` and `ConditionalStringValue` class re-exports.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/core-react/export-conditional-value_2024-09-16-12-56.json
+++ b/common/changes/@itwin/core-react/export-conditional-value_2024-09-16-12-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/docs/changehistory/4.4.0.md
+++ b/docs/changehistory/4.4.0.md
@@ -26,7 +26,7 @@ Table of contents:
 - Fixed store reset when iModelConnection is cleared.
 - Fixed `clearHideIsolateEmphasizeElements` and `hideElements` button display when view changes happen outside AppUI's API.
 - Fixed `openCursorMenu` function so that it opens cursor menu in Strict Mode in React 18.
-- Fixed `Toolbar` and `ToolbarWithOverflow` to correctly handle `ConditionalStringValue`, `ConditionalBooleanValue` and `ConditionalIconValue` tool item properties.
+- Fixed `Toolbar` and `ToolbarWithOverflow` to correctly handle `ConditionalStringValue`, `ConditionalBooleanValue` and `ConditionalIconItem` tool item properties.
 
 ### Deprecations
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -6,10 +6,11 @@ Table of contents:
   - [Deprecations](#deprecations)
 - [@itwin/appui-react](#itwinappui-react)
   - [Deprecations](#deprecations-1)
+  - [Additions](#additions)
   - [Changes](#changes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Deprecations](#deprecations-2)
-  - [Additions](#additions)
+  - [Additions](#additions-1)
 
 ## @itwin/core-react
 
@@ -107,6 +108,10 @@ Table of contents:
 - Deprecated `BaseUiItemsProvider`, `StandardContentToolsProvider`, `StandardNavigationToolsProvider`, `StandardStatusbarItemsProvider` classes. Use `UiItemsProviderOverrides` to specify supported frontstages when registering the provider. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead. [#1024](https://github.com/iTwin/appui/pull/1024)
+
+### Additions
+
+- Added `ConditionalBooleanValue` and `ConditionalStringValue` class re-exports from `@itwin/appui-abstract` package.
 
 ### Changes
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -111,7 +111,7 @@ Table of contents:
 
 ### Additions
 
-- Added `ConditionalBooleanValue` and `ConditionalStringValue` class re-exports from `@itwin/appui-abstract` package.
+- Added `ConditionalBooleanValue` and `ConditionalStringValue` class re-exports from `@itwin/appui-abstract` package. [#1031](https://github.com/iTwin/appui/pull/1031)
 
 ### Changes
 

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -156,6 +156,7 @@ export * from "./appui-react/shared/ActionButtonItemDef";
 export * from "./appui-react/shared/AnyItemDef";
 export * from "./appui-react/shared/AnyToolbarItemDef";
 export * from "./appui-react/shared/CommandItemDef";
+export * from "./appui-react/shared/ConditionalValue";
 export * from "./appui-react/shared/CustomItemDef";
 export * from "./appui-react/shared/CustomItemProps";
 export * from "./appui-react/shared/GroupItemProps";

--- a/ui/appui-react/src/appui-react/shared/ConditionalValue.ts
+++ b/ui/appui-react/src/appui-react/shared/ConditionalValue.ts
@@ -26,12 +26,3 @@ export const ConditionalBooleanValue = _ConditionalBooleanValue;
 export type ConditionalStringValue = _ConditionalStringValue;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ConditionalStringValue = _ConditionalStringValue;
-
-/** Class used to return an icon value. The value is refreshed by using the specified function. The `syncEventIds` define
- * events that would require the `iconGetter` function to be rerun.
- * @public
- */
-// eslint-disable-next-line deprecation/deprecation
-export type ConditionalIconValue = _ConditionalIconItem;
-// eslint-disable-next-line @typescript-eslint/no-redeclare, deprecation/deprecation
-export const ConditionalIconValue = _ConditionalIconItem;

--- a/ui/appui-react/src/appui-react/shared/ConditionalValue.ts
+++ b/ui/appui-react/src/appui-react/shared/ConditionalValue.ts
@@ -16,6 +16,7 @@ import { ConditionalIconItem as _ConditionalIconItem } from "@itwin/core-react";
  * @public
  */
 export type ConditionalBooleanValue = _ConditionalBooleanValue;
+/** @public */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ConditionalBooleanValue = _ConditionalBooleanValue;
 
@@ -24,5 +25,6 @@ export const ConditionalBooleanValue = _ConditionalBooleanValue;
  * @public
  */
 export type ConditionalStringValue = _ConditionalStringValue;
+/** @public */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ConditionalStringValue = _ConditionalStringValue;

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItemsManager.ts
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItemsManager.ts
@@ -11,13 +11,13 @@ import {
   ConditionalStringValue,
 } from "@itwin/appui-abstract";
 import { BeEvent } from "@itwin/core-bentley";
+import { ConditionalIconItem } from "@itwin/core-react";
 import type {
   ToolbarActionItem,
   ToolbarGroupItem,
   ToolbarItem,
 } from "./ToolbarItem";
 import { isToolbarGroupItem } from "./ToolbarItem";
-import { ConditionalIconValue } from "../shared/ConditionalValue";
 
 function isInstance<T>(args: T | ReadonlyArray<T>): args is T {
   return !Array.isArray(args);
@@ -136,7 +136,8 @@ export class ToolbarItemsManager {
           entry.syncEventIds.forEach((eventId: string) =>
             eventIds.add(eventId.toLowerCase())
           );
-        } else if (entry instanceof ConditionalIconValue) {
+          // eslint-disable-next-line deprecation/deprecation
+        } else if (entry instanceof ConditionalIconItem) {
           entry.syncEventIds.forEach((eventId: string) =>
             eventIds.add(eventId.toLowerCase())
           );
@@ -187,8 +188,10 @@ export class ToolbarItemsManager {
         } else if (entry instanceof ConditionalStringValue) {
           if (ConditionalStringValue.refreshValue(entry, eventIds))
             itemsUpdated = true;
-        } else if (entry instanceof ConditionalIconValue) {
-          if (ConditionalIconValue.refreshValue(entry, eventIds))
+          // eslint-disable-next-line deprecation/deprecation
+        } else if (entry instanceof ConditionalIconItem) {
+          // eslint-disable-next-line deprecation/deprecation
+          if (ConditionalIconItem.refreshValue(entry, eventIds))
             itemsUpdated = true;
         }
       }
@@ -229,8 +232,10 @@ export class ToolbarItemsManager {
         } else if (entry instanceof ConditionalStringValue) {
           if (ConditionalStringValue.refreshValue(entry, eventIds))
             updateRequired = true;
-        } else if (entry instanceof ConditionalIconValue) {
-          if (ConditionalIconValue.refreshValue(entry, eventIds))
+          // eslint-disable-next-line deprecation/deprecation
+        } else if (entry instanceof ConditionalIconItem) {
+          // eslint-disable-next-line deprecation/deprecation
+          if (ConditionalIconItem.refreshValue(entry, eventIds))
             updateRequired = true;
         }
       }

--- a/ui/appui-react/src/test/shared/ConditionalValue.test.ts
+++ b/ui/appui-react/src/test/shared/ConditionalValue.test.ts
@@ -2,17 +2,20 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import { ConditionalIconItem } from "@itwin/core-react";
-import { ConditionalIconValue } from "../../appui-react/shared/ConditionalValue";
+import { ConditionalStringValue as AbstractConditionalStringValue } from "@itwin/appui-abstract";
+import { ConditionalStringValue } from "../../appui-react/shared/ConditionalValue";
 
-describe("ConditionalIconValue", () => {
+describe("ConditionalStringValue", () => {
   it("should use the same type for instanceof check", () => {
-    const item = new ConditionalIconItem(() => "item", []);
-    const value = new ConditionalIconValue(() => "value", []);
+    const abstractValue = new AbstractConditionalStringValue(
+      () => "abstractValue",
+      []
+    );
+    const value = new ConditionalStringValue(() => "value", []);
 
-    expect(item instanceof ConditionalIconItem).toBe(true);
-    expect(value instanceof ConditionalIconItem).toBe(true);
-    expect(item instanceof ConditionalIconValue).toBe(true);
-    expect(value instanceof ConditionalIconValue).toBe(true);
+    expect(abstractValue instanceof AbstractConditionalStringValue).toBe(true);
+    expect(value instanceof AbstractConditionalStringValue).toBe(true);
+    expect(value instanceof ConditionalStringValue).toBe(true);
+    expect(value instanceof ConditionalStringValue).toBe(true);
   });
 });

--- a/ui/core-react/src/core-react/icons/ConditionalIconItem.tsx
+++ b/ui/core-react/src/core-react/icons/ConditionalIconItem.tsx
@@ -12,7 +12,7 @@ import type { IconSpec } from "./IconComponent";
 
 /** Class used to return an icon. The icon is variable and can be changed in response to subscribed event ids.
  * @public
- * @deprecated in 4.16.0. Use {@link @itwin/appui-react#ConditionalIconValue} instead.
+ * @deprecated in 4.16.0. Uses a deprecated {@link IconSpec} type. Use conditional rendering to render different icons.
  */
 export class ConditionalIconItem {
   private _value?: IconSpec;


### PR DESCRIPTION
## Changes

This PR adds `ConditionalBooleanValue` and `ConditionalStringValue` class re-exports from `@itwin/appui-abstract` package.
`ConditionalIconValue` is removed, since it was never exported from the barrel and should have never been used via `@itwin/appui-react/lib` relative path (the class alias was added recently in the last minor).

## Testing

N/A
