### PR TITLE
Updated `MessageManager.addMessage` to only add unique messages

### DIFF
--- a/common/changes/@itwin/appui-react/add-message-once_2024-09-23-12-30.json
+++ b/common/changes/@itwin/appui-react/add-message-once_2024-09-23-12-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Update `MessageManager.addMessage` to ignore messages that are already active.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/appui-react](#itwinappui-react)
+  - [Changes](#changes)
+
+## @itwin/appui-react
+
+### Changes
+
+- Updated `MessageManager.addMessage` and `MessageManager.outputMessage` to ignore already active messages displayed to the user. This API is used by various tools indirectly via `IModelApp.notifications.outputMessage` when `AppNotificationManager` is set up. This change should prevent the same message from being displayed multiple times unnecessarily.

--- a/ui/appui-react/src/appui-react/messages/MessageManager.tsx
+++ b/ui/appui-react/src/appui-react/messages/MessageManager.tsx
@@ -365,19 +365,23 @@ export class MessageManager {
   }
 
   /** Output a message and/or alert to the user.
-   * @param  message  Details about the message to output.
+   * @param message Details about the message to output.
    */
   public static addMessage(message: NotifyMessageDetailsType): void {
+    const activeMessage = this.activeMessageManager.messages.find((m) =>
+      isEqual(message, m.messageDetails)
+    );
+    if (activeMessage) return;
+
+    this.activeMessageManager.add(message);
+    this.refreshToastMessages();
+    this.onMessageAddedEvent.emit({ message });
+
     if (!isEqual(message, this._lastMessage)) {
+      // Add message to message center if it is not the same as the last message.
       this.addToMessageCenter(message);
       this._lastMessage = message;
     }
-
-    this._activeMessageManager.add(message);
-
-    this.refreshToastMessages();
-
-    this.onMessageAddedEvent.emit({ message });
   }
 
   /**

--- a/ui/appui-react/src/test/messages/MessageManager.test.tsx
+++ b/ui/appui-react/src/test/messages/MessageManager.test.tsx
@@ -192,6 +192,51 @@ describe("MessageManager", () => {
     expect(MessageManager.messages.length).toEqual(1);
   });
 
+  it("should activate the same message once", async () => {
+    function getActiveMessages() {
+      return MessageManager.activeMessageManager.messages.map(({ id }) => id);
+    }
+    function getMessages() {
+      return MessageManager.messages.map(({ briefMessage }) =>
+        typeof briefMessage === "string" ? briefMessage : "Brief message"
+      );
+    }
+
+    MessageManager.addMessage(
+      new NotifyMessageDetails(OutputMessagePriority.Debug, "Message 1")
+    );
+    expect(getActiveMessages()).toEqual(["0"]);
+    MessageManager.addMessage(
+      new NotifyMessageDetails(OutputMessagePriority.Debug, "Message 2")
+    );
+    expect(getActiveMessages()).toEqual(["1", "0"]);
+    MessageManager.addMessage(
+      new NotifyMessageDetails(OutputMessagePriority.Debug, "Message 1")
+    );
+    expect(getActiveMessages(), "Message 1 is already active").toEqual([
+      "1",
+      "0",
+    ]);
+
+    // `Message 1` is removed when i.e. toast is closed
+    MessageManager.activeMessageManager.remove("0");
+
+    MessageManager.addMessage(
+      new NotifyMessageDetails(OutputMessagePriority.Debug, "Message 1")
+    );
+    expect(getActiveMessages()).toEqual(["2", "1"]);
+
+    MessageManager.addMessage(
+      new NotifyMessageDetails(OutputMessagePriority.Debug, "Message 2")
+    );
+    expect(getActiveMessages(), "Message 2 is still active").toEqual([
+      "2",
+      "1",
+    ]);
+
+    expect(getMessages()).toEqual(["Message 1", "Message 2", "Message 1"]);
+  });
+
   it("React based message should be supported", () => {
     MessageManager.clearMessages();
     expect(MessageManager.messages.length).toEqual(0);


### PR DESCRIPTION
## Changes

This PR changes `MessageManager.addMessage()` to ignore already active messages displayed to the user (for all message types, like `Toast` or `Sticky`). This API is used by various tools indirectly via `IModelApp.notifications.outputMessage` when `AppNotificationManager` is set up. This change should prevent the same message from being displayed multiple times unnecessarily.

Ideally, tools and other consumers should throttle the messages manually i.e. in mouse wheel scroll handlers.
In the future, an option argument can be added if there is a use case where multiple equal messages need to be added.

## Testing

Additional unit tests were added and tested via the test app.
