### PR TITLE
Add `types` field back

### DIFF
--- a/common/changes/@itwin/appui-react/add-types_2024-10-25-06-55.json
+++ b/common/changes/@itwin/appui-react/add-types_2024-10-25-06-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/add-types_2024-10-25-06-55.json
+++ b/common/changes/@itwin/components-react/add-types_2024-10-25-06-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/add-types_2024-10-25-06-55.json
+++ b/common/changes/@itwin/core-react/add-types_2024-10-25-06-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/add-types_2024-10-25-06-55.json
+++ b/common/changes/@itwin/imodel-components-react/add-types_2024-10-25-06-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.0-dev.0",
   "description": "A react component library for AppUI framework",
   "type": "module",
+  "types": "./lib/appui-react.d.ts",
   "exports": {
     ".": "./lib/appui-react.js",
     "./package.json": "./package.json",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.0-dev.0",
   "description": "A react component library of iTwin.js UI data-oriented components",
   "type": "module",
+  "types": "./lib/components-react.d.ts",
   "exports": {
     ".": "./lib/components-react.js",
     "./internal": "./lib/internal.js",

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.0-dev.0",
   "description": "A react component library of iTwin.js UI general purpose components",
   "type": "module",
+  "types": "./lib/core-react.d.ts",
   "exports": {
     ".": "./lib/core-react.js",
     "./internal": "./lib/internal.js",

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.0-dev.0",
   "description": "A react component library of iTwin.js UI iModel components",
   "type": "module",
+  "types": "./lib/imodel-components-react.d.ts",
   "exports": {
     ".": "./lib/imodel-components-react.js",
     "./internal": "./lib/internal.js",


### PR DESCRIPTION
## Changes

This PR adds the `types` field back, mainly to keep the TS icon in the npm registry as recommended in https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-main-and-types

This field was removed in https://github.com/iTwin/appui/pull/1081

## Testing

N/A
