### PR TITLE
docs ci: one more agent pool to update

### DIFF
--- a/common/config/azure-pipelines/jobs/docs-ci.yaml
+++ b/common/config/azure-pipelines/jobs/docs-ci.yaml
@@ -93,8 +93,7 @@ stages:
       - job:
         displayName: Tag build
         pool:
-          name: iModelTechCI
-          demands: Agent.OS -equals Windows_NT
+          name: imodelNative-Win11-VS2022
 
         steps:
           - powershell: |


### PR DESCRIPTION
Both agent pools in docs-ci should migrate off iModelTechCi.