### PR TITLE
Update accudraw core 4 11

### DIFF
--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawFieldContainer.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawFieldContainer.tsx
@@ -202,14 +202,6 @@ export function AccuDrawFieldContainer(props: AccuDrawFieldContainerProps) {
     return FrameworkAccuDraw.onAccuDrawSetFieldFocusEvent.addListener(
       async (args) => {
         if (focusField.current) {
-          // eslint-disable-next-line no-console
-          console.log(
-            `AccuDrawShortcuts.itemFieldAcceptInput(focusField.current, IModelApp.accuDraw.getFormattedValueByIndex(focusField.current)) ${
-              focusField.current
-            } : ${IModelApp.accuDraw.getFormattedValueByIndex(
-              focusField.current
-            )}`
-          );
           await AccuDrawShortcuts.itemFieldAcceptInput(
             focusField.current,
             IModelApp.accuDraw.getFormattedValueByIndex(focusField.current)

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.tsx
@@ -112,11 +112,6 @@ const ForwardRefAccuDrawInput = React.forwardRef<
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>): void => {
       let value = event.currentTarget.value;
-
-      // eslint-disable-next-line no-console
-      console.log(
-        `AccuDrawShortcuts.itemFieldNewInput(field : ${field}) called;`
-      );
       AccuDrawShortcuts.itemFieldNewInput(field);
 
       if (value === undefined) return;

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.tsx
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawInputField.tsx
@@ -10,7 +10,11 @@ import "./AccuDrawInputField.scss";
 import classnames from "classnames";
 import * as React from "react";
 import { Key } from "ts-key-enum";
-import type { ItemField } from "@itwin/core-frontend";
+import {
+  AccuDrawShortcuts,
+  IModelApp,
+  type ItemField,
+} from "@itwin/core-frontend";
 import type { CommonProps, IconSpec } from "@itwin/core-react";
 import { Icon } from "@itwin/core-react";
 import { useRefs } from "@itwin/core-react/internal";
@@ -101,13 +105,19 @@ const ForwardRefAccuDrawInput = React.forwardRef<
     useAllowBearingLettersInAccuDrawInputFields();
 
   React.useEffect(() => {
-    const formattedValue = FrameworkAccuDraw.getFieldDisplayValue(field);
+    const formattedValue = IModelApp.accuDraw.getFormattedValueByIndex(field);
     setStringValue(formattedValue);
   }, [field]);
 
   const handleChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>): void => {
       let value = event.currentTarget.value;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `AccuDrawShortcuts.itemFieldNewInput(field : ${field}) called;`
+      );
+      AccuDrawShortcuts.itemFieldNewInput(field);
 
       if (value === undefined) return;
 
@@ -130,7 +140,7 @@ const ForwardRefAccuDrawInput = React.forwardRef<
         onValueChanged(value);
       }
     },
-    [stringValue, isBearingAngle, onValueChanged]
+    [stringValue, isBearingAngle, onValueChanged, field]
   );
 
   const handleKeyDown = React.useCallback(


### PR DESCRIPTION
## Accudraw updates for ITwin-Core 4.11
ITwin core 4.11 is not released yet, thus the Draft PR. 

Apply updates required by these PRs in Core : 
[itwinjs-core/pull/7488](https://github.com/iTwin/itwinjs-core/pull/7488)
[itwinjs-core/pull/7492](https://github.com/iTwin/itwinjs-core/pull/7492)

Input field now updates to the formatted value when losing focus. 
Using the updated API.
