### PR TITLE
Fix tabbing of tool settings

### DIFF
--- a/common/changes/@itwin/components-react/tool-settings-tab_2025-02-25-22-44.json
+++ b/common/changes/@itwin/components-react/tool-settings-tab_2025-02-25-22-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Fix an issue which prevented tabbing through editor containers.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/ui/components-react/src/components-react/editors/EditorContainer.tsx
+++ b/ui/components-react/src/components-react/editors/EditorContainer.tsx
@@ -115,6 +115,7 @@ export function EditorContainer(props: EditorContainerProps) {
 
   const editorRef = React.useRef<TypeEditor | undefined>();
   const propertyEditorRef = React.useRef<PropertyEditorBase | undefined>();
+  const committedByTab = React.useRef(false);
 
   const handleClick = (e: React.MouseEvent) => {
     onClick?.();
@@ -148,8 +149,8 @@ export function EditorContainer(props: EditorContainerProps) {
   const onPressTab = (e: React.KeyboardEvent) => {
     if (!propertyEditorRef.current?.containerHandlesTab) return;
     e.stopPropagation();
-    e.preventDefault();
     void handleContainerCommit();
+    committedByTab.current = true;
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -170,6 +171,11 @@ export function EditorContainer(props: EditorContainerProps) {
   };
 
   const handleEditorBlur = () => {
+    // Avoid double commit when tabbing.
+    if (committedByTab.current) {
+      committedByTab.current = false;
+      return;
+    }
     if (ignoreEditorBlur) return;
     if (!propertyEditorRef.current?.containerHandlesBlur) return;
     void handleContainerCommit();


### PR DESCRIPTION
## Changes

This PR closes #1218 by fixing an issue introduced by #942 where `preventDefault()` on `keydown` would prevent tabbing.

## Testing

N/A
