### PR TITLE
Fix `useWidget` hook issue when used in a popout widget

### DIFF
--- a/common/changes/@itwin/appui-react/issue-1170_2025-01-15-09-45.json
+++ b/common/changes/@itwin/appui-react/issue-1170_2025-01-15-09-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix `useWidget` hook issue when used in a popout widget.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/e2e-tests/tests/popout-widget.test.ts
+++ b/e2e-tests/tests/popout-widget.test.ts
@@ -68,7 +68,6 @@ test.describe("popout widget", () => {
   });
 
   test("should dock a popout widget (after frontstage change)", async ({
-    context,
     page,
   }) => {
     const tab = tabLocator(page, "WT-2");
@@ -242,4 +241,24 @@ test("should render after link styles are loaded", async ({
       clientHeight: 15,
     })
   );
+});
+
+test("useWidget hook", async ({ page }) => {
+  // TODO: make sure the widget is not overlaid. Need to split into smaller test frontstages.
+  await setWidgetState(
+    page,
+    "appui-test-providers:UseWidgetHookWidget",
+    WidgetState.Floating
+  );
+
+  const tab = tabLocator(page, "Use Widget Hook");
+  const widget = floatingWidgetLocator({
+    tab,
+  });
+
+  const popoutPage = await popoutWidget(widget);
+  const widgetText = popoutPage.getByText(
+    `{"state":0,"widgetLocation":"popout"}`
+  );
+  await expect(widgetText).toBeVisible();
 });

--- a/e2e-tests/tests/popout-widget.test.ts
+++ b/e2e-tests/tests/popout-widget.test.ts
@@ -244,6 +244,8 @@ test("should render after link styles are loaded", async ({
 });
 
 test("useWidget hook", async ({ page }) => {
+  await page.goto("./blank?frontstageId=widget-api");
+
   // TODO: make sure the widget is not overlaid. Need to split into smaller test frontstages.
   await setWidgetState(
     page,

--- a/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/FrontstageDef.tsx
@@ -753,6 +753,7 @@ export class FrontstageDef {
       content: popoutContent,
       location: position,
       useDefaultPopoutUrl: UiFramework.useDefaultPopoutUrl,
+      tabId,
     });
 
     // Use outer size if available to avoid inner size + browser zoom issues: https://github.com/iTwin/appui/issues/563


### PR DESCRIPTION
## Changes

This PR fixes #1170 by correctly providing a widget id via `TabIdContext` to avoid a runtime issue in `useWidget` hook when it is used in a popout widget.

## Testing

Added additional e2e test (which was failing before a fix was applied).
