### PR TITLE
Add tool setting with custom editor story

### DIFF
--- a/docs/storybook/src/frontstage/ToolSettings.stories.tsx
+++ b/docs/storybook/src/frontstage/ToolSettings.stories.tsx
@@ -15,6 +15,11 @@ import { createFrontstage, removeProperty } from "../Utils";
 import { ToolSettingsStory } from "./ToolSettings";
 import { CustomTool } from "../tools/CustomTool";
 import { LockPropertyTool } from "../tools/LockPropertyTool";
+import {
+  CustomEditorTool,
+  CustomTagsPropertyEditor,
+} from "src/tools/CustomEditorTool";
+import { PropertyEditorManager } from "@itwin/components-react";
 
 const meta = {
   title: "Frontstage/ToolSettings",
@@ -47,6 +52,7 @@ const meta = {
   argTypes: {
     frontstages: removeProperty(),
     onFrontstageActivated: removeProperty(),
+    onInitialize: removeProperty(),
   },
 } satisfies Meta<typeof ToolSettingsStory>;
 
@@ -55,21 +61,43 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    onFrontstageActivated: async () => {
+    onInitialize: async () => {
       IModelApp.tools.register(CustomTool, UiFramework.localizationNamespace);
-      IModelApp.tools.run(CustomTool.toolId);
+    },
+    onFrontstageActivated: async () => {
+      await IModelApp.tools.run(CustomTool.toolId);
     },
   },
 };
 
 export const LockProperty: Story = {
   args: {
-    onFrontstageActivated: async () => {
+    onInitialize: async () => {
       IModelApp.tools.register(
         LockPropertyTool,
         UiFramework.localizationNamespace
       );
-      IModelApp.tools.run(LockPropertyTool.toolId);
+    },
+    onFrontstageActivated: async () => {
+      await IModelApp.tools.run(LockPropertyTool.toolId);
+    },
+  },
+};
+
+export const CustomEditor: Story = {
+  args: {
+    onInitialize: async () => {
+      PropertyEditorManager.registerEditor(
+        "custom-tags",
+        CustomTagsPropertyEditor
+      );
+      IModelApp.tools.register(
+        CustomEditorTool,
+        UiFramework.localizationNamespace
+      );
+    },
+    onFrontstageActivated: async () => {
+      await IModelApp.tools.run(CustomEditorTool.toolId);
     },
   },
 };

--- a/docs/storybook/src/frontstage/ToolSettings.tsx
+++ b/docs/storybook/src/frontstage/ToolSettings.tsx
@@ -6,7 +6,10 @@ import { AppUiStory, AppUiStoryProps } from "../AppUiStory";
 
 /** [FrontstageProvider](https://www.itwinjs.org/reference/appui-react/frontstage/frontstageprovider/) can be used to configure a frontstage. */
 export function ToolSettingsStory(
-  props: Pick<AppUiStoryProps, "frontstages" | "onFrontstageActivated">
+  props: Pick<
+    AppUiStoryProps,
+    "onInitialize" | "frontstages" | "onFrontstageActivated"
+  >
 ) {
   return (
     <AppUiStory

--- a/docs/storybook/src/tools/CustomEditorTool.tsx
+++ b/docs/storybook/src/tools/CustomEditorTool.tsx
@@ -1,0 +1,193 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import {
+  BasePropertyEditorParams,
+  DialogItem,
+  DialogPropertySyncItem,
+  PropertyDescription,
+  PropertyValueFormat,
+} from "@itwin/appui-abstract";
+import { EventHandled, PrimitiveTool } from "@itwin/core-frontend";
+import { Tag, TagContainer } from "@itwin/itwinui-react";
+import {
+  PropertyEditorBase,
+  PropertyEditorProps,
+  TypeEditor,
+} from "@itwin/components-react";
+
+const properties = {
+  tags: "tagsProperty",
+} as const;
+
+function createTagsProperty(tags: TagData[]): PropertyDescription {
+  return {
+    typename: "custom-tags",
+    name: properties.tags,
+    displayLabel: "Custom Property",
+    editor: {
+      // Provide tag data to the custom property editor component
+      params: [createTagsParam(tags)],
+    },
+  };
+}
+
+export class CustomEditorTool extends PrimitiveTool {
+  public static override toolId = "CustomEditorTool";
+
+  // All tags are active initially
+  private _activeTagIds: TagData["id"][] = tagsStore.map((tag) => tag.id);
+
+  public override requireWriteableTarget() {
+    return false;
+  }
+
+  public override onRestartTool() {
+    return this.exitTool();
+  }
+
+  public override async onDataButtonDown() {
+    // Reset active tags
+    this._activeTagIds = tagsStore.map((tag) => tag.id);
+    this.syncToolSettingsProperties([
+      {
+        propertyName: properties.tags,
+        property: createTagsProperty(tagsStore),
+        value: {},
+      },
+    ]);
+    return EventHandled.Yes;
+  }
+
+  public override supplyToolSettingsProperties(): DialogItem[] | undefined {
+    const activeTags = tagsStore.filter((tag) =>
+      this._activeTagIds.includes(tag.id)
+    );
+    return [
+      {
+        property: createTagsProperty(activeTags),
+        // We are using params to pass active tag data to the component
+        value: {},
+        editorPosition: {
+          columnIndex: 0,
+          rowPriority: 0,
+        },
+      },
+    ];
+  }
+
+  public override async applyToolSettingPropertyChange(
+    updatedValue: DialogPropertySyncItem
+  ): Promise<boolean> {
+    // Sync active tag changes from the component
+    switch (updatedValue.propertyName) {
+      case properties.tags: {
+        const tagIdsStr = updatedValue.value.value;
+        if (typeof tagIdsStr !== "string") return false;
+        this._activeTagIds = JSON.parse(tagIdsStr);
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+
+export class CustomTagsPropertyEditor extends PropertyEditorBase {
+  public get reactNode(): React.ReactNode {
+    return <CustomTagsEditor />;
+  }
+}
+
+// Data structure for tags
+interface TagData {
+  id: string;
+  label: string;
+}
+
+const tagsStore: TagData[] = [
+  {
+    id: "1",
+    label: "Tag 1",
+  },
+  {
+    id: "2",
+    label: "Tag 2",
+  },
+  {
+    id: "3",
+    label: "Tag 3",
+  },
+];
+
+// Custom property editor param for tags.
+interface TagsParam extends BasePropertyEditorParams {
+  type: "custom-tags-param";
+  tags: TagData[];
+}
+
+// Helper to create custom tags param.
+function createTagsParam(tags: TagData[]): BasePropertyEditorParams {
+  return {
+    type: createTagsParam.type,
+    tags,
+  } as TagsParam;
+}
+createTagsParam.type = "custom-tags-param";
+
+// eslint-disable-next-line react-refresh/only-export-components
+const CustomTagsEditor = React.forwardRef<TypeEditor, PropertyEditorProps>(
+  (props, ref) => {
+    const { propertyRecord } = props;
+    const elRef = React.useRef<HTMLDivElement>(null);
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        getPropertyValue: async () => {
+          return undefined;
+        },
+        htmlElement: null,
+        hasFocus: false,
+      }),
+      []
+    );
+    const tags = React.useMemo(() => {
+      if (!propertyRecord) return [];
+      const params = propertyRecord.property.editor?.params;
+      const tagsParam = params?.find((param): param is TagsParam => {
+        return param.type === createTagsParam.type;
+      });
+      return tagsParam?.tags ?? [];
+    }, [propertyRecord]);
+
+    return (
+      <TagContainer ref={elRef}>
+        {tags.map((tag) => (
+          <Tag
+            key={tag.id}
+            style={{
+              blockSize: "var(--iui-size-l)",
+            }}
+            onRemove={() => {
+              if (!props.propertyRecord) return;
+
+              const tagIds = tags.map((t) => t.id);
+              const newTagIds = tagIds.filter((id) => id !== tag.id);
+              props.onCommit?.({
+                propertyRecord: props.propertyRecord,
+                newValue: {
+                  valueFormat: PropertyValueFormat.Primitive,
+                  value: JSON.stringify(newTagIds),
+                },
+              });
+            }}
+          >
+            {tag.label}
+          </Tag>
+        ))}
+      </TagContainer>
+    );
+  }
+);


### PR DESCRIPTION
## Changes

Closes #1204 by adding a tool settings story that uses a custom editor component.
New story renders [iTwinUI Tag](https://itwinui.bentley.com/docs/tag) components in tool setting area by using tool setting APIs.

Live demo: https://itwin.github.io/appui/1226/?path=/story/frontstage-toolsettings--custom-editor

## Testing

N/A
