### PR TITLE
Cesium viewer sample

### DIFF
--- a/apps/cesium-app/index.html
+++ b/apps/cesium-app/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="initial-scale=1,viewport-fit=cover,shrink-to-fit=no"
+    />
+    <title>AppUI Cesium App</title>
+  </head>
+
+  <body>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/apps/cesium-app/package.json
+++ b/apps/cesium-app/package.json
@@ -7,13 +7,17 @@
   "version": "0.0.0",
   "homepage": "http://localhost:3000/",
   "scripts": {
+    "build": "",
     "start": "vite"
   },
   "author": {
     "name": "Bentley Systems, Inc.",
     "url": "http://www.bentley.com"
   },
-  "devDependencies": {"vite":"^5.4.7"},
+  "devDependencies": {
+    "vite": "^5.4.7",
+    "@types/react": "^18.3.12"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/iTwin/appui.git",
@@ -21,6 +25,9 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@itwin/appui-react": "workspace:*",
+    "@itwin/core-react": "workspace:*",
+    "@bentley/icons-generic": "^1.0.34"
   }
 }

--- a/apps/cesium-app/package.json
+++ b/apps/cesium-app/package.json
@@ -30,6 +30,9 @@
     "@itwin/appui-react": "workspace:*",
     "@itwin/core-react": "workspace:*",
     "@bentley/icons-generic": "^1.0.34",
-    "cesium": "~1.123.1"
+    "cesium": "~1.123.1",
+    "zustand": "^4.4.1",
+    "@itwin/itwinui-icons-react": "^2.8.0",
+    "@itwin/itwinui-react": "^3.15.0"
   }
 }

--- a/apps/cesium-app/package.json
+++ b/apps/cesium-app/package.json
@@ -7,7 +7,7 @@
   "version": "0.0.0",
   "homepage": "http://localhost:3000/",
   "scripts": {
-    "build": "",
+    "build": "vite build",
     "start": "vite"
   },
   "author": {

--- a/apps/cesium-app/package.json
+++ b/apps/cesium-app/package.json
@@ -16,7 +16,8 @@
   },
   "devDependencies": {
     "vite": "^5.4.7",
-    "@types/react": "^18.3.12"
+    "@types/react": "^18.3.12",
+    "vite-plugin-static-copy": "^1.0.6"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
     "react-dom": "^18.3.1",
     "@itwin/appui-react": "workspace:*",
     "@itwin/core-react": "workspace:*",
-    "@bentley/icons-generic": "^1.0.34"
+    "@bentley/icons-generic": "^1.0.34",
+    "cesium": "~1.123.1"
   }
 }

--- a/apps/cesium-app/package.json
+++ b/apps/cesium-app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cesium-app",
+  "type": "module",
+  "description": "AppUI Cesium Application",
+  "private": true,
+  "license": "MIT",
+  "version": "0.0.0",
+  "homepage": "http://localhost:3000/",
+  "scripts": {
+    "start": "vite"
+  },
+  "author": {
+    "name": "Bentley Systems, Inc.",
+    "url": "http://www.bentley.com"
+  },
+  "devDependencies": {"vite":"^5.4.7"},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iTwin/appui.git",
+    "directory": "apps/cesium-app"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/apps/cesium-app/public/iTwinPopup.html
+++ b/apps/cesium-app/public/iTwinPopup.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html,
+      body {
+        height: 100%;
+        width: 100%;
+        margin: 0;
+        overflow: hidden;
+      }
+
+      #root {
+        height: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/apps/cesium-app/src/CesiumUiItemsProvider.tsx
+++ b/apps/cesium-app/src/CesiumUiItemsProvider.tsx
@@ -1,0 +1,133 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import {
+  ConditionalStringValue,
+  StagePanelLocation,
+  StagePanelSection,
+  StatusBarItemUtilities,
+  SyncUiEventDispatcher,
+  ToolbarItemUtilities,
+  ToolbarOrientation,
+  ToolbarUsage,
+  UiItemsProvider,
+  useConditionalValue,
+} from "@itwin/appui-react";
+import { Button, Input } from "@itwin/itwinui-react";
+import { useAppStore } from "./useAppStore";
+import { Command, Fullscreen, GeocoderViewModel, Viewer } from "cesium";
+import {
+  SvgHome,
+  SvgWindowCollapse,
+  SvgWindowFullScreen,
+} from "@itwin/itwinui-icons-react";
+
+export function createCesiumUIItemsProvider() {
+  return {
+    id: "cesium-provider",
+    getToolbarItems: () => [
+      ToolbarItemUtilities.createActionItem({
+        id: "home",
+        label: "Home",
+        icon: <SvgHome />,
+        execute: () => {
+          const viewer = useAppStore.getState().viewer;
+          if (!viewer) return;
+
+          viewer.scene.camera.flyHome();
+        },
+        layouts: {
+          standard: {
+            orientation: ToolbarOrientation.Horizontal,
+            usage: ToolbarUsage.ContentManipulation,
+          },
+        },
+      }),
+    ],
+    getWidgets: () => {
+      return [
+        {
+          id: "geocoder",
+          label: "Geocoder",
+          canPopout: true,
+          content: <GeocoderWidget />,
+          layouts: {
+            standard: {
+              location: StagePanelLocation.Right,
+              section: StagePanelSection.Start,
+            },
+          },
+        },
+      ];
+    },
+    getStatusBarItems: () => [
+      StatusBarItemUtilities.createActionItem({
+        id: "fullscreen",
+        tooltip: new ConditionalStringValue(() => {
+          if (Fullscreen.fullscreen) return "Exit fullscreen";
+          return "Enter fullscreen";
+        }, ["test-app:fullscreen"]),
+        icon: <FullScreenIcon />,
+        execute: () => {
+          if (Fullscreen.fullscreen) {
+            Fullscreen.exitFullscreen();
+            return;
+          }
+          Fullscreen.requestFullscreen(document.body);
+        },
+      }),
+    ],
+  } satisfies UiItemsProvider;
+}
+
+function FullScreenIcon() {
+  const fullScreen = useConditionalValue(
+    () => Fullscreen.fullscreen,
+    ["test-app:fullscreen"]
+  );
+  React.useEffect(() => {
+    const listener = () => {
+      // Needed to update the label.
+      SyncUiEventDispatcher.dispatchSyncUiEvent("test-app:fullscreen");
+    };
+    document.addEventListener(Fullscreen.changeEventName, listener);
+    return () => {
+      document.removeEventListener(Fullscreen.changeEventName, listener);
+    };
+  }, []);
+  if (fullScreen) return <SvgWindowCollapse />;
+  return <SvgWindowFullScreen />;
+}
+
+function GeocoderWidget() {
+  const viewer = useAppStore((state) => state.viewer);
+  const geocoder = React.useMemo(() => {
+    if (!viewer) return undefined;
+    return new GeocoderViewModel({
+      scene: viewer.scene,
+    });
+  }, [viewer]);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  return (
+    <div style={{ padding: 12, display: "flex", gap: 8 }}>
+      <Input defaultValue="Vilnius" ref={inputRef} />
+      <Button
+        onClick={async () => {
+          if (!inputRef.current) return;
+          if (!geocoder) return;
+          geocoder.searchText = inputRef.current.value;
+          callCommand(geocoder.search);
+        }}
+        styleType="cta"
+      >
+        Fly to
+      </Button>
+    </div>
+  );
+}
+
+function callCommand(command: Command) {
+  return (command as unknown as Function)();
+}

--- a/apps/cesium-app/src/CesiumViewer.tsx
+++ b/apps/cesium-app/src/CesiumViewer.tsx
@@ -57,5 +57,6 @@ async function appSpecificInitializer(viewer: Viewer) {
   });
 
   const buildingTileset = await createOsmBuildingsAsync();
+  if (viewer.isDestroyed()) return;
   viewer.scene.primitives.add(buildingTileset);
 }

--- a/apps/cesium-app/src/CesiumViewer.tsx
+++ b/apps/cesium-app/src/CesiumViewer.tsx
@@ -26,11 +26,7 @@ const disableCesiumUI = {
   navigationHelpButton: false,
 } satisfies Viewer.ConstructorOptions;
 
-interface CesiumViewerProps {
-  viewerRef?: (viewer: Viewer | null) => void;
-}
-
-export function CesiumViewer({ viewerRef }: CesiumViewerProps) {
+export function CesiumViewer() {
   React.useEffect(() => {
     const viewer = new Viewer("cesiumContainer", {
       terrain: Terrain.fromWorldTerrain(),
@@ -41,7 +37,6 @@ export function CesiumViewer({ viewerRef }: CesiumViewerProps) {
 
     return () => {
       viewer.destroy();
-      viewerRef?.(null);
     };
   }, []);
   return <div style={{ height: "100%" }} id="cesiumContainer" />;

--- a/apps/cesium-app/src/CesiumViewer.tsx
+++ b/apps/cesium-app/src/CesiumViewer.tsx
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React from "react";
+import {
+  Cartesian3,
+  Math as CesiumMath,
+  Terrain,
+  Viewer,
+  createOsmBuildingsAsync,
+} from "cesium";
+import "cesium/Build/Cesium/Widgets/widgets.css";
+
+export function CesiumViewer() {
+  React.useEffect(() => {
+    const viewer = new Viewer("cesiumContainer", {
+      terrain: Terrain.fromWorldTerrain(),
+    });
+
+    viewer.camera.flyTo({
+      destination: Cartesian3.fromDegrees(-122.4175, 37.655, 400),
+      orientation: {
+        heading: CesiumMath.toRadians(0.0),
+        pitch: CesiumMath.toRadians(-15.0),
+      },
+    });
+
+    void (async () => {
+      const buildingTileset = await createOsmBuildingsAsync();
+      viewer.scene.primitives.add(buildingTileset);
+    })();
+
+    return () => {
+      viewer.destroy();
+    };
+  }, []);
+  return <div style={{ height: "100%" }} id="cesiumContainer" />;
+}

--- a/apps/cesium-app/src/CesiumViewer.tsx
+++ b/apps/cesium-app/src/CesiumViewer.tsx
@@ -12,10 +12,24 @@ import {
 } from "cesium";
 import "cesium/Build/Cesium/Widgets/widgets.css";
 
+const disableCesiumUI = {
+  animation: false,
+  baseLayerPicker: false,
+  fullscreenButton: false,
+  geocoder: false,
+  homeButton: false,
+  infoBox: false,
+  sceneModePicker: false,
+  selectionIndicator: false,
+  timeline: false,
+  navigationHelpButton: false,
+} satisfies Viewer.ConstructorOptions;
+
 export function CesiumViewer() {
   React.useEffect(() => {
     const viewer = new Viewer("cesiumContainer", {
       terrain: Terrain.fromWorldTerrain(),
+      ...disableCesiumUI,
     });
 
     viewer.camera.flyTo({

--- a/apps/cesium-app/src/index.css
+++ b/apps/cesium-app/src/index.css
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+body {
+  margin: 0;
+}
+
+#root {
+  height: 100vh;
+}

--- a/apps/cesium-app/src/index.tsx
+++ b/apps/cesium-app/src/index.tsx
@@ -17,7 +17,6 @@ import {
 import { CesiumViewer } from "./CesiumViewer";
 import { Ion } from "cesium";
 import { createCesiumUIItemsProvider } from "./CesiumUiItemsProvider";
-import { useAppStore } from "./useAppStore";
 
 // Set up the application
 (() => {

--- a/apps/cesium-app/src/index.tsx
+++ b/apps/cesium-app/src/index.tsx
@@ -12,9 +12,12 @@ import {
   StandardContentLayouts,
   ThemeManager,
   UiFramework,
+  UiItemsManager,
 } from "@itwin/appui-react";
 import { CesiumViewer } from "./CesiumViewer";
 import { Ion } from "cesium";
+import { createCesiumUIItemsProvider } from "./CesiumUiItemsProvider";
+import { useAppStore } from "./useAppStore";
 
 // Set up the application
 (() => {
@@ -40,6 +43,8 @@ import { Ion } from "cesium";
       hideToolSettings: true,
     })
   );
+
+  UiItemsManager.register(createCesiumUIItemsProvider());
 
   UiFramework.frontstages.setActiveFrontstage("cesium-frontstage");
 })();

--- a/apps/cesium-app/src/index.tsx
+++ b/apps/cesium-app/src/index.tsx
@@ -46,6 +46,9 @@ import { createCesiumUIItemsProvider } from "./CesiumUiItemsProvider";
   UiItemsManager.register(createCesiumUIItemsProvider());
 
   UiFramework.frontstages.setActiveFrontstage("cesium-frontstage");
+
+  // TODO: `pagehide` is not emitted when the widget is closed.
+  UiFramework.useDefaultPopoutUrl = true;
 })();
 
 // Render the app

--- a/apps/cesium-app/src/index.tsx
+++ b/apps/cesium-app/src/index.tsx
@@ -2,9 +2,42 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import React, { StrictMode } from "react";
+import "./index.css";
+import * as React from "react";
 import ReactDOM from "react-dom/client";
-import { ConfigurableUiContent, ThemeManager } from "@itwin/appui-react";
+import {
+  ConfigurableUiContent,
+  FrontstageUtilities,
+  StageUsage,
+  StandardContentLayouts,
+  ThemeManager,
+  UiFramework,
+} from "@itwin/appui-react";
+
+// Set up the application
+(() => {
+  UiFramework.frontstages.addFrontstage(
+    FrontstageUtilities.createStandardFrontstage({
+      id: "cesium-frontstage",
+      usage: StageUsage.General,
+      contentGroupProps: {
+        id: "cesium-content",
+        layout: StandardContentLayouts.singleView,
+        contents: [
+          {
+            id: "cesium-content-view",
+            classId: "",
+            content: <>Hello Cesium App</>,
+          },
+        ],
+      },
+      // TODO: tool settings rely on IModelApp
+      hideToolSettings: true,
+    })
+  );
+
+  UiFramework.frontstages.setActiveFrontstage("cesium-frontstage");
+})();
 
 // Render the app
 const rootElement = document.getElementById("root")!;
@@ -15,10 +48,10 @@ if (!rootElement.innerHTML) {
 
 function App() {
   return (
-    <StrictMode>
+    <React.StrictMode>
       <ThemeManager>
         <ConfigurableUiContent />
       </ThemeManager>
-    </StrictMode>
+    </React.StrictMode>
   );
 }

--- a/apps/cesium-app/src/index.tsx
+++ b/apps/cesium-app/src/index.tsx
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import React, { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+
+// Render the app
+const rootElement = document.getElementById("root")!;
+if (!rootElement.innerHTML) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<App />);
+}
+
+function App() {
+  return <StrictMode>Test App</StrictMode>;
+}

--- a/apps/cesium-app/src/index.tsx
+++ b/apps/cesium-app/src/index.tsx
@@ -3,7 +3,7 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import "./index.css";
-import * as React from "react";
+import React from "react";
 import ReactDOM from "react-dom/client";
 import {
   ConfigurableUiContent,
@@ -13,9 +13,14 @@ import {
   ThemeManager,
   UiFramework,
 } from "@itwin/appui-react";
+import { CesiumViewer } from "./CesiumViewer";
+import { Ion } from "cesium";
 
 // Set up the application
 (() => {
+  const ionToken = import.meta.env.VITE_ION_TOKEN;
+  Ion.defaultAccessToken = ionToken;
+
   UiFramework.frontstages.addFrontstage(
     FrontstageUtilities.createStandardFrontstage({
       id: "cesium-frontstage",
@@ -27,7 +32,7 @@ import {
           {
             id: "cesium-content-view",
             classId: "",
-            content: <>Hello Cesium App</>,
+            content: <CesiumViewer />,
           },
         ],
       },

--- a/apps/cesium-app/src/index.tsx
+++ b/apps/cesium-app/src/index.tsx
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import React, { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
+import { ConfigurableUiContent, ThemeManager } from "@itwin/appui-react";
 
 // Render the app
 const rootElement = document.getElementById("root")!;
@@ -13,5 +14,11 @@ if (!rootElement.innerHTML) {
 }
 
 function App() {
-  return <StrictMode>Test App</StrictMode>;
+  return (
+    <StrictMode>
+      <ThemeManager>
+        <ConfigurableUiContent />
+      </ThemeManager>
+    </StrictMode>
+  );
 }

--- a/apps/cesium-app/src/useAppStore.ts
+++ b/apps/cesium-app/src/useAppStore.ts
@@ -2,4 +2,11 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-/// <reference types="vite/client" />
+import { Viewer } from "cesium";
+import { create } from "zustand";
+
+export const useAppStore = create<{
+  viewer: Viewer | undefined;
+}>(() => ({
+  viewer: undefined,
+}));

--- a/apps/cesium-app/src/vite-env.d.ts
+++ b/apps/cesium-app/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/// <reference types="vite/client" />
+
+declare module "*.md";

--- a/apps/cesium-app/vite.config.ts
+++ b/apps/cesium-app/vite.config.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: "modern-compiler",
+      },
+    },
+  },
+  resolve: {
+    alias: [
+      {
+        find: "~@itwin/appui-react",
+        replacement: "@itwin/appui-react",
+      },
+      {
+        find: "~@itwin/core-react",
+        replacement: "@itwin/core-react",
+      },
+    ],
+  },
+});

--- a/apps/cesium-app/vite.config.ts
+++ b/apps/cesium-app/vite.config.ts
@@ -6,19 +6,20 @@ import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 
 const cesiumSource = "node_modules/cesium/Build/Cesium";
+const cesiumBaseUrl = "public";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   define: {
-    CESIUM_BASE_URL: JSON.stringify(`/`),
+    CESIUM_BASE_URL: JSON.stringify(`/${cesiumBaseUrl}`),
   },
   plugins: [
     viteStaticCopy({
       targets: [
-        { src: `${cesiumSource}/ThirdParty`, dest: "." },
-        { src: `${cesiumSource}/Workers`, dest: "." },
-        { src: `${cesiumSource}/Assets`, dest: "." },
-        { src: `${cesiumSource}/Widgets`, dest: "." },
+        { src: `${cesiumSource}/ThirdParty`, dest: cesiumBaseUrl },
+        { src: `${cesiumSource}/Workers`, dest: cesiumBaseUrl },
+        { src: `${cesiumSource}/Assets`, dest: cesiumBaseUrl },
+        { src: `${cesiumSource}/Widgets`, dest: cesiumBaseUrl },
       ],
     }),
   ],

--- a/apps/cesium-app/vite.config.ts
+++ b/apps/cesium-app/vite.config.ts
@@ -3,9 +3,25 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { defineConfig } from "vite";
+import { viteStaticCopy } from "vite-plugin-static-copy";
+
+const cesiumSource = "node_modules/cesium/Build/Cesium";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  define: {
+    CESIUM_BASE_URL: JSON.stringify(`/`),
+  },
+  plugins: [
+    viteStaticCopy({
+      targets: [
+        { src: `${cesiumSource}/ThirdParty`, dest: "." },
+        { src: `${cesiumSource}/Workers`, dest: "." },
+        { src: `${cesiumSource}/Assets`, dest: "." },
+        { src: `${cesiumSource}/Widgets`, dest: "." },
+      ],
+    }),
+  ],
   css: {
     preprocessorOptions: {
       scss: {

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -283,6 +283,10 @@
       "allowedCategories": [ "frontend" ]
     },
     {
+      "name": "cesium",
+      "allowedCategories": [ "internal" ]
+    },
+    {
       "name": "classnames",
       "allowedCategories": [ "frontend", "internal" ]
     },

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -524,7 +524,7 @@
     },
     {
       "name": "zustand",
-      "allowedCategories": [ "frontend" ]
+      "allowedCategories": [ "frontend", "internal" ]
     }
   ]
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
       '@itwin/core-react':
         specifier: workspace:*
         version: link:../../ui/core-react
+      '@itwin/itwinui-icons-react':
+        specifier: ^2.8.0
+        version: 2.8.0(react-dom@18.3.1)(react@18.3.1)
+      '@itwin/itwinui-react':
+        specifier: ^3.15.0
+        version: 3.15.5(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       cesium:
         specifier: ~1.123.1
         version: 1.123.1
@@ -33,6 +39,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      zustand:
+        specifier: ^4.4.1
+        version: 4.5.0(@types/react@18.3.12)(immer@10.1.1)(react@18.3.1)
     devDependencies:
       '@types/react':
         specifier: ^18.3.12

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -13,6 +13,19 @@ importers:
 
   .: {}
 
+  ../../apps/cesium-app:
+    dependencies:
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      vite:
+        specifier: ^5.4.7
+        version: 5.4.7(@types/node@18.11.5)(sass@1.80.5)
+
   ../../apps/test-app:
     dependencies:
       '@bentley/icons-generic':

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@itwin/core-react':
         specifier: workspace:*
         version: link:../../ui/core-react
+      cesium:
+        specifier: ~1.123.1
+        version: 1.123.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -37,6 +40,9 @@ importers:
       vite:
         specifier: ^5.4.7
         version: 5.4.7(@types/node@18.11.5)(sass@1.80.5)
+      vite-plugin-static-copy:
+        specifier: ^1.0.6
+        version: 1.0.6(vite@5.4.7)
 
   ../../apps/test-app:
     dependencies:
@@ -2086,6 +2092,39 @@ packages:
     requiresBuild: true
     dev: false
 
+  /@cesium/engine@12.0.1:
+    resolution: {integrity: sha512-ou/Vu/tthTHDa2GbCrPiVWgue9AhPevWRk8hOQiEmwd1gy8aQCeMfCAfN3DXfBu7uj4wcw0+AeM7ObQgfVjjdg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@tweenjs/tween.js': 25.0.0
+      '@zip.js/zip.js': 2.7.53
+      autolinker: 4.0.0
+      bitmap-sdf: 1.0.4
+      dompurify: 3.2.1
+      draco3d: 1.5.5
+      earcut: 3.0.0
+      grapheme-splitter: 1.0.4
+      jsep: 1.4.0
+      kdbush: 4.0.2
+      ktx-parse: 0.7.1
+      lerc: 2.0.0
+      mersenne-twister: 1.1.0
+      meshoptimizer: 0.22.0
+      pako: 2.1.0
+      protobufjs: 7.4.0
+      rbush: 3.0.1
+      topojson-client: 3.1.0
+      urijs: 1.19.11
+    dev: false
+
+  /@cesium/widgets@9.0.1:
+    resolution: {integrity: sha512-qSm5c97zsGk1IWJKkPhsPNLWTcBqn9RdtumTm5dJCCtpOtJw05H/Uywr5Jz93H7QXs9ClygxLwe5nshNaa+6ig==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@cesium/engine': 12.0.1
+      nosleep.js: 0.12.0
+    dev: false
+
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -4064,6 +4103,49 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.8
 
+  /@protobufjs/aspromise@1.1.2:
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+    dev: false
+
+  /@protobufjs/base64@1.1.2:
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+    dev: false
+
+  /@protobufjs/codegen@2.0.4:
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+    dev: false
+
+  /@protobufjs/eventemitter@1.1.0:
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+    dev: false
+
+  /@protobufjs/fetch@1.1.0:
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+    dev: false
+
+  /@protobufjs/float@1.0.2:
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+    dev: false
+
+  /@protobufjs/inquire@1.1.0:
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+    dev: false
+
+  /@protobufjs/path@1.1.2:
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+    dev: false
+
+  /@protobufjs/pool@1.1.0:
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+    dev: false
+
+  /@protobufjs/utf8@1.1.0:
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+    dev: false
+
   /@reduxjs/toolkit@1.9.7(react-redux@7.2.9)(react@18.3.1):
     resolution: {integrity: sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==}
     peerDependencies:
@@ -5056,6 +5138,10 @@ packages:
   /@tsconfig/node16@1.0.4:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  /@tweenjs/tween.js@25.0.0:
+    resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
+    dev: false
+
   /@types/argparse@1.0.38:
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
     dev: true
@@ -5426,7 +5512,6 @@ packages:
 
   /@types/trusted-types@2.0.7:
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
-    dev: true
 
   /@types/tunnel@0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
@@ -5902,6 +5987,11 @@ packages:
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
     dev: true
 
+  /@zip.js/zip.js@2.7.53:
+    resolution: {integrity: sha512-G6Bl5wN9EXXVaTUIox71vIX5Z454zEBe+akKpV4m1tUboIctT5h7ID3QXCJd/Lfy2rSvmkTmZIucf1jGRR4f5A==}
+    engines: {bun: '>=0.7.0', deno: '>=1.0.0', node: '>=16.5.0'}
+    dev: false
+
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: false
@@ -6264,6 +6354,12 @@ packages:
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  /autolinker@4.0.0:
+    resolution: {integrity: sha512-fl5Kh6BmEEZx+IWBfEirnRUU5+cOiV0OK7PEt0RBKvJMJ8GaRseIOeDU3FKf4j3CE5HVefcjHmhYPOcaVt0bZw==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
@@ -6438,6 +6534,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /bitmap-sdf@1.0.4:
+    resolution: {integrity: sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg==}
+    dev: false
+
   /body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -6591,6 +6691,14 @@ packages:
 
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+    dev: false
+
+  /cesium@1.123.1:
+    resolution: {integrity: sha512-3BMru4i1aNa98YhaA9pLbJkc1Ghpt6BZjJMsSLkD1UVUZzxu3xTYe/3/woKNRmMtBzvx13wyiS5QADyns2w5qA==}
+    engines: {node: '>=18.18.0'}
+    dependencies:
+      '@cesium/engine': 12.0.1
+      '@cesium/widgets': 9.0.1
     dev: false
 
   /chai@4.4.1:
@@ -6799,6 +6907,10 @@ packages:
 
   /comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+    dev: false
+
+  /commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: false
 
   /comment-parser@1.4.1:
@@ -7205,6 +7317,12 @@ packages:
     resolution: {integrity: sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==}
     dev: false
 
+  /dompurify@3.2.1:
+    resolution: {integrity: sha512-NBHEsc0/kzRYQd+AY6HR6B/IgsqzBABrqJbpCDQII/OK6h7B7LXzweZTDsqSW2LkTRpoxf18YUP+YjGySk6B3w==}
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    dev: false
+
   /dotenv-expand@5.1.0:
     resolution: {integrity: sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==}
     dev: true
@@ -7220,6 +7338,10 @@ packages:
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
+
+  /earcut@3.0.0:
+    resolution: {integrity: sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg==}
+    dev: false
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -8832,6 +8954,10 @@ packages:
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  /grapheme-splitter@1.0.4:
+    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
+    dev: false
+
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
@@ -10133,6 +10259,11 @@ packages:
       - utf-8-validate
     dev: true
 
+  /jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
+    dev: false
+
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
@@ -10209,6 +10340,10 @@ packages:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
     dev: false
 
+  /kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
+    dev: false
+
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
@@ -10224,6 +10359,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /ktx-parse@0.7.1:
+    resolution: {integrity: sha512-FeA3g56ksdFNwjXJJsc1CCc7co+AJYDp6ipIp878zZ2bU8kWROatLYf39TQEd4/XRSUvBXovQ8gaVKWPXsCLEQ==}
+    dev: false
+
   /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: true
@@ -10234,6 +10373,10 @@ packages:
     dependencies:
       language-subtag-registry: 0.3.22
     dev: true
+
+  /lerc@2.0.0:
+    resolution: {integrity: sha512-7qo1Mq8ZNmaR4USHHm615nEW2lPeeWJ3bTyoqFbd35DLx0LUH7C6ptt5FDCTAlbIzs3+WKrk5SkJvw8AFDE2hg==}
+    dev: false
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -10325,6 +10468,10 @@ packages:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
     dev: true
+
+  /long@5.2.3:
+    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
+    dev: false
 
   /longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -10620,6 +10767,14 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
     dev: true
+
+  /mersenne-twister@1.1.0:
+    resolution: {integrity: sha512-mUYWsMKNrm4lfygPkL3OfGzOPTR2DBlTkBNHM//F6hGp8cLThY897crAlk3/Jo17LEOOjQUrNAx6DvgO77QJkA==}
+    dev: false
+
+  /meshoptimizer@0.22.0:
+    resolution: {integrity: sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==}
+    dev: false
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -11077,6 +11232,10 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  /nosleep.js@0.12.0:
+    resolution: {integrity: sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==}
+    dev: false
+
   /npm-run-all@4.1.5:
     resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
     engines: {node: '>= 4'}
@@ -11330,6 +11489,10 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  /pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+    dev: false
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -11658,6 +11821,25 @@ packages:
     resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
     dev: false
 
+  /protobufjs@7.4.0:
+    resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
+    engines: {node: '>=12.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 18.11.5
+      long: 5.2.3
+    dev: false
+
   /protocols@2.0.1:
     resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
     dev: true
@@ -11712,6 +11894,10 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  /quickselect@2.0.0:
+    resolution: {integrity: sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==}
+    dev: false
+
   /raf@3.4.1:
     resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
     dependencies:
@@ -11741,6 +11927,12 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  /rbush@3.0.1:
+    resolution: {integrity: sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==}
+    dependencies:
+      quickselect: 2.0.0
+    dev: false
 
   /react-autosuggest@10.1.0(react@18.3.1):
     resolution: {integrity: sha512-/azBHmc6z/31s/lBf6irxPf/7eejQdR0IqnZUzjdSibtlS8+Rw/R79pgDAo6Ft5QqCUTyEQ+f0FhL+1olDQ8OA==}
@@ -13035,6 +13227,13 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  /topojson-client@3.1.0:
+    resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+    dev: false
+
   /touch@3.1.0:
     resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
     hasBin: true
@@ -13528,6 +13727,10 @@ packages:
     dependencies:
       punycode: 2.3.1
     dev: true
+
+  /urijs@1.19.11:
+    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
+    dev: false
 
   /url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -15,6 +15,15 @@ importers:
 
   ../../apps/cesium-app:
     dependencies:
+      '@bentley/icons-generic':
+        specifier: ^1.0.34
+        version: 1.0.34
+      '@itwin/appui-react':
+        specifier: workspace:*
+        version: link:../../ui/appui-react
+      '@itwin/core-react':
+        specifier: workspace:*
+        version: link:../../ui/core-react
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -22,6 +31,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.12
       vite:
         specifier: ^5.4.7
         version: 5.4.7(@types/node@18.11.5)(sass@1.80.5)

--- a/rush.json
+++ b/rush.json
@@ -32,6 +32,12 @@
       "shouldPublish": false
     },
     {
+      "packageName": "cesium-app",
+      "projectFolder": "apps/cesium-app",
+      "reviewCategory": "internal",
+      "shouldPublish": false
+    },
+    {
       "packageName": "test-app",
       "projectFolder": "apps/test-app",
       "reviewCategory": "internal",

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -386,11 +386,7 @@ export class UiFramework {
   /** @alpha */
   public static get widgetManager(): WidgetManager {
     if (!UiFramework._widgetManager)
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      throw new UiError(
-        UiFramework.loggerCategory("UiFramework"),
-        UiFramework._complaint
-      );
+      UiFramework._widgetManager = new WidgetManager();
     return UiFramework._widgetManager;
   }
 

--- a/ui/appui-react/src/appui-react/hooks/useActiveViewport.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useActiveViewport.tsx
@@ -11,12 +11,16 @@ import type { ScreenViewport } from "@itwin/core-frontend";
 import { IModelApp } from "@itwin/core-frontend";
 
 const subscribe = (onStoreChange: () => void) => {
+  if (!IModelApp.initialized) return () => {};
   return IModelApp.viewManager.onSelectedViewportChanged.addListener(
     onStoreChange
   );
 };
 
 const getSnapshot = () => {
+  if (!IModelApp.initialized) {
+    return undefined;
+  }
   return IModelApp.viewManager.selectedView;
 };
 


### PR DESCRIPTION
## Changes

A sample application with the [cesium viewer](https://cesium.com/learn/cesiumjs/ref-doc/Viewer.html) rendered in a frontstage which consists a few other UI items: widget, toolbar button, status bar item.
In this application `IModelApp.startup` and `UiFramework.initialize` are not called.

PR will not be merged as it serves as an POC around using the widget system w/o  the `IModelApp` initialization.

Related Three.js viewer sample: https://github.com/iTwin/appui/pull/1119

## Testing

N/A
