### PR TITLE
Expose all `Popover` props in `StatusBarPopover` component

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4499,7 +4499,7 @@ export enum StatusBarLabelSide {
 export function StatusBarLeftSection(props: CommonDivProps): React_2.JSX.Element;
 
 // @public
-export function StatusBarPopover({ content, ...props }: StatusBarPopoverProps): React_2.JSX.Element;
+export function StatusBarPopover({ content, middleware, ...other }: React_2.ComponentProps<typeof Popover>): React_2.JSX.Element;
 
 // @public
 export namespace StatusBarPopover {

--- a/common/changes/@itwin/appui-react/status-bar-popover-props_2024-10-08-17-02.json
+++ b/common/changes/@itwin/appui-react/status-bar-popover-props_2024-10-08-17-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Expose all `Popover` props in `StatusBarPopover` component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -38,7 +38,7 @@ Table of contents:
   }
   ```
 
-- `StatusBarPopover` component now accepts all props that are accepted by `Popover` component from `@itwin/itwinui-react`.
+- `StatusBarPopover` component now accepts all props that are accepted by `Popover` component from `@itwin/itwinui-react`. [#1068](https://github.com/iTwin/appui/pull/1068)
 
 ### Changes
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -38,6 +38,8 @@ Table of contents:
   }
   ```
 
+- `StatusBarPopover` component now accepts all props that are accepted by `Popover` component from `@itwin/itwinui-react`.
+
 ### Changes
 
 - Updated `MessageManager.addMessage` and `MessageManager.outputMessage` to ignore already active messages displayed to the user. This API is used by various tools indirectly via `IModelApp.notifications.outputMessage` when `AppNotificationManager` is set up. This change should prevent the same message from being displayed multiple times unnecessarily. [#1042](https://github.com/iTwin/appui/pull/1042)

--- a/ui/appui-react/src/appui-react/statusbar/popup/StatusBarPopover.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/popup/StatusBarPopover.tsx
@@ -9,32 +9,24 @@
 import * as React from "react";
 import { Popover } from "@itwin/itwinui-react";
 import { ButtonExpandIndicator } from "./ExpandIndicator.js";
-import type { CommonProps } from "@itwin/core-react";
 import { PopupContext } from "@itwin/core-react/internal";
-
-// eslint-disable-next-line deprecation/deprecation
-type StatusBarPopoverProps = CommonProps &
-  Pick<
-    React.ComponentProps<typeof Popover>,
-    | "content"
-    | "children"
-    | "visible"
-    | "onVisibleChange"
-    | "closeOnOutsideClick"
-  >;
 
 /** Popover component used in `StatusBar` component.
  * This component should wrap the element that triggers the popover.
  * @note Add the `StatusBarPopover.ExpandIndicator` to popover trigger buttons.
  * @public
  */
-export function StatusBarPopover({ content, ...props }: StatusBarPopoverProps) {
+export function StatusBarPopover({
+  content,
+  middleware,
+  ...other
+}: React.ComponentProps<typeof Popover>) {
   const [portalTarget, setPortalTarget] = React.useState<
     HTMLElement | undefined
   >(undefined);
   return (
     <Popover
-      {...props}
+      {...other}
       content={
         <PopupContext.Provider value={portalTarget}>
           {content}
@@ -43,6 +35,7 @@ export function StatusBarPopover({ content, ...props }: StatusBarPopoverProps) {
       placement="top"
       applyBackground
       middleware={{
+        ...middleware,
         offset: 4,
       }}
       ref={(el) => {


### PR DESCRIPTION
## Changes

This PR fixes #1051 by allowing all `Popover` props to be passed into the `StatusBarPopover` and extending customization.

## Testing

N/A
