### PR TITLE
Copy SCSS files to `cjs` and `esm` directories for compatibility

### DIFF
--- a/common/changes/@itwin/appui-react/css-compat_2024-11-19-16-11.json
+++ b/common/changes/@itwin/appui-react/css-compat_2024-11-19-16-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/css-compat_2024-11-19-16-11.json
+++ b/common/changes/@itwin/components-react/css-compat_2024-11-19-16-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/css-compat_2024-11-19-16-11.json
+++ b/common/changes/@itwin/core-react/css-compat_2024-11-19-16-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/css-compat_2024-11-19-16-11.json
+++ b/common/changes/@itwin/imodel-components-react/css-compat_2024-11-19-16-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -25,9 +25,12 @@
   },
   "scripts": {
     "start": "run-p -l \"build -- -w\" \"copy:** -- -w\"",
-    "build": "npm run copy:css && npm run copy:locale && tsc",
+    "build": "npm run copy:css && npm run compat:css && npm run copy:locale && tsc",
     "copy:css": "cpx \"./src/**/*.{*css,json,svg}\" ./lib",
     "copy:locale": "cpx ./src/appui-react/UiFramework.json ./lib/public/locales/en",
+    "compat:css": "npm run compat:cjs && npm run compat:esm",
+    "compat:cjs": "cpx \"./src/**/*.{*css,svg}\" ./lib/cjs",
+    "compat:esm": "cpx \"./src/**/*.{*css,svg}\" ./lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "vitest run --coverage",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -26,9 +26,12 @@
   },
   "scripts": {
     "start": "run-p -l \"build -- -w\" \"copy:** -- -w\"",
-    "build": "npm run copy:css && npm run copy:locale && tsc",
+    "build": "npm run copy:css && npm run compat:css && npm run copy:locale && tsc",
     "copy:css": "cpx \"./src/**/*.*css\" ./lib",
     "copy:locale": "cpx ./src/components-react/UiComponents.json ./lib/public/locales/en",
+    "compat:css": "npm run compat:cjs && npm run compat:esm",
+    "compat:cjs": "cpx \"./src/**/*.{*css,svg}\" ./lib/cjs",
+    "compat:esm": "cpx \"./src/**/*.{*css,svg}\" ./lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "vitest run --coverage",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -26,9 +26,12 @@
   },
   "scripts": {
     "start": "run-p -l \"build -- -w\" \"copy:** -- -w\"",
-    "build": "npm run copy:css && npm run copy:locale && tsc",
+    "build": "npm run copy:css && npm run compat:css && npm run copy:locale && tsc",
     "copy:css": "cpx \"./src/**/*.{*css,svg}\" ./lib",
     "copy:locale": "cpx ./src/core-react/UiCore.json ./lib/public/locales/en",
+    "compat:css": "npm run compat:cjs && npm run compat:esm",
+    "compat:cjs": "cpx \"./src/**/*.{*css,svg}\" ./lib/cjs",
+    "compat:esm": "cpx \"./src/**/*.{*css,svg}\" ./lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "vitest run --coverage",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -26,9 +26,12 @@
   },
   "scripts": {
     "start": "run-p -l \"build -- -w\" \"copy:** -- -w\"",
-    "build": "npm run copy:css && npm run copy:locale && tsc",
+    "build": "npm run copy:css && npm run compat:css && npm run copy:locale && tsc",
     "copy:css": "cpx \"./src/**/*.*css\" ./lib",
     "copy:locale": "cpx ./src/imodel-components-react/UiIModelComponents.json ./lib/public/locales/en",
+    "compat:css": "npm run compat:cjs && npm run compat:esm",
+    "compat:cjs": "cpx \"./src/**/*.{*css,svg}\" ./lib/cjs",
+    "compat:esm": "cpx \"./src/**/*.{*css,svg}\" ./lib/esm",
     "clean": "rimraf lib .rush/temp/package-deps*.json",
     "cover": "vitest run --coverage",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",


### PR DESCRIPTION
## Changes

Copy SCSS files to `cjs` and `esm` directories for backwards compatibility. 
Previously assumed https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/ is not a viable solution, since it requires an explicit `pkg:` URL scheme https://sass-lang.com/documentation/at-rules/use/#pkg-ur-ls

Some bundlers/loaders do additional work to ensure that `exports` field is respected when resolving the imports (verified in `vite` and `sass-loader` for `webpack`). `esbuild-sass-plugin` does not respect the `exports` field and only built with custom `importMapper`. 

## Testing

N/A
