### PR TITLE
Update `vitest` version

### DIFF
--- a/common/changes/@itwin/appui-react/bump-vitest_2025-02-19-08-34.json
+++ b/common/changes/@itwin/appui-react/bump-vitest_2025-02-19-08-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/components-react/bump-vitest_2025-02-19-08-34.json
+++ b/common/changes/@itwin/components-react/bump-vitest_2025-02-19-08-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/core-react/bump-vitest_2025-02-19-08-34.json
+++ b/common/changes/@itwin/core-react/bump-vitest_2025-02-19-08-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/core-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/core-react"
+}

--- a/common/changes/@itwin/imodel-components-react/bump-vitest_2025-02-19-08-34.json
+++ b/common/changes/@itwin/imodel-components-react/bump-vitest_2025-02-19-08-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/imodel-components-react",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/imodel-components-react"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -664,7 +664,7 @@ importers:
         version: 4.4.10
       '@vitest/coverage-v8':
         specifier: ^1.6.0
-        version: 1.6.0(vitest@1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
+        version: 1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
       cpx2:
         specifier: ^3.0.0
         version: 3.0.2
@@ -723,8 +723,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
+        specifier: ^3.0.6
+        version: 3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
 
   ../../ui/components-react:
     dependencies:
@@ -809,7 +809,7 @@ importers:
         version: 1.8.8
       '@vitest/coverage-v8':
         specifier: ^1.6.0
-        version: 1.6.0(vitest@1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
+        version: 1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
       cpx2:
         specifier: ^3.0.0
         version: 3.0.2
@@ -856,8 +856,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
+        specifier: ^3.0.6
+        version: 3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
 
   ../../ui/core-react:
     dependencies:
@@ -933,7 +933,7 @@ importers:
         version: 18.3.1
       '@vitest/coverage-v8':
         specifier: ^1.6.0
-        version: 1.6.0(vitest@1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
+        version: 1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
       cpx2:
         specifier: ^3.0.0
         version: 3.0.2
@@ -977,8 +977,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
+        specifier: ^3.0.6
+        version: 3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
 
   ../../ui/imodel-components-react:
     dependencies:
@@ -1054,7 +1054,7 @@ importers:
         version: 18.3.1
       '@vitest/coverage-v8':
         specifier: ^1.6.0
-        version: 1.6.0(vitest@1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
+        version: 1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
       cpx2:
         specifier: ^3.0.0
         version: 3.0.2
@@ -1107,8 +1107,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       vitest:
-        specifier: ^1.6.0
-        version: 1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
+        specifier: ^3.0.6
+        version: 3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
 
 packages:
 
@@ -2700,6 +2700,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -3676,11 +3679,22 @@ packages:
     peerDependencies:
       vitest: 1.6.0
 
-  '@vitest/expect@1.6.0':
-    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
-
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
+
+  '@vitest/expect@3.0.6':
+    resolution: {integrity: sha512-zBduHf/ja7/QRX4HdP1DSq5XrPgdN+jzLOwaTq/0qZjYfgETNFCKf9nOAp2j3hmom3oTbczuUzrzg9Hafh7hNg==}
+
+  '@vitest/mocker@3.0.6':
+    resolution: {integrity: sha512-KPztr4/tn7qDGZfqlSPQoF2VgJcKxnDNhmfR3VgZ6Fy1bO8T9Fc1stUiTXtqz0yG24VpD00pZP5f8EOFknjNuQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/pretty-format@2.0.5':
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
@@ -3688,26 +3702,29 @@ packages:
   '@vitest/pretty-format@2.1.1':
     resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
 
-  '@vitest/runner@1.6.0':
-    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
+  '@vitest/pretty-format@3.0.6':
+    resolution: {integrity: sha512-Zyctv3dbNL+67qtHfRnUE/k8qxduOamRfAL1BurEIQSyOEFffoMvx2pnDSSbKAAVxY0Ej2J/GH2dQKI0W2JyVg==}
 
-  '@vitest/snapshot@1.6.0':
-    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
+  '@vitest/runner@3.0.6':
+    resolution: {integrity: sha512-JopP4m/jGoaG1+CBqubV/5VMbi7L+NQCJTu1J1Pf6YaUbk7bZtaq5CX7p+8sY64Sjn1UQ1XJparHfcvTTdu9cA==}
 
-  '@vitest/spy@1.6.0':
-    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
+  '@vitest/snapshot@3.0.6':
+    resolution: {integrity: sha512-qKSmxNQwT60kNwwJHMVwavvZsMGXWmngD023OHSgn873pV0lylK7dwBTfYP7e4URy5NiBCHHiQGA9DHkYkqRqg==}
 
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
 
-  '@vitest/utils@1.6.0':
-    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
+  '@vitest/spy@3.0.6':
+    resolution: {integrity: sha512-HfOGx/bXtjy24fDlTOpgiAEJbRfFxoX3zIGagCqACkFKKZ/TTOE6gYMKXlqecvxEndKFuNHcHqP081ggZ2yM0Q==}
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
   '@vitest/utils@2.1.1':
     resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
+
+  '@vitest/utils@3.0.6':
+    resolution: {integrity: sha512-18ktZpf4GQFTbf9jK543uspU03Q2qya7ZGya5yiZ0Gx0nnnalBvd5ZBislbl2EhLjM8A8rt4OilqKG7QwcGkvQ==}
 
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
@@ -3875,9 +3892,6 @@ packages:
   arraybuffer.prototype.slice@1.0.3:
     resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
-
-  assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -4059,12 +4073,12 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@4.4.1:
-    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
-    engines: {node: '>=4'}
-
   chai@5.1.1:
     resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+    engines: {node: '>=12'}
+
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
   chalk@2.4.2:
@@ -4097,9 +4111,6 @@ packages:
 
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
-
-  check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -4305,6 +4316,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize@4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
@@ -4326,10 +4346,6 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
-
-  deep-eql@4.1.3:
-    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
-    engines: {node: '>=6'}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -4513,6 +4529,9 @@ packages:
 
   es-module-lexer@1.5.4:
     resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+
+  es-module-lexer@1.6.0:
+    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   es-object-atoms@1.0.0:
     resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
@@ -4856,13 +4875,13 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.1.0:
+    resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -5076,10 +5095,6 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
 
   get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -5299,10 +5314,6 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
 
   i18next-browser-languagedetector@6.1.8:
     resolution: {integrity: sha512-Svm+MduCElO0Meqpj1kJAriTC6OhI41VhlT/A0UPjGoPZBhAHIaGE5EfsHlTpgdH09UVX7rcc72pSDDBeKSQQA==}
@@ -5541,10 +5552,6 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -5861,9 +5868,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonc-parser@3.2.1:
-    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
-
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
@@ -5916,10 +5920,6 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
 
-  local-pkg@0.5.0:
-    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
-    engines: {node: '>=14'}
-
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
@@ -5955,11 +5955,11 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-
   loupe@3.1.1:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
+
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -5990,6 +5990,9 @@ packages:
   magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
@@ -6187,10 +6190,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-
   mimic-response@1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
     engines: {node: '>=4'}
@@ -6253,9 +6252,6 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
-
-  mlly@1.6.1:
-    resolution: {integrity: sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==}
 
   mocha-junit-reporter@2.2.1:
     resolution: {integrity: sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==}
@@ -6356,10 +6352,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  npm-run-path@5.2.0:
-    resolution: {integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   nwsapi@2.2.7:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
 
@@ -6413,10 +6405,6 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-
   oniguruma-to-es@0.7.0:
     resolution: {integrity: sha512-HRaRh09cE0gRS3+wi2zxekB+I5L8C/gN60S+vb11eADHUaB/q4u8wGGOX3GvwvitG8ixaeycZfeoyruKQzUgNg==}
 
@@ -6459,10 +6447,6 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
-
-  p-limit@5.0.0:
-    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
-    engines: {node: '>=18'}
 
   p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
@@ -6535,10 +6519,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -6565,11 +6545,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
-  pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
@@ -6615,9 +6592,6 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
-
-  pkg-types@1.0.3:
-    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
 
   playwright-core@1.46.1:
     resolution: {integrity: sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==}
@@ -7250,6 +7224,9 @@ packages:
   std-env@3.7.0:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
 
+  std-env@3.8.0:
+    resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
+
   storybook@8.3.2:
     resolution: {integrity: sha512-jfDPtoPTtXcQ4O82u6+VE0V8q05hnj9NdmTVJvUxab796FoEbhk07xFLynOopfd9h9i0D/jc5Sf4C+iMe1bhmA==}
     hasBin: true
@@ -7339,10 +7316,6 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
-
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
@@ -7420,19 +7393,22 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
-  tinybench@2.6.0:
-    resolution: {integrity: sha512-N8hW3PG/3aOoZAN5V/NSAEDz0ZixDSSt5b/a05iqtpgfLWMSVuCo7w0k2vVvEjdrIoeGqZzweX2WlyioNIHchA==}
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinypool@0.8.3:
-    resolution: {integrity: sha512-Ud7uepAklqRH1bvwy22ynrliC7Dljz7Tm8M/0RBUW+YRa4YHhZ6e4PpgE+fu1zr/WqB1kbeuVrdfeuyIBpy4tw==}
-    engines: {node: '>=14.0.0'}
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@2.2.1:
-    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@3.0.2:
@@ -7663,9 +7639,6 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  ufo@1.3.2:
-    resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
-
   uid-safe@2.1.5:
     resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
     engines: {node: '>= 0.8'}
@@ -7814,9 +7787,9 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@1.6.0:
-    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.0.6:
+    resolution: {integrity: sha512-s51RzrTkXKJrhNbUzQRsarjmAae7VmMPAsRT7lppVpIg6mK3zGthP9Hgz0YQQKuNcF+Ii7DfYk3Fxz40jRmePw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite-plugin-static-copy@1.0.6:
@@ -7864,19 +7837,22 @@ packages:
       terser:
         optional: true
 
-  vitest@1.6.0:
-    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.0.6:
+    resolution: {integrity: sha512-/iL1Sc5VeDZKPDe58oGK4HUFLhw6b5XdY1MYawjuSaDA4sEfYlY9HnS6aCEG26fX+MgUi7MwlduTBHHAI/OvMA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.0
-      '@vitest/ui': 1.6.0
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.0.6
+      '@vitest/ui': 3.0.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -7952,8 +7928,8 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
-  why-is-node-running@2.2.2:
-    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
@@ -8073,10 +8049,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.0.0:
-    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
-    engines: {node: '>=12.20'}
 
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
@@ -9974,6 +9946,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
@@ -11223,7 +11197,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))':
+  '@vitest/coverage-v8@1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))':
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@bcoe/v8-coverage': 0.2.3
@@ -11238,15 +11212,9 @@ snapshots:
       std-env: 3.7.0
       strip-literal: 2.1.0
       test-exclude: 6.0.0
-      vitest: 1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
+      vitest: 3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
     transitivePeerDependencies:
       - supports-color
-
-  '@vitest/expect@1.6.0':
-    dependencies:
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      chai: 4.4.1
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -11254,6 +11222,21 @@ snapshots:
       '@vitest/utils': 2.0.5
       chai: 5.1.1
       tinyrainbow: 1.2.0
+
+  '@vitest/expect@3.0.6':
+    dependencies:
+      '@vitest/spy': 3.0.6
+      '@vitest/utils': 3.0.6
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.0.6(vite@5.4.7(@types/node@20.17.8)(sass@1.80.5))':
+    dependencies:
+      '@vitest/spy': 3.0.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 5.4.7(@types/node@20.17.8)(sass@1.80.5)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -11263,32 +11246,28 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@1.6.0':
+  '@vitest/pretty-format@3.0.6':
     dependencies:
-      '@vitest/utils': 1.6.0
-      p-limit: 5.0.0
-      pathe: 1.1.2
+      tinyrainbow: 2.0.0
 
-  '@vitest/snapshot@1.6.0':
+  '@vitest/runner@3.0.6':
     dependencies:
-      magic-string: 0.30.5
-      pathe: 1.1.2
-      pretty-format: 29.7.0
+      '@vitest/utils': 3.0.6
+      pathe: 2.0.3
 
-  '@vitest/spy@1.6.0':
+  '@vitest/snapshot@3.0.6':
     dependencies:
-      tinyspy: 2.2.1
+      '@vitest/pretty-format': 3.0.6
+      magic-string: 0.30.17
+      pathe: 2.0.3
 
   '@vitest/spy@2.0.5':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@1.6.0':
+  '@vitest/spy@3.0.6':
     dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
+      tinyspy: 3.0.2
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -11302,6 +11281,12 @@ snapshots:
       '@vitest/pretty-format': 2.1.1
       loupe: 3.1.1
       tinyrainbow: 1.2.0
+
+  '@vitest/utils@3.0.6':
+    dependencies:
+      '@vitest/pretty-format': 3.0.6
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
 
   '@yarnpkg/lockfile@1.1.0': {}
 
@@ -11493,8 +11478,6 @@ snapshots:
       get-intrinsic: 1.2.4
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
-
-  assertion-error@1.1.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -11719,17 +11702,15 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@4.4.1:
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.3
-      get-func-name: 2.0.2
-      loupe: 2.3.7
-      pathval: 1.1.1
-      type-detect: 4.0.8
-
   chai@5.1.1:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.1
+      pathval: 2.0.0
+
+  chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -11764,10 +11745,6 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   charenc@0.0.2: {}
-
-  check-error@1.0.3:
-    dependencies:
-      get-func-name: 2.0.2
 
   check-error@2.1.1: {}
 
@@ -12002,6 +11979,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
   decamelize@4.0.0: {}
 
   decimal.js@10.4.3: {}
@@ -12015,10 +11996,6 @@ snapshots:
       mimic-response: 3.1.0
 
   dedent@1.5.1: {}
-
-  deep-eql@4.1.3:
-    dependencies:
-      type-detect: 4.0.8
 
   deep-eql@5.0.2: {}
 
@@ -12254,6 +12231,8 @@ snapshots:
       safe-array-concat: 1.1.2
 
   es-module-lexer@1.5.4: {}
+
+  es-module-lexer@1.6.0: {}
 
   es-object-atoms@1.0.0:
     dependencies:
@@ -12715,19 +12694,9 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.5
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.2.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
   exit@0.1.2: {}
+
+  expect-type@1.1.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -12982,8 +12951,6 @@ snapshots:
       pump: 3.0.0
 
   get-stream@6.0.1: {}
-
-  get-stream@8.0.1: {}
 
   get-symbol-description@1.0.0:
     dependencies:
@@ -13272,8 +13239,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  human-signals@5.0.0: {}
-
   i18next-browser-languagedetector@6.1.8:
     dependencies:
       '@babel/runtime': 7.23.8
@@ -13481,8 +13446,6 @@ snapshots:
   is-stream@1.1.0: {}
 
   is-stream@2.0.1: {}
-
-  is-stream@3.0.0: {}
 
   is-string@1.0.7:
     dependencies:
@@ -14013,8 +13976,6 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonc-parser@3.2.1: {}
-
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -14072,11 +14033,6 @@ snapshots:
       pify: 3.0.0
       strip-bom: 3.0.0
 
-  local-pkg@0.5.0:
-    dependencies:
-      mlly: 1.6.1
-      pkg-types: 1.0.3
-
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -14109,13 +14065,11 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@2.3.7:
-    dependencies:
-      get-func-name: 2.0.2
-
   loupe@3.1.1:
     dependencies:
       get-func-name: 2.0.2
+
+  loupe@3.1.3: {}
 
   lowercase-keys@2.0.0: {}
 
@@ -14138,6 +14092,10 @@ snapshots:
   magic-string@0.27.0:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
 
   magic-string@0.30.5:
     dependencies:
@@ -14465,8 +14423,6 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-fn@4.0.0: {}
-
   mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
@@ -14512,13 +14468,6 @@ snapshots:
   mkdirp@1.0.4: {}
 
   mkdirp@3.0.1: {}
-
-  mlly@1.6.1:
-    dependencies:
-      acorn: 8.14.0
-      pathe: 1.1.2
-      pkg-types: 1.0.3
-      ufo: 1.3.2
 
   mocha-junit-reporter@2.2.1(mocha@10.2.0):
     dependencies:
@@ -14633,10 +14582,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  npm-run-path@5.2.0:
-    dependencies:
-      path-key: 4.0.0
-
   nwsapi@2.2.7: {}
 
   object-assign@3.0.0: {}
@@ -14696,10 +14641,6 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
-
   oniguruma-to-es@0.7.0:
     dependencies:
       emoji-regex-xs: 1.0.0
@@ -14743,10 +14684,6 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
-
-  p-limit@5.0.0:
-    dependencies:
-      yocto-queue: 1.0.0
 
   p-locate@3.0.0:
     dependencies:
@@ -14820,8 +14757,6 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-key@4.0.0: {}
-
   path-parse@1.0.7: {}
 
   path-scurry@1.10.1:
@@ -14847,9 +14782,7 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2: {}
-
-  pathval@1.1.1: {}
+  pathe@2.0.3: {}
 
   pathval@2.0.0: {}
 
@@ -14878,12 +14811,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  pkg-types@1.0.3:
-    dependencies:
-      jsonc-parser: 3.2.1
-      mlly: 1.6.1
-      pathe: 1.1.2
 
   playwright-core@1.46.1: {}
 
@@ -15604,6 +15531,8 @@ snapshots:
 
   std-env@3.7.0: {}
 
+  std-env@3.8.0: {}
+
   storybook@8.3.2:
     dependencies:
       '@storybook/core': 8.3.2
@@ -15727,8 +15656,6 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
-  strip-final-newline@3.0.0: {}
-
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
@@ -15808,13 +15735,15 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
-  tinybench@2.6.0: {}
+  tinybench@2.9.0: {}
 
-  tinypool@0.8.3: {}
+  tinyexec@0.3.2: {}
+
+  tinypool@1.0.2: {}
 
   tinyrainbow@1.2.0: {}
 
-  tinyspy@2.2.1: {}
+  tinyrainbow@2.0.0: {}
 
   tinyspy@3.0.2: {}
 
@@ -16052,8 +15981,6 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  ufo@1.3.2: {}
-
   uid-safe@2.1.5:
     dependencies:
       random-bytes: 1.0.0
@@ -16209,12 +16136,12 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@1.6.0(@types/node@20.17.8)(sass@1.80.5):
+  vite-node@3.0.6(@types/node@20.17.8)(sass@1.80.5):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.7
-      pathe: 1.1.2
-      picocolors: 1.1.0
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
       vite: 5.4.7(@types/node@20.17.8)(sass@1.80.5)
     transitivePeerDependencies:
       - '@types/node'
@@ -16274,34 +16201,36 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.80.5
 
-  vitest@1.6.0(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5):
+  vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5):
     dependencies:
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      acorn-walk: 8.3.2
-      chai: 4.4.1
-      debug: 4.3.4(supports-color@8.1.1)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.5
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.6.0
-      tinypool: 0.8.3
+      '@vitest/expect': 3.0.6
+      '@vitest/mocker': 3.0.6(vite@5.4.7(@types/node@20.17.8)(sass@1.80.5))
+      '@vitest/pretty-format': 3.0.6
+      '@vitest/runner': 3.0.6
+      '@vitest/snapshot': 3.0.6
+      '@vitest/spy': 3.0.6
+      '@vitest/utils': 3.0.6
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.1.0
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.8.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
       vite: 5.4.7(@types/node@20.17.8)(sass@1.80.5)
-      vite-node: 1.6.0(@types/node@20.17.8)(sass@1.80.5)
-      why-is-node-running: 2.2.2
+      vite-node: 3.0.6(@types/node@20.17.8)(sass@1.80.5)
+      why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.12
       '@types/node': 20.17.8
       jsdom: 24.0.0
     transitivePeerDependencies:
       - less
       - lightningcss
+      - msw
       - sass
       - sass-embedded
       - stylus
@@ -16395,7 +16324,7 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
-  why-is-node-running@2.2.2:
+  why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
@@ -16501,8 +16430,6 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.0.0: {}
 
   zod@3.23.8: {}
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -663,8 +663,8 @@ importers:
         specifier: ^4.4.4
         version: 4.4.10
       '@vitest/coverage-v8':
-        specifier: ^1.6.0
-        version: 1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
+        specifier: ^3.0.6
+        version: 3.0.6(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
       cpx2:
         specifier: ^3.0.0
         version: 3.0.2
@@ -808,8 +808,8 @@ importers:
         specifier: ^1.8.2
         version: 1.8.8
       '@vitest/coverage-v8':
-        specifier: ^1.6.0
-        version: 1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
+        specifier: ^3.0.6
+        version: 3.0.6(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
       cpx2:
         specifier: ^3.0.0
         version: 3.0.2
@@ -932,8 +932,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       '@vitest/coverage-v8':
-        specifier: ^1.6.0
-        version: 1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
+        specifier: ^3.0.6
+        version: 3.0.6(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
       cpx2:
         specifier: ^3.0.0
         version: 3.0.2
@@ -1053,8 +1053,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1
       '@vitest/coverage-v8':
-        specifier: ^1.6.0
-        version: 1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
+        specifier: ^3.0.6
+        version: 3.0.6(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))
       cpx2:
         specifier: ^3.0.0
         version: 3.0.2
@@ -1121,6 +1121,10 @@ packages:
 
   '@ampproject/remapping@2.2.1':
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
+    engines: {node: '>=6.0.0'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
   '@azure/abort-controller@1.1.0':
@@ -1818,6 +1822,10 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bentley/icons-generic-webfont@1.0.34':
     resolution: {integrity: sha512-5zZgs+himE2vjf39CVlDXMHCFAwSfcoORqJBk3Vji8QVCF8AIX4IX2DO6HlsIAM7szxMNqhz1kd07Xfppro6MA==}
@@ -3674,10 +3682,14 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
 
-  '@vitest/coverage-v8@1.6.0':
-    resolution: {integrity: sha512-KvapcbMY/8GYIG0rlwwOKCVNRc0OL20rrhFkg/CHNzncV03TE2XWvO5w9uZYoxNiMEBacAJt3unSOiZ7svePew==}
+  '@vitest/coverage-v8@3.0.6':
+    resolution: {integrity: sha512-JRTlR8Bw+4BcmVTICa7tJsxqphAktakiLsAmibVLAWbu1lauFddY/tXeM6sAyl1cgkPuXtpnUgaCPhTdz1Qapg==}
     peerDependencies:
-      vitest: 1.6.0
+      '@vitest/browser': 3.0.6
+      vitest: 3.0.6
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
 
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
@@ -5147,6 +5159,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
     engines: {node: 20 || >=22}
@@ -5622,12 +5638,16 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.4:
-    resolution: {integrity: sha512-wHOoEsNJTVltaJp8eVkm8w+GVkVNHT2YDYo53YdzQEL2gWm1hBX5cGFR9hQJtuGLebidVX7et3+dmDZrmclduw==}
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.1.6:
     resolution: {integrity: sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==}
+    engines: {node: '>=8'}
+
+  istanbul-reports@3.1.7:
+    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
 
   iterator.prototype@1.1.3:
@@ -5637,6 +5657,9 @@ packages:
   jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jackspeak@4.0.2:
     resolution: {integrity: sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==}
@@ -5795,9 +5818,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.0:
-    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -5998,8 +6018,8 @@ packages:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
 
-  magicast@0.3.3:
-    resolution: {integrity: sha512-ZbrP1Qxnpoes8sz47AM0z08U+jW6TyRgZzcWy3Ma3vDhJttwMwAFDMMQFobwdBxByBD46JYmxRzeF7w2+wJEuw==}
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -6529,6 +6549,10 @@ packages:
   path-scurry@1.10.2:
     resolution: {integrity: sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
@@ -7221,9 +7245,6 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
-
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
@@ -7328,9 +7349,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strip-literal@2.1.0:
-    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
-
   strnum@1.0.5:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
 
@@ -7380,6 +7398,10 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -8082,6 +8104,11 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+
   '@azure/abort-controller@1.1.0':
     dependencies:
       tslib: 2.8.1
@@ -8259,7 +8286,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -8961,7 +8988,7 @@ snapshots:
       '@babel/parser': 7.26.3
       '@babel/template': 7.25.9
       '@babel/types': 7.26.3
-      debug: 4.3.7
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -8992,6 +9019,8 @@ snapshots:
   '@base2/pretty-print-object@1.0.1': {}
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@bentley/icons-generic-webfont@1.0.34': {}
 
@@ -11135,7 +11164,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
-      debug: 4.3.7
+      debug: 4.4.0
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -11197,21 +11226,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@1.6.0(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))':
+  '@vitest/coverage-v8@3.0.6(vitest@3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5))':
     dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.7
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.4
-      istanbul-reports: 3.1.6
-      magic-string: 0.30.5
-      magicast: 0.3.3
-      picocolors: 1.1.0
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      test-exclude: 6.0.0
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.8.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
       vitest: 3.0.6(@types/debug@4.1.12)(@types/node@20.17.8)(jsdom@24.0.0)(sass@1.80.5)
     transitivePeerDependencies:
       - supports-color
@@ -11317,7 +11345,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12315,7 +12343,7 @@ snapshots:
 
   esbuild-register@3.5.0(esbuild@0.21.5):
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       esbuild: 0.21.5
     transitivePeerDependencies:
       - supports-color
@@ -13015,6 +13043,15 @@ snapshots:
       minipass: 7.1.0
       path-scurry: 1.10.2
 
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@11.0.0:
     dependencies:
       foreground-child: 3.3.0
@@ -13520,21 +13557,26 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-source-maps@5.0.4:
+  istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.7
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
 
   istanbul-reports@3.1.6:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  istanbul-reports@3.1.7:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
@@ -13548,6 +13590,12 @@ snapshots:
       set-function-name: 2.0.2
 
   jackspeak@2.3.6:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
@@ -13884,8 +13932,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.0: {}
-
   js-yaml@3.14.1:
     dependencies:
       argparse: 1.0.10
@@ -14101,7 +14147,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  magicast@0.3.3:
+  magicast@0.3.5:
     dependencies:
       '@babel/parser': 7.26.3
       '@babel/types': 7.26.3
@@ -14384,7 +14430,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.7
+      debug: 4.4.0
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -14768,6 +14814,11 @@ snapshots:
     dependencies:
       lru-cache: 10.2.2
       minipass: 7.1.0
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.2.2
+      minipass: 7.1.2
 
   path-scurry@2.0.0:
     dependencies:
@@ -15529,8 +15580,6 @@ snapshots:
 
   statuses@2.0.1: {}
 
-  std-env@3.7.0: {}
-
   std-env@3.8.0: {}
 
   storybook@8.3.2:
@@ -15666,10 +15715,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@2.1.0:
-    dependencies:
-      js-tokens: 9.0.0
-
   strnum@1.0.5: {}
 
   style-to-object@1.0.7:
@@ -15723,6 +15768,12 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
+
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
 
   text-table@0.2.0: {}
 

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -93,7 +93,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/react-transition-group": "^4.4.4",
-    "@vitest/coverage-v8": "^1.6.0",
+    "@vitest/coverage-v8": "^3.0.6",
     "cpx2": "^3.0.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "~8.8.0",

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -113,7 +113,7 @@
     "typemoq": "^2.1.0",
     "typescript": "~5.6.2",
     "upath": "^2.0.1",
-    "vitest": "^1.6.0"
+    "vitest": "^3.0.6"
   },
   "dependencies": {
     "@itwin/itwinui-icons-react": "^2.8.0",

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -331,6 +331,9 @@ export class UiFramework {
 
   /** Un-registers the UiFramework internationalization service namespace. */
   public static terminate() {
+    InternalModalDialogManager.closeAll();
+    InternalModelessDialogManager.closeAll();
+
     InternalKeyboardShortcutManager.shortcutContainer.emptyData();
     UiFramework._store = undefined;
     UiFramework._frameworkStateKeyInStore = "frameworkState";

--- a/ui/appui-react/src/test/UiFramework.test.ts
+++ b/ui/appui-react/src/test/UiFramework.test.ts
@@ -492,6 +492,7 @@ describe("UiFramework localStorage Wrapper", () => {
     });
 
     it("showDimensionEditor(height) forwards to AccuDrawPopupManager", () => {
+      const el = document.createElement("div");
       const lengthStub = vi
         .spyOn(AccuDrawPopupManager, "showLengthEditor")
         .mockReturnValue(true);
@@ -504,7 +505,8 @@ describe("UiFramework localStorage Wrapper", () => {
           23,
           { x: 0, y: 0 },
           () => {},
-          () => {}
+          () => {},
+          el
         )
       ).toEqual(true);
 
@@ -518,7 +520,8 @@ describe("UiFramework localStorage Wrapper", () => {
           23,
           { x: 0, y: 0 },
           () => {},
-          () => {}
+          () => {},
+          el
         )
       );
 
@@ -527,6 +530,7 @@ describe("UiFramework localStorage Wrapper", () => {
     });
 
     it("showDimensionEditor(length) forwards to AccuDrawPopupManager", () => {
+      const el = document.createElement("div");
       const lengthStub = vi
         .spyOn(AccuDrawPopupManager, "showLengthEditor")
         .mockReturnValue(true);
@@ -539,7 +543,8 @@ describe("UiFramework localStorage Wrapper", () => {
           23,
           { x: 0, y: 0 },
           () => {},
-          () => {}
+          () => {},
+          el
         )
       ).toEqual(true);
 
@@ -553,7 +558,8 @@ describe("UiFramework localStorage Wrapper", () => {
           23,
           { x: 0, y: 0 },
           () => {},
-          () => {}
+          () => {},
+          el
         )
       );
 

--- a/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageDef.test.tsx
@@ -795,11 +795,7 @@ describe("FrontstageDef", () => {
 
       const spy =
         vi.fn<
-          Parameters<
-            ListenerType<
-              typeof UiFramework.frontstages.onPanelStateChangedEvent
-            >
-          >
+          ListenerType<typeof UiFramework.frontstages.onPanelStateChangedEvent>
         >();
       UiFramework.frontstages.onPanelStateChangedEvent.addListener(spy);
 
@@ -840,11 +836,7 @@ describe("FrontstageDef", () => {
 
       const spy =
         vi.fn<
-          Parameters<
-            ListenerType<
-              typeof UiFramework.frontstages.onPanelStateChangedEvent
-            >
-          >
+          ListenerType<typeof UiFramework.frontstages.onPanelStateChangedEvent>
         >();
       UiFramework.frontstages.onPanelStateChangedEvent.addListener(spy);
 

--- a/ui/appui-react/src/test/layout/base/NineZone.test.tsx
+++ b/ui/appui-react/src/test/layout/base/NineZone.test.tsx
@@ -74,7 +74,7 @@ describe("<NineZone />", () => {
     vi.stubGlobal("ResizeObserver", ResizeObserver);
     const observe = vi.spyOn(ResizeObserver.prototype, "observe");
 
-    const spy = vi.fn<Parameters<NineZoneDispatch>>();
+    const spy = vi.fn<NineZoneDispatch>();
     render(<NineZone dispatch={spy} layout={createLayoutStore()} />);
     spy.mockReset();
 
@@ -117,7 +117,7 @@ describe("<NineZone />", () => {
       createRect(0, 0, 10, 20)
     );
 
-    const spy = vi.fn<Parameters<NineZoneDispatch>>();
+    const spy = vi.fn<NineZoneDispatch>();
     render(<NineZone dispatch={spy} layout={createLayoutStore()} />);
 
     spy.mockReset();

--- a/ui/appui-react/src/test/layout/tool-settings/Handle.test.tsx
+++ b/ui/appui-react/src/test/layout/tool-settings/Handle.test.tsx
@@ -15,7 +15,7 @@ import { DockedToolSettingsHandle } from "../../../appui-react/layout/tool-setti
 describe("DockedToolSettingsHandle", () => {
   it("should dispatch TOOL_SETTINGS_DRAG_START", () => {
     const dragManager = new DragManager();
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const { container } = render(
       <NineZoneDispatchContext.Provider value={dispatch}>
         <DragManagerContext.Provider value={dragManager}>

--- a/ui/appui-react/src/test/layout/widget-panels/Expander.test.tsx
+++ b/ui/appui-react/src/test/layout/widget-panels/Expander.test.tsx
@@ -37,7 +37,7 @@ describe("WidgetPanelExpanders", () => {
 
 describe("WidgetPanelExpander", () => {
   it("should dispatch `PANEL_SET_COLLAPSED`", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const { container } = render(
       <TestNineZoneProvider dispatch={dispatch}>
         <WidgetPanelExpander side="left" />
@@ -58,7 +58,7 @@ describe("WidgetPanelExpander", () => {
   });
 
   it("should not dispatch `PANEL_SET_COLLAPSED` if mouse moves out", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const { container } = render(
       <TestNineZoneProvider dispatch={dispatch}>
         <WidgetPanelExpander side="left" />
@@ -74,7 +74,7 @@ describe("WidgetPanelExpander", () => {
   });
 
   it("should reset timer if mouse moves", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const { container } = render(
       <TestNineZoneProvider dispatch={dispatch}>
         <WidgetPanelExpander side="left" />
@@ -99,7 +99,7 @@ describe("WidgetPanelExpander", () => {
   });
 
   it("should not reset timer if mouse move threshold is not exceeded", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const { container } = render(
       <TestNineZoneProvider dispatch={dispatch}>
         <WidgetPanelExpander side="left" />

--- a/ui/appui-react/src/test/layout/widget-panels/Grip.test.tsx
+++ b/ui/appui-react/src/test/layout/widget-panels/Grip.test.tsx
@@ -59,7 +59,7 @@ describe("WidgetPanelGrip", () => {
   });
 
   it("should dispatch PANEL_TOGGLE_COLLAPSED", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -86,7 +86,7 @@ describe("WidgetPanelGrip", () => {
   });
 
   it("should start resize via timer and dispatch PANEL_SET_SIZE", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = updatePanelState(state, "left", (draft) => {
       draft.size = 200;
@@ -139,7 +139,7 @@ describe("WidgetPanelGrip", () => {
   });
 
   it("should auto-open collapsed unpinned panel", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = updatePanelState(state, "left", (draft) => {
       draft.pinned = false;
@@ -194,7 +194,7 @@ describe("useResizeGrip", () => {
     const defaultState = produce(createNineZoneState(), (draft) => {
       draft.panels.top.size = 200;
     });
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const wrapperProps: WrapperProps = {
       dispatch,
       defaultState,
@@ -218,7 +218,7 @@ describe("useResizeGrip", () => {
     const defaultState = produce(createNineZoneState(), (draft) => {
       draft.panels.bottom.size = 200;
     });
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const wrapperProps: WrapperProps = {
       dispatch,
       defaultState,
@@ -239,7 +239,7 @@ describe("useResizeGrip", () => {
   });
 
   it("should not invoke onResize if ref is unset", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const dragManagerRef = React.createRef<DragManager>();
     const wrapperProps: WrapperProps = {
       dragManagerRef,
@@ -289,7 +289,7 @@ describe("useResizeGrip", () => {
   });
 
   it("should not resize if panel size is not set", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const wrapperProps: WrapperProps = {
       dispatch,
       side: "left",
@@ -309,7 +309,7 @@ describe("useResizeGrip", () => {
       draft.panels.left.size = 300;
       draft.panels.left.collapsed = true;
     });
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const wrapperProps: WrapperProps = {
       dispatch,
       side: "left",
@@ -334,7 +334,7 @@ describe("useResizeGrip", () => {
       draft.panels.left.size = 300;
       draft.panels.left.collapsed = true;
     });
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const wrapperProps: WrapperProps = {
       dispatch,
       side: "left",
@@ -354,7 +354,7 @@ describe("useResizeGrip", () => {
     const defaultState = produce(createNineZoneState(), (draft) => {
       draft.panels.left.size = 200;
     });
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const wrapperProps: WrapperProps = {
       dispatch,
       side: "left",
@@ -386,7 +386,7 @@ describe("useResizeGrip", () => {
     const defaultState = produce(createNineZoneState(), (draft) => {
       draft.panels.left.size = 300;
     });
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const wrapperProps: WrapperProps = {
       dispatch,
       side: "left",

--- a/ui/appui-react/src/test/layout/widget-panels/Panel.test.tsx
+++ b/ui/appui-react/src/test/layout/widget-panels/Panel.test.tsx
@@ -86,7 +86,7 @@ describe("WidgetPanelProvider", () => {
   });
 
   it("should dispatch PANEL_INITIALIZE", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);

--- a/ui/appui-react/src/test/layout/widget-panels/usePanelsAutoCollapse.test.tsx
+++ b/ui/appui-react/src/test/layout/widget-panels/usePanelsAutoCollapse.test.tsx
@@ -12,7 +12,7 @@ import { usePanelsAutoCollapse } from "../../../appui-react/layout/widget-panels
 
 describe("usePanelsAutoCollapse", () => {
   it("should collapse unpinned panels", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = updatePanelState(state, "right", (draft) => {
       draft.pinned = false;
@@ -39,7 +39,7 @@ describe("usePanelsAutoCollapse", () => {
   });
 
   it("should auto collapse unpinned panels", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = updatePanelState(state, "left", (draft) => {
       draft.pinned = false;

--- a/ui/appui-react/src/test/layout/widget/Dock.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/Dock.test.tsx
@@ -13,7 +13,7 @@ import { Dock } from "../../../appui-react/layout/widget/Dock.js";
 
 describe("Dock", () => {
   it("should dispatch TOOL_SETTINGS_DOCK", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const component = render(
       <NineZoneDispatchContext.Provider value={dispatch}>
         <NineZoneLabelsContext.Provider

--- a/ui/appui-react/src/test/layout/widget/FloatingTab.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/FloatingTab.test.tsx
@@ -55,7 +55,7 @@ describe("FloatingTab", () => {
 
   it("should dispatch WIDGET_TAB_DRAG", () => {
     const dragManager = React.createRef<DragManager>();
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1", { label: "tab 1" });
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -93,7 +93,7 @@ describe("FloatingTab", () => {
 
   it("should dispatch WIDGET_TAB_DRAG_END with tab start target", () => {
     const dragManager = React.createRef<DragManager>();
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1", {
       label: "tab 1",
@@ -138,7 +138,7 @@ describe("FloatingTab", () => {
 
   it("should dispatch WIDGET_TAB_DRAG_END with tab end target", () => {
     const dragManager = React.createRef<DragManager>();
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1", {
       label: "tab 1",
@@ -183,7 +183,7 @@ describe("FloatingTab", () => {
 
   it("should dispatch WIDGET_TAB_DRAG_END with floatingWidget target", () => {
     const dragManager = React.createRef<DragManager>();
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1", {
       label: "tab 1",
@@ -234,7 +234,7 @@ describe("FloatingTab", () => {
 
   it("should dispatch WIDGET_TAB_DRAG_END with panel target", () => {
     const dragManager = React.createRef<DragManager>();
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1", { label: "tab 1" });
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -281,7 +281,7 @@ describe("FloatingTab", () => {
 
   it("should dispatch WIDGET_TAB_DRAG_END with widget target", () => {
     const dragManager = React.createRef<DragManager>();
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1", { label: "tab 1" });
     state = addPanelWidget(state, "left", "w1", ["t1"]);

--- a/ui/appui-react/src/test/layout/widget/FloatingWidget.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/FloatingWidget.test.tsx
@@ -72,7 +72,7 @@ describe("FloatingWidget", () => {
   });
 
   it("should dispatch FLOATING_WIDGET_RESIZE", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(
@@ -107,7 +107,7 @@ describe("FloatingWidget", () => {
   });
 
   it("tool settings should NOT have resize handles", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "ts");
     state = addFloatingWidget(

--- a/ui/appui-react/src/test/layout/widget/PanelWidget.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PanelWidget.test.tsx
@@ -95,7 +95,7 @@ describe("PanelWidget", () => {
   describe("PANEL_WIDGET_DRAG_START", () => {
     it("should dispatch", () => {
       vi.spyOn(NineZoneModule, "getUniqueId").mockReturnValue("newId");
-      const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+      const dispatch = vi.fn<NineZoneDispatch>();
       let state = createNineZoneState();
       state = addTab(state, "t1");
       state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -125,7 +125,7 @@ describe("PanelWidget", () => {
     });
 
     it("should adjust bounds to keep widget under pointer", () => {
-      const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+      const dispatch = vi.fn<NineZoneDispatch>();
       let state = createNineZoneState();
       state = addTab(state, "t1");
       state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -156,7 +156,7 @@ describe("PanelWidget", () => {
     });
 
     it("should use preferredFloatingWidgetSize of active tab", () => {
-      const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+      const dispatch = vi.fn<NineZoneDispatch>();
       let state = createNineZoneState();
       state = addTab(state, "t1", {
         preferredFloatingWidgetSize: {

--- a/ui/appui-react/src/test/layout/widget/PinToggle.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PinToggle.test.tsx
@@ -48,7 +48,7 @@ describe("PinToggle", () => {
   });
 
   it("should dispatch PANEL_TOGGLE_PINNED", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     const state = createNineZoneState();
     const component = render(
       <TestNineZoneProvider

--- a/ui/appui-react/src/test/layout/widget/PopoutToggle.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PopoutToggle.test.tsx
@@ -14,7 +14,7 @@ import { TestNineZoneProvider } from "../Providers.js";
 
 describe("PopoutToggle", () => {
   it("should dispatch PANEL_TOGGLE_PINNED", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);

--- a/ui/appui-react/src/test/layout/widget/SendBack.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/SendBack.test.tsx
@@ -34,7 +34,7 @@ describe("SendBack", () => {
   });
 
   it("should dispatch TOOL_SETTINGS_DOCK", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);

--- a/ui/appui-react/src/test/layout/widget/Tab.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/Tab.test.tsx
@@ -158,7 +158,7 @@ describe("WidgetTab", () => {
   });
 
   it("should dispatch WIDGET_TAB_CLICK on click", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -195,7 +195,7 @@ describe("WidgetTab", () => {
   });
 
   it("should dispatch WIDGET_TAB_CLICK on 'Enter'", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -231,7 +231,7 @@ describe("WidgetTab", () => {
   });
 
   it("should dispatch WIDGET_TAB_CLICK on 'space'", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -267,7 +267,7 @@ describe("WidgetTab", () => {
   });
 
   it("should not dispatch WIDGET_TAB_CLICK on other key", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -296,7 +296,7 @@ describe("WidgetTab", () => {
   });
 
   it("should dispatch WIDGET_TAB_DOUBLE_CLICK", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -335,7 +335,7 @@ describe("WidgetTab", () => {
   });
 
   it("should dispatch WIDGET_TAB_DRAG_START on pointer move", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1", { hideWithUiWhenFloating: true });
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -363,7 +363,7 @@ describe("WidgetTab", () => {
   });
 
   it("should not dispatch WIDGET_TAB_DRAG_START on pointer move if pointer moved less than 10px", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
@@ -383,7 +383,7 @@ describe("WidgetTab", () => {
   });
 
   it("should dispatch FLOATING_WIDGET_BRING_TO_FRONT", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);

--- a/ui/appui-react/src/test/layout/widget/TabBar.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/TabBar.test.tsx
@@ -27,7 +27,7 @@ import { addTabs } from "../Utils.js";
 
 describe("WidgetTitleBar", () => {
   it("should dispatch WIDGET_DRAG_END", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
@@ -56,7 +56,7 @@ describe("WidgetTitleBar", () => {
   });
 
   it("should dispatch FLOATING_WIDGET_CLEAR_USER_SIZED", async () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
@@ -85,7 +85,7 @@ describe("WidgetTitleBar", () => {
   });
 
   it("should dispatch WIDGET_DRAG_END with tab target", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTabs(state, ["t1", "t2"]);
     state = addFloatingWidget(state, "w1", ["t1"]);
@@ -128,7 +128,7 @@ describe("WidgetTitleBar", () => {
 
   it("should dispatch WIDGET_DRAG_END with panel target", () => {
     vi.spyOn(NineZoneModule, "getUniqueId").mockReturnValue("newId");
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
@@ -161,7 +161,7 @@ describe("WidgetTitleBar", () => {
   });
 
   it("should dispatch FLOATING_WIDGET_BRING_TO_FRONT", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
@@ -189,7 +189,7 @@ describe("WidgetTitleBar", () => {
 
 describe("useDrag", () => {
   it("should start drag on pointer move", () => {
-    const spy = vi.fn<Parameters<Required<Parameters<typeof useDrag>>[0]>>();
+    const spy = vi.fn<Required<Parameters<typeof useDrag>>[0]>();
     const { result } = renderHook(() => useDrag(spy));
     act(() => {
       const instance = document.createElement("div");
@@ -201,7 +201,7 @@ describe("useDrag", () => {
   });
 
   it("should not start drag on subsequent pointer move", () => {
-    const spy = vi.fn<Parameters<Required<Parameters<typeof useDrag>>[0]>>();
+    const spy = vi.fn<Required<Parameters<typeof useDrag>>[0]>();
     const { result } = renderHook(() => useDrag(spy));
     act(() => {
       const instance = document.createElement("div");
@@ -215,7 +215,7 @@ describe("useDrag", () => {
   });
 
   it("should report drag action", () => {
-    const spy = vi.fn<Parameters<Required<Parameters<typeof useDrag>>[1]>>();
+    const spy = vi.fn<Required<Parameters<typeof useDrag>>[1]>();
     const { result } = renderHook(() => useDrag(undefined, spy));
     act(() => {
       const instance = document.createElement("div");
@@ -228,7 +228,7 @@ describe("useDrag", () => {
   });
 
   it("should report drag end action", () => {
-    const spy = vi.fn<Parameters<Required<Parameters<typeof useDrag>>[2]>>();
+    const spy = vi.fn<Required<Parameters<typeof useDrag>>[2]>();
     const { result } = renderHook(() => useDrag(undefined, undefined, spy));
     act(() => {
       const instance = document.createElement("div");

--- a/ui/appui-react/src/test/layout/widget/Widget.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/Widget.test.tsx
@@ -16,7 +16,7 @@ import { TestNineZoneProvider } from "../Providers.js";
 
 describe("Widget", () => {
   it("should dispatch FLOATING_WIDGET_BRING_TO_FRONT", () => {
-    const dispatch = vi.fn<Parameters<NineZoneDispatch>>();
+    const dispatch = vi.fn<NineZoneDispatch>();
     let state = createNineZoneState();
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);

--- a/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
+++ b/ui/appui-react/src/test/statusfields/SnapMode.test.tsx
@@ -40,9 +40,7 @@ describe("SnapModeField", () => {
 
   it("should change snapMode and dispatch SyncEvent on click", async () => {
     const spy =
-      vi.fn<
-        Parameters<ListenerType<typeof SyncUiEventDispatcher.onSyncUiEvent>>
-      >();
+      vi.fn<ListenerType<typeof SyncUiEventDispatcher.onSyncUiEvent>>();
     SyncUiEventDispatcher.onSyncUiEvent.addListener(spy);
     render(
       <Provider store={TestUtils.store}>

--- a/ui/appui-react/vitest.config.ts
+++ b/ui/appui-react/vitest.config.ts
@@ -15,9 +15,9 @@ export default defineConfig({
     outputFile: "coverage/junit.xml",
     coverage: {
       thresholds: {
-        lines: 90,
+        lines: 87,
         functions: 84,
-        statements: 90,
+        statements: 87,
         branches: 87,
       },
     },

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -80,7 +80,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/react-window": "^1.8.2",
-    "@vitest/coverage-v8": "^1.6.0",
+    "@vitest/coverage-v8": "^3.0.6",
     "cpx2": "^3.0.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "~8.8.0",

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -96,7 +96,7 @@
     "typemoq": "^2.1.0",
     "typescript": "~5.6.2",
     "upath": "^2.0.1",
-    "vitest": "^1.6.0"
+    "vitest": "^3.0.6"
   },
   "dependencies": {
     "@itwin/itwinui-icons-react": "^2.8.0",

--- a/ui/components-react/src/test/tree/controlled/TreeEventDispatcher.test.ts
+++ b/ui/components-react/src/test/tree/controlled/TreeEventDispatcher.test.ts
@@ -35,7 +35,7 @@ import type { TreeSelectionManager } from "../../../components-react/tree/contro
 describe("TreeEventDispatcher", () => {
   const treeEvents = {
     onSelectionModified: vi.fn(),
-    onSelectionReplaced: vi.fn(),
+    onSelectionReplaced: vi.fn<Required<TreeEvents>["onSelectionReplaced"]>(),
     onNodeExpanded: vi.fn(),
     onNodeCollapsed: vi.fn(),
     onDelayedNodeClick: vi.fn(),

--- a/ui/components-react/src/test/tree/controlled/internal/TreeModelMutator.test.ts
+++ b/ui/components-react/src/test/tree/controlled/internal/TreeModelMutator.test.ts
@@ -313,7 +313,7 @@ describe("TreeModelMutator", () => {
     });
 
     describe("nodeEditingInfo callbacks", () => {
-      let onNodeUpdatedSpy: Mock<any, any>;
+      let onNodeUpdatedSpy: Mock;
       beforeEach(() => {
         onNodeUpdatedSpy = vi.fn();
         treeModelMock.setup((x) => x.getNode(node.id)).returns(() => node);

--- a/ui/components-react/vitest.config.ts
+++ b/ui/components-react/vitest.config.ts
@@ -15,9 +15,9 @@ export default defineConfig({
     outputFile: "coverage/junit.xml",
     coverage: {
       thresholds: {
-        lines: 97,
+        lines: 96,
         functions: 94,
-        statements: 97,
+        statements: 96,
         branches: 96,
       },
     },

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -94,7 +94,7 @@
     "typemoq": "^2.1.0",
     "typescript": "~5.6.2",
     "upath": "^2.0.1",
-    "vitest": "^1.6.0"
+    "vitest": "^3.0.6"
   },
   "dependencies": {
     "@itwin/itwinui-icons-react": "^2.8.0",

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -79,7 +79,7 @@
     "@types/react": "^18.3.12",
     "@types/react-autosuggest": "10.1.2",
     "@types/react-dom": "^18.3.1",
-    "@vitest/coverage-v8": "^1.6.0",
+    "@vitest/coverage-v8": "^3.0.6",
     "cpx2": "^3.0.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "~8.8.0",

--- a/ui/core-react/src/test/elementseparator/ElementSeparator.test.tsx
+++ b/ui/core-react/src/test/elementseparator/ElementSeparator.test.tsx
@@ -77,8 +77,8 @@ describe("ElementSeparator", () => {
     const testCaseName = TestCallbackType[callbackType];
     describe(`Callback indifferent tests: ${testCaseName}`, () => {
       let onRatioChanged:
-        | Mock<[number], void>
-        | Mock<[number], RatioChangeResult>;
+        | Mock<(ratio: number) => void>
+        | Mock<(ratio: number) => RatioChangeResult>;
 
       beforeEach(() => {
         switch (callbackType) {

--- a/ui/core-react/src/test/tree/Tree.test.tsx
+++ b/ui/core-react/src/test/tree/Tree.test.tsx
@@ -39,7 +39,7 @@ describe("<Tree />", () => {
     const overrides = {
       scrollTo: Element.prototype.scrollTo,
     };
-    let scrollToSpy: MockInstance<[x: number, y: number], void>;
+    let scrollToSpy: MockInstance<(x: number, y: number) => void>;
 
     beforeEach(() => {
       Element.prototype.scrollTo = () => {};

--- a/ui/core-react/src/test/utils/hooks/useDisposable.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useDisposable.test.tsx
@@ -51,7 +51,7 @@ describe("useDisposable", () => {
 });
 
 describe("useOptionalDisposable", () => {
-  let disposeSpy: Mock<any, any[]>;
+  let disposeSpy: Mock;
   let createDisposable: () => IDisposable;
 
   beforeEach(() => {

--- a/ui/core-react/src/test/utils/hooks/useOnOutsideClick.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useOnOutsideClick.test.tsx
@@ -21,7 +21,7 @@ describe("useOnOutsideClick", () => {
 
   describe("PointerEvent", () => {
     it("should call onOutsideClick", () => {
-      const spy = vi.fn<[], void>();
+      const spy = vi.fn<() => void>();
       const { result } = renderHook(() => useOnOutsideClick(spy));
       const element = document.createElement("div");
       act(() => {
@@ -38,7 +38,7 @@ describe("useOnOutsideClick", () => {
     });
 
     it("should respect outside event predicate", () => {
-      const spy = vi.fn<[], void>();
+      const spy = vi.fn<() => void>();
       const predicate = vi.fn(() => {
         return false;
       });
@@ -60,7 +60,7 @@ describe("useOnOutsideClick", () => {
     });
 
     it("should respect outside event predicate", async () => {
-      const spy = vi.fn<[], void>();
+      const spy = vi.fn<() => void>();
       const onOutsideClick = vi.fn((ev: OutsideClickEvent) => {
         if (ev.type === "pointerup") return false;
         return true;
@@ -87,7 +87,7 @@ describe("useOnOutsideClick", () => {
   });
 
   it("should call onOutsideClick for touch", () => {
-    const spy = vi.fn<[], void>();
+    const spy = vi.fn<() => void>();
     global.PointerEvent = undefined!;
     const { result } = renderHook(() => useOnOutsideClick(spy));
     const element = document.createElement("div");
@@ -112,7 +112,7 @@ describe("useOnOutsideClick", () => {
   });
 
   it("should not handle mouse event after touch event", () => {
-    const spy = vi.fn<[], void>();
+    const spy = vi.fn<() => void>();
     global.PointerEvent = undefined!;
     const { result } = renderHook(() => useOnOutsideClick(spy));
     const element = document.createElement("div");

--- a/ui/core-react/src/test/utils/hooks/useRefEffect.test.tsx
+++ b/ui/core-react/src/test/utils/hooks/useRefEffect.test.tsx
@@ -20,7 +20,7 @@ describe("useRefEffect", () => {
   it("should invoke cleanup", () => {
     const cleanups = new Array<{
       instance: string | null;
-      cleanup: Mock<[], void>;
+      cleanup: Mock;
     }>();
     const createCleanup = (instance: string | null) => {
       const cleanup = vi.fn(() => {});

--- a/ui/core-react/vitest.config.ts
+++ b/ui/core-react/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     coverage: {
       thresholds: {
         lines: 98,
-        functions: 97,
+        functions: 96,
         statements: 98,
         branches: 95,
       },

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -86,7 +86,7 @@
     "@types/node": "20.17.8",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@vitest/coverage-v8": "^1.6.0",
+    "@vitest/coverage-v8": "^3.0.6",
     "cpx2": "^3.0.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "~8.8.0",

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -104,7 +104,7 @@
     "typemoq": "^2.1.0",
     "typescript": "~5.6.2",
     "upath": "^2.0.1",
-    "vitest": "^1.6.0"
+    "vitest": "^3.0.6"
   },
   "dependencies": {
     "@itwin/itwinui-icons-react": "^2.8.0",

--- a/ui/imodel-components-react/src/test/TestUtils.ts
+++ b/ui/imodel-components-react/src/test/TestUtils.ts
@@ -531,17 +531,4 @@ export async function waitForPosition() {
   return act(async () => {});
 }
 
-/** Simplified type for `vi.fn` for a React component.
- * @internal
- */
-export type ComponentSpy<
-  T extends
-    | keyof React.JSX.IntrinsicElements
-    | React.JSXElementConstructor<any>,
-  K extends keyof React.ComponentProps<T>
-> = Mock<
-  Parameters<React.ComponentProps<T>[K]>,
-  ReturnType<React.ComponentProps<T>[K]>
->;
-
 export default TestUtils;

--- a/ui/imodel-components-react/src/test/TestUtils.ts
+++ b/ui/imodel-components-react/src/test/TestUtils.ts
@@ -31,7 +31,6 @@ import type { AsyncValueProcessingResult } from "@itwin/components-react";
 import { DataControllerBase } from "@itwin/components-react";
 import { UiIModelComponents } from "../imodel-components-react/UiIModelComponents.js";
 import { act, prettyDOM } from "@testing-library/react";
-import type { Mock } from "vitest";
 
 /** @internal */
 export class TestUtils {

--- a/ui/imodel-components-react/src/test/quantityformat/FormatUnits.test.tsx
+++ b/ui/imodel-components-react/src/test/quantityformat/FormatUnits.test.tsx
@@ -6,7 +6,6 @@ import * as React from "react";
 import { fireEvent, render, within } from "@testing-library/react";
 import { IModelApp, NoRenderApp } from "@itwin/core-frontend";
 import type { FormatProps } from "@itwin/core-quantity";
-import type { ComponentSpy } from "../TestUtils.js";
 import { TestUtils, waitForPosition } from "../TestUtils.js";
 import { stubScrollIntoView } from "../test-helpers/misc.js";
 import { FormatUnits } from "../../imodel-components-react/quantityformat/FormatUnits.js";
@@ -51,7 +50,10 @@ describe("FormatUnits", () => {
     const unitsProvider = IModelApp.quantityFormatter.unitsProvider;
     const pu = await unitsProvider.findUnitByName("Units.M");
 
-    const spy: ComponentSpy<typeof FormatUnits, "onUnitsChange"> = vi.fn();
+    const spy =
+      vi.fn<
+        Required<React.ComponentProps<typeof FormatUnits>>["onUnitsChange"]
+      >();
     const component = render(
       <FormatUnits
         initialFormat={numericFormatProps}
@@ -91,7 +93,10 @@ describe("FormatUnits", () => {
     const unitsProvider = IModelApp.quantityFormatter.unitsProvider;
     const pu = await unitsProvider.findUnitByName("Units.M");
 
-    const spy: ComponentSpy<typeof FormatUnits, "onUnitsChange"> = vi.fn();
+    const spy =
+      vi.fn<
+        Required<React.ComponentProps<typeof FormatUnits>>["onUnitsChange"]
+      >();
     const component = render(
       <FormatUnits
         initialFormat={compositeFormatProps}

--- a/ui/imodel-components-react/vitest.config.ts
+++ b/ui/imodel-components-react/vitest.config.ts
@@ -15,9 +15,9 @@ export default defineConfig({
     outputFile: "coverage/junit.xml",
     coverage: {
       thresholds: {
-        lines: 93,
+        lines: 91,
         functions: 82,
-        statements: 93,
+        statements: 91,
         branches: 90,
       },
     },


### PR DESCRIPTION
## Changes

This PR updates to latest `vitest` version.
Fixes GHSA-9crc-q9x8-hgqq

Usages of `Mock` type and `vi.fn` generic arguments are updated to react to [mock function generic type changes](https://github.com/vitest-dev/vitest/releases/tag/v2.0.0#:~:text=Simplify%20mock%20function%20generic%20types%20and%20align%20with%20jest).

## Testing

N/A
