### PR TITLE
Update Node.js version used in release pipelines

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.x
 
       - name: Rush cspell
         run: node common/scripts/install-run-rush.js cspell

--- a/.github/workflows/extract-api.yaml
+++ b/.github/workflows/extract-api.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.x
 
       - name: Rush install
         run: node common/scripts/install-run-rush.js install

--- a/.github/workflows/publish-storybook.yaml
+++ b/.github/workflows/publish-storybook.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.x
 
       - name: Rush install
         run: node common/scripts/install-run-rush.js install

--- a/common/config/azure-pipelines/jobs/docs-ci.yaml
+++ b/common/config/azure-pipelines/jobs/docs-ci.yaml
@@ -39,7 +39,7 @@ stages:
             clean: true
 
           - task: NodeTool@0
-            displayName: Use Node 20
+            displayName: Use Node 20.x
             inputs:
               versionSpec: 20.x
               checkLatest: true

--- a/common/config/azure-pipelines/jobs/version-bump-individual.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump-individual.yaml
@@ -24,9 +24,9 @@ jobs:
       - checkout: self
 
       - task: NodeTool@0
-        displayName: Use Node 18.x
+        displayName: Use Node 20.x
         inputs:
-          versionSpec: 18.x
+          versionSpec: 20.x
           checkLatest: true
 
       - bash: |

--- a/common/config/azure-pipelines/jobs/version-bump.yaml
+++ b/common/config/azure-pipelines/jobs/version-bump.yaml
@@ -49,9 +49,9 @@ jobs:
       - checkout: self
 
       - task: NodeTool@0
-        displayName: Use Node 18.x
+        displayName: Use Node 20.x
         inputs:
-          versionSpec: 18.x
+          versionSpec: 20.x
           checkLatest: true
 
       - bash: |
@@ -184,9 +184,9 @@ jobs:
         steps:
           - checkout: self
           - task: NodeTool@0
-            displayName: "Use Node 18.x"
+            displayName: Use Node 20.x
             inputs:
-              versionSpec: 18.x
+              versionSpec: 20.x
               checkLatest: true
 
           - bash: |


### PR DESCRIPTION
## Changes

Update leftover Node.js v18 usage of https://github.com/iTwin/appui/pull/1214 which caused issues in release pipeline.

## Testing

N/A