### PR TITLE
Deprecate hooks that depend on `@internal` managers

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -5610,7 +5610,7 @@ export const useContentOverlayStore: UseBoundStore<StoreApi<number>>;
 // @internal
 export const useDefaultBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[];
 
-// @public
+// @public @deprecated
 export const useDefaultStatusBarItems: (manager: StatusBarItemsManager) => readonly StatusBarItem[];
 
 // @public @deprecated
@@ -5687,10 +5687,10 @@ export function useToolSettingsNode(): string | number | boolean | React_2.React
 // @public
 export function useTransientState(onSave?: () => void, onRestore?: () => void): void;
 
-// @public
+// @public @deprecated
 export const useUiItemsProviderBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[];
 
-// @public
+// @public @deprecated
 export const useUiItemsProviderStatusBarItems: (manager: StatusBarItemsManager) => readonly StatusBarItem[];
 
 // @public @deprecated

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -808,6 +808,7 @@ public;useConditionalValue
 internal;useContentOverlayStore: UseBoundStore
 internal;useDefaultBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[]
 public;useDefaultStatusBarItems: (manager: StatusBarItemsManager) => readonly StatusBarItem[]
+deprecated;useDefaultStatusBarItems: (manager: StatusBarItemsManager) => readonly StatusBarItem[]
 public;useDefaultToolbarItems: (manager: ToolbarItemsManager) => readonly ToolbarItem[]
 deprecated;useDefaultToolbarItems: (manager: ToolbarItemsManager) => readonly ToolbarItem[]
 alpha;useFloatingViewport(args: FloatingViewportContentProps):
@@ -833,7 +834,9 @@ internal;useStatusBarEntry(): DockedStatusBarEntryContextArg
 internal;useToolSettingsNode(): string | number | boolean | React_2.ReactElement
 public;useTransientState(onSave?: () => void, onRestore?: () => void): void
 public;useUiItemsProviderBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[]
+deprecated;useUiItemsProviderBackstageItems: (manager: BackstageItemsManager) => readonly BackstageItem[]
 public;useUiItemsProviderStatusBarItems: (manager: StatusBarItemsManager) => readonly StatusBarItem[]
+deprecated;useUiItemsProviderStatusBarItems: (manager: StatusBarItemsManager) => readonly StatusBarItem[]
 public;useUiItemsProviderToolbarItems: (manager: ToolbarItemsManager, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation) => readonly ToolbarItem[]
 deprecated;useUiItemsProviderToolbarItems: (manager: ToolbarItemsManager, toolbarUsage: ToolbarUsage, toolbarOrientation: ToolbarOrientation) => readonly ToolbarItem[]
 public;useUiStateStorageHandler(): UiStateStorage

--- a/common/changes/@itwin/appui-react/deprecate-internal-manager-apis_2024-09-18-15-37.json
+++ b/common/changes/@itwin/appui-react/deprecate-internal-manager-apis_2024-09-18-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Deprecate `useDefaultStatusBarItems`, `useUiItemsProviderStatusBarItems` and `useUiItemsProviderBackstageItems` hooks.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -122,8 +122,8 @@ Table of contents:
 - Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `floatingContentControls` getter of `FrontstageDef` class that used a deprecated `ContentControl` class. Use floating widgets instead. [#1030](https://github.com/iTwin/appui/pull/1030)
-- Deprecated `useDefaultStatusBarItems` and `useUiItemsProviderStatusBarItems` hooks, which require an internal class as a parameter. Use `StatusBarComposer` component instead.
-- Deprecated `useUiItemsProviderBackstageItems` hook, which requires an internal class as a parameter. Use `BackstageComposer` component instead.
+- Deprecated `useDefaultStatusBarItems` and `useUiItemsProviderStatusBarItems` hooks, which require an internal class as a parameter. Use `StatusBarComposer` component instead. [#1037](https://github.com/iTwin/appui/pull/1037)
+- Deprecated `useUiItemsProviderBackstageItems` hook, which requires an internal class as a parameter. Use `BackstageComposer` component instead. [#1037](https://github.com/iTwin/appui/pull/1037)
 
 ### Additions
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -122,6 +122,8 @@ Table of contents:
 - Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `floatingContentControls` getter of `FrontstageDef` class that used a deprecated `ContentControl` class. Use floating widgets instead. [#1030](https://github.com/iTwin/appui/pull/1030)
+- Deprecated `useDefaultStatusBarItems` and `useUiItemsProviderStatusBarItems` hooks, which require an internal class as a parameter. Use `StatusBarComposer` component instead.
+- Deprecated `useUiItemsProviderBackstageItems` hook, which requires an internal class as a parameter. Use `BackstageComposer` component instead.
 
 ### Additions
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -107,9 +107,6 @@ Table of contents:
 
 ### Deprecations
 
-- Deprecated `BaseUiItemsProvider`, `StandardContentToolsProvider`, `StandardNavigationToolsProvider`, `StandardStatusbarItemsProvider` classes. Use `UiItemsProviderOverrides` to specify supported frontstages when registering the provider. [#1024](https://github.com/iTwin/appui/pull/1024)
-- Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs. [#1024](https://github.com/iTwin/appui/pull/1024)
-- Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead. [#1024](https://github.com/iTwin/appui/pull/1024)
 - Deprecated `AccuDrawDialogProps`, `AccuDrawFieldContainerProps`, `AccuDrawInputFieldProps`, `BackstageComposerProps`, `ConfigurableUiContentProps`, `SplitPaneProps`, `StatusBarComposerProps`, `ExtensibleToolbarProps`, `UiSettingsProviderProps`, `BasicNavigationWidgetProps`, `BasicToolWidgetProps`, `ContentToolWidgetComposerProps`, `NavigationAidHostProps`, `NavigationWidgetComposerProps`, `ToolWidgetComposerProps`, `ViewToolWidgetComposerProps` in favor of `React.ComponentProps<typeof ...>`. [#991](https://github.com/iTwin/appui/pull/991)
   Usage example:
 
@@ -119,13 +116,18 @@ Table of contents:
   type AccuDrawDialogProps = React.ComponentProps<typeof AccuDrawDialog>;
   ```
 
-- Deprecated `floatingContentControls` getter of `FrontstageDef` class that used a deprecated `ContentControl` class. Use floating widgets instead. [#1030](https://github.com/iTwin/appui/pull/1030)
-- Deprecated `UiFramework.setIsUiVisible` and `UiFramework.getIsUiVisible`. Use `UiFramework.visibility.isUiVisible` instead. [#1023](https://github.com/iTwin/appui/pull/1023)
 - Deprecated `FrameworkFrontstages.clearFrontstageProviders`, use `FrameworkFrontstages.clearFrontstages` instead. [#1022](https://github.com/iTwin/appui/pull/1022)
+- Deprecated `UiFramework.setIsUiVisible` and `UiFramework.getIsUiVisible`. Use `UiFramework.visibility.isUiVisible` instead. [#1023](https://github.com/iTwin/appui/pull/1023)
+- Deprecated `BaseUiItemsProvider`, `StandardContentToolsProvider`, `StandardNavigationToolsProvider`, `StandardStatusbarItemsProvider` classes. Use `UiItemsProviderOverrides` to specify supported frontstages when registering the provider. [#1024](https://github.com/iTwin/appui/pull/1024)
+- Deprecated `DefaultContentToolsAppData` interface that is a remnant of discontinued frontstage APIs. [#1024](https://github.com/iTwin/appui/pull/1024)
+- Deprecated `StandardContentToolsUiItemsProvider.provideStatusBarItems`, `StandardContentToolsUiItemsProvider.provideToolbarItems`, `StandardNavigationToolsUiItemsProvider.provideToolbarItems`, `StandardStatusbarUiItemsProvider.provideStatusBarItems` methods. Use `get*` variants instead. [#1024](https://github.com/iTwin/appui/pull/1024)
+- Deprecated `floatingContentControls` getter of `FrontstageDef` class that used a deprecated `ContentControl` class. Use floating widgets instead. [#1030](https://github.com/iTwin/appui/pull/1030)
 
 ### Additions
 
+- Added `UiFramework.onIModelConnectionChanged` event to get notified whenever the iModel targeted by `UiFramework.getIModelConnection()` changes. This is a replacement for listening to the deprecated `SessionStateActionId.SetIModelConnection`. [#1027](https://github.com/iTwin/appui/pull/1027)
 - Added `ConditionalBooleanValue` and `ConditionalStringValue` class re-exports from `@itwin/appui-abstract` package. [#1031](https://github.com/iTwin/appui/pull/1031)
+- Added `StandardContentLayouts`, `ContentLayoutProps`, `LayoutFragmentProps`, `LayoutHorizontalSplitProps`, `LayoutSplitPropsBase`, and `LayoutVerticalSplitProps` interfaces from `@itwin/appui-abstract` package. [#1033](https://github.com/iTwin/appui/pull/1033)
 - Added a generic `ConditionalValue<T>` interface to track the conditional value of any type. This interface can be used as a replacement for existing `ConditionalBooleanValue` and `ConditionalStringValue` classes. [#1036](https://github.com/iTwin/appui/pull/1036)
 
 ```tsx
@@ -197,9 +199,6 @@ const content: ContentProps = {
 };
 ```
 
-- Added `StandardContentLayouts`, `ContentLayoutProps`, `LayoutFragmentProps`, `LayoutHorizontalSplitProps`, `LayoutSplitPropsBase`, and `LayoutVerticalSplitProps` interfaces from `@itwin/appui-abstract` package. [#1033](https://github.com/iTwin/appui/pull/1033)
-- Added `UiFramework.onIModelConnectionChanged` event to get notified whenever the iModel targeted by `UiFramework.getIModelConnection()` changes. This is a replacement for listening to the deprecated `SessionStateActionId.SetIModelConnection`. [#1027](https://github.com/iTwin/appui/pull/1027)
-
 ### Changes
 
 - Allow to set the available snap modes in `SnapModeField` component. [#974](https://github.com/iTwin/appui/pull/974)
@@ -212,7 +211,6 @@ const content: ContentProps = {
 
 ### Deprecations
 
-- Deprecated `defaultPropertyFilterBuilderRuleValidator`. Newly added `useDefaultPropertyFilterBuilderRuleValidator` should be used instead. [#1000](https://github.com/iTwin/appui/pull/1000)
 - Deprecated `HighlightedTextProps`, `EditorContainerProps`, `OkCancelProps`, `FavoritePropertyListProps`, `ParsedInputProps`, `LinksRendererProps`, `VirtualizedPropertyGridWithDataProviderProps`, `ControlledSelectableContentProps`, `SelectableContentProps`, `TreeNodeContentProps`, `TreeNodeIconProps` in favor of `React.ComponentProps<typeof ...>`. [#991](https://github.com/iTwin/appui/pull/991)
 
   Usage example:
@@ -222,6 +220,8 @@ const content: ContentProps = {
 
   type HighlightedTextProps = React.ComponentProps<typeof HighlightedText>;
   ```
+
+- Deprecated `defaultPropertyFilterBuilderRuleValidator`. Newly added `useDefaultPropertyFilterBuilderRuleValidator` should be used instead. [#1000](https://github.com/iTwin/appui/pull/1000)
 
 ### Additions
 

--- a/ui/appui-react/src/appui-react/backstage/BackstageComposer.tsx
+++ b/ui/appui-react/src/appui-react/backstage/BackstageComposer.tsx
@@ -171,6 +171,7 @@ export function BackstageComposer(props: BackstageComposerProps) {
   useBackstageItemSyncEffect(defaultItemsManager, syncIdsOfInterest);
 
   const [addonItemsManager] = React.useState(new BackstageItemsManager());
+  // eslint-disable-next-line deprecation/deprecation
   const addonItems = useUiItemsProviderBackstageItems(addonItemsManager);
   const addonSyncIdsOfInterest = React.useMemo(
     () => BackstageItemsManager.getSyncIdsOfInterest(addonItems),

--- a/ui/appui-react/src/appui-react/backstage/useUiItemsProviderBackstageItems.tsx
+++ b/ui/appui-react/src/appui-react/backstage/useUiItemsProviderBackstageItems.tsx
@@ -11,8 +11,10 @@ import { useAvailableUiItemsProviders } from "../hooks/useAvailableUiItemsProvid
 import type { BackstageItem } from "./BackstageItem";
 import { UiItemsManager } from "../ui-items-provider/UiItemsManager";
 import type { BackstageItemsManager } from "./BackstageItemsManager";
+import type { BackstageComposer } from "./BackstageComposer";
 
-/** Hook that returns items from [[BackstageItemsManager]].
+/** Hook that returns backstage items from {@link UiItemsManager}.
+ * @deprecated in 4.17.0. Uses an internal `BackstageItemsManager` API. Use {@link BackstageComposer} instead.
  * @public
  */
 export const useUiItemsProviderBackstageItems = (

--- a/ui/appui-react/src/appui-react/statusbar/StatusBarComposer.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBarComposer.tsx
@@ -325,6 +325,7 @@ export function StatusBarComposer(props: StatusBarComposerProps) {
       setDefaultItemsManager(new StatusBarItemsManager(items));
     }
   }, [items]);
+  // eslint-disable-next-line deprecation/deprecation
   const defaultItems = useDefaultStatusBarItems(defaultItemsManager);
   const syncIdsOfInterest = React.useMemo(
     () => StatusBarItemsManager.getSyncIdsOfInterest(defaultItems),
@@ -333,6 +334,7 @@ export function StatusBarComposer(props: StatusBarComposerProps) {
   useStatusBarItemSyncEffect(defaultItemsManager, syncIdsOfInterest);
 
   const [addonItemsManager] = React.useState(() => new StatusBarItemsManager());
+  // eslint-disable-next-line deprecation/deprecation
   const addonItems = useUiItemsProviderStatusBarItems(addonItemsManager);
   const addonSyncIdsOfInterest = React.useMemo(
     () => StatusBarItemsManager.getSyncIdsOfInterest(addonItems),

--- a/ui/appui-react/src/appui-react/statusbar/useDefaultStatusBarItems.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/useDefaultStatusBarItems.tsx
@@ -11,6 +11,7 @@ import type { StatusBarItem } from "./StatusBarItem";
 import type { StatusBarItemsManager } from "./StatusBarItemsManager";
 
 /** Hook that returns items from [[StatusBarItemsManager]].
+ * @deprecated in 4.17.0. Uses an internal `StatusBarItemsManager` API. Use {@link StatusBarComposer} instead.
  * @public
  */
 export const useDefaultStatusBarItems = (

--- a/ui/appui-react/src/appui-react/statusbar/useUiItemsProviderStatusBarItems.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/useUiItemsProviderStatusBarItems.tsx
@@ -13,8 +13,10 @@ import { UiFramework } from "../UiFramework";
 import { UiItemsManager } from "../ui-items-provider/UiItemsManager";
 import type { StatusBarItem } from "./StatusBarItem";
 import type { StatusBarItemsManager } from "./StatusBarItemsManager";
+import type { StatusBarComposer } from "./StatusBarComposer";
 
 /** Hook that returns items from [[StatusBarItemsManager]].
+ * @deprecated in 4.17.0. Uses an internal `StatusBarItemsManager` API. Use {@link StatusBarComposer} instead.
  * @public
  */
 export const useUiItemsProviderStatusBarItems = (


### PR DESCRIPTION
## Changes

This PR deprecates the `useDefaultStatusBarItems`, `useUiItemsProviderBackstageItems`, and `useUiItemsProviderStatusBarItems` hooks, which require an `@internal` class as a parameter.

## Testing

N/A
