### PR TITLE
Adding -g option to rimraf and updating node version

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Rush cspell
         run: node common/scripts/install-run-rush.js cspell

--- a/.github/workflows/extract-api.yaml
+++ b/.github/workflows/extract-api.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Rush install
         run: node common/scripts/install-run-rush.js install

--- a/.github/workflows/publish-storybook.yaml
+++ b/.github/workflows/publish-storybook.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Rush install
         run: node common/scripts/install-run-rush.js install

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Each package has its own **node_modules** directory that contains symbolic links
 ## Prerequisites
 
 - [Git](https://git-scm.com/)
-- [Node](https://nodejs.org/en/): an installation of the latest security patch of Node 18. The Node installation also includes the **npm** package manager.
+- [Node](https://nodejs.org/en/): an installation of the latest security patch of Node 20. The Node installation also includes the **npm** package manager.
 - [Rush](https://github.com/Microsoft/web-build-tools/wiki/Rush): to install `npm install -g @microsoft/rush`
 - [TypeScript](https://www.typescriptlang.org/): this is listed as a devDependency, so if you're building it from source, you will get it with `rush install`.
 - [Visual Studio Code](https://code.visualstudio.com/): an optional dependency, but the repository structure is optimized for its use

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -12,7 +12,7 @@
     "build:frontend": "npm run copy:webfont && npm run pseudolocalize && vite build",
     "package:cjs": "node ./scripts/package-cjs.js ./lib",
     "preview": "vite preview --port 3000",
-    "clean": "rimraf lib build dist .rush/temp/package-deps*.json",
+    "clean": "rimraf -g lib build dist .rush/temp/package-deps*.json",
     "electron": "run-p start:webserver start:electron",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "start": "run-p start:webserver start:backend",

--- a/apps/test-providers/package.json
+++ b/apps/test-providers/package.json
@@ -14,7 +14,7 @@
     "build": "npm run copy:css && npm run copy:locale && tsc",
     "copy:css": "cpx \"./src/**/*.{*css,json,svg}\" ./lib",
     "copy:locale": "cpx \"./public/**/*\" ./lib/public",
-    "clean": "rimraf lib .rush/temp/package-deps*.json",
+    "clean": "rimraf -g lib .rush/temp/package-deps*.json",
     "cover": "",
     "docs": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=../../generated-docs/extract",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",

--- a/common/changes/@itwin/appui-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
+++ b/common/changes/@itwin/appui-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Upgrade to Node version 20",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/appui-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
+++ b/common/changes/@itwin/appui-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Upgrade to Node version 20",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
+++ b/common/changes/@itwin/components-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/components-react",
-      "comment": "Upgrade to Node version 20",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/components-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
+++ b/common/changes/@itwin/components-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Upgrade to Node version 20",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
+++ b/common/changes/@itwin/core-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "Upgrade to Node version 20",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/core-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
+++ b/common/changes/@itwin/core-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/core-react",
-      "comment": "Upgrade to Node version 20",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
+++ b/common/changes/@itwin/imodel-components-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/imodel-components-react",
-      "comment": "Upgrade to Node version 20",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/common/changes/@itwin/imodel-components-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
+++ b/common/changes/@itwin/imodel-components-react/Linas-updating-rimraf-arguments-and-deps_2025-02-14-09-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "Upgrade to Node version 20",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/common/config/azure-pipelines/jobs/docs-ci.yaml
+++ b/common/config/azure-pipelines/jobs/docs-ci.yaml
@@ -40,9 +40,9 @@ stages:
             clean: true
 
           - task: NodeTool@0
-            displayName: Use Node 18
+            displayName: Use Node 20
             inputs:
-              versionSpec: 18.x
+              versionSpec: 20.x
               checkLatest: true
 
           - script: |

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -14,4 +14,3 @@
 ### Changes
 
 - Updated `cursorPromptTimeout` prop of `ToolAssistanceField` component to handle `Number.POSITIVE_INFINITY`, which when enabled will display the cursor prompt indefinitely. [#1211](https://github.com/iTwin/appui/pull/1211)
-- Required `Node` version is updated from `18.12.0` to `20.0.0`.

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -14,3 +14,4 @@
 ### Changes
 
 - Updated `cursorPromptTimeout` prop of `ToolAssistanceField` component to handle `Number.POSITIVE_INFINITY`, which when enabled will display the cursor prompt indefinitely. [#1211](https://github.com/iTwin/appui/pull/1211)
+- Required `Node` version is updated from `18.12.0` to `20.0.0`.

--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush.schema.json",
   "rushVersion": "5.145.0",
   "pnpmVersion": "9.15.0",
-  "nodeSupportedVersionRange": ">=18.12.0",
+  "nodeSupportedVersionRange": ">=20.0.0",
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 3,
   "ensureConsistentVersions": true,

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -31,7 +31,7 @@
     "compat:css": "npm run compat:cjs && npm run compat:esm",
     "compat:cjs": "cpx \"./src/**/*.{*css,svg}\" ./lib/cjs",
     "compat:esm": "cpx \"./src/**/*.{*css,svg}\" ./lib/esm",
-    "clean": "rimraf lib .rush/temp/package-deps*.json",
+    "clean": "rimraf -g lib .rush/temp/package-deps*.json",
     "cover": "vitest run --coverage",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run -s lint -- --fix",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -32,7 +32,7 @@
     "compat:css": "npm run compat:cjs && npm run compat:esm",
     "compat:cjs": "cpx \"./src/**/*.{*css,svg}\" ./lib/cjs",
     "compat:esm": "cpx \"./src/**/*.{*css,svg}\" ./lib/esm",
-    "clean": "rimraf lib .rush/temp/package-deps*.json",
+    "clean": "rimraf -g lib .rush/temp/package-deps*.json",
     "cover": "vitest run --coverage",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run -s lint -- --fix",

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -32,7 +32,7 @@
     "compat:css": "npm run compat:cjs && npm run compat:esm",
     "compat:cjs": "cpx \"./src/**/*.{*css,svg}\" ./lib/cjs",
     "compat:esm": "cpx \"./src/**/*.{*css,svg}\" ./lib/esm",
-    "clean": "rimraf lib .rush/temp/package-deps*.json",
+    "clean": "rimraf -g lib .rush/temp/package-deps*.json",
     "cover": "vitest run --coverage",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run -s lint -- --fix",

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -32,7 +32,7 @@
     "compat:css": "npm run compat:cjs && npm run compat:esm",
     "compat:cjs": "cpx \"./src/**/*.{*css,svg}\" ./lib/cjs",
     "compat:esm": "cpx \"./src/**/*.{*css,svg}\" ./lib/esm",
-    "clean": "rimraf lib .rush/temp/package-deps*.json",
+    "clean": "rimraf -g lib .rush/temp/package-deps*.json",
     "cover": "vitest run --coverage",
     "lint": "eslint -f visualstudio \"./src/**/*.{ts,tsx}\" 1>&2",
     "lint:fix": "npm run -s lint -- --fix",


### PR DESCRIPTION
Rimraf package have been previously upgraded from version `3` to version `6` in our `package.json` files. However, since version `4` it requires `--glob` option in order to accept paths that contain star symbol (`*`). Without `--glob` option `npm run clean` failed on my Windows machine. Also, now package requires Node version 20 or higher.
https://www.npmjs.com/package/rimraf

## Changes
- Added `-g` option to `rimraf` command in package.json files.
- Updated required Node version to `20.0.0` and updated readme file.
- Updated node version in pipelines

## Testing
After adding `-g` option `npm run clean` no longer fails.