### PR TITLE
Move `@itwin/itwinui-react` to peerDependencies

### DIFF
--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -98,7 +98,7 @@
     "@itwin/imodels-access-frontend": "^3.0.0",
     "@itwin/imodels-client-authoring": "^3.0.0",
     "@itwin/imodels-client-management": "^3.0.0",
-    "@itwin/itwinui-react": "^3.11.2",
+    "@itwin/itwinui-react": "^3.15.0",
     "@itwin/itwinui-react-v2": "npm:@itwin/itwinui-react@^2.12.26",
     "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -97,7 +97,6 @@
     "@itwin/imodels-client-management": "^3.0.0",
     "@itwin/itwinui-react": "^3.15.0",
     "@itwin/itwinui-react-v2": "npm:@itwin/itwinui-react@^2.12.26",
-    "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "@itwin/itwinui-layouts-react": "~0.4.1",
     "@itwin/itwinui-layouts-css": "~0.4.0",

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -37,9 +37,6 @@
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
   },
-  "//devDependencies": [
-    "NOTE: All tools used by scripts in this package must be listed as devDependencies"
-  ],
   "devDependencies": {
     "@itwin/build-tools": "4.10.0-dev.34",
     "@itwin/eslint-plugin": "5.0.0-dev.1",

--- a/apps/test-providers/package.json
+++ b/apps/test-providers/package.json
@@ -56,7 +56,7 @@
     "@itwin/core-react": "workspace:*",
     "@itwin/appui-react": "workspace:*",
     "@itwin/imodel-components-react": "workspace:*",
-    "@itwin/itwinui-react": "^3.11.2",
+    "@itwin/itwinui-react": "^3.15.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/webgl-compatibility": "^4.0.0",

--- a/apps/test-providers/package.json
+++ b/apps/test-providers/package.json
@@ -58,7 +58,6 @@
     "@itwin/imodel-components-react": "workspace:*",
     "@itwin/itwinui-react": "^3.15.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
-    "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/webgl-compatibility": "^4.0.0",
     "classnames": "2.5.1",
     "react": "^18.3.1",

--- a/common/changes/@itwin/appui-react/itwinui-peer_2024-11-13-14-05.json
+++ b/common/changes/@itwin/appui-react/itwinui-peer_2024-11-13-14-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Move @itwin/itwinui-react to peerDependencies.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/itwinui-peer_2024-11-13-14-05.json
+++ b/common/changes/@itwin/components-react/itwinui-peer_2024-11-13-14-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Move @itwin/itwinui-react to peerDependencies.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/itwinui-peer_2024-11-13-14-05.json
+++ b/common/changes/@itwin/core-react/itwinui-peer_2024-11-13-14-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Move @itwin/itwinui-react to peerDependencies.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/itwinui-peer_2024-11-13-14-05.json
+++ b/common/changes/@itwin/imodel-components-react/itwinui-peer_2024-11-13-14-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Move @itwin/itwinui-react to peerDependencies.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -171,10 +171,6 @@
       "allowedCategories": [ "frontend", "internal" ]
     },
     {
-      "name": "@itwin/itwinui-variables",
-      "allowedCategories": [ "frontend", "internal" ]
-    },
-    {
       "name": "@itwin/presentation-common",
       "allowedCategories": [ "internal" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       '@itwin/itwinui-react-v2':
         specifier: npm:@itwin/itwinui-react@^2.12.26
         version: /@itwin/itwinui-react@2.12.26(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-variables':
-        specifier: ^3.0.0
-        version: 3.1.0
       '@itwin/presentation-common':
         specifier: ^4.0.0
         version: 4.4.0(@itwin/core-bentley@4.4.0)(@itwin/core-common@4.4.0)(@itwin/core-quantity@4.4.0)
@@ -277,9 +274,6 @@ importers:
       '@itwin/itwinui-react':
         specifier: ^3.15.0
         version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-variables':
-        specifier: ^3.0.0
-        version: 3.1.0
       '@itwin/webgl-compatibility':
         specifier: ^4.0.0
         version: 4.4.0
@@ -559,9 +553,6 @@ importers:
       '@itwin/itwinui-illustrations-react':
         specifier: ^2.0.1
         version: 2.1.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-variables':
-        specifier: ^3.0.0
-        version: 3.1.0
       classnames:
         specifier: 2.5.1
         version: 2.5.1
@@ -731,9 +722,6 @@ importers:
       '@itwin/itwinui-icons-react':
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-variables':
-        specifier: ^3.0.0
-        version: 3.1.0
       classnames:
         specifier: 2.5.1
         version: 2.5.1
@@ -873,9 +861,6 @@ importers:
       '@itwin/itwinui-icons-react':
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-variables':
-        specifier: ^3.0.0
-        version: 3.1.0
       classnames:
         specifier: 2.5.1
         version: 2.5.1
@@ -997,9 +982,6 @@ importers:
       '@itwin/itwinui-icons-react':
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-variables':
-        specifier: ^3.0.0
-        version: 3.1.0
       classnames:
         specifier: 2.5.1
         version: 2.5.1
@@ -3379,10 +3361,6 @@ packages:
       react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
-
-  /@itwin/itwinui-variables@3.1.0:
-    resolution: {integrity: sha512-CHCS+hkaO4c0SUT1Lgi23Gpy8d/fZZKXCyd907c+a5wf8JAOtFQbuCa566YJS+08QDP11Jr+mzDDAMF1Yhk3yg==}
-    dev: false
 
   /@itwin/object-storage-azure@1.6.0:
     resolution: {integrity: sha512-b0rxhn0NAFY1alOEGMAUaJtK8WG7xoJPDOVjuA8nC7zFcxxtP2VOsSOauuie2zzL3GDi9OU6vywR3gAcJcTZww==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: ~0.4.1
         version: 0.4.1(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-react':
-        specifier: ^3.11.2
-        version: 3.11.2(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^3.15.0
+        version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-react-v2':
         specifier: npm:@itwin/itwinui-react@^2.12.26
         version: /@itwin/itwinui-react@2.12.26(react-dom@18.3.1)(react@18.3.1)
@@ -275,8 +275,8 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-react':
-        specifier: ^3.11.2
-        version: 3.11.2(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^3.15.0
+        version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-variables':
         specifier: ^3.0.0
         version: 3.1.0
@@ -384,8 +384,8 @@ importers:
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-react':
-        specifier: ^3.11.2
-        version: 3.11.2(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
+        specifier: ^3.15.0
+        version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -559,9 +559,6 @@ importers:
       '@itwin/itwinui-illustrations-react':
         specifier: ^2.0.1
         version: 2.1.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-react':
-        specifier: ^3.11.2
-        version: 3.11.2(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-variables':
         specifier: ^3.0.0
         version: 3.1.0
@@ -632,6 +629,9 @@ importers:
       '@itwin/imodel-components-react':
         specifier: workspace:*
         version: link:../imodel-components-react
+      '@itwin/itwinui-react':
+        specifier: ^3.15.0
+        version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/webgl-compatibility':
         specifier: ^4.0.0
         version: 4.4.0
@@ -731,9 +731,6 @@ importers:
       '@itwin/itwinui-icons-react':
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-react':
-        specifier: ^3.11.2
-        version: 3.11.2(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-variables':
         specifier: ^3.0.0
         version: 3.1.0
@@ -783,6 +780,9 @@ importers:
       '@itwin/eslint-plugin':
         specifier: 5.0.0-dev.1
         version: 5.0.0-dev.1(eslint@8.57.1)(typescript@5.6.2)
+      '@itwin/itwinui-react':
+        specifier: ^3.15.0
+        version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/dom':
         specifier: ^10.1.0
         version: 10.1.0
@@ -873,9 +873,6 @@ importers:
       '@itwin/itwinui-icons-react':
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-react':
-        specifier: ^3.11.2
-        version: 3.11.2(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-variables':
         specifier: ^3.0.0
         version: 3.1.0
@@ -913,6 +910,9 @@ importers:
       '@itwin/eslint-plugin':
         specifier: 5.0.0-dev.1
         version: 5.0.0-dev.1(eslint@8.57.1)(typescript@5.6.2)
+      '@itwin/itwinui-react':
+        specifier: ^3.15.0
+        version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@testing-library/dom':
         specifier: ^10.1.0
         version: 10.1.0
@@ -997,9 +997,6 @@ importers:
       '@itwin/itwinui-icons-react':
         specifier: ^2.8.0
         version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-react':
-        specifier: ^3.11.2
-        version: 3.11.2(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-variables':
         specifier: ^3.0.0
         version: 3.1.0
@@ -1043,6 +1040,9 @@ importers:
       '@itwin/eslint-plugin':
         specifier: 5.0.0-dev.1
         version: 5.0.0-dev.1(eslint@8.57.1)(typescript@5.6.2)
+      '@itwin/itwinui-react':
+        specifier: ^3.15.0
+        version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@itwin/webgl-compatibility':
         specifier: ^4.0.0
         version: 4.4.0
@@ -2780,18 +2780,16 @@ packages:
   /@floating-ui/core@1.5.3:
     resolution: {integrity: sha512-O0WKDOo0yhJuugCx6trZQj5jVJ9yR0ystG2JaNAemYUWce+pmM6WUEFIibnWyEJKdrDxhm75NoSRME35FNaM/Q==}
     dependencies:
-      '@floating-ui/utils': 0.2.1
-    dev: false
+      '@floating-ui/utils': 0.2.8
 
   /@floating-ui/dom@1.6.3:
     resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
     dependencies:
       '@floating-ui/core': 1.5.3
-      '@floating-ui/utils': 0.2.1
-    dev: false
+      '@floating-ui/utils': 0.2.8
 
-  /@floating-ui/react-dom@2.1.0(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==}
+  /@floating-ui/react-dom@2.1.2(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -2799,24 +2797,21 @@ packages:
       '@floating-ui/dom': 1.6.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    dev: false
 
-  /@floating-ui/react@0.26.16(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-HEf43zxZNAI/E781QIVpYSF3K2VH4TTYZpqecjdsFkjsaU1EbaWcM++kw0HXFffj7gDUcBFevX8s0rQGQpxkow==}
+  /@floating-ui/react@0.26.27(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-jLP72x0Kr2CgY6eTYi/ra3VA9LOkTo4C+DUTrbFgFOExKy3omYVmwMjNKqxAHdsnyLS96BIDLcO2SlnsNf8KUQ==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/react-dom': 2.1.0(react-dom@18.3.1)(react@18.3.1)
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1)(react@18.3.1)
+      '@floating-ui/utils': 0.2.8
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tabbable: 6.2.0
-    dev: false
 
-  /@floating-ui/utils@0.2.1:
-    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
-    dev: false
+  /@floating-ui/utils@0.2.8:
+    resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
   /@humanwhocodes/config-array@0.13.0:
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -3254,7 +3249,7 @@ packages:
       react-dom: ^16.13.0 || ^17.0.2
     dependencies:
       '@itwin/itwinui-icons-react': 2.8.0(react-dom@18.3.1)(react@18.3.1)
-      '@itwin/itwinui-react': 2.12.20(react-dom@18.3.1)(react@18.3.1)
+      '@itwin/itwinui-react': 2.12.26(react-dom@18.3.1)(react@18.3.1)
       classnames: 2.5.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -3332,7 +3327,6 @@ packages:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    dev: false
 
   /@itwin/itwinui-layouts-css@0.4.0:
     resolution: {integrity: sha512-yFbE7X5RBpa6SM2MsupUcmt16XcwyTHDG1gsuywVacoDmK2D2BKiqRw3zxx+cutOWTysokIrW2fek1Bo7EBcMA==}
@@ -3348,23 +3342,6 @@ packages:
       classnames: 2.5.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    dev: false
-
-  /@itwin/itwinui-react@2.12.20(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-ksZ8rSRHGLjmtcW1jdCUgsj31CmbiEE9C6VsDgleYTF1470NpavNoG+frvJ6TxosisuzW8Ovcrn7QANFAF5lDA==}
-    peerDependencies:
-      react: '>=16.8.6 < 19.0.0'
-      react-dom: '>=16.8.6 < 19.0.0'
-    dependencies:
-      '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1)(react@18.3.1)
-      '@tippyjs/react': 4.2.6(react-dom@18.3.1)(react@18.3.1)
-      '@types/react-table': 7.7.19
-      classnames: 2.5.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-table: 7.8.0(react@18.3.1)
-      react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
-      tippy.js: 6.3.7
     dev: false
 
   /@itwin/itwinui-react@2.12.26(react-dom@18.3.1)(react@18.3.1):
@@ -3384,24 +3361,24 @@ packages:
       tippy.js: 6.3.7
     dev: false
 
-  /@itwin/itwinui-react@3.11.2(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-STZOp3I2Z9lauRPoWpwuwwBbJpHK2Aece3H5zxU11E/uerb2oarDm6ck6GxWjWFEAvXXKjA+35ruErIr8Rq0Hw==}
+  /@itwin/itwinui-react@3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-AqoFWFGwgZUrGzxn1J8Ea/DKOcXUt0haLjZBQ3lPeCmO6tNQow9NrbHWn+B9KiMAENADwgS9ElqTseDrSRksig==}
     peerDependencies:
       react: '>= 17.0.0 < 19.0.0'
       react-dom: '>=17.0.0 < 19.0.0'
     dependencies:
-      '@floating-ui/react': 0.26.16(react-dom@18.3.1)(react@18.3.1)
+      '@floating-ui/react': 0.26.27(react-dom@18.3.1)(react@18.3.1)
       '@itwin/itwinui-illustrations-react': 2.1.0(react-dom@18.3.1)(react@18.3.1)
+      '@swc/helpers': 0.5.15
+      '@tanstack/react-virtual': 3.10.9(react-dom@18.3.1)(react@18.3.1)
       classnames: 2.5.1
       jotai: 2.8.2(@types/react@18.3.12)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-table: 7.8.0(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1)(react@18.3.1)
-      tslib: 2.6.2
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
 
   /@itwin/itwinui-variables@3.1.0:
     resolution: {integrity: sha512-CHCS+hkaO4c0SUT1Lgi23Gpy8d/fZZKXCyd907c+a5wf8JAOtFQbuCa566YJS+08QDP11Jr+mzDDAMF1Yhk3yg==}
@@ -4851,6 +4828,11 @@ packages:
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
     dev: true
 
+  /@swc/helpers@0.5.15:
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+    dependencies:
+      tslib: 2.8.1
+
   /@swc/types@0.1.12:
     resolution: {integrity: sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==}
     dependencies:
@@ -4891,6 +4873,16 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.2.2(react@18.3.1)
+
+  /@tanstack/react-virtual@3.10.9(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-OXO2uBjFqA4Ibr2O3y0YMnkrRWGVNqcvHQXmGvMu6IK8chZl3PrDxFXdGZ2iZkSrKh3/qUYoFqYe+Rx23RoU0g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@tanstack/virtual-core': 3.10.9
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   /@tanstack/router-devtools@1.46.9(@tanstack/react-router@1.46.8)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-KuUCKB3p2M1nyfQ+8Rz0m8ZerECNVjE/CdxsaR4M/HvNS+yL78K1otXm0YeSlnMEqN7SGdWVqw+8CcBi9qEYnw==}
@@ -4956,6 +4948,9 @@ packages:
 
   /@tanstack/store@0.5.5:
     resolution: {integrity: sha512-EOSrgdDAJExbvRZEQ/Xhh9iZchXpMN+ga1Bnk8Nmygzs8TfiE6hbzThF+Pr2G19uHL6+DTDTHhJ8VQiOd7l4tA==}
+
+  /@tanstack/virtual-core@3.10.9:
+    resolution: {integrity: sha512-kBknKOKzmeR7lN+vSadaKWXaLS0SZZG+oqpQ/k80Q6g9REn6zRHS/ZYdrIzHnpHgy/eWs00SujveUN/GJT2qTw==}
 
   /@testing-library/dom@10.1.0:
     resolution: {integrity: sha512-wdsYKy5zupPyLCW2Je5DLHSxSfbIp6h80WoHOQc+RPtmPGA52O9x5MJEkv92Sjonpq+poOAtUKhh1kBGAXBrNA==}
@@ -6739,7 +6734,6 @@ packages:
 
   /classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
-    dev: false
 
   /cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -7211,7 +7205,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.8
       csstype: 3.1.3
-    dev: false
 
   /dompurify@2.5.6:
     resolution: {integrity: sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==}
@@ -10050,7 +10043,6 @@ packages:
     dependencies:
       '@types/react': 18.3.12
       react: 18.3.1
-    dev: false
 
   /js-base64@3.7.6:
     resolution: {integrity: sha512-NPrWuHFxFUknr1KqJRDgUQPexQF0uIJWjeT+2KjEePhitQxQEx5EJBG1lVn5/hc8aLycTpXrDOgPQ6Zq+EDiTA==}
@@ -11917,7 +11909,6 @@ packages:
       react: ^16.8.3 || ^17.0.0-0 || ^18.0.0
     dependencies:
       react: 18.3.1
-    dev: false
 
   /react-themeable@1.1.0:
     resolution: {integrity: sha512-kl5tQ8K+r9IdQXZd8WLa+xxYN04lLnJXRVhHfdgwsUJr/SlKJxIejoc9z9obEkx1mdqbTw1ry43fxEUwyD9u7w==}
@@ -11937,7 +11928,6 @@ packages:
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    dev: false
 
   /react-window@1.8.10(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==}
@@ -12968,7 +12958,6 @@ packages:
 
   /tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
-    dev: false
 
   /telejson@7.2.0:
     resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
@@ -13223,6 +13212,9 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  /tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   /tsutils@3.21.0(typescript@5.6.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -31,7 +31,7 @@
     "@itwin/imodels-access-frontend": "^3.0.0",
     "@itwin/imodels-client-authoring": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
-    "@itwin/itwinui-react": "^3.11.2",
+    "@itwin/itwinui-react": "^3.15.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^7.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "appui",
-  "//private": "NOTE: This 'root' package is private. It is never published",
   "private": true,
   "description": "iTwin.js appui components",
   "license": "MIT",
@@ -28,7 +27,5 @@
   "author": {
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
-  },
-  "//dependencies": "NOTE: dependencies will be empty here and instead specified in each package.",
-  "//devDependencies": "NOTE: devDependencies will be empty here and instead specified in each package."
+  }
 }

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -60,6 +60,7 @@
     "@itwin/core-react": "workspace:^5.1.0-dev.0",
     "@itwin/core-telemetry": "^4.0.0",
     "@itwin/imodel-components-react": "workspace:^5.1.0-dev.0",
+    "@itwin/itwinui-react": "^3.15.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-redux": "^7.2.2",
@@ -84,6 +85,7 @@
     "@itwin/ecschema-metadata": "^4.0.0",
     "@itwin/eslint-plugin": "5.0.0-dev.1",
     "@itwin/imodel-components-react": "workspace:*",
+    "@itwin/itwinui-react": "^3.15.0",
     "@itwin/webgl-compatibility": "^4.0.0",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^15.0.7",
@@ -122,7 +124,6 @@
   ],
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
-    "@itwin/itwinui-react": "^3.11.2",
     "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "@itwin/itwinui-illustrations-react": "^2.0.1",

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -116,7 +116,6 @@
   },
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
-    "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "@itwin/itwinui-illustrations-react": "^2.0.1",
     "classnames": "2.5.1",

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -66,10 +66,6 @@
     "react-redux": "^7.2.2",
     "redux": "^4.1.0"
   },
-  "//devDependencies": [
-    "NOTE: All peerDependencies should also be listed as devDependencies since peerDependencies are not considered by npm install",
-    "NOTE: All tools used by scripts in this package must be listed as devDependencies"
-  ],
   "devDependencies": {
     "@itwin/appui-abstract": "^4.0.0",
     "@itwin/build-tools": "4.10.0-dev.34",
@@ -118,10 +114,6 @@
     "upath": "^2.0.1",
     "vitest": "^1.6.0"
   },
-  "//dependencies": [
-    "NOTE: these dependencies should be only for things that DO NOT APPEAR IN THE API",
-    "NOTE: core-frontend should remain UI technology agnostic, so no react/angular dependencies are allowed"
-  ],
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
     "@itwin/itwinui-variables": "^3.0.0",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -58,10 +58,6 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
-  "//devDependencies": [
-    "NOTE: All peerDependencies should also be listed as devDependencies since peerDependencies are not considered by npm install",
-    "NOTE: All tools used by scripts in this package must be listed as devDependencies"
-  ],
   "devDependencies": {
     "@itwin/appui-abstract": "^4.0.0",
     "@itwin/build-tools": "4.10.0-dev.34",
@@ -100,10 +96,6 @@
     "upath": "^2.0.1",
     "vitest": "^1.6.0"
   },
-  "//dependencies": [
-    "NOTE: these dependencies should be only for things that DO NOT APPEAR IN THE API",
-    "NOTE: core-frontend should remain UI technology agnostic, so no react/angular dependencies are allowed"
-  ],
   "dependencies": {
     "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -97,7 +97,6 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
-    "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "classnames": "2.5.1",
     "immer": "^10.1.1",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -54,6 +54,7 @@
     "@itwin/appui-abstract": "^4.0.0",
     "@itwin/core-bentley": "^4.0.0",
     "@itwin/core-react": "workspace:^5.1.0-dev.0",
+    "@itwin/itwinui-react": "^3.15.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
@@ -70,6 +71,7 @@
     "@itwin/core-i18n": "^4.0.0",
     "@itwin/core-react": "workspace:*",
     "@itwin/eslint-plugin": "5.0.0-dev.1",
+    "@itwin/itwinui-react": "^3.15.0",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.5.2",
@@ -105,7 +107,6 @@
   "dependencies": {
     "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
-    "@itwin/itwinui-react": "^3.11.2",
     "classnames": "2.5.1",
     "immer": "^10.1.1",
     "linkify-it": "~2.2.0",

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -58,10 +58,6 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
-  "//devDependencies": [
-    "NOTE: All peerDependencies should also be listed as devDependencies since peerDependencies are not considered by npm install",
-    "NOTE: All tools used by scripts in this package must be listed as devDependencies"
-  ],
   "devDependencies": {
     "@itwin/appui-abstract": "^4.0.0",
     "@itwin/build-tools": "4.10.0-dev.34",
@@ -96,10 +92,6 @@
     "upath": "^2.0.1",
     "vitest": "^1.6.0"
   },
-  "//dependencies": [
-    "NOTE: these dependencies should be only for things that DO NOT APPEAR IN THE API",
-    "NOTE: core-frontend should remain UI technology agnostic, so no react/angular dependencies are allowed"
-  ],
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
     "@itwin/itwinui-variables": "^3.0.0",

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -54,6 +54,7 @@
   "peerDependencies": {
     "@itwin/appui-abstract": "^4.0.0",
     "@itwin/core-bentley": "^4.0.0",
+    "@itwin/itwinui-react": "^3.15.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
@@ -68,6 +69,7 @@
     "@itwin/core-common": "^4.0.0",
     "@itwin/core-i18n": "^4.0.0",
     "@itwin/eslint-plugin": "5.0.0-dev.1",
+    "@itwin/itwinui-react": "^3.15.0",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.5.2",
@@ -100,7 +102,6 @@
   ],
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
-    "@itwin/itwinui-react": "^3.11.2",
     "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "classnames": "2.5.1",

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -94,7 +94,6 @@
   },
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
-    "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "classnames": "2.5.1",
     "dompurify": "^2.5.6",

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -62,10 +62,6 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
-  "//devDependencies": [
-    "NOTE: All peerDependencies should also be listed as devDependencies since peerDependencies are not considered by npm install",
-    "NOTE: All tools used by scripts in this package must be listed as devDependencies"
-  ],
   "devDependencies": {
     "@itwin/appui-abstract": "^4.0.0",
     "@itwin/build-tools": "4.10.0-dev.34",
@@ -105,10 +101,6 @@
     "upath": "^2.0.1",
     "vitest": "^1.6.0"
   },
-  "//dependencies": [
-    "NOTE: these dependencies should be only for things that DO NOT APPEAR IN THE API",
-    "NOTE: core-frontend should remain UI technology agnostic, so no react/angular dependencies are allowed"
-  ],
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
     "@itwin/itwinui-variables": "^3.0.0",

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -58,6 +58,7 @@
     "@itwin/core-geometry": "^4.0.0",
     "@itwin/core-quantity": "^4.0.0",
     "@itwin/core-react": "workspace:^5.1.0-dev.0",
+    "@itwin/itwinui-react": "^3.15.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
@@ -77,6 +78,7 @@
     "@itwin/core-quantity": "^4.0.0",
     "@itwin/core-react": "workspace:*",
     "@itwin/eslint-plugin": "5.0.0-dev.1",
+    "@itwin/itwinui-react": "^3.15.0",
     "@itwin/webgl-compatibility": "^4.0.0",
     "@testing-library/dom": "^10.1.0",
     "@testing-library/react": "^15.0.7",
@@ -109,7 +111,6 @@
   ],
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
-    "@itwin/itwinui-react": "^3.11.2",
     "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "classnames": "2.5.1",

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -103,7 +103,6 @@
   },
   "dependencies": {
     "@bentley/icons-generic": "^1.0.34",
-    "@itwin/itwinui-variables": "^3.0.0",
     "@itwin/itwinui-icons-react": "^2.8.0",
     "classnames": "2.5.1",
     "ts-key-enum": "~2.0.12"


### PR DESCRIPTION
## Changes

This PR moves `@itwin/itwinui-react` to peerDependencies to simplify the process of ensuring that a single version of iTwinUI package is installed per major version.
Will be backported to `release/5.0.x` branch where `NextVersion.md` will be updated to mention this change.

## Testing

N/A
