### PR TITLE
Update `react-error-boundary` version

### DIFF
--- a/common/changes/@itwin/appui-react/fix-1185_2025-01-21-10-08.json
+++ b/common/changes/@itwin/appui-react/fix-1185_2025-01-21-10-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Update `react-error-boundary` version.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -580,8 +580,8 @@ importers:
         specifier: ^4.17.10
         version: 4.17.21
       react-error-boundary:
-        specifier: 4.0.3
-        version: 4.0.3(react@18.3.1)
+        specifier: 5.0.0
+        version: 5.0.0(react@18.3.1)
       react-transition-group:
         specifier: ^4.4.2
         version: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6799,8 +6799,8 @@ packages:
       react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
       react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
 
-  react-error-boundary@4.0.3:
-    resolution: {integrity: sha512-IzNKP/ViHWp2QRDgsDMirEcf0XLsLueN6Wgzm1TVwgbAH+paX8Z42VyKvZcFFRHgd+rPK2P4TLrOrHC/dommew==}
+  react-error-boundary@5.0.0:
+    resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
     peerDependencies:
       react: '>=16.13.1'
 
@@ -15072,7 +15072,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.1.0
 
-  react-error-boundary@4.0.3(react@18.3.1):
+  react-error-boundary@5.0.0(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.23.8
       react: 18.3.1

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -580,7 +580,7 @@ importers:
         specifier: ^4.17.10
         version: 4.17.21
       react-error-boundary:
-        specifier: 5.0.0
+        specifier: ^5.0.0
         version: 5.0.0(react@18.3.1)
       react-transition-group:
         specifier: ^4.4.2

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -123,7 +123,7 @@
     "classnames": "2.5.1",
     "immer": "^10.1.1",
     "lodash": "^4.17.10",
-    "react-error-boundary": "4.0.3",
+    "react-error-boundary": "5.0.0",
     "react-transition-group": "^4.4.2",
     "rxjs": "^7.8.1",
     "ts-key-enum": "~2.0.12",

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -123,7 +123,7 @@
     "classnames": "2.5.1",
     "immer": "^10.1.1",
     "lodash": "^4.17.10",
-    "react-error-boundary": "5.0.0",
+    "react-error-boundary": "^5.0.0",
     "react-transition-group": "^4.4.2",
     "rxjs": "^7.8.1",
     "ts-key-enum": "~2.0.12",


### PR DESCRIPTION
## Changes

This PR fixes #1185 by updating `react-error-boundary` version to avoid module loader issues in Node.js

## Testing

N/A
