### PR TITLE
Bump `sass` version

### DIFF
--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -61,7 +61,7 @@
     "npm-run-all": "^4.1.5",
     "null-loader": "^4.0.1",
     "rimraf": "^3.0.2",
-    "sass": "^1.77.7",
+    "sass": "^1.80.3",
     "typescript": "~5.3.3",
     "vite": "^5.4.7",
     "vite-plugin-static-copy": "^1.0.6"

--- a/apps/test-app/src/frontend/appui/settingsproviders/Settings.scss
+++ b/apps/test-app/src/frontend/appui/settingsproviders/Settings.scss
@@ -2,13 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/base/base";
-
-// cspell:ignore leftpanel rightpanel
-
-$settings-leftpanel-width: 225px;
-$settings-rightpanel-width: 220px;
-
 .components-settings-container {
   height: calc(100% - 50px);
   overflow: hidden;
@@ -34,7 +27,7 @@ $settings-rightpanel-width: 220px;
 
   > .left-panel {
     flex-direction: column;
-    min-width: $settings-leftpanel-width;
+    min-width: 225px;
     padding: 20px 15px 20px 15px;
 
     > .title {
@@ -51,7 +44,7 @@ $settings-rightpanel-width: 220px;
   > .right-panel {
     display: flex;
     align-items: center;
-    min-width: $settings-rightpanel-width;
+    min-width: 220px;
     padding: 30px 50px 30px 30px;
 
     .toggle {

--- a/apps/test-app/vite.config.ts
+++ b/apps/test-app/vite.config.ts
@@ -38,6 +38,13 @@ export default defineConfig(({ mode }) => {
       chunkSizeWarningLimit: 7000,
     },
     customLogger,
+    css: {
+      preprocessorOptions: {
+        scss: {
+          api: "modern-compiler",
+        },
+      },
+    },
     plugins: [
       TanStackRouterVite(),
       react(),

--- a/apps/test-providers/src/ui/frontstages/ComponentExamples.scss
+++ b/apps/test-providers/src/ui/frontstages/ComponentExamples.scss
@@ -2,12 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/scrollbar";
-
-$component-examples-leftpanel-width: 225px;
-$component-examples-rightpanel-width: 200px;
-
 .component-examples {
   width: 100%;
   height: 100%;
@@ -24,9 +18,6 @@ $component-examples-rightpanel-width: 200px;
 
     height: 100%;
     overflow-y: auto;
-
-    @include uicore-touch-scrolling;
-    @include uicore-scrollbar();
   }
 
   .component-examples-items {
@@ -35,9 +26,6 @@ $component-examples-rightpanel-width: 200px;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-
-    @include uicore-touch-scrolling;
-    @include uicore-scrollbar();
 
     .component-examples-item {
       display: flex;
@@ -50,7 +38,7 @@ $component-examples-rightpanel-width: 200px;
       > .left-panel {
         flex: 1;
         flex-direction: column;
-        min-width: $component-examples-leftpanel-width;
+        min-width: 225px;
         padding: 15px;
 
         > .title {
@@ -67,7 +55,7 @@ $component-examples-rightpanel-width: 200px;
       > .right-panel {
         flex: 4;
         align-items: center;
-        min-width: $component-examples-rightpanel-width;
+        min-width: 200px;
         padding: 15px;
       }
     }

--- a/common/changes/@itwin/appui-react/update-scss_2024-10-24-11-55.json
+++ b/common/changes/@itwin/appui-react/update-scss_2024-10-24-11-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Replaced SCSS `@import` rules with `@use` rules.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/update-scss_2024-10-24-11-55.json
+++ b/common/changes/@itwin/components-react/update-scss_2024-10-24-11-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Replaced SCSS `@import` rules with `@use` rules.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/update-scss_2024-10-24-11-55.json
+++ b/common/changes/@itwin/core-react/update-scss_2024-10-24-11-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Replaced SCSS `@import` rules with `@use` rules.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/update-scss_2024-10-24-11-55.json
+++ b/common/changes/@itwin/imodel-components-react/update-scss_2024-10-24-11-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Replaced SCSS `@import` rules with `@use` rules.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -222,13 +222,13 @@ importers:
         version: 3.0.2
       sass:
         specifier: ^1.80.3
-        version: 1.80.3
+        version: 1.80.4
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
       vite:
         specifier: ^5.4.7
-        version: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+        version: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
       vite-plugin-static-copy:
         specifier: ^1.0.6
         version: 1.0.6(vite@5.4.7)
@@ -482,7 +482,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.4.7
-        version: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+        version: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
       vite-plugin-static-copy:
         specifier: ^1.0.6
         version: 1.0.6(vite@5.4.7)
@@ -3731,7 +3731,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.3.3)
       typescript: 5.3.3
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -4523,7 +4523,7 @@ packages:
       storybook: 8.3.2
       ts-dedent: 2.2.0
       typescript: 5.3.3
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
     dev: true
 
   /@storybook/components@8.3.2(storybook@8.3.2):
@@ -4652,7 +4652,7 @@ packages:
       resolve: 1.22.8
       storybook: 8.3.2
       tsconfig-paths: 4.2.0
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - '@storybook/test'
@@ -4945,7 +4945,7 @@ packages:
       babel-dead-code-elimination: 1.0.6
       chokidar: 3.6.0
       unplugin: 1.12.3
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
       zod: 3.23.8
     transitivePeerDependencies:
       - supports-color
@@ -5837,7 +5837,7 @@ packages:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.7.26
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -5853,7 +5853,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.25.2)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12074,8 +12074,8 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass@1.80.3:
-    resolution: {integrity: sha512-ptDWyVmDMVielpz/oWy3YP3nfs7LpJTHIJZboMVs8GEC9eUmtZTZhMHlTW98wY4aEorDfjN38+Wr/XjskFWcfA==}
+  /sass@1.80.4:
+    resolution: {integrity: sha512-rhMQ2tSF5CsuuspvC94nPM9rToiAFw2h3JTrLlgmNw1MH79v8Cr3DH6KF6o6r+8oofY3iYVPUf66KzC8yuVN1w==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
@@ -13266,7 +13266,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -13289,7 +13289,7 @@ packages:
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       picocolors: 1.1.0
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
     dev: true
 
   /vite-tsconfig-paths@5.0.1(typescript@5.3.3)(vite@5.4.7):
@@ -13303,13 +13303,13 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.3(typescript@5.3.3)
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /vite@5.4.7(@types/node@18.11.5)(sass@1.80.3):
+  /vite@5.4.7(@types/node@18.11.5)(sass@1.80.4):
     resolution: {integrity: sha512-5l2zxqMEPVENgvzTuBpHer2awaetimj2BGkhBPdnwKbPNOlHsODU+oiazEZzLK7KhAnOrO+XGYJYn4ZlUhDtDQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -13344,7 +13344,7 @@ packages:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.22.4
-      sass: 1.80.3
+      sass: 1.80.4
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -13393,7 +13393,7 @@ packages:
       strip-literal: 2.1.0
       tinybench: 2.6.0
       tinypool: 0.8.3
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.4)
       vite-node: 1.6.0(@types/node@18.11.5)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -221,14 +221,14 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       sass:
-        specifier: ^1.77.7
-        version: 1.77.8
+        specifier: ^1.80.3
+        version: 1.80.3
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
       vite:
         specifier: ^5.4.7
-        version: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+        version: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
       vite-plugin-static-copy:
         specifier: ^1.0.6
         version: 1.0.6(vite@5.4.7)
@@ -482,7 +482,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.4.7
-        version: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+        version: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
       vite-plugin-static-copy:
         specifier: ^1.0.6
         version: 1.0.6(vite@5.4.7)
@@ -3731,7 +3731,7 @@ packages:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.3.3)
       typescript: 5.3.3
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
     dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -3918,6 +3918,137 @@ packages:
     resolution: {integrity: sha512-KuEXeGPptM2lyxdIEJ4R11+5ztipHoE7hy8ClZt3PYaOVQ/pyngd2alaSrPnwyFeOW1UagRBaQ752aA1dTMdOQ==}
     dependencies:
       esbuild: 0.14.54
+    dev: true
+
+  /@parcel/watcher-android-arm64@2.4.1:
+    resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-darwin-arm64@2.4.1:
+    resolution: {integrity: sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-darwin-x64@2.4.1:
+    resolution: {integrity: sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-freebsd-x64@2.4.1:
+    resolution: {integrity: sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-arm-glibc@2.4.1:
+    resolution: {integrity: sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-arm64-glibc@2.4.1:
+    resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-arm64-musl@2.4.1:
+    resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-x64-glibc@2.4.1:
+    resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-linux-x64-musl@2.4.1:
+    resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-win32-arm64@2.4.1:
+    resolution: {integrity: sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-win32-ia32@2.4.1:
+    resolution: {integrity: sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher-win32-x64@2.4.1:
+    resolution: {integrity: sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@parcel/watcher@2.4.1:
+    resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      detect-libc: 1.0.3
+      is-glob: 4.0.3
+      micromatch: 4.0.5
+      node-addon-api: 7.1.1
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.4.1
+      '@parcel/watcher-darwin-arm64': 2.4.1
+      '@parcel/watcher-darwin-x64': 2.4.1
+      '@parcel/watcher-freebsd-x64': 2.4.1
+      '@parcel/watcher-linux-arm-glibc': 2.4.1
+      '@parcel/watcher-linux-arm64-glibc': 2.4.1
+      '@parcel/watcher-linux-arm64-musl': 2.4.1
+      '@parcel/watcher-linux-x64-glibc': 2.4.1
+      '@parcel/watcher-linux-x64-musl': 2.4.1
+      '@parcel/watcher-win32-arm64': 2.4.1
+      '@parcel/watcher-win32-ia32': 2.4.1
+      '@parcel/watcher-win32-x64': 2.4.1
     dev: true
 
   /@pkgjs/parseargs@0.11.0:
@@ -4392,7 +4523,7 @@ packages:
       storybook: 8.3.2
       ts-dedent: 2.2.0
       typescript: 5.3.3
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
     dev: true
 
   /@storybook/components@8.3.2(storybook@8.3.2):
@@ -4521,7 +4652,7 @@ packages:
       resolve: 1.22.8
       storybook: 8.3.2
       tsconfig-paths: 4.2.0
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
     transitivePeerDependencies:
       - '@preact/preset-vite'
       - '@storybook/test'
@@ -4814,7 +4945,7 @@ packages:
       babel-dead-code-elimination: 1.0.6
       chokidar: 3.6.0
       unplugin: 1.12.3
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
       zod: 3.23.8
     transitivePeerDependencies:
       - supports-color
@@ -5706,7 +5837,7 @@ packages:
       vite: ^4 || ^5
     dependencies:
       '@swc/core': 1.7.26
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
@@ -5722,7 +5853,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.25.2)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6599,6 +6730,13 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /chokidar@4.0.1:
+    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
+    engines: {node: '>= 14.16.0'}
+    dependencies:
+      readdirp: 4.0.2
+    dev: true
+
   /ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -6977,6 +7115,12 @@ packages:
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  /detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+    dev: true
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -10658,6 +10802,10 @@ packages:
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
+  /node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+    dev: true
+
   /node-dir@0.1.17:
     resolution: {integrity: sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==}
     engines: {node: '>= 0.10.5'}
@@ -11614,6 +11762,11 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /readdirp@4.0.2:
+    resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
+    engines: {node: '>= 14.16.0'}
+    dev: true
+
   /recast@0.20.5:
     resolution: {integrity: sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==}
     engines: {node: '>= 4'}
@@ -11921,14 +12074,15 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass@1.77.8:
-    resolution: {integrity: sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==}
+  /sass@1.80.3:
+    resolution: {integrity: sha512-ptDWyVmDMVielpz/oWy3YP3nfs7LpJTHIJZboMVs8GEC9eUmtZTZhMHlTW98wY4aEorDfjN38+Wr/XjskFWcfA==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.5.3
+      '@parcel/watcher': 2.4.1
+      chokidar: 4.0.1
       immutable: 4.3.5
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
     dev: true
 
   /sax@1.3.0:
@@ -13112,7 +13266,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -13135,7 +13289,7 @@ packages:
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       picocolors: 1.1.0
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
     dev: true
 
   /vite-tsconfig-paths@5.0.1(typescript@5.3.3)(vite@5.4.7):
@@ -13149,13 +13303,13 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.3(typescript@5.3.3)
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /vite@5.4.7(@types/node@18.11.5)(sass@1.77.8):
+  /vite@5.4.7(@types/node@18.11.5)(sass@1.80.3):
     resolution: {integrity: sha512-5l2zxqMEPVENgvzTuBpHer2awaetimj2BGkhBPdnwKbPNOlHsODU+oiazEZzLK7KhAnOrO+XGYJYn4ZlUhDtDQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -13190,7 +13344,7 @@ packages:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.22.4
-      sass: 1.77.8
+      sass: 1.80.3
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -13239,7 +13393,7 @@ packages:
       strip-literal: 2.1.0
       tinybench: 2.6.0
       tinypool: 0.8.3
-      vite: 5.4.7(@types/node@18.11.5)(sass@1.77.8)
+      vite: 5.4.7(@types/node@18.11.5)(sass@1.80.3)
       vite-node: 1.6.0(@types/node@18.11.5)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -115,7 +115,13 @@ Additionally, file extensions are provided in import declarations, which are [ma
 
 ## Style sheet changes
 
-- Replaced internal usage of `--buic` CSS variables and `$buic` SCSS variables with [iTwinUI CSS variables](https://itwinui.bentley.com/docs/variables). [#1079](https://github.com/iTwin/appui/pull/1079)
+SCSS files have been updated to use the [`@use`](https://sass-lang.com/documentation/at-rules/use/) rule instead of the [deprecated](https://sass-lang.com/documentation/breaking-changes/import/) [`@import`](https://sass-lang.com/documentation/at-rules/import/) rule. [#1085](https://github.com/iTwin/appui/pull/1085)
+
+To avoid breaking existing SCSS of AppUI consumers, [`@forward`](https://sass-lang.com/documentation/at-rules/forward/) rules were added to SCSS partial files to forward previously imported SCSS modules.
+
+Additionally, all internal usage of `--buic` CSS variables and `$buic` SCSS variables have been replaced with [iTwinUI CSS variables](https://itwinui.bentley.com/docs/variables). [#1079](https://github.com/iTwin/appui/pull/1079)
+
+Consumers of AppUI are expected to avoid using AppUI `SCSS` partial files directly and instead use the available CSS variables from iTwinUI.
 
 ## @itwin/appui-react
 

--- a/docs/storybook/vite.config.ts
+++ b/docs/storybook/vite.config.ts
@@ -29,6 +29,13 @@ const localeDirs = [
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: "modern-compiler",
+      },
+    },
+  },
   plugins: [
     react(),
     fixedViteCommonjs({

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.scss
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/base/base" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
 
 .uifw-accudraw-input-label {
   min-width: 16px;

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.scss
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.scss
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .uifw-accudraw-input-label {
   min-width: 16px;

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.scss
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/base/base";
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .uifw-accudraw-input-label {
   min-width: 16px;

--- a/ui/appui-react/src/appui-react/accudraw/Calculator.scss
+++ b/ui/appui-react/src/appui-react/accudraw/Calculator.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
-
 $button-size: 36px;
 $button-operator-size: $button-size + 10px;
 

--- a/ui/appui-react/src/appui-react/accudraw/Calculator.scss
+++ b/ui/appui-react/src/appui-react/accudraw/Calculator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 
 $button-size: 36px;
 $button-operator-size: $button-size + 10px;

--- a/ui/appui-react/src/appui-react/accudraw/MenuButton.scss
+++ b/ui/appui-react/src/appui-react/accudraw/MenuButton.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 
 .uifw-menu-button {
   position: absolute;

--- a/ui/appui-react/src/appui-react/accudraw/MenuButton.scss
+++ b/ui/appui-react/src/appui-react/accudraw/MenuButton.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
 
 .uifw-menu-button {
   position: absolute;

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
@@ -2,11 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/base/base";
-@import "~@itwin/core-react/lib/cjs/core-react/icons/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @import "../variables";
 
 #uifw-configurableui-wrapper {

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/base/base" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 #uifw-configurableui-wrapper {
   position: relative;

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
@@ -3,11 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@use "../variables" as *;
 
 #uifw-configurableui-wrapper {
   position: relative;

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.scss
@@ -7,7 +7,7 @@
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@import "../variables";
+@use "../variables" as *;
 
 #uifw-configurableui-wrapper {
   position: relative;

--- a/ui/appui-react/src/appui-react/content/ContentLayout.scss
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/base/base";
-@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 
 #uifw-contentlayout-div {
   position: absolute;

--- a/ui/appui-react/src/appui-react/content/ContentLayout.scss
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
+@use "~@itwin/core-react/lib/core-react/base/base" as *;
 
 #uifw-contentlayout-div {
   position: absolute;

--- a/ui/appui-react/src/appui-react/content/ContentLayout.scss
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 
 #uifw-contentlayout-div {
   position: absolute;

--- a/ui/appui-react/src/appui-react/content/DefaultViewOverlay.scss
+++ b/ui/appui-react/src/appui-react/content/DefaultViewOverlay.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .uifw-view-overlay {
   display: flex;

--- a/ui/appui-react/src/appui-react/content/DefaultViewOverlay.scss
+++ b/ui/appui-react/src/appui-react/content/DefaultViewOverlay.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .uifw-view-overlay {
   display: flex;

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.scss
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../../variables";
+@use "../../variables" as *;
 
 .uifw-cursorpopup {
   border: {

--- a/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.scss
+++ b/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/icons/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .uifw-cursor-prompt {
   padding: 5px;

--- a/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.scss
+++ b/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .uifw-cursor-prompt {
   padding: 5px;

--- a/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.scss
+++ b/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
+@use "~@itwin/core-react/lib/core-react/icons/variables" as *;
 
 .uifw-cursor-prompt {
   padding: 5px;

--- a/ui/appui-react/src/appui-react/dialog/DialogManagerBase.scss
+++ b/ui/appui-react/src/appui-react/dialog/DialogManagerBase.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .uifw-dialog-dialogManagerBase_renderer {
   position: relative;

--- a/ui/appui-react/src/appui-react/dialog/DialogManagerBase.scss
+++ b/ui/appui-react/src/appui-react/dialog/DialogManagerBase.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .uifw-dialog-dialogManagerBase_renderer {
   position: relative;

--- a/ui/appui-react/src/appui-react/feedback/ElementTooltip.scss
+++ b/ui/appui-react/src/appui-react/feedback/ElementTooltip.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@import "../variables";
+@use "../variables" as *;
 
 .uifw-feedback-elementTooltip {
   pointer-events: none;

--- a/ui/appui-react/src/appui-react/feedback/ElementTooltip.scss
+++ b/ui/appui-react/src/appui-react/feedback/ElementTooltip.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @import "../variables";
 
 .uifw-feedback-elementTooltip {

--- a/ui/appui-react/src/appui-react/feedback/ElementTooltip.scss
+++ b/ui/appui-react/src/appui-react/feedback/ElementTooltip.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 @use "../variables" as *;
 
 .uifw-feedback-elementTooltip {

--- a/ui/appui-react/src/appui-react/feedback/ValidationTextbox.scss
+++ b/ui/appui-react/src/appui-react/feedback/ValidationTextbox.scss
@@ -2,9 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/baseline" as *;
 
 .uifw-ValidationTextbox {
   font-family: var(--iui-font-sans);

--- a/ui/appui-react/src/appui-react/feedback/ValidationTextbox.scss
+++ b/ui/appui-react/src/appui-react/feedback/ValidationTextbox.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/icons/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .uifw-ValidationTextbox {
   font-family: var(--iui-font-sans);

--- a/ui/appui-react/src/appui-react/feedback/ValidationTextbox.scss
+++ b/ui/appui-react/src/appui-react/feedback/ValidationTextbox.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/baseline" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/style/baseline" as *;
 
 .uifw-ValidationTextbox {
   font-family: var(--iui-font-sans);

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.scss
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .uifw-modal-frontstage {
   height: 100%;

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.scss
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .uifw-modal-frontstage {
   height: 100%;

--- a/ui/appui-react/src/appui-react/layout/StandardLayout.scss
+++ b/ui/appui-react/src/appui-react/layout/StandardLayout.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 @layer appui.component {
   .nz-standardLayout {
     position: relative;

--- a/ui/appui-react/src/appui-react/layout/StandardLayout.scss
+++ b/ui/appui-react/src/appui-react/layout/StandardLayout.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 @layer appui.component {
   .nz-standardLayout {

--- a/ui/appui-react/src/appui-react/layout/_scrollbar.scss
+++ b/ui/appui-react/src/appui-react/layout/_scrollbar.scss
@@ -2,7 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/scrollbar";
+
+@forward "~@itwin/core-react/lib/cjs/core-react/scrollbar";
 
 $nz-scrollbar-width: 12px;
 $nz-scrollbar-padding: 2px;
@@ -12,9 +14,9 @@ $nz-scrollbar-padding: 2px;
   $width: $nz-scrollbar-width,
   $padding: $nz-scrollbar-padding
 ) {
-  @include uicore-scrollbar($color, $width, $padding);
+  @include scrollbar.uicore-scrollbar($color, $width, $padding);
 }
 
 @mixin nz-hidden-scrollbar {
-  @include uicore-hidden-scrollbar;
+  @include scrollbar.uicore-hidden-scrollbar;
 }

--- a/ui/appui-react/src/appui-react/layout/_scrollbar.scss
+++ b/ui/appui-react/src/appui-react/layout/_scrollbar.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/scrollbar";
+@use "~@itwin/core-react/lib/core-react/scrollbar";
 
-@forward "~@itwin/core-react/lib/cjs/core-react/scrollbar";
+@forward "~@itwin/core-react/lib/core-react/scrollbar";
 
 $nz-scrollbar-width: 12px;
 $nz-scrollbar-padding: 2px;

--- a/ui/appui-react/src/appui-react/layout/_scrollbar.scss
+++ b/ui/appui-react/src/appui-react/layout/_scrollbar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/scrollbar";
+@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
 
 $nz-scrollbar-width: 12px;
 $nz-scrollbar-padding: 2px;

--- a/ui/appui-react/src/appui-react/layout/_widgetopacity.scss
+++ b/ui/appui-react/src/appui-react/layout/_widgetopacity.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 @mixin nz-widget-opacity {
   opacity: var(--buic-widget-opacity, 0.9);

--- a/ui/appui-react/src/appui-react/layout/_widgetopacity.scss
+++ b/ui/appui-react/src/appui-react/layout/_widgetopacity.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/core-react/style/themecolors";
 
 @mixin nz-widget-opacity {
   opacity: var(--buic-widget-opacity, 0.9);

--- a/ui/appui-react/src/appui-react/layout/_widgetopacity.scss
+++ b/ui/appui-react/src/appui-react/layout/_widgetopacity.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
 
 @mixin nz-widget-opacity {
   opacity: var(--buic-widget-opacity, 0.9);

--- a/ui/appui-react/src/appui-react/layout/backstage/Backstage.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/Backstage.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
-@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 @import "../prefix";
 @import "../safearea";
 @import "../scrollbar";

--- a/ui/appui-react/src/appui-react/layout/backstage/Backstage.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/Backstage.scss
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
-@import "../prefix";
-@import "../safearea";
-@import "../scrollbar";
-@import "variables";
+@use "../prefix" as *;
+@use "../safearea" as *;
+@use "../scrollbar" as *;
+@use "variables" as *;
 
 .nz-backstage-backstage {
   display: flex;

--- a/ui/appui-react/src/appui-react/layout/backstage/Backstage.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/Backstage.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/style/breakpoints" as *;
 @use "../prefix" as *;
 @use "../safearea" as *;
 @use "../scrollbar" as *;

--- a/ui/appui-react/src/appui-react/layout/backstage/Item.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/Item.scss
@@ -3,9 +3,9 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
-@import "../prefix";
-@import "../safearea";
-@import "variables";
+@use "../prefix" as *;
+@use "../safearea" as *;
+@use "variables" as *;
 
 .nz-backstage-item {
   position: relative;

--- a/ui/appui-react/src/appui-react/layout/backstage/Item.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/Item.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 @import "../prefix";
 @import "../safearea";
 @import "variables";

--- a/ui/appui-react/src/appui-react/layout/backstage/Item.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/Item.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@use "~@itwin/core-react/lib/core-react/style/breakpoints" as *;
 @use "../prefix" as *;
 @use "../safearea" as *;
 @use "variables" as *;

--- a/ui/appui-react/src/appui-react/layout/backstage/Separator.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/Separator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-backstage-separator {
   height: $nz-backstage-divider-height;

--- a/ui/appui-react/src/appui-react/layout/backstage/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/core-react/style/themecolors";
 
 // backstage common values
 $nz-backstage-width: 300px;

--- a/ui/appui-react/src/appui-react/layout/backstage/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 // backstage common values
 $nz-backstage-width: 300px;

--- a/ui/appui-react/src/appui-react/layout/backstage/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/backstage/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
 
 // backstage common values
 $nz-backstage-width: 300px;

--- a/ui/appui-react/src/appui-react/layout/footer/dialog/Dialog.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/dialog/Dialog.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-footer-dialog-dialog {
   border-radius: var(--iui-border-radius-1);

--- a/ui/appui-react/src/appui-react/layout/footer/dialog/Dialog.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/dialog/Dialog.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "variables" as *;
-
 .nz-footer-dialog-dialog {
   border-radius: var(--iui-border-radius-1);
   background-color: var(--iui-color-background);

--- a/ui/appui-react/src/appui-react/layout/footer/dialog/TitleBar.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/dialog/TitleBar.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
 @import "variables";
-@import "~@itwin/core-react/lib/cjs/core-react/typography";
 
 .nz-footer-dialog-titleBar {
   $horizontal-padding: $nz-dialog-padding;

--- a/ui/appui-react/src/appui-react/layout/footer/dialog/TitleBar.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/dialog/TitleBar.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
-@import "variables";
+@use "variables" as *;
 
 .nz-footer-dialog-titleBar {
   $horizontal-padding: $nz-dialog-padding;

--- a/ui/appui-react/src/appui-react/layout/footer/dialog/TitleBar.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/dialog/TitleBar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
+@use "~@itwin/core-react/lib/core-react/typography" as *;
 @use "variables" as *;
 
 .nz-footer-dialog-titleBar {

--- a/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
 
 .nz-footer-snapMode-panel {

--- a/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
+@use "~@itwin/core-react/lib/core-react/typography" as *;
 
 .nz-footer-snapMode-panel {
   background-color: var(--iui-color-background);

--- a/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
-@import "~@itwin/core-react/lib/cjs/core-react/typography";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
 
 .nz-footer-snapMode-panel {
   background-color: var(--iui-color-background);

--- a/ui/appui-react/src/appui-react/layout/footer/snap-mode/Snap.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/snap-mode/Snap.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .nz-footer-snapMode-snap {
   display: grid;

--- a/ui/appui-react/src/appui-react/layout/footer/snap-mode/Snap.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/snap-mode/Snap.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .nz-footer-snapMode-snap {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/ui/appui-react/src/appui-react/layout/footer/tool-assistance/Dialog.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/tool-assistance/Dialog.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-
 .nz-footer-toolAssistance-dialog {
   min-width: 300px;
   min-height: 75px;

--- a/ui/appui-react/src/appui-react/layout/footer/tool-assistance/Dialog.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/tool-assistance/Dialog.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .nz-footer-toolAssistance-dialog {
   min-width: 300px;

--- a/ui/appui-react/src/appui-react/layout/footer/tool-assistance/Separator.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/tool-assistance/Separator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
+@use "~@itwin/core-react/lib/core-react/typography" as *;
 
 .nz-footer-toolAssistance-separator {
   margin-top: 18px;

--- a/ui/appui-react/src/appui-react/layout/footer/tool-assistance/Separator.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/tool-assistance/Separator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/typography";
+@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
 
 .nz-footer-toolAssistance-separator {
   margin-top: 18px;

--- a/ui/appui-react/src/appui-react/layout/outline/PanelOutline.scss
+++ b/ui/appui-react/src/appui-react/layout/outline/PanelOutline.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-outline-panelOutline {
   background-color: $nz-outline-color;

--- a/ui/appui-react/src/appui-react/layout/outline/SectionOutline.scss
+++ b/ui/appui-react/src/appui-react/layout/outline/SectionOutline.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-outline-sectionOutline {
   background-color: $nz-outline-color;

--- a/ui/appui-react/src/appui-react/layout/outline/TabOutline.scss
+++ b/ui/appui-react/src/appui-react/layout/outline/TabOutline.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-outline-tabOutline {
   background-color: $nz-outline-color;

--- a/ui/appui-react/src/appui-react/layout/outline/WidgetOutline.scss
+++ b/ui/appui-react/src/appui-react/layout/outline/WidgetOutline.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-outline-widgetOutline {
   background-color: $nz-outline-color;

--- a/ui/appui-react/src/appui-react/layout/popup/Tooltip.scss
+++ b/ui/appui-react/src/appui-react/layout/popup/Tooltip.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .nz-popup-tooltip {
   position: absolute;

--- a/ui/appui-react/src/appui-react/layout/popup/Tooltip.scss
+++ b/ui/appui-react/src/appui-react/layout/popup/Tooltip.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
-@import "~@itwin/core-react/lib/cjs/core-react/geometry";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
 
 .nz-popup-tooltip {
   position: absolute;

--- a/ui/appui-react/src/appui-react/layout/popup/Tooltip.scss
+++ b/ui/appui-react/src/appui-react/layout/popup/Tooltip.scss
@@ -2,9 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
 
 .nz-popup-tooltip {
   position: absolute;

--- a/ui/appui-react/src/appui-react/layout/target/MergeTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/MergeTarget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-target-mergeTarget {
   @include nz-widget-target;

--- a/ui/appui-react/src/appui-react/layout/target/PanelTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/PanelTarget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-target-panelTarget {
   $length: 6em;

--- a/ui/appui-react/src/appui-react/layout/target/SectionTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/SectionTarget.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "variables" as *;
 
 .nz-target-sectionTarget {

--- a/ui/appui-react/src/appui-react/layout/target/SectionTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/SectionTarget.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@import "variables";
+@use "variables" as *;
 
 .nz-target-sectionTarget {
   @include nz-widget-target;

--- a/ui/appui-react/src/appui-react/layout/target/SectionTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/SectionTarget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @import "variables";
 
 .nz-target-sectionTarget {

--- a/ui/appui-react/src/appui-react/layout/target/TabTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/TabTarget.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@import "../outline/variables";
+@use "../outline/variables" as *;
 
 .nz-target-tabTarget {
   position: absolute;

--- a/ui/appui-react/src/appui-react/layout/target/TabTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/TabTarget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 @use "../outline/variables" as *;
 
 .nz-target-tabTarget {

--- a/ui/appui-react/src/appui-react/layout/target/TabTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/TabTarget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @import "../outline/variables";
 
 .nz-target-tabTarget {

--- a/ui/appui-react/src/appui-react/layout/target/TitleBarTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/TitleBarTarget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .nz-target-titleBarTarget {
   flex: 1 1 0;

--- a/ui/appui-react/src/appui-react/layout/target/TitleBarTarget.scss
+++ b/ui/appui-react/src/appui-react/layout/target/TitleBarTarget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .nz-target-titleBarTarget {
   flex: 1 1 0;

--- a/ui/appui-react/src/appui-react/layout/target/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/target/_variables.scss
@@ -2,11 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/core-react/z-index";
 @use "../outline/variables";
 
-@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@forward "~@itwin/core-react/lib/cjs/core-react/z-index";
+@forward "~@itwin/core-react/lib/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/core-react/z-index";
 @forward "../outline/variables";
 
 $nz-widget-target-border-color: var(--iui-color-background-disabled);

--- a/ui/appui-react/src/appui-react/layout/target/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/target/_variables.scss
@@ -2,9 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@use "../outline/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "../outline/variables";
+
+@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/cjs/core-react/z-index";
+@forward "../outline/variables";
 
 $nz-widget-target-border-color: var(--iui-color-background-disabled);
 $nz-widget-target-background: var(--iui-color-background-backdrop-hover);
@@ -26,7 +29,7 @@ $nz-widget-target-border-size: 2px;
   animation: nz-grow var(--iui-duration-1) ease-in-out,
     nz-pulse 3s ease-in-out 2s infinite;
 
-  @include uicore-z-index(drop-target);
+  @include z-index.uicore-z-index(drop-target);
 
   @media (prefers-reduced-motion: no-preference) {
     @keyframes nz-pulse {
@@ -57,7 +60,7 @@ $nz-widget-target-border-size: 2px;
 
 @mixin nz-targeted-widget-target {
   transform: scale(1.2);
-  background-color: $nz-opaque-outline-color;
+  background-color: variables.$nz-opaque-outline-color;
   box-shadow: var(--iui-shadow-4);
   animation-iteration-count: 0, 0;
 }

--- a/ui/appui-react/src/appui-react/layout/target/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/target/_variables.scss
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@import "../outline/variables";
+@use "../outline/variables" as *;
 
 $nz-widget-target-border-color: var(--iui-color-background-disabled);
 $nz-widget-target-background: var(--iui-color-background-backdrop-hover);

--- a/ui/appui-react/src/appui-react/layout/target/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/target/_variables.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @import "../outline/variables";
 
 $nz-widget-target-border-color: var(--iui-color-background-disabled);

--- a/ui/appui-react/src/appui-react/layout/tool-settings/Overflow.scss
+++ b/ui/appui-react/src/appui-react/layout/tool-settings/Overflow.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .nz-toolSettings-overflow {
   margin-left: auto;

--- a/ui/appui-react/src/appui-react/layout/tool-settings/Overflow.scss
+++ b/ui/appui-react/src/appui-react/layout/tool-settings/Overflow.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .nz-toolSettings-overflow {
   margin-left: auto;
 

--- a/ui/appui-react/src/appui-react/layout/widget-panels/CursorOverlay.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/CursorOverlay.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-
 $nz-cursors: (nwse-resize, nesw-resize, ew-resize, ns-resize, grabbing);
 
 body {

--- a/ui/appui-react/src/appui-react/layout/widget-panels/CursorOverlay.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/CursorOverlay.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 $nz-cursors: (nwse-resize, nesw-resize, ew-resize, ns-resize, grabbing);
 

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "variables" as *;
 
 $line-grip-translate: 1px;

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@import "variables";
+@use "variables" as *;
 
 $line-grip-translate: 1px;
 $full-bar-width: calc(#{$nz-grip-width} * 0.5);

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @import "variables";
 
 $line-grip-translate: 1px;

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Panel.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Panel.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "variables" as *;
 
 @layer appui.component {

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Panel.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Panel.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@import "variables";
+@use "variables" as *;
 
 @layer appui.component {
   .nz-widgetPanels-panel {

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Panel.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Panel.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @import "variables";
 
 @layer appui.component {

--- a/ui/appui-react/src/appui-react/layout/widget/Content.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Content.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../scrollbar";
+@use "../scrollbar" as *;
 
 .nz-widget-content {
   overflow: auto;

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingTab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingTab.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@import "variables";
+@use "variables" as *;
 
 .nz-widget-floatingTab {
   position: absolute;

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingTab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingTab.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @import "variables";
 
 .nz-widget-floatingTab {

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingTab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingTab.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 @use "variables" as *;
 
 .nz-widget-floatingTab {

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @import "../widgetopacity";
 @import "variables";
 

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 @use "../widgetopacity" as *;
 @use "variables" as *;
 

--- a/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/FloatingWidget.scss
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@import "../widgetopacity";
-@import "variables";
+@use "../widgetopacity" as *;
+@use "variables" as *;
 
 @layer appui.component {
   .nz-widget-floatingWidget {

--- a/ui/appui-react/src/appui-react/layout/widget/NavigationArea.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/NavigationArea.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./tools/button/variables";
-@import "../widgetopacity";
+@use "./tools/button/variables" as *;
+@use "../widgetopacity" as *;
 
 .nz-widget-navigationArea {
   transition: visibility var(--iui-duration-2) ease,

--- a/ui/appui-react/src/appui-react/layout/widget/Overflow.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Overflow.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .nz-widget-overflow {
   width: 2em;
   position: relative;

--- a/ui/appui-react/src/appui-react/layout/widget/Overflow.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Overflow.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .nz-widget-overflow {
   width: 2em;

--- a/ui/appui-react/src/appui-react/layout/widget/Tab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Tab.scss
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 @use "sass:math";
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@import "../prefix";
-@import "variables";
+@use "../prefix" as *;
+@use "variables" as *;
 
 .nz-widget-tab {
   user-select: none;

--- a/ui/appui-react/src/appui-react/layout/widget/Tab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Tab.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "sass:math";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @import "../prefix";
 @import "variables";
 

--- a/ui/appui-react/src/appui-react/layout/widget/Tab.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/Tab.scss
@@ -3,8 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "sass:math";
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@use "../prefix" as *;
 @use "variables" as *;
 
 .nz-widget-tab {

--- a/ui/appui-react/src/appui-react/layout/widget/TabBar.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/TabBar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 @layer appui.component {
   .nz-widget-tabBar {

--- a/ui/appui-react/src/appui-react/layout/widget/ToolsArea.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/ToolsArea.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./tools/button/variables" as *;
 @use "../widgetopacity" as *;
 
 .nz-tools-widget {

--- a/ui/appui-react/src/appui-react/layout/widget/ToolsArea.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/ToolsArea.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./tools/button/variables";
-@import "../widgetopacity";
+@use "./tools/button/variables" as *;
+@use "../widgetopacity" as *;
 
 .nz-tools-widget {
   transition: visibility var(--iui-duration-2) ease,

--- a/ui/appui-react/src/appui-react/layout/widget/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/_variables.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 $nz-tab-height: 60px;
 $nz-tab-width: 32px;

--- a/ui/appui-react/src/appui-react/layout/widget/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/_variables.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@forward "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
-@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/core-react/style/breakpoints";
+@forward "~@itwin/core-react/lib/core-react/style/themecolors";
 
 $nz-tab-height: 60px;
 $nz-tab-width: 32px;

--- a/ui/appui-react/src/appui-react/layout/widget/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/_variables.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@forward "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
 
 $nz-tab-height: 60px;
 $nz-tab-width: 32px;

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/Back.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/Back.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-toolbar-button-back {
   border-radius: $mls-button-width * 0.5;

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/Button.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/Button.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-toolbar-button-button {
   box-sizing: border-box;

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/Expandable.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/Expandable.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
+@use "~@itwin/core-react/lib/core-react/geometry" as *;
 @use "variables" as *;
 
 .nz-widget-tools-button-expandable {

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/Expandable.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/Expandable.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/geometry";
+@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
 @import "variables";
 
 .nz-widget-tools-button-expandable {

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/Expandable.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/Expandable.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
-@import "variables";
+@use "variables" as *;
 
 .nz-widget-tools-button-expandable {
   $triangle-width: 6px;

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/Icon.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/Icon.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .nz-toolbar-button-icon {
   font-size: $mls-icon-size;

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/core-react/style/themecolors";
 
 // Common
 $button-stroke-width: 2px;

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
 
 // Common
 $button-stroke-width: 2px;

--- a/ui/appui-react/src/appui-react/layout/widget/tools/button/_variables.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/tools/button/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 // Common
 $button-stroke-width: 2px;

--- a/ui/appui-react/src/appui-react/messages/InputField.scss
+++ b/ui/appui-react/src/appui-react/messages/InputField.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/text/mixins";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/text/mixins" as *;
 
 .uifw-popup-message-inputField {
   background-color: var(--iui-color-background);

--- a/ui/appui-react/src/appui-react/messages/InputField.scss
+++ b/ui/appui-react/src/appui-react/messages/InputField.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/text/mixins" as *;
 
 .uifw-popup-message-inputField {

--- a/ui/appui-react/src/appui-react/messages/InputField.scss
+++ b/ui/appui-react/src/appui-react/messages/InputField.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/text/mixins" as *;
+@use "~@itwin/core-react/lib/core-react/text/mixins" as *;
 
 .uifw-popup-message-inputField {
   background-color: var(--iui-color-background);

--- a/ui/appui-react/src/appui-react/messages/Pointer.scss
+++ b/ui/appui-react/src/appui-react/messages/Pointer.scss
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/text/mixins" as *;
-@import "../variables";
+@use "../variables" as *;
 
 .uifw-pointer-message {
   border: {

--- a/ui/appui-react/src/appui-react/messages/Pointer.scss
+++ b/ui/appui-react/src/appui-react/messages/Pointer.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/text/mixins";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/text/mixins" as *;
 @import "../variables";
 
 .uifw-pointer-message {

--- a/ui/appui-react/src/appui-react/messages/Pointer.scss
+++ b/ui/appui-react/src/appui-react/messages/Pointer.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/text/mixins" as *;
+@use "~@itwin/core-react/lib/core-react/text/mixins" as *;
 @use "../variables" as *;
 
 .uifw-pointer-message {

--- a/ui/appui-react/src/appui-react/messages/Pointer.scss
+++ b/ui/appui-react/src/appui-react/messages/Pointer.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/text/mixins" as *;
 @use "../variables" as *;
 

--- a/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.scss
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 
 .uifw-sheet-navigation {
   height: 96px;

--- a/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.scss
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetNavigationAid.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
-
 .uifw-sheet-navigation {
   height: 96px;
   width: 96px;

--- a/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.scss
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/colors" as *;
+@use "~@itwin/core-react/lib/core-react/style/colors" as *;
 
 $sheets-modal-padding: 10px;
 

--- a/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.scss
+++ b/ui/appui-react/src/appui-react/navigationaids/SheetsModalFrontstage.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/colors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/colors" as *;
 
 $sheets-modal-padding: 10px;
 

--- a/ui/appui-react/src/appui-react/pickers/ListPicker.scss
+++ b/ui/appui-react/src/appui-react/pickers/ListPicker.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
+@use "~@itwin/core-react/lib/core-react/scrollbar" as *;
+@use "~@itwin/core-react/lib/core-react/typography" as *;
 
 $no-shadow: none;
 $shadow: drop-shadow(

--- a/ui/appui-react/src/appui-react/pickers/ListPicker.scss
+++ b/ui/appui-react/src/appui-react/pickers/ListPicker.scss
@@ -2,10 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
-@import "~@itwin/core-react/lib/cjs/core-react/scrollbar";
-@import "~@itwin/core-react/lib/cjs/core-react/typography";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
 
 $no-shadow: none;
 $shadow: drop-shadow(

--- a/ui/appui-react/src/appui-react/pickers/ListPicker.scss
+++ b/ui/appui-react/src/appui-react/pickers/ListPicker.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
 

--- a/ui/appui-react/src/appui-react/popup/CardPopup.scss
+++ b/ui/appui-react/src/appui-react/popup/CardPopup.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .uifw-card {

--- a/ui/appui-react/src/appui-react/popup/CardPopup.scss
+++ b/ui/appui-react/src/appui-react/popup/CardPopup.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .uifw-card {
   background-color: hsl(var(--iui-color-background-hsl) / 0.9);

--- a/ui/appui-react/src/appui-react/popup/CardPopup.scss
+++ b/ui/appui-react/src/appui-react/popup/CardPopup.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .uifw-card {
   background-color: hsl(var(--iui-color-background-hsl) / 0.9);

--- a/ui/appui-react/src/appui-react/popup/KeyinPalettePanel.scss
+++ b/ui/appui-react/src/appui-react/popup/KeyinPalettePanel.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .uifw-command-palette-popup-container {
   @include uicore-z-index(keyin-palette-overlay);

--- a/ui/appui-react/src/appui-react/popup/KeyinPalettePanel.scss
+++ b/ui/appui-react/src/appui-react/popup/KeyinPalettePanel.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .uifw-command-palette-popup-container {
   @include uicore-z-index(keyin-palette-overlay);

--- a/ui/appui-react/src/appui-react/popup/KeyinPalettePanel.scss
+++ b/ui/appui-react/src/appui-react/popup/KeyinPalettePanel.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .uifw-command-palette-popup-container {

--- a/ui/appui-react/src/appui-react/popup/PositionPopup.scss
+++ b/ui/appui-react/src/appui-react/popup/PositionPopup.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../variables";
+@use "../variables" as *;
 
 .uifw-position-popup {
   border: {

--- a/ui/appui-react/src/appui-react/preview/enable-maximized-widget/useMaximizedWidget.scss
+++ b/ui/appui-react/src/appui-react/preview/enable-maximized-widget/useMaximizedWidget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 @layer appui.preview.enable-maximized-widget {
   .uifw-preview-enableMaximizedWidget_panel-layout {

--- a/ui/appui-react/src/appui-react/preview/enable-maximized-widget/useMaximizedWidget.scss
+++ b/ui/appui-react/src/appui-react/preview/enable-maximized-widget/useMaximizedWidget.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 @layer appui.preview.enable-maximized-widget {
   .uifw-preview-enableMaximizedWidget_panel-layout {

--- a/ui/appui-react/src/appui-react/settings/quantityformatting/QuantityFormat.scss
+++ b/ui/appui-react/src/appui-react/settings/quantityformatting/QuantityFormat.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .quantity-formatting-container {
   box-sizing: border-box;

--- a/ui/appui-react/src/appui-react/settings/quantityformatting/QuantityFormat.scss
+++ b/ui/appui-react/src/appui-react/settings/quantityformatting/QuantityFormat.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .quantity-formatting-container {

--- a/ui/appui-react/src/appui-react/settings/quantityformatting/QuantityFormat.scss
+++ b/ui/appui-react/src/appui-react/settings/quantityformatting/QuantityFormat.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .quantity-formatting-container {
   box-sizing: border-box;

--- a/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.scss
+++ b/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/base/base";
+@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
 
 // cspell:ignore leftpanel rightpanel
 

--- a/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.scss
+++ b/ui/appui-react/src/appui-react/settings/ui/UiSettingsPage.scss
@@ -2,10 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
-
-// cspell:ignore leftpanel rightpanel
-
 $settings-leftpanel-width: 225px;
 $settings-rightpanel-width: 220px;
 

--- a/ui/appui-react/src/appui-react/statusbar/LabelIndicator.scss
+++ b/ui/appui-react/src/appui-react/statusbar/LabelIndicator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@use "~@itwin/core-react/lib/core-react/style/breakpoints" as *;
 
 .uifw-statusbar-labelIndicator {
   &.uifw-reversed {

--- a/ui/appui-react/src/appui-react/statusbar/LabelIndicator.scss
+++ b/ui/appui-react/src/appui-react/statusbar/LabelIndicator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 
 .uifw-statusbar-labelIndicator {
   &.uifw-reversed {

--- a/ui/appui-react/src/appui-react/statusbar/StatusBar.scss
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@use "~@itwin/core-react/lib/core-react/style/breakpoints" as *;
 @use "../layout/safearea" as *;
 
 .uifw-statusBar {

--- a/ui/appui-react/src/appui-react/statusbar/StatusBar.scss
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBar.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
-@import "../layout/safearea";
+@use "../layout/safearea" as *;
 
 .uifw-statusBar {
   display: flex;

--- a/ui/appui-react/src/appui-react/statusbar/StatusBar.scss
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 @import "../layout/safearea";
 
 .uifw-statusBar {

--- a/ui/appui-react/src/appui-react/statusbar/popup/ExpandIndicator.scss
+++ b/ui/appui-react/src/appui-react/statusbar/popup/ExpandIndicator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/geometry";
+@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
 
 .uifw-statusBar-popup-expandIndicator {
   position: absolute;

--- a/ui/appui-react/src/appui-react/statusbar/popup/ExpandIndicator.scss
+++ b/ui/appui-react/src/appui-react/statusbar/popup/ExpandIndicator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
+@use "~@itwin/core-react/lib/core-react/geometry" as *;
 
 .uifw-statusBar-popup-expandIndicator {
   position: absolute;

--- a/ui/appui-react/src/appui-react/statusbar/popup/Popup.scss
+++ b/ui/appui-react/src/appui-react/statusbar/popup/Popup.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .nz-status-bar-popup {
   font-size: var(--iui-font-size-1);

--- a/ui/appui-react/src/appui-react/statusbar/popup/Popup.scss
+++ b/ui/appui-react/src/appui-react/statusbar/popup/Popup.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .nz-status-bar-popup {

--- a/ui/appui-react/src/appui-react/statusbar/popup/Popup.scss
+++ b/ui/appui-react/src/appui-react/statusbar/popup/Popup.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/index";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .nz-status-bar-popup {
   font-size: var(--iui-font-size-1);

--- a/ui/appui-react/src/appui-react/statusfields/SectionsField.scss
+++ b/ui/appui-react/src/appui-react/statusfields/SectionsField.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .uifw-sections-footer-contents {
   display: flex;

--- a/ui/appui-react/src/appui-react/statusfields/SectionsField.scss
+++ b/ui/appui-react/src/appui-react/statusfields/SectionsField.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .uifw-sections-footer-contents {
   display: flex;
   flex-direction: column;

--- a/ui/appui-react/src/appui-react/statusfields/SelectionScope.scss
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionScope.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 
 .uifw-statusFields-selectionScope {
   display: flex;

--- a/ui/appui-react/src/appui-react/statusfields/SelectionScope.scss
+++ b/ui/appui-react/src/appui-react/statusfields/SelectionScope.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
-
 .uifw-statusFields-selectionScope {
   display: flex;
   align-items: center;

--- a/ui/appui-react/src/appui-react/statusfields/message-center/MessageCenterMessage.scss
+++ b/ui/appui-react/src/appui-react/statusfields/message-center/MessageCenterMessage.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .uifw-statusFields-messageCenter-messageCenterMessage {
   min-height: 48px;

--- a/ui/appui-react/src/appui-react/statusfields/message-center/MessageCenterMessage.scss
+++ b/ui/appui-react/src/appui-react/statusfields/message-center/MessageCenterMessage.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .uifw-statusFields-messageCenter-messageCenterMessage {
   min-height: 48px;
   box-sizing: border-box;

--- a/ui/appui-react/src/appui-react/statusfields/tileloading/TileLoadingIndicator.scss
+++ b/ui/appui-react/src/appui-react/statusfields/tileloading/TileLoadingIndicator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@use "~@itwin/core-react/lib/core-react/style/breakpoints" as *;
 
 .uifw-tile-loading-bar {
   $font-size-medium: var(--iui-font-size-0);

--- a/ui/appui-react/src/appui-react/statusfields/tileloading/TileLoadingIndicator.scss
+++ b/ui/appui-react/src/appui-react/statusfields/tileloading/TileLoadingIndicator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 
 .uifw-tile-loading-bar {
   $font-size-medium: var(--iui-font-size-0);

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.scss
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 $image-size: 22px;
 $image-size-wide: 30px;

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.scss
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.scss
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 $image-size: 22px;
 $image-size-wide: 30px;
 $image-size-medium: 16px;

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/ExpandIndicator.scss
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/ExpandIndicator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/geometry";
+@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
 
 .uifw-toolbar-group-expandIndicator {
   position: absolute;

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/ExpandIndicator.scss
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/ExpandIndicator.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
+@use "~@itwin/core-react/lib/core-react/geometry" as *;
 
 .uifw-toolbar-group-expandIndicator {
   position: absolute;

--- a/ui/components-react/src/components-react/datepicker/DateField.scss
+++ b/ui/components-react/src/components-react/datepicker/DateField.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 
 .components-date-input {
   width: auto;

--- a/ui/components-react/src/components-react/datepicker/DateField.scss
+++ b/ui/components-react/src/components-react/datepicker/DateField.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
 
 .components-date-input {
   width: auto;

--- a/ui/components-react/src/components-react/datepicker/DateField.scss
+++ b/ui/components-react/src/components-react/datepicker/DateField.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 
 .components-date-input {

--- a/ui/components-react/src/components-react/datepicker/DatePicker.scss
+++ b/ui/components-react/src/components-react/datepicker/DatePicker.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/style/opacity";
-@import "~@itwin/core-react/lib/cjs/core-react/icons/variables";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/opacity" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
 
 $date-picker-m: 16px;
 $date-picker-icons-color-actionable: rgba(

--- a/ui/components-react/src/components-react/datepicker/DatePicker.scss
+++ b/ui/components-react/src/components-react/datepicker/DatePicker.scss
@@ -2,18 +2,14 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/opacity" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
-
 $date-picker-m: 16px;
 $date-picker-icons-color-actionable: rgba(
   var(--iui-color-text),
-  $uicore-opacity-2
+  var(--iui-opacity-2)
 );
 $date-picker-icons-color-actionable-hover: rgba(
   var(--iui-color-text),
-  $uicore-opacity-1
+  var(--iui-opacity-1)
 );
 $date-picker-outside-month-color: var(--iui-color-text-disabled);
 $outline-size: 2px;
@@ -167,7 +163,7 @@ $outline-size: 2px;
       }
 
       &.today {
-        background-color: rgba(var(--iui-color-text), $uicore-opacity-6);
+        background-color: rgba(var(--iui-color-text), var(--iui-opacity-6));
         font-weight: var(--iui-font-weight-semibold);
         border-radius: 50%;
       }

--- a/ui/components-react/src/components-react/datepicker/DatePickerPopupButton.scss
+++ b/ui/components-react/src/components-react/datepicker/DatePickerPopupButton.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/index";
+@use "~@itwin/core-react/lib/cjs/core-react/index" as *;
 
 .components-date-picker-calendar-popup-button {
   color: var(--iui-color-text);

--- a/ui/components-react/src/components-react/datepicker/DatePickerPopupButton.scss
+++ b/ui/components-react/src/components-react/datepicker/DatePickerPopupButton.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/index" as *;
-
 .components-date-picker-calendar-popup-button {
   color: var(--iui-color-text);
   font-size: var(--iui-font-size-1);

--- a/ui/components-react/src/components-react/datepicker/TimeField.scss
+++ b/ui/components-react/src/components-react/datepicker/TimeField.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .components-time {
   display: inline-flex;

--- a/ui/components-react/src/components-react/datepicker/TimeField.scss
+++ b/ui/components-react/src/components-react/datepicker/TimeField.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .components-time {
   display: inline-flex;

--- a/ui/components-react/src/components-react/datepicker/TimeField.scss
+++ b/ui/components-react/src/components-react/datepicker/TimeField.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
 
 .components-time {
   display: inline-flex;

--- a/ui/components-react/src/components-react/editors/CustomNumberEditor.scss
+++ b/ui/components-react/src/components-react/editors/CustomNumberEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./variables";
+@use "./variables" as *;
 
 .components-customnumber-editor {
   width: 100%;

--- a/ui/components-react/src/components-react/editors/EnumEditor.scss
+++ b/ui/components-react/src/components-react/editors/EnumEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./variables";
+@use "./variables" as *;
 
 .components-enum-editor {
   width: 100%;

--- a/ui/components-react/src/components-react/editors/IconEditor.scss
+++ b/ui/components-react/src/components-react/editors/IconEditor.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 $components-color-editor-item-height: 100%;
 
 .components-icon-editor {

--- a/ui/components-react/src/components-react/editors/IconEditor.scss
+++ b/ui/components-react/src/components-react/editors/IconEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 $components-color-editor-item-height: 100%;
 

--- a/ui/components-react/src/components-react/editors/NumericInputEditor.scss
+++ b/ui/components-react/src/components-react/editors/NumericInputEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./variables";
+@use "./variables" as *;
 
 .components-smallEditor-host {
   .components-numeric-input-editor {

--- a/ui/components-react/src/components-react/editors/PopupButton.scss
+++ b/ui/components-react/src/components-react/editors/PopupButton.scss
@@ -6,7 +6,7 @@
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/style/baseline" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@import "./variables.scss";
+@use "./variables" as *;
 
 .components-popup-button {
   min-width: 100%;

--- a/ui/components-react/src/components-react/editors/PopupButton.scss
+++ b/ui/components-react/src/components-react/editors/PopupButton.scss
@@ -2,10 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/baseline" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "./variables" as *;
 
 .components-popup-button {

--- a/ui/components-react/src/components-react/editors/PopupButton.scss
+++ b/ui/components-react/src/components-react/editors/PopupButton.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
 @use "./variables" as *;
 
 .components-popup-button {

--- a/ui/components-react/src/components-react/editors/PopupButton.scss
+++ b/ui/components-react/src/components-react/editors/PopupButton.scss
@@ -2,10 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/icons/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/baseline";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/icons/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/baseline" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @import "./variables.scss";
 
 .components-popup-button {

--- a/ui/components-react/src/components-react/editors/SliderEditor.scss
+++ b/ui/components-react/src/components-react/editors/SliderEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./variables";
+@use "./variables" as *;
 
 .components-slider-editor {
   min-width: 100%;

--- a/ui/components-react/src/components-react/editors/TextEditor.scss
+++ b/ui/components-react/src/components-react/editors/TextEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./variables";
+@use "./variables" as *;
 
 .components-text-editor {
   min-width: 100%;

--- a/ui/components-react/src/components-react/editors/TextareaEditor.scss
+++ b/ui/components-react/src/components-react/editors/TextareaEditor.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/colors" as *;
-
 .components-textarea-editor {
   min-width: 100%;
   margin: 0;

--- a/ui/components-react/src/components-react/editors/TextareaEditor.scss
+++ b/ui/components-react/src/components-react/editors/TextareaEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/colors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/colors" as *;
 
 .components-textarea-editor {
   min-width: 100%;

--- a/ui/components-react/src/components-react/editors/variables.scss
+++ b/ui/components-react/src/components-react/editors/variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 
 $editor-component-height-small: 24px;
 $editor-iui-input-padding: $uicore-iui-input-padding;

--- a/ui/components-react/src/components-react/editors/variables.scss
+++ b/ui/components-react/src/components-react/editors/variables.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
+@use "~@itwin/core-react/lib/core-react/inputs/variables";
 
-@forward "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
+@forward "~@itwin/core-react/lib/core-react/inputs/variables";
 
 $editor-component-height-small: 24px;
 $editor-iui-input-padding: variables.$uicore-iui-input-padding;

--- a/ui/components-react/src/components-react/editors/variables.scss
+++ b/ui/components-react/src/components-react/editors/variables.scss
@@ -2,7 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
+
+@forward "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
 
 $editor-component-height-small: 24px;
-$editor-iui-input-padding: $uicore-iui-input-padding;
+$editor-iui-input-padding: variables.$uicore-iui-input-padding;

--- a/ui/components-react/src/components-react/filtering/FilteringInput.scss
+++ b/ui/components-react/src/components-react/filtering/FilteringInput.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .components-filtering-input {
   display: flex;

--- a/ui/components-react/src/components-react/filtering/FilteringInput.scss
+++ b/ui/components-react/src/components-react/filtering/FilteringInput.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .components-filtering-input {
   display: flex;

--- a/ui/components-react/src/components-react/filtering/FilteringInput.scss
+++ b/ui/components-react/src/components-react/filtering/FilteringInput.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
 
 .components-filtering-input {
   display: flex;

--- a/ui/components-react/src/components-react/filtering/ResultSelector.scss
+++ b/ui/components-react/src/components-react/filtering/ResultSelector.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .components-result-selector {
   display: flex;

--- a/ui/components-react/src/components-react/filtering/ResultSelector.scss
+++ b/ui/components-react/src/components-react/filtering/ResultSelector.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .components-result-selector {
   display: flex;
   align-items: center;

--- a/ui/components-react/src/components-react/iconpicker/IconPickerButton.scss
+++ b/ui/components-react/src/components-react/iconpicker/IconPickerButton.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .components-iconpicker-button {

--- a/ui/components-react/src/components-react/iconpicker/IconPickerButton.scss
+++ b/ui/components-react/src/components-react/iconpicker/IconPickerButton.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .components-iconpicker-button {
   color: var(--iui-color-text);

--- a/ui/components-react/src/components-react/iconpicker/IconPickerButton.scss
+++ b/ui/components-react/src/components-react/iconpicker/IconPickerButton.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .components-iconpicker-button {
   color: var(--iui-color-text);

--- a/ui/components-react/src/components-react/inputs/ParsedInput.scss
+++ b/ui/components-react/src/components-react/inputs/ParsedInput.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
+@use "~@itwin/core-react/lib/core-react/inputs/variables" as *;
 
 .components-parsed-input {
   width: auto;

--- a/ui/components-react/src/components-react/inputs/ParsedInput.scss
+++ b/ui/components-react/src/components-react/inputs/ParsedInput.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 
 .components-parsed-input {
   width: auto;

--- a/ui/components-react/src/components-react/inputs/ParsedInput.scss
+++ b/ui/components-react/src/components-react/inputs/ParsedInput.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 
 .components-parsed-input {

--- a/ui/components-react/src/components-react/properties/renderers/NonPrimitivePropertyRenderer.scss
+++ b/ui/components-react/src/components-react/properties/renderers/NonPrimitivePropertyRenderer.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-@import "~@itwin/core-react/lib/cjs/core-react/style/colors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/colors" as *;
 
 .components-nonprimitive-property {
   padding: 10px;

--- a/ui/components-react/src/components-react/properties/renderers/NonPrimitivePropertyRenderer.scss
+++ b/ui/components-react/src/components-react/properties/renderers/NonPrimitivePropertyRenderer.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-@use "~@itwin/core-react/lib/cjs/core-react/style/colors" as *;
+@use "~@itwin/core-react/lib/core-react/style/colors" as *;
 
 .components-nonprimitive-property {
   padding: 10px;

--- a/ui/components-react/src/components-react/properties/renderers/PropertyView.scss
+++ b/ui/components-react/src/components-react/properties/renderers/PropertyView.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 $text-font-size: var(--iui-font-size-1);
 $text-font-color: var(--iui-color-text);
 

--- a/ui/components-react/src/components-react/properties/renderers/PropertyView.scss
+++ b/ui/components-react/src/components-react/properties/renderers/PropertyView.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 $text-font-size: var(--iui-font-size-1);
 $text-font-color: var(--iui-color-text);

--- a/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
+++ b/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 @mixin rotate($amount) {
   -webkit-transform: rotate($amount);

--- a/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
+++ b/ui/components-react/src/components-react/properties/renderers/label/PropertyLabelRenderer.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 @mixin rotate($amount) {
   -webkit-transform: rotate($amount);
   -ms-transform: rotate($amount);

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGrid.scss
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGrid.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
+@use "~@itwin/core-react/lib/core-react/scrollbar" as *;
 
 .components-property-grid-loader {
   position: relative;

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGrid.scss
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGrid.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/scrollbar";
+@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
 
 .components-property-grid-loader {
   position: relative;

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.scss
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
+@use "~@itwin/core-react/lib/core-react/scrollbar" as *;
 
 .components-virtualized-property-grid-loader {
   height: 100%;

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.scss
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/scrollbar";
+@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
 
 .components-virtualized-property-grid-loader {
   height: 100%;

--- a/ui/components-react/src/components-react/toolbar/Item.scss
+++ b/ui/components-react/src/components-react/toolbar/Item.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-button-item {
   box-sizing: border-box;

--- a/ui/components-react/src/components-react/toolbar/Items.scss
+++ b/ui/components-react/src/components-react/toolbar/Items.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 $separator-color: var(--iui-color-border-subtle);
 

--- a/ui/components-react/src/components-react/toolbar/Overflow.scss
+++ b/ui/components-react/src/components-react/toolbar/Overflow.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 @use "variables" as *;
 
 .components-toolbar-button-item.components-ellipsis-icon {

--- a/ui/components-react/src/components-react/toolbar/Overflow.scss
+++ b/ui/components-react/src/components-react/toolbar/Overflow.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @import "variables";
 
 .components-toolbar-button-item.components-ellipsis-icon {

--- a/ui/components-react/src/components-react/toolbar/Overflow.scss
+++ b/ui/components-react/src/components-react/toolbar/Overflow.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-button-item.components-ellipsis-icon {
   position: relative;

--- a/ui/components-react/src/components-react/toolbar/OverflowPanel.scss
+++ b/ui/components-react/src/components-react/toolbar/OverflowPanel.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-overflow-panel {
   background: var(--iui-color-background);

--- a/ui/components-react/src/components-react/toolbar/PopupItem.scss
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/geometry" as *;
 @use "variables" as *;
 
 .components-toolbar-expandable-button {

--- a/ui/components-react/src/components-react/toolbar/PopupItem.scss
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
-@import "~@itwin/core-react/lib/cjs/core-react/geometry";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
 @import "variables";
 
 .components-toolbar-expandable-button {

--- a/ui/components-react/src/components-react/toolbar/PopupItem.scss
+++ b/ui/components-react/src/components-react/toolbar/PopupItem.scss
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/geometry" as *;
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-expandable-button {
   $triangle-width: 4px;

--- a/ui/components-react/src/components-react/toolbar/Toolbar.scss
+++ b/ui/components-react/src/components-react/toolbar/Toolbar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 @import "variables";
 
 .components-toolbar-overflow-sizer {

--- a/ui/components-react/src/components-react/toolbar/Toolbar.scss
+++ b/ui/components-react/src/components-react/toolbar/Toolbar.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-overflow-sizer {
   display: inline-block;

--- a/ui/components-react/src/components-react/toolbar/Toolbar.scss
+++ b/ui/components-react/src/components-react/toolbar/Toolbar.scss
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@use "variables" as *;
-
 .components-toolbar-overflow-sizer {
   display: inline-block;
   position: relative;

--- a/ui/components-react/src/components-react/toolbar/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@forward "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
+@forward "~@itwin/core-react/lib/core-react/style/breakpoints";
 
 $components-desktop-item-width: 40px;
 $components-desktop-item-height: 40px;

--- a/ui/components-react/src/components-react/toolbar/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/index";
+@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
 
 $components-desktop-item-width: 40px;
 $components-desktop-item-height: 40px;

--- a/ui/components-react/src/components-react/toolbar/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/breakpoints" as *;
+@forward "~@itwin/core-react/lib/cjs/core-react/style/breakpoints";
 
 $components-desktop-item-width: 40px;
 $components-desktop-item-height: 40px;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/BackArrow.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/BackArrow.scss
@@ -3,8 +3,8 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "sass:math";
-@import "../../target";
-@import "variables";
+@use "../../target" as *;
+@use "variables" as *;
 
 .components-toolbar-item-expandable-group-backArrow {
   $border: solid $back-arrow-thickness currentColor;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/Panel.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/Panel.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-item-expandable-group-panel {
   line-height: normal;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/Title.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/Title.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-item-expandable-group-title {
   white-space: nowrap;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/_variables.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@forward "~@itwin/core-react/lib/cjs/core-react/typography";
+@forward "~@itwin/core-react/lib/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/core-react/typography";
 @forward "../variables";
 
 $panel-padding-left: 16px;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/_variables.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
-@use "../variables" as *;
+@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/cjs/core-react/typography";
+@forward "../variables";
 
 $panel-padding-left: 16px;
 $panel-padding-right: 8px;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/_variables.scss
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
-@import "../variables";
+@use "../variables" as *;
 
 $panel-padding-left: 16px;
 $panel-padding-right: 8px;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/_variables.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
-@import "~@itwin/core-react/lib/cjs/core-react/typography";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
 @import "../variables";
 
 $panel-padding-left: 16px;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/tool/Expander.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/tool/Expander.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "sass:math";
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-item-expandable-group-tool-expander {
   > .components-expansion-indicator {

--- a/ui/components-react/src/components-react/toolbar/groupPanel/tool/Tool.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/tool/Tool.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @import "../../../target";
-@import "~@itwin/core-react/lib/cjs/core-react/typography";
+@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
 @import "variables";
 
 .components-toolbar-item-expandable-group-tool-item {

--- a/ui/components-react/src/components-react/toolbar/groupPanel/tool/Tool.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/tool/Tool.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../../../target";
+@use "../../../target" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
-@import "variables";
+@use "variables" as *;
 
 .components-toolbar-item-expandable-group-tool-item {
   $item-height: 32px;

--- a/ui/components-react/src/components-react/toolbar/groupPanel/tool/Tool.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/tool/Tool.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
+@use "~@itwin/core-react/lib/core-react/typography" as *;
 @use "../../../target" as *;
 @use "variables" as *;
 

--- a/ui/components-react/src/components-react/toolbar/groupPanel/tool/Tool.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/tool/Tool.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../../../target" as *;
 @use "~@itwin/core-react/lib/cjs/core-react/typography" as *;
+@use "../../../target" as *;
 @use "variables" as *;
 
 .components-toolbar-item-expandable-group-tool-item {

--- a/ui/components-react/src/components-react/toolbar/groupPanel/tool/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/tool/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
+@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
 
 $no-shadow: none;
 $shadow: drop-shadow(

--- a/ui/components-react/src/components-react/toolbar/groupPanel/tool/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/tool/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@forward "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@forward "~@itwin/core-react/lib/core-react/style/themecolors";
 
 $no-shadow: none;
 $shadow: drop-shadow(

--- a/ui/components-react/src/components-react/toolbar/groupPanel/tool/_variables.scss
+++ b/ui/components-react/src/components-react/toolbar/groupPanel/tool/_variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 $no-shadow: none;
 $shadow: drop-shadow(

--- a/ui/components-react/src/components-react/tree/controlled/component/ControlledTree.scss
+++ b/ui/components-react/src/components-react/tree/controlled/component/ControlledTree.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
+@use "~@itwin/core-react/lib/core-react/scrollbar" as *;
 
 .components-controlledTree-loader {
   position: relative;

--- a/ui/components-react/src/components-react/tree/controlled/component/ControlledTree.scss
+++ b/ui/components-react/src/components-react/tree/controlled/component/ControlledTree.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/scrollbar";
+@use "~@itwin/core-react/lib/cjs/core-react/scrollbar" as *;
 
 .components-controlledTree-loader {
   position: relative;

--- a/ui/core-react/src/core-react/_helpers.scss
+++ b/ui/core-react/src/core-react/_helpers.scss
@@ -2,6 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+@use "sass:map";
+@use "sass:meta";
 
 // Generates map from array.
 // Key of each entry is ($array entry value: result of $fn call).
@@ -19,9 +21,9 @@
   $map: ();
   @each $item in $array {
     $kvp: (
-      $item: call($fn, $args...),
+      $item: meta.call($fn, $args...),
     );
-    $map: map-merge($map, $kvp);
+    $map: map.merge($map, $kvp);
   }
   @return $map;
 }
@@ -42,11 +44,11 @@
   $map: ();
   $result: $initialArg;
   @each $item in $array {
-    $result: call($fn, $result);
+    $result: meta.call($fn, $result);
     $kvp: (
       $item: $result,
     );
-    $map: map-merge($map, $kvp);
+    $map: map.merge($map, $kvp);
   }
   @return $map;
 }

--- a/ui/core-react/src/core-react/_scrollbar.scss
+++ b/ui/core-react/src/core-react/_scrollbar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./style/themecolors" as *;
+@forward "./style/themecolors";
 
 $uicore-scrollbar-width: 12px;
 $uicore-scrollbar-padding: 2px;

--- a/ui/core-react/src/core-react/_scrollbar.scss
+++ b/ui/core-react/src/core-react/_scrollbar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./style/themecolors.scss";
+@use "./style/themecolors" as *;
 
 $uicore-scrollbar-width: 12px;
 $uicore-scrollbar-padding: 2px;

--- a/ui/core-react/src/core-react/_typography.scss
+++ b/ui/core-react/src/core-react/_typography.scss
@@ -2,19 +2,19 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./style/opacity" as *;
+@forward "./style/opacity";
 
 $title-weight: var(--iui-font-weight-normal);
 $title-size: var(--iui-font-size-2);
-$title-opacity: $uicore-opacity-1;
+$title-opacity: var(--iui-opacity-1);
 
 $body-weight: var(--iui-font-weight-light);
 $body-size: var(--iui-font-size-1);
-$body-opacity: $uicore-opacity-2;
+$body-opacity: var(--iui-opacity-2);
 
 $body1-weight: var(--iui-font-weight-normal);
 $body1-size: var(--iui-font-size-1);
-$body1-opacity: $uicore-opacity-2;
+$body1-opacity: var(--iui-opacity-2);
 
 @mixin title($rgb: unset) {
   font-weight: $title-weight;

--- a/ui/core-react/src/core-react/_typography.scss
+++ b/ui/core-react/src/core-react/_typography.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./style/opacity.scss";
+@use "./style/opacity" as *;
 
 $title-weight: var(--iui-font-weight-normal);
 $title-size: var(--iui-font-size-2);

--- a/ui/core-react/src/core-react/_z-index.scss
+++ b/ui/core-react/src/core-react/_z-index.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "_helpers";
+@use "_helpers" as *;
 
 // Order matters, last is top-most on screen.
 $uicore-internal-z-index-layers: view-overlay, view-content-dialog,

--- a/ui/core-react/src/core-react/_z-index.scss
+++ b/ui/core-react/src/core-react/_z-index.scss
@@ -2,7 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "_helpers" as *;
+@use "sass:map";
+@use "sass:meta";
+@use "_helpers";
+
+@forward "_helpers";
 
 // Order matters, last is top-most on screen.
 $uicore-internal-z-index-layers: view-overlay, view-content-dialog,
@@ -18,16 +22,16 @@ $uicore-z-index-step: 1000;
   @return $counter + $uicore-z-index-step;
 }
 
-$uicore-internal-z-index-layer-map: uicore-map-from-array-with-result-arg(
+$uicore-internal-z-index-layer-map: helpers.uicore-map-from-array-with-result-arg(
   $uicore-internal-z-index-layers,
-  get-function(uicore-internal-get-next-z-index-step),
+  meta.get-function(uicore-internal-get-next-z-index-step),
   0
 );
 
 // Use this to get z-index value
 @function uicore-get-z-index($layer) {
-  @if map_has_key($uicore-internal-z-index-layer-map, $layer) {
-    @return map-get($uicore-internal-z-index-layer-map, $layer);
+  @if map.has-key($uicore-internal-z-index-layer-map, $layer) {
+    @return map.get($uicore-internal-z-index-layer-map, $layer);
   } @else {
     @error "Failed to get z-index for $layer: #{$layer}";
   }

--- a/ui/core-react/src/core-react/autosuggest/AutoSuggest.scss
+++ b/ui/core-react/src/core-react/autosuggest/AutoSuggest.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../scrollbar";
-@import "../inputs/variables";
+@use "../scrollbar" as *;
+@use "../inputs/variables" as *;
 
 .uicore-autosuggest__container {
   position: relative;

--- a/ui/core-react/src/core-react/base/base.scss
+++ b/ui/core-react/src/core-react/base/base.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../_scrollbar";
+@use "../_scrollbar" as *;
 
 @mixin uicore-centered {
   display: flex;

--- a/ui/core-react/src/core-react/base/base.scss
+++ b/ui/core-react/src/core-react/base/base.scss
@@ -2,7 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../_scrollbar" as *;
+@use "../_scrollbar";
+
+@forward "../_scrollbar";
 
 @mixin uicore-centered {
   display: flex;
@@ -32,8 +34,8 @@
   @include uicore-full-size;
   overflow-y: auto;
 
-  @include uicore-touch-scrolling;
-  @include uicore-scrollbar();
+  @include scrollbar.uicore-touch-scrolling;
+  @include scrollbar.uicore-scrollbar();
 }
 
 @mixin uicore-flex-wrap-container {

--- a/ui/core-react/src/core-react/base/classes.scss
+++ b/ui/core-react/src/core-react/base/classes.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./index";
+@use "./index" as *;
 
 .uicore-centered {
   @include uicore-centered;

--- a/ui/core-react/src/core-react/base/index.scss
+++ b/ui/core-react/src/core-react/base/index.scss
@@ -2,4 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./base";
+@use "./base" as *;

--- a/ui/core-react/src/core-react/base/index.scss
+++ b/ui/core-react/src/core-react/base/index.scss
@@ -2,4 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./base" as *;
+@forward "./base";

--- a/ui/core-react/src/core-react/button/UnderlinedButton.scss
+++ b/ui/core-react/src/core-react/button/UnderlinedButton.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/index.scss";
-@import "../inputs/index.scss";
+@use "../style/index" as *;
+@use "../inputs/index" as *;
 
 $color: var(--iui-color-icon-accent);
 $hoverColor: var(--iui-color-text-accent-hover);

--- a/ui/core-react/src/core-react/button/UnderlinedButton.scss
+++ b/ui/core-react/src/core-react/button/UnderlinedButton.scss
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/index" as *;
-@use "../inputs/index" as *;
-
 $color: var(--iui-color-icon-accent);
 $hoverColor: var(--iui-color-text-accent-hover);
 

--- a/ui/core-react/src/core-react/classes.scss
+++ b/ui/core-react/src/core-react/classes.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./style/index" as *;
 @use "./base/classes" as *;
 @use "./icons/classes" as *;
 @use "./inputs/classes" as *;

--- a/ui/core-react/src/core-react/classes.scss
+++ b/ui/core-react/src/core-react/classes.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./style/index";
-@import "./base/classes";
-@import "./icons/classes";
-@import "./inputs/classes";
-@import "./tabs/classes";
-@import "./text/classes";
+@use "./style/index" as *;
+@use "./base/classes" as *;
+@use "./icons/classes" as *;
+@use "./inputs/classes" as *;
+@use "./tabs/classes" as *;
+@use "./text/classes" as *;

--- a/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
+++ b/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
@@ -4,11 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 @use "../icons/variables" as *;
 @use "../style/baseline" as *;
-@use "../style/colors" as *;
-@use "../style/themecolors" as *;
 @use "../z-index" as *;
-
-// cspell:ignore themecolors unbordered
 
 $uicore-menu-padding: $uicore-bordered-padding;
 $uicore-menu-top-bottom-padding: calc(#{$uicore-menu-padding} * 0.6667);

--- a/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
+++ b/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
@@ -5,7 +5,6 @@
 @use "../icons/variables" as *;
 @use "../style/baseline" as *;
 @use "../style/colors" as *;
-@use "../style/opacity" as *;
 @use "../style/themecolors" as *;
 @use "../z-index" as *;
 
@@ -129,7 +128,7 @@ $uicore-menu-top-bottom-padding: calc(#{$uicore-menu-padding} * 0.6667);
         line-height: var(--iui-size-l);
         text-align: center;
         margin-right: $uicore-unbordered-padding;
-        opacity: $uicore-opacity-2;
+        opacity: var(--iui-opacity-2);
         display: flex;
         align-items: center;
 

--- a/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
+++ b/ui/core-react/src/core-react/contextmenu/ContextMenu.scss
@@ -2,12 +2,12 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../icons/variables";
-@import "../style/baseline";
-@import "../style/colors";
-@import "../style/opacity";
-@import "../style/themecolors";
-@import "../z-index";
+@use "../icons/variables" as *;
+@use "../style/baseline" as *;
+@use "../style/colors" as *;
+@use "../style/opacity" as *;
+@use "../style/themecolors" as *;
+@use "../z-index" as *;
 
 // cspell:ignore themecolors unbordered
 

--- a/ui/core-react/src/core-react/dialog/Dialog.scss
+++ b/ui/core-react/src/core-react/dialog/Dialog.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../z-index";
+@use "../z-index" as *;
 
 .core-dialog {
   @include uicore-z-index(dialog);

--- a/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
+++ b/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/themecolors" as *;
-@use "../z-index" as *;
-
 @function background-line($orientation) {
   @return linear-gradient(
     $orientation,

--- a/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
+++ b/ui/core-react/src/core-react/elementseparator/ElementSeparator.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/themecolors";
-@import "../z-index";
+@use "../style/themecolors" as *;
+@use "../z-index" as *;
 
 @function background-line($orientation) {
   @return linear-gradient(

--- a/ui/core-react/src/core-react/icons/IconComponent.scss
+++ b/ui/core-react/src/core-react/icons/IconComponent.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./variables";
+@use "./variables" as *;
 
 .core-svg-icon {
   width: $uicore-icons-small;

--- a/ui/core-react/src/core-react/icons/WebFontIcon.scss
+++ b/ui/core-react/src/core-react/icons/WebFontIcon.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./index";
+@use "./index" as *;
 
 .bui-webfont-icon {
   font-family: bentley-icons-generic-webfont !important;

--- a/ui/core-react/src/core-react/icons/WebFontIcon.scss
+++ b/ui/core-react/src/core-react/icons/WebFontIcon.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./index" as *;
-
 .bui-webfont-icon {
   font-family: bentley-icons-generic-webfont !important;
   speak: none;

--- a/ui/core-react/src/core-react/icons/classes.scss
+++ b/ui/core-react/src/core-react/icons/classes.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./index";
+@use "./index" as *;
 
 .uicore-icons-large {
   @include uicore-icons-large;

--- a/ui/core-react/src/core-react/icons/index.scss
+++ b/ui/core-react/src/core-react/icons/index.scss
@@ -2,5 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./variables" as *;
-@use "./mixins" as *;
+@forward "./variables";
+@forward "./mixins";

--- a/ui/core-react/src/core-react/icons/index.scss
+++ b/ui/core-react/src/core-react/icons/index.scss
@@ -2,5 +2,5 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./variables";
-@import "./mixins";
+@use "./variables" as *;
+@use "./mixins" as *;

--- a/ui/core-react/src/core-react/icons/mixins.scss
+++ b/ui/core-react/src/core-react/icons/mixins.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./variables";
+@use "./variables" as *;
 
 @mixin uicore-icons-small {
   width: $uicore-icons-small;

--- a/ui/core-react/src/core-react/icons/mixins.scss
+++ b/ui/core-react/src/core-react/icons/mixins.scss
@@ -2,24 +2,26 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./variables" as *;
+@use "./variables";
+
+@forward "./variables";
 
 @mixin uicore-icons-small {
-  width: $uicore-icons-small;
-  height: $uicore-icons-small;
+  width: variables.$uicore-icons-small;
+  height: variables.$uicore-icons-small;
 }
 
 @mixin uicore-icons-medium {
-  width: $uicore-icons-medium;
-  height: $uicore-icons-medium;
+  width: variables.$uicore-icons-medium;
+  height: variables.$uicore-icons-medium;
 }
 
 @mixin uicore-icons-large {
-  width: $uicore-icons-large;
-  height: $uicore-icons-large;
+  width: variables.$uicore-icons-large;
+  height: variables.$uicore-icons-large;
 }
 
 @mixin uicore-icons-x-large {
-  width: $uicore-icons-x-large;
-  height: $uicore-icons-x-large;
+  width: variables.$uicore-icons-x-large;
+  height: variables.$uicore-icons-x-large;
 }

--- a/ui/core-react/src/core-react/imagecheckbox/ImageCheckBox.scss
+++ b/ui/core-react/src/core-react/imagecheckbox/ImageCheckBox.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/index.scss";
-@import "../icons/variables.scss";
+@use "../style/index" as *;
+@use "../icons/variables" as *;
 
 .core-image-checkbox {
   display: inline-block;

--- a/ui/core-react/src/core-react/imagecheckbox/ImageCheckBox.scss
+++ b/ui/core-react/src/core-react/imagecheckbox/ImageCheckBox.scss
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/index" as *;
-@use "../icons/variables" as *;
-
 .core-image-checkbox {
   display: inline-block;
   font-size: 16px;

--- a/ui/core-react/src/core-react/index.scss
+++ b/ui/core-react/src/core-react/index.scss
@@ -2,19 +2,17 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "sass:math";
+@forward "./style/index";
 
-@use "./style/index" as *;
+@forward "./_scrollbar";
+@forward "./_z-index";
+@forward "./_geometry";
+@forward "./_math";
+@forward "./_typography";
 
-@use "./_scrollbar" as *;
-@use "./_z-index" as *;
-@use "./_geometry" as *;
-@use "./_math" as *;
-@use "./_typography" as *;
-
-@use "./base/index" as *;
-@use "./icons/index" as *;
-@use "./inputs/index" as *;
-@use "./loading/index" as *;
-@use "./tabs/index" as *;
-@use "./text/index" as *;
+@forward "./base/index";
+@forward "./icons/index";
+@forward "./inputs/index";
+@forward "./loading/index";
+@forward "./tabs/index";
+@forward "./text/index";

--- a/ui/core-react/src/core-react/index.scss
+++ b/ui/core-react/src/core-react/index.scss
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 @use "sass:math";
 
-@import "./style/index";
+@use "./style/index" as *;
 
-@import "./_scrollbar";
-@import "./_z-index";
-@import "./_geometry";
-@import "./_math";
-@import "./_typography";
+@use "./_scrollbar" as *;
+@use "./_z-index" as *;
+@use "./_geometry" as *;
+@use "./_math" as *;
+@use "./_typography" as *;
 
-@import "./base/index";
-@import "./icons/index";
-@import "./inputs/index";
-@import "./loading/index";
-@import "./tabs/index";
-@import "./text/index";
+@use "./base/index" as *;
+@use "./icons/index" as *;
+@use "./inputs/index" as *;
+@use "./loading/index" as *;
+@use "./tabs/index" as *;
+@use "./text/index" as *;

--- a/ui/core-react/src/core-react/inputs/classes.scss
+++ b/ui/core-react/src/core-react/inputs/classes.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./index";
+@use "./index" as *;
 
 .uicore-inputs-input {
   @include uicore-inputs-input;

--- a/ui/core-react/src/core-react/inputs/iconinput/IconInput.scss
+++ b/ui/core-react/src/core-react/inputs/iconinput/IconInput.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../../base/base";
-@import "../variables";
+@use "../../base/base" as *;
+@use "../variables" as *;
 
 .core-iconInput-container {
   position: relative;

--- a/ui/core-react/src/core-react/inputs/iconinput/IconInput.scss
+++ b/ui/core-react/src/core-react/inputs/iconinput/IconInput.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "../../base/base" as *;
-@use "../variables" as *;
 
 .core-iconInput-container {
   position: relative;

--- a/ui/core-react/src/core-react/inputs/index.scss
+++ b/ui/core-react/src/core-react/inputs/index.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/index";
+@use "../style/index" as *;
 
-@import "./variables";
-@import "./input";
-@import "./input-label";
+@use "./variables" as *;
+@use "./input" as *;
+@use "./input-label" as *;

--- a/ui/core-react/src/core-react/inputs/index.scss
+++ b/ui/core-react/src/core-react/inputs/index.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/index" as *;
+@forward "../style/index";
 
-@use "./variables" as *;
-@use "./input" as *;
-@use "./input-label" as *;
+@forward "./variables";
+@forward "./input";
+@forward "./input-label";

--- a/ui/core-react/src/core-react/inputs/input-label.scss
+++ b/ui/core-react/src/core-react/inputs/input-label.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/index";
+@use "../style/index" as *;
 
 @mixin uicore-inputs-labeled-input {
   display: block;

--- a/ui/core-react/src/core-react/inputs/input-label.scss
+++ b/ui/core-react/src/core-react/inputs/input-label.scss
@@ -81,7 +81,7 @@
 
         &:focus {
           border-color: rgb($color);
-          box-shadow: rgba($color, $uicore-opacity-boxshadow) 0px 0px 0px 2px;
+          box-shadow: rgba($color, var(--iui-opacity-4)) 0px 0px 0px 2px;
         }
       }
     }

--- a/ui/core-react/src/core-react/inputs/input-label.scss
+++ b/ui/core-react/src/core-react/inputs/input-label.scss
@@ -2,12 +2,14 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/index" as *;
+@use "../style/baseline";
+
+@forward "../style/index";
 
 @mixin uicore-inputs-labeled-input {
   display: block;
   padding: 0;
-  margin: 0 0 $uicore-unbordered-padding;
+  margin: 0 0 baseline.$uicore-unbordered-padding;
   text-align: left;
   font-size: var(--iui-font-size-1);
   font-weight: var(--iui-font-weight-normal);
@@ -33,8 +35,12 @@
 
     &.with-icon {
       > input {
-        padding-right: calc(#{$uicore-bordered-padding} + var(--iui-size-l));
-        margin-right: calc(#{$uicore-bordered-padding} + var(--iui-size-l));
+        padding-right: calc(
+          #{baseline.$uicore-bordered-padding} + var(--iui-size-l)
+        );
+        margin-right: calc(
+          #{baseline.$uicore-bordered-padding} + var(--iui-size-l)
+        );
       }
     }
 
@@ -45,7 +51,7 @@
       right: 0;
       top: 0;
       bottom: 0;
-      padding: $uicore-bordered-padding;
+      padding: baseline.$uicore-bordered-padding;
 
       font-size: var(--iui-font-size-1);
       font-weight: normal;

--- a/ui/core-react/src/core-react/inputs/input.scss
+++ b/ui/core-react/src/core-react/inputs/input.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/index";
-@import "./variables";
+@use "../style/index" as *;
+@use "./variables" as *;
 
 @mixin uicore-inputs-input {
   display: block;

--- a/ui/core-react/src/core-react/inputs/input.scss
+++ b/ui/core-react/src/core-react/inputs/input.scss
@@ -38,7 +38,7 @@
     border-color: var(--iui-color-text-disabled);
     color: var(--iui-color-text-disabled);
     cursor: not-allowed;
-    opacity: $uicore-opacity-disabled;
+    opacity: var(--iui-opacity-4);
   }
 
   &[readonly] {

--- a/ui/core-react/src/core-react/inputs/input.scss
+++ b/ui/core-react/src/core-react/inputs/input.scss
@@ -2,14 +2,16 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/index" as *;
-@use "./variables" as *;
+@use "./variables";
+
+@forward "../style/index";
+@forward "./variables";
 
 @mixin uicore-inputs-input {
   display: block;
   width: 100%;
-  padding: $uicore-iui-input-padding;
-  margin: $uicore-inputs-margin 0;
+  padding: variables.$uicore-iui-input-padding;
+  margin: variables.$uicore-inputs-margin 0;
   font-family: var(--iui-font-sans);
   font-size: var(--iui-font-size-1);
   line-height: normal;
@@ -49,6 +51,6 @@
   &:focus {
     outline: 0px;
     border-color: hsl(var(--iui-color-foreground-hsl) / var(--iui-opacity-4));
-    box-shadow: $uicore-inputs-focus-boxshadow;
+    box-shadow: variables.$uicore-inputs-focus-boxshadow;
   }
 }

--- a/ui/core-react/src/core-react/inputs/numberinput/NumberInput.scss
+++ b/ui/core-react/src/core-react/inputs/numberinput/NumberInput.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../../base/base";
-@import "../variables";
+@use "../../base/base" as *;
+@use "../variables" as *;
 
 .core-number-input-container {
   position: relative;

--- a/ui/core-react/src/core-react/inputs/variables.scss
+++ b/ui/core-react/src/core-react/inputs/variables.scss
@@ -5,6 +5,9 @@
 @use "../style/baseline" as *;
 @use "../style/themecolors" as *;
 
+@forward "../style/baseline";
+@forward "../style/themecolors";
+
 // cspell:ignore unbordered
 
 $uicore-inputs-height: 22px;

--- a/ui/core-react/src/core-react/inputs/variables.scss
+++ b/ui/core-react/src/core-react/inputs/variables.scss
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/baseline" as *;
-@use "../style/themecolors" as *;
-
 @forward "../style/baseline";
 @forward "../style/themecolors";
 

--- a/ui/core-react/src/core-react/inputs/variables.scss
+++ b/ui/core-react/src/core-react/inputs/variables.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/baseline";
-@import "../style/themecolors";
+@use "../style/baseline" as *;
+@use "../style/themecolors" as *;
 
 // cspell:ignore unbordered
 

--- a/ui/core-react/src/core-react/layout-variables.scss
+++ b/ui/core-react/src/core-react/layout-variables.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./z-index";
+@use "./z-index" as *;
 
 :root {
   /** Default Widget Opacity */

--- a/ui/core-react/src/core-react/listbox/Listbox.scss
+++ b/ui/core-react/src/core-react/listbox/Listbox.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../index";
+@use "../index" as *;
 
 $uicore-list-item-height: calc(var(--iui-size-s) * 2);
 

--- a/ui/core-react/src/core-react/loading/LoadingBar.scss
+++ b/ui/core-react/src/core-react/loading/LoadingBar.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/themecolors" as *;
-
 .core-lb {
   display: flex;
   align-items: center;

--- a/ui/core-react/src/core-react/loading/LoadingBar.scss
+++ b/ui/core-react/src/core-react/loading/LoadingBar.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/themecolors";
+@use "../style/themecolors" as *;
 
 .core-lb {
   display: flex;

--- a/ui/core-react/src/core-react/loading/LoadingPrompt.scss
+++ b/ui/core-react/src/core-react/loading/LoadingPrompt.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/themecolors";
+@use "../style/themecolors" as *;
 
 // cspell:ignore loadingprompt
 

--- a/ui/core-react/src/core-react/loading/LoadingPrompt.scss
+++ b/ui/core-react/src/core-react/loading/LoadingPrompt.scss
@@ -2,10 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/themecolors" as *;
-
-// cspell:ignore loadingprompt
-
 .core-loadingprompt {
   height: 100%;
   display: flex;

--- a/ui/core-react/src/core-react/loading/LoadingSpinner.scss
+++ b/ui/core-react/src/core-react/loading/LoadingSpinner.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/themecolors" as *;
-
 .core-ls {
   display: flex;
   align-items: center;

--- a/ui/core-react/src/core-react/loading/LoadingSpinner.scss
+++ b/ui/core-react/src/core-react/loading/LoadingSpinner.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/themecolors";
+@use "../style/themecolors" as *;
 
 .core-ls {
   display: flex;

--- a/ui/core-react/src/core-react/loading/index.scss
+++ b/ui/core-react/src/core-react/loading/index.scss
@@ -2,4 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./mixins" as *;
+@forward "./mixins";

--- a/ui/core-react/src/core-react/loading/index.scss
+++ b/ui/core-react/src/core-react/loading/index.scss
@@ -2,4 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./mixins";
+@use "./mixins" as *;

--- a/ui/core-react/src/core-react/loading/mixins.scss
+++ b/ui/core-react/src/core-react/loading/mixins.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/index" as *;
+@forward "../style/index";
 
 @mixin uicore-spinner(
   $size,

--- a/ui/core-react/src/core-react/loading/mixins.scss
+++ b/ui/core-react/src/core-react/loading/mixins.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/index";
+@use "../style/index" as *;
 
 @mixin uicore-spinner(
   $size,

--- a/ui/core-react/src/core-react/messagebox/MessageBox.scss
+++ b/ui/core-react/src/core-react/messagebox/MessageBox.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "../icons/variables" as *;
-@use "../style/colors" as *;
 @use "../style/baseline" as *;
 
 .core-message-box-container {

--- a/ui/core-react/src/core-react/messagebox/MessageBox.scss
+++ b/ui/core-react/src/core-react/messagebox/MessageBox.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../icons/variables";
-@import "../style/colors";
-@import "../style/baseline";
+@use "../icons/variables" as *;
+@use "../style/colors" as *;
+@use "../style/baseline" as *;
 
 .core-message-box-container {
   display: flex;

--- a/ui/core-react/src/core-react/popup/Popup.scss
+++ b/ui/core-react/src/core-react/popup/Popup.scss
@@ -2,7 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../inputs/variables" as *;
 @use "../z-index" as *;
 
 .core-popup {

--- a/ui/core-react/src/core-react/popup/Popup.scss
+++ b/ui/core-react/src/core-react/popup/Popup.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../inputs/variables";
-@import "../z-index";
+@use "../inputs/variables" as *;
+@use "../z-index" as *;
 
 .core-popup {
   top: 0;

--- a/ui/core-react/src/core-react/radialmenu/RadialMenu.scss
+++ b/ui/core-react/src/core-react/radialmenu/RadialMenu.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../z-index";
-@import "../style/themecolors";
-@import "../icons/variables";
+@use "../z-index" as *;
+@use "../style/themecolors" as *;
+@use "../icons/variables" as *;
 
 .core-radial-menu {
   visibility: hidden;

--- a/ui/core-react/src/core-react/radialmenu/RadialMenu.scss
+++ b/ui/core-react/src/core-react/radialmenu/RadialMenu.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "../z-index" as *;
-@use "../style/themecolors" as *;
 @use "../icons/variables" as *;
 
 .core-radial-menu {

--- a/ui/core-react/src/core-react/searchbox/SearchBox.scss
+++ b/ui/core-react/src/core-react/searchbox/SearchBox.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/themecolors";
+@use "../style/themecolors" as *;
 
 .core-searchbox {
   font-family: var(--iui-font-sans);

--- a/ui/core-react/src/core-react/searchbox/SearchBox.scss
+++ b/ui/core-react/src/core-react/searchbox/SearchBox.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/themecolors" as *;
-
 .core-searchbox {
   font-family: var(--iui-font-sans);
   display: flex;

--- a/ui/core-react/src/core-react/settings/SettingsContainer.scss
+++ b/ui/core-react/src/core-react/settings/SettingsContainer.scss
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 
-@import "../style/themecolors";
+@use "../style/themecolors" as *;
 
 div.core-settings-container {
   display: flex;

--- a/ui/core-react/src/core-react/settings/SettingsContainer.scss
+++ b/ui/core-react/src/core-react/settings/SettingsContainer.scss
@@ -2,9 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
-@use "../style/themecolors" as *;
-
 div.core-settings-container {
   display: flex;
   box-sizing: border-box;

--- a/ui/core-react/src/core-react/style/index.scss
+++ b/ui/core-react/src/core-react/style/index.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./baseline";
-@import "./breakpoints";
-@import "./themecolors";
-@import "./colors";
-@import "./mixins";
-@import "./opacity";
+@use "./baseline" as *;
+@use "./breakpoints" as *;
+@use "./themecolors" as *;
+@use "./colors" as *;
+@use "./mixins" as *;
+@use "./opacity" as *;

--- a/ui/core-react/src/core-react/style/index.scss
+++ b/ui/core-react/src/core-react/style/index.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./baseline" as *;
-@use "./breakpoints" as *;
-@use "./themecolors" as *;
-@use "./colors" as *;
-@use "./mixins" as *;
-@use "./opacity" as *;
+@forward "./baseline";
+@forward "./breakpoints";
+@forward "./themecolors";
+@forward "./colors";
+@forward "./mixins";
+@forward "./opacity";

--- a/ui/core-react/src/core-react/tabs/classes.scss
+++ b/ui/core-react/src/core-react/tabs/classes.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./index";
+@use "./index" as *;
 
 .uicore-tabs-vertical {
   @include uicore-tabs-vertical;

--- a/ui/core-react/src/core-react/tabs/index.scss
+++ b/ui/core-react/src/core-react/tabs/index.scss
@@ -2,4 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./vertical" as *;
+@forward "./vertical";

--- a/ui/core-react/src/core-react/tabs/index.scss
+++ b/ui/core-react/src/core-react/tabs/index.scss
@@ -2,4 +2,4 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./vertical";
+@use "./vertical" as *;

--- a/ui/core-react/src/core-react/tabs/tabs.scss
+++ b/ui/core-react/src/core-react/tabs/tabs.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/index";
-@import "../icons/variables";
+@use "../style/index" as *;
+@use "../icons/variables" as *;
 
 @mixin uicore-tabs {
   display: block;

--- a/ui/core-react/src/core-react/tabs/tabs.scss
+++ b/ui/core-react/src/core-react/tabs/tabs.scss
@@ -2,8 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/index" as *;
-@use "../icons/variables" as *;
+@use "../style/baseline";
+@use "../icons/variables";
+
+@forward "../style/index";
+@forward "../icons/variables";
 
 @mixin uicore-tabs {
   display: block;
@@ -27,8 +30,8 @@
     > a {
       display: block;
       position: relative;
-      padding: $uicore-bordered-padding calc(var(--iui-font-size-1) - 1px)
-        $uicore-unbordered-padding;
+      padding: baseline.$uicore-bordered-padding
+        calc(var(--iui-font-size-1) - 1px) baseline.$uicore-unbordered-padding;
       margin: 0;
       line-height: var(--iui-size-l);
       color: var(--iui-color-text);
@@ -44,8 +47,8 @@
         }
 
         .uicore-tabs-icon {
-          width: ($uicore-icons-small + 12px);
-          height: ($uicore-icons-small + 12px);
+          width: (variables.$uicore-icons-small + 12px);
+          height: (variables.$uicore-icons-small + 12px);
           display: flex;
           align-items: center;
         }

--- a/ui/core-react/src/core-react/tabs/vertical.scss
+++ b/ui/core-react/src/core-react/tabs/vertical.scss
@@ -2,11 +2,13 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/index" as *;
-@use "./tabs" as *;
+@use "./tabs";
+
+@forward "../style/index";
+@forward "./tabs";
 
 @mixin uicore-tabs-vertical {
-  @include uicore-tabs;
+  @include tabs.uicore-tabs;
 
   > li {
     display: block;

--- a/ui/core-react/src/core-react/tabs/vertical.scss
+++ b/ui/core-react/src/core-react/tabs/vertical.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/index";
-@import "./tabs";
+@use "../style/index" as *;
+@use "./tabs" as *;
 
 @mixin uicore-tabs-vertical {
   @include uicore-tabs;

--- a/ui/core-react/src/core-react/text/FilteredText.scss
+++ b/ui/core-react/src/core-react/text/FilteredText.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/themecolors" as *;
-
 .uicore-filtered-text-match {
   color: var(--iui-color-icon-accent);
   font-weight: bold;

--- a/ui/core-react/src/core-react/text/FilteredText.scss
+++ b/ui/core-react/src/core-react/text/FilteredText.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/themecolors";
+@use "../style/themecolors" as *;
 
 .uicore-filtered-text-match {
   color: var(--iui-color-icon-accent);

--- a/ui/core-react/src/core-react/text/classes.scss
+++ b/ui/core-react/src/core-react/text/classes.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./index";
+@use "./index" as *;
 
 .uicore-text-body {
   @include uicore-text-body;

--- a/ui/core-react/src/core-react/text/disabled.scss
+++ b/ui/core-react/src/core-react/text/disabled.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/themecolors" as *;
-
 @mixin uicore-text-disabled {
   color: var(--iui-color-text-disabled);
 }

--- a/ui/core-react/src/core-react/text/disabled.scss
+++ b/ui/core-react/src/core-react/text/disabled.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/themecolors";
+@use "../style/themecolors" as *;
 
 @mixin uicore-text-disabled {
   color: var(--iui-color-text-disabled);

--- a/ui/core-react/src/core-react/text/index.scss
+++ b/ui/core-react/src/core-react/text/index.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "./mixins" as *;
+@forward "./mixins";
 
-@use "./body" as *;
-@use "./block" as *;
-@use "./disabled" as *;
-@use "./muted" as *;
+@forward "./body";
+@forward "./block";
+@forward "./disabled";
+@forward "./muted";

--- a/ui/core-react/src/core-react/text/index.scss
+++ b/ui/core-react/src/core-react/text/index.scss
@@ -2,9 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "./mixins";
+@use "./mixins" as *;
 
-@import "./body";
-@import "./block";
-@import "./disabled";
-@import "./muted";
+@use "./body" as *;
+@use "./block" as *;
+@use "./disabled" as *;
+@use "./muted" as *;

--- a/ui/core-react/src/core-react/text/mixins.scss
+++ b/ui/core-react/src/core-react/text/mixins.scss
@@ -2,7 +2,9 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "../style/themecolors" as *;
+@use "sass:map";
+
+@forward "../style/themecolors";
 
 @mixin uicore-text-block-spacing {
   padding: 0;
@@ -15,9 +17,9 @@
     small: var(--iui-font-size-0),
   );
 
-  $type: if(map-has-key($sizes, $type), $type, body);
+  $type: if(map.has-key($sizes, $type), $type, body);
 
-  font-size: map-get($sizes, $type);
+  font-size: map.get($sizes, $type);
   font-weight: var(--iui-font-weight-normal);
   line-height: var(--iui-size-l);
   color: var(--iui-color-text);

--- a/ui/core-react/src/core-react/text/mixins.scss
+++ b/ui/core-react/src/core-react/text/mixins.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "../style/themecolors";
+@use "../style/themecolors" as *;
 
 @mixin uicore-text-block-spacing {
   padding: 0;

--- a/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerButton.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerButton.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 button.components-colorpicker-button {
   font-family: var(--iui-font-sans);

--- a/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerButton.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/color/ColorPickerButton.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 button.components-colorpicker-button {
   font-family: var(--iui-font-sans);
   font-size: var(--iui-font-size-1);

--- a/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 $components-color-editor-item-height: 100%;
 

--- a/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/ColorEditor.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 $components-color-editor-item-height: 100%;
 
 .components-color-editor {

--- a/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 $components-weight-editor-item-height: 100%;
 
 .components-weight-editor {

--- a/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/editors/WeightEditor.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 $components-weight-editor-item-height: 100%;
 

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/QuantityNumberInput.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/QuantityNumberInput.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
+@use "~@itwin/core-react/lib/core-react/base/base" as *;
 
 .component-quantity-number-input-container {
   display: flex;

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/QuantityNumberInput.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/QuantityNumberInput.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/base/base";
+@use "~@itwin/core-react/lib/cjs/core-react/base/base" as *;
 
 .component-quantity-number-input-container {
   display: flex;

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/Swatch.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/Swatch.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .components-lineweight-swatch {
   font-size: var(--iui-font-size-1);
   color: var(--iui-color-text);

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/Swatch.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/Swatch.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .components-lineweight-swatch {
   font-size: var(--iui-font-size-1);

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .components-weightpicker-button {
   color: var(--iui-color-text);

--- a/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/lineweight/WeightPickerButton.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .components-weightpicker-button {
   color: var(--iui-color-text);
   background: var(--iui-color-background);

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 $cube-outer-width: 96px;
 $button-width: 20px;

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/CubeNavigationAid.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 $cube-outer-width: 96px;
 $button-width: 20px;
 $nav-cube-width: 64px;

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 #components-drawing-portal {
   @include uicore-z-index(dragged-widget);

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.scss
@@ -2,8 +2,8 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 #components-drawing-portal {
   @include uicore-z-index(dragged-widget);

--- a/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/navigationaids/DrawingNavigationAid.scss
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 @use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 #components-drawing-portal {
   @include uicore-z-index(dragged-widget);

--- a/ui/imodel-components-react/src/imodel-components-react/quantityformat/FormatPanel.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/quantityformat/FormatPanel.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
-
 .components-quantityFormat-panel {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/ui/imodel-components-react/src/imodel-components-react/quantityformat/FormatPanel.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/quantityformat/FormatPanel.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/inputs/variables";
+@use "~@itwin/core-react/lib/cjs/core-react/inputs/variables" as *;
 
 .components-quantityFormat-panel {
   display: grid;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/InlineEdit.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/InlineEdit.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .inline-edit-input {
   color: var(--iui-color-text);

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/InlineEdit.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/InlineEdit.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .inline-edit-input {
   color: var(--iui-color-text);
   background: inherit;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/Scrubber.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/Scrubber.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 
 .components-timeline-thumb {
   display: flex;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/Scrubber.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/Scrubber.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/z-index";
+@use "~@itwin/core-react/lib/cjs/core-react/z-index" as *;
 
 .components-timeline-thumb {
   display: flex;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/SolarTimeline.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/SolarTimeline.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .solar-timeline-wrapper {
   width: 100%;
   position: relative;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/SolarTimeline.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/SolarTimeline.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .solar-timeline-wrapper {
   width: 100%;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/SpeedTimeline.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/SpeedTimeline.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .speed-timeline {
   position: relative;
   height: 25px;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/SpeedTimeline.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/SpeedTimeline.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .speed-timeline {
   position: relative;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/Timeline.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/Timeline.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@import "~@itwin/core-react/lib/cjs/core-react/style/themecolors";
+@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
 
 .timeline {
   position: relative;

--- a/ui/imodel-components-react/src/imodel-components-react/timeline/Timeline.scss
+++ b/ui/imodel-components-react/src/imodel-components-react/timeline/Timeline.scss
@@ -2,8 +2,6 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-@use "~@itwin/core-react/lib/cjs/core-react/style/themecolors" as *;
-
 .timeline {
   position: relative;
   height: 110px;


### PR DESCRIPTION
## Changes

This PR bumps the `sass` version to the latest.

The SCSS files are updated to avoid  https://sass-lang.com/documentation/breaking-changes/import/ warnings:
- Replaced `@import` rules with `@use` rules
- Added `@forward` rules to SCSS partial files to forward previously imported `SCSS` modules (to avoid breaking existing SCSS of AppUI consumers)

The `test-app` and `storybook` now use [`modern-compiler`](https://vite.dev/config/shared-options#css-preprocessoroptions) to avoid https://sass-lang.com/documentation/breaking-changes/legacy-js-api/.

The SCSS module paths are updated to drop the `cjs` subdirectory.

## Testing

N/A
