### PR TITLE
Fix user-select issue when resizing a stage panel

### DIFF
--- a/apps/test-providers/src/ui/content/SampleContentControl.scss
+++ b/apps/test-providers/src/ui/content/SampleContentControl.scss
@@ -9,4 +9,5 @@
   width: 100%;
   justify-content: center;
   user-select: none;
+  -webkit-user-select: none;
 }

--- a/common/changes/@itwin/appui-react/fix-user-select_2024-10-08-12-20.json
+++ b/common/changes/@itwin/appui-react/fix-user-select_2024-10-08-12-20.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix an issue where resizing a panel would sometimes select widget contents.",
+      "type": "none"
+    },
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add `-webkit` prefix to `user-select` CSS property to fix selection issues on Safari.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
@@ -26,6 +26,7 @@
 
 .uifw-unselectable {
   user-select: none;
+  -webkit-user-select: none;
 }
 
 .uifw-centered {

--- a/ui/appui-react/src/appui-react/layout/widget-panels/CursorOverlay.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/CursorOverlay.scss
@@ -12,6 +12,7 @@ body {
       * {
         cursor: $cursor !important;
         user-select: none;
+        -webkit-user-select: none;
       }
     }
   }

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
@@ -18,6 +18,8 @@ $line-grip-width: calc(#{$nz-grip-width} - 2px);
     position: relative;
     display: flex;
     transition: 0.2s ease-out;
+    user-select: none;
+    -webkit-user-select: none;
 
     > .nz-handle {
       position: absolute;

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingTab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingTab.scss
@@ -12,6 +12,7 @@
   align-items: center;
   background: $buic-background-4;
   user-select: none;
+  -webkit-user-select: none;
   white-space: nowrap;
   height: $nz-widget-tab-height;
   border-radius: $nz-widget-tab-border-radius;

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
@@ -57,6 +57,7 @@
 
     position: absolute;
     user-select: none;
+    -webkit-user-select: none;
 
     &.nz-left,
     &.nz-right {

--- a/ui/appui-react/src/appui-react/layout/widget/MenuTab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/MenuTab.scss
@@ -9,6 +9,7 @@
   height: 2em;
   cursor: pointer;
   user-select: none;
+  -webkit-user-select: none;
   padding-right: 3em;
   padding-left: 0.5em;
 

--- a/ui/appui-react/src/appui-react/layout/widget/Overflow.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Overflow.scss
@@ -20,6 +20,7 @@
     height: 100%;
     cursor: pointer;
     user-select: none;
+    -webkit-user-select: none;
 
     > .nz-icon {
       background: $buic-background-2;

--- a/ui/appui-react/src/appui-react/layout/widget/Tab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Tab.scss
@@ -9,6 +9,7 @@
 
 .nz-widget-tab {
   user-select: none;
+  -webkit-user-select: none;
   white-space: nowrap;
   display: flex;
   gap: 6px;

--- a/ui/appui-react/src/appui-react/layout/widget/TabBar.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/TabBar.scss
@@ -23,6 +23,7 @@
       position: absolute;
       cursor: auto;
       user-select: none;
+      -webkit-user-select: none;
     }
   }
 }

--- a/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.scss
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.scss
@@ -22,6 +22,7 @@ $sheets-modal-padding: 10px;
   border-style: solid;
   box-sizing: border-box;
   user-select: none;
+  -webkit-user-select: none;
 
   &:hover {
     cursor: pointer;

--- a/ui/components-react/src/components-react/datepicker/DatePicker.scss
+++ b/ui/components-react/src/components-react/datepicker/DatePicker.scss
@@ -43,6 +43,7 @@ $outline-size: 2px;
       padding: 5px;
       font-size: var(--iui-font-size-2);
       user-select: none;
+      -webkit-user-select: none;
       color: $date-picker-icons-color-actionable;
 
       &:focus {

--- a/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleGroup.scss
+++ b/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleGroup.scss
@@ -22,6 +22,7 @@
     text-align: center;
     background-color: var(--iui-color-background-hover);
     user-select: none;
+    -webkit-user-select: none;
     display: grid;
     place-items: center;
     box-sizing: border-box;

--- a/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
+++ b/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
@@ -66,6 +66,7 @@
   opacity: 0;
   z-index: 1;
   user-select: none;
+  -webkit-user-select: none;
 
   &--vertical {
     width: 100%;

--- a/ui/core-react/src/core-react/radialmenu/RadialMenu.scss
+++ b/ui/core-react/src/core-react/radialmenu/RadialMenu.scss
@@ -48,6 +48,7 @@
           color: var(--iui-color-text);
           font-size: var(--iui-font-size-0);
           user-select: none;
+          -webkit-user-select: none;
         }
       }
     }

--- a/ui/core-react/src/core-react/tree/Tree.scss
+++ b/ui/core-react/src/core-react/tree/Tree.scss
@@ -5,6 +5,7 @@
 
 .core-tree {
   user-select: none;
+  -webkit-user-select: none;
   box-sizing: border-box;
   width: 100%;
   height: 100%;

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.scss
@@ -57,6 +57,7 @@ $arrow-margin: -3px;
           .face-cell {
             cursor: pointer;
             user-select: none;
+            -webkit-user-select: none;
             width: $nav-cube-side-width;
 
             &.cube-center {


### PR DESCRIPTION
## Changes

This PR fixes #1057 by setting the [`user-select`](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select) property on a stage panel resize handle to avoid content selection when resizing the panel.

Additionally, `-webkit-user-select` property is added with each `user-select` to fix widget drag/resize issues in Safari.

## Testing

Tested manually in test-app.
