### PR TITLE
lodash import fix

### DIFF
--- a/common/changes/@itwin/appui-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/appui-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "fix lodash imports from named to default for compatibility with esm",
+      "comment": "Fixed `module 'lodash' does not provide an export named...` error when running in Node.js.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/appui-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "fix lodash imports from named to default for compatability with esm",
+      "comment": "fix lodash imports from named to default for compatibility with esm",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/appui-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "fix lodash imports from named to default for compatability with esm",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/components-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "fix lodash imports from named to default for compatibility with esm",
+      "comment": "Fixed `module 'lodash' does not provide an export named...` error when running in Node.js.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/components-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "fix lodash imports from named to default for compatability with esm",
+      "comment": "fix lodash imports from named to default for compatibility with esm",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/components-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "fix lodash imports from named to default for compatability with esm",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/core-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "fix lodash imports from named to default for compatability with esm",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/core-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/core-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "fix lodash imports from named to default for compatibility with esm",
+      "comment": "Fixed `module 'lodash' does not provide an export named...` error when running in Node.js.",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/core-react/mast-lodash-import-fix_2025-01-17-12-23.json
+++ b/common/changes/@itwin/core-react/mast-lodash-import-fix_2025-01-17-12-23.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "fix lodash imports from named to default for compatability with esm",
+      "comment": "fix lodash imports from named to default for compatibility with esm",
       "type": "none"
     }
   ],

--- a/ui/appui-react/src/appui-react/layout/base/DragManager.tsx
+++ b/ui/appui-react/src/appui-react/layout/base/DragManager.tsx
@@ -6,7 +6,7 @@
  * @module Base
  */
 import * as React from "react";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual.js";
 import { BeEvent } from "@itwin/core-bentley";
 import { Point } from "@itwin/core-react/internal";
 import type { PanelSide } from "../widget-panels/PanelTypes.js";

--- a/ui/appui-react/src/appui-react/messages/MessageManager.tsx
+++ b/ui/appui-react/src/appui-react/messages/MessageManager.tsx
@@ -7,7 +7,7 @@
  */
 
 import classnames from "classnames";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual.js";
 import * as React from "react";
 import type { XAndY } from "@itwin/core-geometry";
 import type {

--- a/ui/appui-react/src/appui-react/pickers/ViewSelector.tsx
+++ b/ui/appui-react/src/appui-react/pickers/ViewSelector.tsx
@@ -17,7 +17,7 @@ import { UiFramework } from "../UiFramework.js";
 import { ViewUtilities } from "../utils/ViewUtilities.js";
 import type { ListItem } from "./ListPicker.js";
 import { ListItemType, ListPicker } from "./ListPicker.js";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce.js";
 import { SvgSavedView } from "../icons/SvgSavedView.js";
 import { useReduxFrameworkState } from "../uistate/useReduxFrameworkState.js";
 import type { ListenerType } from "@itwin/core-react/internal";

--- a/ui/appui-react/src/appui-react/widget-panels/useSaveFrontstageSettings.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/useSaveFrontstageSettings.tsx
@@ -18,8 +18,7 @@ import {
   packNineZoneState,
   stateVersion,
 } from "./Frontstage.js";
-import type { DebouncedFunc } from "lodash";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce.js";
 
 type SaveSettingFn = (
   frontstage: FrontstageDef,
@@ -32,9 +31,9 @@ export function useSaveFrontstageSettings(
   store: LayoutStore
 ) {
   const uiSettingsStorage = useUiStateStorageHandler();
-  const saveSettingRef = React.useRef<DebouncedFunc<SaveSettingFn> | undefined>(
-    undefined
-  );
+  const saveSettingRef = React.useRef<
+    ReturnType<typeof debounce<SaveSettingFn>> | undefined
+  >(undefined);
   const save = React.useCallback<SaveSettingFn>(async (frontstage, state) => {
     if (!saveSettingRef.current) return;
     if (state.draggedTab) return;

--- a/ui/components-react/src/components-react/tree/controlled/TreeModel.ts
+++ b/ui/components-react/src/components-react/tree/controlled/TreeModel.ts
@@ -7,7 +7,7 @@
  */
 
 import { immerable } from "immer";
-import { cloneDeep } from "lodash";
+import cloneDeep from "lodash/cloneDeep.js";
 import { assert } from "@itwin/core-bentley";
 import type { PropertyRecord } from "@itwin/appui-abstract";
 import type {

--- a/ui/core-react/src/core-react/utils/hooks/useThrottledFn.tsx
+++ b/ui/core-react/src/core-react/utils/hooks/useThrottledFn.tsx
@@ -7,7 +7,7 @@
  */
 
 import * as React from "react";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle.js";
 
 /** lodash throttle options
  * @internal


### PR DESCRIPTION
It seems with v5 there are some issues with `lodash` imports.

demo:
https://stackblitz.com/edit/stackblitz-starters-dgh2ehtd?file=package.json,index.js

## Changes

<!--
Changed lodash imports from named to default.
-->

