### PR TITLE
Remove beta tag from addFrontstage since addFrontstageProvider is deprecated

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -1937,7 +1937,6 @@ export interface FrameworkFrontstages {
     readonly activeToolId: string;
     // @deprecated
     readonly activeToolInformation: ToolInformation | undefined;
-    // @beta
     addFrontstage(frontstage: Frontstage): void;
     // @deprecated
     addFrontstageProvider(frontstageProvider: FrontstageProvider): void;

--- a/common/changes/@itwin/appui-react/todd-addfrontstage-nonbeta_2024-11-29-17-23.json
+++ b/common/changes/@itwin/appui-react/todd-addfrontstage-nonbeta_2024-11-29-17-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Removed beta tag from addFrontstage",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -287,9 +287,7 @@ export interface FrameworkFrontstages {
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   addFrontstageProvider(frontstageProvider: FrontstageProvider): void;
 
-  /** Adds a frontstage.
-   * @beta
-   */
+  /** Adds a frontstage. */
   addFrontstage(frontstage: Frontstage): void;
 
   /** Find a loaded Frontstage with a given id. If the id is not provided, the active Frontstage is returned. If


### PR DESCRIPTION
## Changes
FrameworkFrontstages.addFrontstage is the replacement of the deprecated addFrontstageProvider but it is marked as beta! In iTwin Studio we're not supposed to use any internal/alpha/beta tagged functions.