### PR TITLE
Handle snap opacity in toolbars

### DIFF
--- a/common/changes/@itwin/appui-react/toolbar-opacity_2024-10-22-16-05.json
+++ b/common/changes/@itwin/appui-react/toolbar-opacity_2024-10-22-16-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Handle snap toolbar opacity in toolbars.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/toolbar-opacity_2024-10-22-16-05.json
+++ b/common/changes/@itwin/components-react/toolbar-opacity_2024-10-22-16-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/toolbar-opacity_2024-10-22-16-05.json
+++ b/common/changes/@itwin/core-react/toolbar-opacity_2024-10-22-16-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -55,6 +55,7 @@ Table of contents:
 - Use React portal instead of creating a separate element tree for each child window. [#1062](https://github.com/iTwin/appui/pull/1062)
 - Removed incorrect usage of internal `IModelApp.renderSystem.options.displaySolarShadows` check from 'useSolarDataProvider'. `wantShadows` property of viewport display style is used instead. [#1066](https://github.com/iTwin/appui/pull/1066)
 - Updated the styling of `BackstageAppButton` and `NestedFrontstageAppButton` components to match the updated toolbars. [#1078](https://github.com/iTwin/appui/pull/1078)
+- The new toolbars will now handle snap opacity mode when enabled. [#1082](https://github.com/iTwin/appui/pull/1082)
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/widgets/BackstageAppButton.tsx
+++ b/ui/appui-react/src/appui-react/widgets/BackstageAppButton.tsx
@@ -44,7 +44,6 @@ export function BackstageAppButton({
 }: BackstageAppButtonProps) {
   const { translate } = useTranslation();
   label = label ?? translate("buttons.openBackstageMenu");
-  const ref = React.useRef<HTMLDivElement>(null);
 
   const handleClick = React.useCallback(() => {
     if (execute) {
@@ -61,7 +60,7 @@ export function BackstageAppButton({
   ) : undefined;
   const icon = iconNode ?? iconSpecElement ?? <SvgHome />;
   return (
-    <Surface ref={ref} orientation="horizontal">
+    <Surface orientation="horizontal">
       <IconButton
         className="uifw-widget-backstageAppButton"
         styleType="borderless"

--- a/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
@@ -148,18 +148,7 @@ export function NavigationAidHost(props: NavigationAidHostProps) {
       ),
     [activeContentControl, navigationAidId, activeContentViewport]
   );
-
-  const ref = React.useRef<HTMLDivElement>(null);
-
-  const isInitialMount = React.useRef(true);
-  const { onElementRef, proximityScale } = useWidgetOpacityContext();
-
-  React.useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      onElementRef(ref);
-    }
-  }, [onElementRef]);
+  const { ref, proximityScale } = useWidgetOpacityContext<HTMLDivElement>();
 
   const divStyle: React.CSSProperties = {
     minWidth: props.minWidth ? props.minWidth : "64px",
@@ -246,12 +235,6 @@ export function NavigationWidgetComposer(props: NavigationWidgetComposerProps) {
     ...otherProps
   } = props;
   const [elementSet] = React.useState(new WidgetElementSet());
-  const handleChildRef = React.useCallback(
-    (elementRef: React.RefObject<Element>) => {
-      elementSet.add(elementRef);
-    },
-    [elementSet]
-  );
   const proximityScale = useProximityToMouse(
     elementSet,
     UiFramework.visibility.snapWidgetOpacity
@@ -264,7 +247,12 @@ export function NavigationWidgetComposer(props: NavigationWidgetComposerProps) {
   return (
     <WidgetOpacityContext.Provider
       value={{
-        onElementRef: handleChildRef,
+        addRef: (ref) => {
+          elementSet.add(ref);
+        },
+        removeRef: (ref) => {
+          elementSet.delete(ref);
+        },
         proximityScale,
       }}
     >

--- a/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
@@ -244,15 +244,27 @@ export function NavigationWidgetComposer(props: NavigationWidgetComposerProps) {
     ? undefined
     : navigationAidHost ?? <NavigationAidHost />;
 
+  const addRef = React.useCallback<
+    React.ContextType<typeof WidgetOpacityContext>["addRef"]
+  >(
+    (ref) => {
+      elementSet.add(ref);
+    },
+    [elementSet]
+  );
+  const removeRef = React.useCallback<
+    React.ContextType<typeof WidgetOpacityContext>["removeRef"]
+  >(
+    (ref) => {
+      elementSet.delete(ref);
+    },
+    [elementSet]
+  );
   return (
     <WidgetOpacityContext.Provider
       value={{
-        addRef: (ref) => {
-          elementSet.add(ref);
-        },
-        removeRef: (ref) => {
-          elementSet.delete(ref);
-        },
+        addRef,
+        removeRef,
         proximityScale,
       }}
     >

--- a/ui/appui-react/src/appui-react/widgets/ToolWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/ToolWidgetComposer.tsx
@@ -46,15 +46,27 @@ export function ToolWidgetComposer(props: ToolWidgetComposerProps) {
     UiFramework.visibility.snapWidgetOpacity
   );
 
+  const addRef = React.useCallback<
+    React.ContextType<typeof WidgetOpacityContext>["addRef"]
+  >(
+    (ref) => {
+      elementSet.add(ref);
+    },
+    [elementSet]
+  );
+  const removeRef = React.useCallback<
+    React.ContextType<typeof WidgetOpacityContext>["removeRef"]
+  >(
+    (ref) => {
+      elementSet.delete(ref);
+    },
+    [elementSet]
+  );
   return (
     <WidgetOpacityContext.Provider
       value={{
-        addRef: (ref) => {
-          elementSet.add(ref);
-        },
-        removeRef: (ref) => {
-          elementSet.delete(ref);
-        },
+        addRef,
+        removeRef,
         proximityScale,
       }}
     >

--- a/ui/appui-react/src/appui-react/widgets/ToolWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/ToolWidgetComposer.tsx
@@ -41,12 +41,6 @@ export function ToolWidgetComposer(props: ToolWidgetComposerProps) {
   const { cornerItem, horizontalToolbar, verticalToolbar, ...otherProps } =
     props;
   const [elementSet] = React.useState(new WidgetElementSet());
-  const handleChildRef = React.useCallback(
-    (elementRef: React.RefObject<Element>) => {
-      elementSet.add(elementRef);
-    },
-    [elementSet]
-  );
   const proximityScale = useProximityToMouse(
     elementSet,
     UiFramework.visibility.snapWidgetOpacity
@@ -55,7 +49,12 @@ export function ToolWidgetComposer(props: ToolWidgetComposerProps) {
   return (
     <WidgetOpacityContext.Provider
       value={{
-        onElementRef: handleChildRef,
+        addRef: (ref) => {
+          elementSet.add(ref);
+        },
+        removeRef: (ref) => {
+          elementSet.delete(ref);
+        },
         proximityScale,
       }}
     >

--- a/ui/components-react/src/components-react/toolbar/Items.tsx
+++ b/ui/components-react/src/components-react/toolbar/Items.tsx
@@ -43,7 +43,6 @@ export interface ToolbarItemsProps extends CommonProps {
  * @internal
  */
 export function ToolbarItems(props: ToolbarItemsProps) {
-  const ref = React.useRef<HTMLDivElement>(null);
   const { toolbarOpacitySetting, openPopupCount, overflowDisplayActive } =
     useToolbarWithOverflowDirectionContext();
   const useTransparentBackground =
@@ -65,15 +64,7 @@ export function ToolbarItems(props: ToolbarItemsProps) {
   let showSeparators =
     toolbarOpacitySetting === ToolbarOpacitySetting.Transparent ? false : true;
 
-  const isInitialMount = React.useRef(true);
-  const { onElementRef, proximityScale } = useWidgetOpacityContext();
-
-  React.useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      onElementRef(ref);
-    }
-  }, [onElementRef]);
+  const { ref, proximityScale } = useWidgetOpacityContext<HTMLDivElement>();
 
   if (
     toolbarOpacitySetting === ToolbarOpacitySetting.Proximity &&

--- a/ui/core-react/src/core-react/utils/hooks/useWidgetOpacityContext.tsx
+++ b/ui/core-react/src/core-react/utils/hooks/useWidgetOpacityContext.tsx
@@ -12,8 +12,9 @@ import * as React from "react";
  * @internal
  */
 export interface WidgetOpacityContextProps {
-  readonly onElementRef: (elementRef: React.RefObject<Element>) => void;
   readonly proximityScale: number;
+  readonly addRef: (ref: React.RefObject<Element>) => void;
+  readonly removeRef: (ref: React.RefObject<Element>) => void;
 }
 
 /**
@@ -22,13 +23,23 @@ export interface WidgetOpacityContextProps {
  */
 export const WidgetOpacityContext =
   React.createContext<WidgetOpacityContextProps>({
-    onElementRef: (_elementRef: React.RefObject<Element>) => void {},
     proximityScale: 1.0,
+    addRef: () => {},
+    removeRef: () => {},
   });
 
 /** Hook for using [[WidgetOpacityContext]]
  * @internal
  */
-export function useWidgetOpacityContext() {
-  return React.useContext(WidgetOpacityContext);
+export function useWidgetOpacityContext<T extends Element>() {
+  const ref = React.useRef<T>(null);
+  const context = React.useContext(WidgetOpacityContext);
+  const { addRef, removeRef } = context;
+  React.useEffect(() => {
+    addRef(ref);
+    return () => {
+      removeRef(ref);
+    };
+  }, [addRef, removeRef]);
+  return { ref, ...context };
 }

--- a/ui/core-react/src/core-react/utils/hooks/useWidgetOpacityContext.tsx
+++ b/ui/core-react/src/core-react/utils/hooks/useWidgetOpacityContext.tsx
@@ -33,13 +33,13 @@ export const WidgetOpacityContext =
  */
 export function useWidgetOpacityContext<T extends Element>() {
   const ref = React.useRef<T>(null);
-  const context = React.useContext(WidgetOpacityContext);
-  const { addRef, removeRef } = context;
+  const { addRef, removeRef, proximityScale } =
+    React.useContext(WidgetOpacityContext);
   React.useEffect(() => {
     addRef(ref);
     return () => {
       removeRef(ref);
     };
   }, [addRef, removeRef]);
-  return { ref, ...context };
+  return { ref, proximityScale };
 }

--- a/ui/core-react/src/test/utils/hooks/useWidgetOpacityContext.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useWidgetOpacityContext.test.tsx
@@ -14,15 +14,7 @@ import {
 } from "../../../core-react/utils/hooks/useWidgetOpacityContext.js";
 
 function WidgetOpacityChild() {
-  const isInitialMount = React.useRef(true);
-  const ref = React.useRef<HTMLDivElement>(null);
-  const { onElementRef } = useWidgetOpacityContext();
-
-  if (isInitialMount.current) {
-    isInitialMount.current = false;
-    onElementRef(ref);
-  }
-
+  const { ref } = useWidgetOpacityContext<HTMLDivElement>();
   return <div ref={ref} />;
 }
 
@@ -32,18 +24,17 @@ interface WidgetOpacityParentProps {
 
 function WidgetOpacityParent(props: WidgetOpacityParentProps) {
   const { elementSet } = props;
-  const handleChildRef = React.useCallback(
-    (elementRef: React.RefObject<Element>) => {
-      elementSet.add(elementRef);
-    },
-    [elementSet]
-  );
   const proximityScale = useProximityToMouse(elementSet);
 
   return (
     <WidgetOpacityContext.Provider
       value={{
-        onElementRef: handleChildRef,
+        addRef: (ref) => {
+          elementSet.add(ref);
+        },
+        removeRef: (ref) => {
+          elementSet.delete(ref);
+        },
         proximityScale,
       }}
     >


### PR DESCRIPTION
## Changes

This PR re-adds the snap opacity behavior to the toolbars.

| Cursor is far | Cursor is close | Toolbar is hovered |
|---|---|---|
| ![Screenshot 2024-10-22 at 19 11 27](https://github.com/user-attachments/assets/835de7a2-138e-45bc-a44c-dc195e5ebb5c) | ![Screenshot 2024-10-22 at 19 11 34](https://github.com/user-attachments/assets/1c3f9246-0e88-448b-82c9-2cd6e5b6be0a) | ![Screenshot 2024-10-22 at 19 11 40](https://github.com/user-attachments/assets/05813749-c2a2-480b-9491-fccff0d37e63) |


## Testing

Tested manually in the test app.