### PR TITLE
Fix popout widget zoom issues

### DIFF
--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -189,6 +189,18 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
     );
     if (!childWindow) return false;
 
+    // Window is opened using inner size which is affected by browser zoom.
+    const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
+    if (frontstageDef && tabId) {
+      const savedTab = frontstageDef.nineZoneState?.savedTabs.byId[tabId];
+      if (savedTab?.popout?.size) {
+        childWindow.resizeTo(
+          savedTab?.popout?.size.width,
+          savedTab?.popout?.size.height
+        );
+      }
+    }
+
     childWindow.addEventListener("pagehide", () => {
       const frontStageDef = UiFramework.frontstages.activeFrontstageDef;
       if (!frontStageDef) return;

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -210,18 +210,6 @@ export class InternalChildWindowManager implements FrameworkChildWindows {
     );
     if (!childWindow) return undefined;
 
-    // Use outer size if available to avoid inner size + browser zoom issues: https://github.com/iTwin/appui/issues/563
-    const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
-    if (frontstageDef && tabId) {
-      const savedTab = frontstageDef.nineZoneState?.savedTabs.byId[tabId];
-      if (savedTab?.popout?.size) {
-        childWindow.resizeTo(
-          savedTab?.popout?.size.width,
-          savedTab?.popout?.size.height
-        );
-      }
-    }
-
     childWindow.addEventListener("pagehide", () => {
       const frontStageDef = UiFramework.frontstages.activeFrontstageDef;
       if (!frontStageDef) return;

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -729,7 +729,7 @@ export class FrontstageDef {
       top: bounds.top,
     };
 
-    const result = appUi.windowManager.openWindow({
+    const childWindow = appUi.windowManager.openWindow({
       childWindowId: widgetContainerId,
       title: widgetDef.label,
       content: popoutContent,
@@ -737,7 +737,16 @@ export class FrontstageDef {
       useDefaultPopoutUrl: UiFramework.useDefaultPopoutUrl,
     });
 
-    if (!result && oldState) {
+    // Use outer size if available to avoid inner size + browser zoom issues: https://github.com/iTwin/appui/issues/563
+    const savedTab = state.savedTabs.byId[tabId];
+    if (childWindow && savedTab?.popout?.size) {
+      childWindow.resizeTo(
+        savedTab.popout.size.width,
+        savedTab.popout.size.height
+      );
+    }
+
+    if (!childWindow && oldState) {
       this.nineZoneState = oldState;
       return false;
     }

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -729,14 +729,13 @@ export class FrontstageDef {
       top: bounds.top,
     };
 
-    const result = appUi.windowManager.open(
-      widgetContainerId,
-      widgetDef.label,
-      popoutContent,
-      position,
-      UiFramework.useDefaultPopoutUrl,
-      tabId
-    );
+    const result = appUi.windowManager.openWindow({
+      childWindowId: widgetContainerId,
+      title: widgetDef.label,
+      content: popoutContent,
+      location: position,
+      useDefaultPopoutUrl: UiFramework.useDefaultPopoutUrl,
+    });
 
     if (!result && oldState) {
       this.nineZoneState = oldState;

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -795,20 +795,21 @@ export class FrontstageDef {
     const widgetDef = this.findWidgetDef(tabId);
     if (!widgetDef) return;
 
-    const height = childWindow.innerHeight;
-    const width = childWindow.innerWidth;
-    const left = childWindow.screenLeft;
-    const top = childWindow.screenTop;
-
-    const bounds = Rectangle.createFromSize({ width, height }).offset({
-      x: left,
-      y: top,
-    });
-
     this.dispatch({
       type: "WIDGET_TAB_SET_POPOUT_BOUNDS",
       id: tabId,
-      bounds,
+      position: {
+        x: childWindow.screenLeft,
+        y: childWindow.screenTop,
+      },
+      size: {
+        height: childWindow.outerHeight,
+        width: childWindow.outerWidth,
+      },
+      contentSize: {
+        height: childWindow.innerHeight,
+        width: childWindow.innerWidth,
+      },
     });
   }
 

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
@@ -25,6 +25,7 @@ import type { XAndY } from "./internal/NineZoneStateHelpers.js";
 import type { StagePanelSizeSpec } from "../../stagepanels/StagePanelConfig.js";
 import type { SizeProps } from "../../utils/SizeProps.js";
 import type { RectangleProps } from "../../utils/RectangleProps.js";
+import type { PopoutBounds } from "./SavedTabState.js";
 
 /** @internal */
 export interface ResizeAction {
@@ -271,10 +272,9 @@ export interface WidgetTabPopoutAction {
 }
 
 /** @internal */
-export interface WidgetTabSetPopoutBoundsAction {
+export interface WidgetTabSetPopoutBoundsAction extends PopoutBounds {
   readonly type: "WIDGET_TAB_SET_POPOUT_BOUNDS";
   readonly id: TabState["id"];
-  readonly bounds: RectangleProps | undefined;
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
@@ -626,6 +626,7 @@ export function NineZoneStateReducer(
         contentWidth = tab.preferredFloatingWidgetSize.width;
         contentHeight = tab.preferredFloatingWidgetSize.height;
       } else {
+        // TODO: reducers should be pure
         const popoutContentContainer = document.getElementById(
           `content-container:${id}`
         );

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
@@ -635,12 +635,15 @@ export function NineZoneStateReducer(
         }
       }
 
-      let preferredBounds = savedTab?.popoutBounds
-        ? Rectangle.create(savedTab.popoutBounds)
-        : Rectangle.createFromSize({
-            height: contentHeight,
-            width: contentWidth,
-          });
+      let preferredBounds = Rectangle.createFromSize({
+        height: contentHeight,
+        width: contentWidth,
+      });
+      if (savedTab?.popout) {
+        preferredBounds = Rectangle.createFromSize(savedTab.popout.contentSize);
+        preferredBounds = preferredBounds.offset(savedTab.popout.position);
+      }
+
       if (size) preferredBounds = preferredBounds.setSize(size);
       if (position) preferredBounds = preferredBounds.setPosition(position);
 
@@ -780,7 +783,13 @@ export function NineZoneStateReducer(
     }
     case "WIDGET_TAB_SET_POPOUT_BOUNDS": {
       return updateSavedTabState(state, action.id, (draft) => {
-        initRectangleProps(draft, "popoutBounds", action.bounds);
+        draft.popout = {
+          position: action.position,
+          contentSize: action.contentSize,
+        };
+        if (action.size) {
+          draft.popout.size = action.size;
+        }
       });
     }
     case "WIDGET_TAB_SHOW": {

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
@@ -40,7 +40,6 @@ import {
   updateTabState,
 } from "./internal/TabStateHelpers.js";
 import {
-  initRectangleProps,
   initSizeProps,
   isToolSettingsFloatingWidget,
   setPointProps,
@@ -787,10 +786,8 @@ export function NineZoneStateReducer(
         draft.popout = {
           position: action.position,
           contentSize: action.contentSize,
+          size: action.size,
         };
-        if (action.size) {
-          draft.popout.size = action.size;
-        }
       });
     }
     case "WIDGET_TAB_SHOW": {

--- a/ui/appui-react/src/appui-react/layout/state/SavedTabState.ts
+++ b/ui/appui-react/src/appui-react/layout/state/SavedTabState.ts
@@ -6,20 +6,30 @@
  * @module Base
  */
 
-import type { RectangleProps } from "../../utils/RectangleProps.js";
+import type { XAndY } from "@itwin/core-geometry";
 import type { TabState } from "./TabState.js";
 import type { WidgetRestoreState } from "./WidgetRestoreState.js";
+import type { SizeProps } from "../../utils/SizeProps.js";
 
 /** @internal */
 export type TabHomeState = WidgetRestoreState & {
-  tabIndex: number;
+  readonly tabIndex: number;
 };
+
+/** @internal */
+export interface PopoutBounds {
+  /** Window position. */
+  readonly position: XAndY;
+  /** Window size. */
+  readonly size?: SizeProps;
+  readonly contentSize: SizeProps;
+}
 
 /** @internal */
 export interface SavedTabState {
   readonly id: TabState["id"];
   readonly home?: TabHomeState;
-  readonly popoutBounds?: RectangleProps;
+  readonly popout?: PopoutBounds;
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -574,7 +574,7 @@ export function initializePanel(
 }
 
 /** @internal */
-export const stateVersion = 18; // this needs to be bumped when NineZoneState is changed (to recreate the layout).
+export const stateVersion = 19; // this needs to be bumped when NineZoneState is changed (to recreate the layout).
 
 /** @internal */
 export function initializeNineZoneState(frontstageDef: FrontstageDef) {

--- a/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
@@ -662,6 +662,7 @@ describe("FrontstageDef", () => {
 
       const spy = vi.spyOn(window, "open").mockReturnValue({
         addEventListener: () => {},
+        removeEventListener: () => {},
       } as unknown as Window);
       frontstageDef.popoutWidget("t1");
 

--- a/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
+++ b/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
@@ -1592,11 +1592,15 @@ describe("NineZoneStateReducer", () => {
           byId: {
             t1: {
               id: "t1",
-              popoutBounds: {
-                top: 10,
-                left: 20,
-                right: 300,
-                bottom: 400,
+              popout: {
+                position: {
+                  x: 20,
+                  y: 10,
+                },
+                contentSize: {
+                  height: 400,
+                  width: 300,
+                },
               },
             },
           },
@@ -2008,25 +2012,31 @@ describe("NineZoneStateReducer", () => {
   });
 
   describe("WIDGET_TAB_SET_POPOUT_BOUNDS", () => {
-    it("should update bounds", () => {
+    it.only("should update bounds", () => {
       let state = createNineZoneState();
       state = addTab(state, "t1");
 
       const newState = NineZoneStateReducer(state, {
         type: "WIDGET_TAB_SET_POPOUT_BOUNDS",
         id: "t1",
-        bounds: {
-          left: 10,
-          top: 20,
-          right: 300,
-          bottom: 400,
+        position: {
+          x: 10,
+          y: 20,
+        },
+        contentSize: {
+          width: 290,
+          height: 380,
         },
       });
-      expect(newState.savedTabs.byId.t1?.popoutBounds).to.eql({
-        left: 10,
-        top: 20,
-        right: 300,
-        bottom: 400,
+      expect(newState.savedTabs.byId.t1?.popout).to.eql({
+        position: {
+          x: 10,
+          y: 20,
+        },
+        contentSize: {
+          width: 290,
+          height: 380,
+        },
       });
     });
   });

--- a/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
+++ b/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
@@ -2037,6 +2037,7 @@ describe("NineZoneStateReducer", () => {
           width: 290,
           height: 380,
         },
+        size: undefined,
       });
     });
   });

--- a/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
+++ b/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
@@ -1585,7 +1585,7 @@ describe("NineZoneStateReducer", () => {
       expect(newState).toEqual(state);
     });
 
-    it("should use saved bounds", () => {
+    it.only("should use saved bounds", () => {
       let state = createNineZoneState({
         savedTabs: {
           allIds: ["t1"],
@@ -1598,8 +1598,8 @@ describe("NineZoneStateReducer", () => {
                   y: 10,
                 },
                 contentSize: {
-                  height: 400,
-                  width: 300,
+                  height: 390,
+                  width: 280,
                 },
               },
             },

--- a/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
+++ b/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
@@ -2012,7 +2012,7 @@ describe("NineZoneStateReducer", () => {
   });
 
   describe("WIDGET_TAB_SET_POPOUT_BOUNDS", () => {
-    it.only("should update bounds", () => {
+    it("should update bounds", () => {
       let state = createNineZoneState();
       state = addTab(state, "t1");
 

--- a/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
+++ b/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
@@ -1585,7 +1585,7 @@ describe("NineZoneStateReducer", () => {
       expect(newState).toEqual(state);
     });
 
-    it.only("should use saved bounds", () => {
+    it("should use saved bounds", () => {
       let state = createNineZoneState({
         savedTabs: {
           allIds: ["t1"],

--- a/ui/appui-react/src/test/layout/state/internal/TabStateHelpers.test.ts
+++ b/ui/appui-react/src/test/layout/state/internal/TabStateHelpers.test.ts
@@ -268,22 +268,30 @@ describe("updateSavedTabState", () => {
   it("should update existing saved tab state", () => {
     let state = createNineZoneState();
     state = updateSavedTabState(state, "t1", () => {});
-    expect(state.savedTabs.byId.t1?.popoutBounds).toEqual(undefined);
+    expect(state.savedTabs.byId.t1?.popout).toEqual(undefined);
 
     state = updateSavedTabState(state, "t1", (draft) => {
-      draft.popoutBounds = {
-        left: 1,
-        top: 2,
-        right: 30,
-        bottom: 40,
+      draft.popout = {
+        position: {
+          x: 1,
+          y: 2,
+        },
+        contentSize: {
+          height: 38,
+          width: 29,
+        },
       };
     });
     expect(state.savedTabs.allIds).to.eql(["t1"]);
-    expect(state.savedTabs.byId.t1?.popoutBounds).to.eql({
-      left: 1,
-      top: 2,
-      right: 30,
-      bottom: 40,
+    expect(state.savedTabs.byId.t1?.popout).to.eql({
+      position: {
+        x: 1,
+        y: 2,
+      },
+      contentSize: {
+        height: 38,
+        width: 29,
+      },
     });
   });
 });


### PR DESCRIPTION
## Changes

This PR is stacked against #1062 to fix popout issues:

- Popout widgets changing size when the browser is zoomed
- `InternalChildWindowManager` will correctly clean-up event listeners

## Testing

N/A
