### PR TITLE
Fixed `pw:` links handling in property grid

### DIFF
--- a/common/changes/@itwin/components-react/pw-link-fix_2024-10-30-10-55.json
+++ b/common/changes/@itwin/components-react/pw-link-fix_2024-10-30-10-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fixed `pw:` links handling in property grid.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/common/Links.ts
+++ b/ui/components-react/src/components-react/common/Links.ts
@@ -89,3 +89,27 @@ export const matchLinks = (
       }>)
     : [];
 };
+
+/**
+ * @internal
+ */
+export const openLink = (url: string) => {
+  if (url.startsWith("mailto:")) {
+    location.href = url;
+    return;
+  }
+
+  const openAndFocus = (link: string) => {
+    const windowOpen = window.open(link, "_blank");
+    windowOpen?.focus();
+  };
+
+  if (url.startsWith("pw:")) {
+    // remove // or \\ from the link. Links with custom schema should use opaque path like `schema:path` instead of `schema://path`
+    const validUrl = url.replace(/pw:\/\/|pw:\\\\/g, "pw:");
+    openAndFocus(validUrl);
+    return;
+  }
+
+  openAndFocus(url);
+};

--- a/ui/components-react/src/components-react/properties/renderers/value/UrlPropertyValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/UrlPropertyValueRenderer.tsx
@@ -15,6 +15,7 @@ import type {
 } from "../../ValueRendererManager.js";
 import { PrimitivePropertyValueRendererImpl } from "./PrimitivePropertyValueRenderer.js";
 import { convertRecordToString } from "./Common.js";
+import { openLink } from "../../../common/Links.js";
 
 /**
  * URL property value renderer that renders the whole value as a URL without matching it
@@ -51,15 +52,6 @@ export class UrlPropertyValueRenderer implements IPropertyValueRenderer {
   }
 }
 
-function handleClick(text: string) {
-  if (text.startsWith("mailto:")) {
-    location.href = text;
-  } else {
-    const windowOpen = window.open(text, "_blank");
-    windowOpen?.focus();
-  }
-}
-
 const URI_PROPERTY_LINK_HANDLER: LinkElementsInfo = {
-  onClick: handleClick,
+  onClick: openLink,
 };

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridCommons.ts
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridCommons.ts
@@ -9,7 +9,7 @@
 import type { PropertyRecord } from "@itwin/appui-abstract";
 import type { CommonProps } from "@itwin/core-react";
 import type { HighlightingComponentProps } from "../../common/HighlightingComponentProps.js";
-import { matchLinks } from "../../common/Links.js";
+import { matchLinks, openLink } from "../../common/Links.js";
 import type { PropertyUpdatedArgs } from "../../editors/EditorContainer.js";
 import type { ActionButtonRenderer } from "../../properties/renderers/ActionButtonRenderer.js";
 import type { PropertyValueRendererManager } from "../../properties/ValueRendererManager.js";
@@ -133,14 +133,11 @@ export class PropertyGridCommons {
     const linksArray = matchLinks(text);
     if (linksArray.length <= 0) return;
     const foundLink = linksArray[0];
-    if (foundLink && foundLink.url) {
-      if (foundLink.schema === "mailto:") {
-        location.href = foundLink.url;
-      } else {
-        const windowOpen = window.open(foundLink.url, "_blank");
-        windowOpen?.focus();
-      }
+    if (!foundLink || !foundLink.url) {
+      return;
     }
+
+    openLink(foundLink.url);
   }
 
   /**

--- a/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
@@ -73,13 +73,13 @@ describe("PropertyGrid Commons", () => {
       );
     });
 
-    it("sets location href value to value got in the text if it is an ProjectWise Explorer link", async () => {
+    it("opens new window if it is an ProjectWise Explorer link", async () => {
       const spy = vi.spyOn(window, "open");
       PropertyGridCommons.handleLinkClick(
         "pw://server.bentley.com:datasource-01/Documents/ProjectName"
       );
       expect(spy).toHaveBeenCalledWith(
-        "pw://server.bentley.com:datasource-01/Documents/ProjectName",
+        "pw:server.bentley.com:datasource-01/Documents/ProjectName",
         "_blank"
       );
     });


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->
Fixed `pw:` links handling in property grid. They stopped working after latest chromium updates. Suggested solution is to use custom schema links with opaque paths: `schema:<path>` instead of `schema://<path>`
https://docs.google.com/document/d/1LjxHl32fE4tCKugrK_PIso7mfXQVEeoD1wSnX2y0ZU8/edit?resourcekey=0-d1gP4X2sG7GPl9mlTeptIA&tab=t.0#heading=h.kjrmsvcywm3o

Also unified links handling between default property grid action and url property renderer.

Closes https://github.com/iTwin/appui/issues/1089

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Tested manually with different browsers