### PR TITLE
Add `widgetActions` prop to `StandardLayout`

### DIFF
--- a/apps/test-app/src/frontend/appui/frontstages/WidgetApiFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/WidgetApiFrontstage.tsx
@@ -14,16 +14,21 @@ import {
   StagePanelState,
   StageUsage,
   StandardContentLayouts,
+  StandardLayout,
   ToolbarItemUtilities,
   ToolbarOrientation,
   ToolbarUsage,
+  UiFramework,
   UiItemsProvider,
   useConditionalValue,
   Widget,
+  WidgetAction,
+  WidgetActions,
   WidgetState,
 } from "@itwin/appui-react";
 import { IModelApp, MeasureDistanceTool } from "@itwin/core-frontend";
 import {
+  SvgRefresh,
   SvgTextAlignCenter,
   SvgTextAlignJustify,
   SvgTextAlignLeft,
@@ -97,9 +102,37 @@ export function createWidgetApiFrontstage(): Frontstage {
   return {
     ...config,
     toolSettings,
+    layout: (
+      <StandardLayout
+        widgetActions={
+          <WidgetActions
+            modifyActions={(defaultActions) => [
+              {
+                id: "restore-layout",
+                action: RestoreLayoutWidgetAction,
+              },
+              ...defaultActions,
+            ]}
+          />
+        }
+      />
+    ),
   };
 }
 createWidgetApiFrontstage.stageId = "widget-api";
+
+function RestoreLayoutWidgetAction() {
+  return (
+    <WidgetAction
+      label="Restore layout"
+      icon={<SvgRefresh />}
+      onClick={() => {
+        const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
+        frontstageDef?.restoreLayout();
+      }}
+    />
+  );
+}
 
 function MyCustomViewOverlay() {
   const [visible, setVisible] = React.useState(

--- a/e2e-tests/tests/Utils.ts
+++ b/e2e-tests/tests/Utils.ts
@@ -228,7 +228,7 @@ export async function dragWidget(
 ) {
   const page = widget.page();
   const titleBarHandle = titleBarHandleLocator(widget);
-  const titleBarButtons = widget.locator(".nz-widget-buttons");
+  const titleBarButtons = widget.locator(".nz-widget-widgetActions");
   const frontstage = frontstageLocator(page);
 
   // Widget tabs or title bar buttons overlay the handle. Make sure we drag the handle.

--- a/ui/appui-react/src/appui-react.ts
+++ b/ui/appui-react/src/appui-react.ts
@@ -326,6 +326,9 @@ export {
   KeyinFieldLocalization,
 } from "./appui-react/keyins/Keyins.js";
 
+export { WidgetAction } from "./appui-react/layout/widget/WidgetAction.js";
+export { WidgetActions } from "./appui-react/layout/widget/WidgetActions.js";
+
 export { AppNotificationManager } from "./appui-react/messages/AppNotificationManager.js";
 export { InputFieldMessage } from "./appui-react/messages/InputField.js";
 export {

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -37,12 +37,14 @@ import { useReduxFrameworkState } from "../uistate/useReduxFrameworkState.js";
 import type { ContentProps } from "../content/ContentGroup.js";
 import { ChildWindowRenderer } from "../childwindow/ChildWindowRenderer.js";
 import { useActiveFrontstageDef } from "../frontstage/FrontstageDef.js";
+import type { WidgetActions } from "../layout/widget/WidgetActions.js";
 
 /** @internal */
 export const ConfigurableUiContext = React.createContext<
   /* eslint-disable-next-line @typescript-eslint/no-deprecated */
   ConfigurableUiContentProps & {
     contentElementRef?: React.RefObject<HTMLElement>;
+    widgetActions?: React.ReactNode;
   }
 >({});
 
@@ -103,10 +105,18 @@ export function ConfigurableUiContent(props: ConfigurableUiContentProps) {
   );
 }
 
+interface StandardLayoutProps {
+  /** Overrides widget specific actions displayed in the title bar area.
+   * Use {@link WidgetActions} component to customize widget actions.
+   */
+  widgetActions?: React.ReactNode;
+}
+
 /** The standard widget based layout used as a default layout for all frontstages.
  * @alpha
  */
-export function StandardLayout() {
+export function StandardLayout(props: StandardLayoutProps) {
+  const { widgetActions } = props;
   const context = React.useContext(ConfigurableUiContext);
   const {
     appBackstage,
@@ -144,8 +154,9 @@ export function StandardLayout() {
         () => ({
           ...context,
           contentElementRef,
+          widgetActions,
         }),
-        [context]
+        [context, widgetActions]
       )}
     >
       <main

--- a/ui/appui-react/src/appui-react/layout/base/NineZone.tsx
+++ b/ui/appui-react/src/appui-react/layout/base/NineZone.tsx
@@ -50,15 +50,10 @@ export interface NineZoneProps {
 
 /** @internal */
 export interface NineZoneLabels {
-  dockToolSettingsTitle?: string;
   moreWidgetsTitle?: string;
   moreToolSettingsTitle?: string;
-  pinPanelTitle?: string;
   resizeGripTitle?: string;
-  sendWidgetHomeTitle?: string;
   toolSettingsHandleTitle?: string;
-  unpinPanelTitle?: string;
-  popoutActiveTab?: string;
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Buttons.tsx
@@ -33,42 +33,47 @@ import {
   useAddTab,
 } from "../../preview/control-widget-visibility/AddWidgetButton.js";
 
-/** @internal */
-export type WidgetFeature =
-  | "popout"
-  | "maximize"
-  | "sendBack"
-  | "dock"
-  | "horizontalAlign"
-  | "pin"
-  | "closeWidget"
-  | "addWidget";
+const widgetActions = {
+  popout: PopoutToggle,
+  sendBack: SendBack,
+  dock: Dock,
+  pin: PinToggle,
+  maximize: MaximizeToggle,
+  horizontalAlign: PreviewHorizontalPanelAlignButton,
+  closeWidget: CloseWidgetButton,
+  addWidget: AddWidgetButton,
+};
+
+type WidgetActionId = keyof typeof widgetActions;
+
+interface WidgetAction {
+  id: WidgetActionId | (string & {});
+  action: React.ComponentType;
+}
+
+interface TabBarButtonsProps {
+  actions?: (defaultActions: WidgetAction[]) => WidgetAction[];
+}
 
 /** @internal */
-export function TabBarButtons() {
+export type WidgetFeature = WidgetActionId;
+
+/** @internal */
+export function TabBarButtons(props: TabBarButtonsProps) {
+  const { actions } = props;
   const features = useWidgetFeatures();
   const [sortedFeatures, isDropdown] = useDropdownFeatures(features);
+  const finalActions = React.useMemo(() => {
+    const knownActions = sortedFeatures.map((feature) => ({
+      id: feature,
+      action: widgetActions[feature],
+    }));
+    if (!actions) return knownActions;
+    return actions(knownActions);
+  }, [sortedFeatures, actions]);
 
-  const buttons = sortedFeatures.map((feature) => {
-    switch (feature) {
-      case "popout":
-        return <PopoutToggle key="popout" />;
-      case "maximize":
-        return <MaximizeToggle key="maximize" />;
-      case "sendBack":
-        return <SendBack key="sendBack" />;
-      case "dock":
-        return <Dock key="dock" />;
-      case "horizontalAlign":
-        return <PreviewHorizontalPanelAlignButton key="horizontalAlign" />;
-      case "pin":
-        return <PinToggle key="pin" />;
-      case "closeWidget":
-        return <CloseWidgetButton key="closeWidget" />;
-      case "addWidget":
-        return <AddWidgetButton key="addWidget" />;
-    }
-    return undefined;
+  const buttons = finalActions.map(({ id, action: Action }) => {
+    return <Action key={id} />;
   });
 
   return (

--- a/ui/appui-react/src/appui-react/layout/widget/Dock.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/Dock.tsx
@@ -8,17 +8,19 @@
 
 import * as React from "react";
 import { SvgDockTop } from "@itwin/itwinui-icons-react";
-import { NineZoneDispatchContext, useLabel } from "../base/NineZone.js";
-import { ActionButton } from "../../preview/widget-action-dropdown/Button.js";
+import { NineZoneDispatchContext } from "../base/NineZone.js";
+import { WidgetAction } from "./WidgetAction.js";
 import { useIsToolSettingsTab } from "./useIsToolSettingsTab.js";
 import { useIsMaximizedWidget } from "../../preview/enable-maximized-widget/useMaximizedWidget.js";
+import { useTranslation } from "../../hooks/useTranslation.js";
 
 /** @internal */
 export function Dock() {
   const dispatch = React.useContext(NineZoneDispatchContext);
-  const label = useLabel("dockToolSettingsTitle");
+  const { translate } = useTranslation();
+  const label = translate("widget.tooltips.dockToolSettings");
   return (
-    <ActionButton
+    <WidgetAction
       icon={<SvgDockTop />}
       label={label}
       onClick={() => {

--- a/ui/appui-react/src/appui-react/layout/widget/PinToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PinToggle.tsx
@@ -9,24 +9,26 @@
 import * as React from "react";
 import { assert } from "@itwin/core-bentley";
 import { SvgPin, SvgPinHollow } from "@itwin/itwinui-icons-react";
-import { NineZoneDispatchContext, useLabel } from "../base/NineZone.js";
+import { NineZoneDispatchContext } from "../base/NineZone.js";
 import { PanelSideContext } from "../widget-panels/Panel.js";
 import { useLayout } from "../base/LayoutStore.js";
-import { ActionButton } from "../../preview/widget-action-dropdown/Button.js";
+import { WidgetAction } from "./WidgetAction.js";
 import { useMainPanelWidgetId } from "./usePanelWidgetId.js";
 import { useIsMaximizedWidget } from "../../preview/enable-maximized-widget/useMaximizedWidget.js";
+import { useTranslation } from "../../hooks/useTranslation.js";
 
 /** @internal */
 export function PinToggle() {
   const side = React.useContext(PanelSideContext);
   assert(!!side);
   const dispatch = React.useContext(NineZoneDispatchContext);
-  const pinLabel = useLabel("pinPanelTitle");
-  const unpinLabel = useLabel("unpinPanelTitle");
+  const { translate } = useTranslation();
+  const pinLabel = translate("widget.tooltips.pinPanel");
+  const unpinLabel = translate("widget.tooltips.unpinPanel");
   const pinned = useLayout((state) => state.panels[side].pinned);
 
   return (
-    <ActionButton
+    <WidgetAction
       icon={pinned ? <SvgPin /> : <SvgPinHollow />}
       label={pinned ? unpinLabel : pinLabel}
       onClick={() => {

--- a/ui/appui-react/src/appui-react/layout/widget/PopoutToggle.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/PopoutToggle.tsx
@@ -8,19 +8,21 @@
 
 import * as React from "react";
 import { SvgWindowPopout } from "@itwin/itwinui-icons-react";
-import { NineZoneDispatchContext, useLabel } from "../base/NineZone.js";
+import { NineZoneDispatchContext } from "../base/NineZone.js";
 import { useActiveTabId } from "./Widget.js";
 import { useLayout } from "../base/LayoutStore.js";
-import { ActionButton } from "../../preview/widget-action-dropdown/Button.js";
+import { WidgetAction } from "./WidgetAction.js";
+import { useTranslation } from "../../hooks/useTranslation.js";
 
 /** @internal */
 export function PopoutToggle() {
   const dispatch = React.useContext(NineZoneDispatchContext);
   const activeTabId = useActiveTabId();
-  const label = useLabel("popoutActiveTab");
+  const { translate } = useTranslation();
+  const label = translate("widget.tooltips.popoutActiveTab");
 
   return (
-    <ActionButton
+    <WidgetAction
       icon={<SvgWindowPopout />}
       label={label}
       onClick={() => {

--- a/ui/appui-react/src/appui-react/layout/widget/SendBack.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/SendBack.tsx
@@ -15,7 +15,7 @@ import {
   SvgDockRight,
   SvgDockTop,
 } from "@itwin/itwinui-icons-react";
-import { NineZoneDispatchContext, useLabel } from "../base/NineZone.js";
+import { NineZoneDispatchContext } from "../base/NineZone.js";
 import { useLayout } from "../base/LayoutStore.js";
 import {
   useFloatingWidgetId,
@@ -25,8 +25,9 @@ import type { WidgetState } from "../state/WidgetState.js";
 import { getWidgetPanelSectionId } from "../state/PanelState.js";
 import type { NineZoneState } from "../state/NineZoneState.js";
 import { useIsToolSettingsTab } from "./useIsToolSettingsTab.js";
-import { ActionButton } from "../../preview/widget-action-dropdown/Button.js";
+import { WidgetAction } from "./WidgetAction.js";
 import { useIsMaximizedWidget } from "../../preview/enable-maximized-widget/useMaximizedWidget.js";
+import { useTranslation } from "../../hooks/useTranslation.js";
 
 /** @internal */
 export const useActiveSendBackWidgetIdStore = create<
@@ -102,7 +103,8 @@ export function SendBack() {
   const id = useFloatingWidgetId();
   assert(!!id);
   const dispatch = React.useContext(NineZoneDispatchContext);
-  const label = useLabel("sendWidgetHomeTitle");
+  const { translate } = useTranslation();
+  const label = translate("widget.tooltips.sendHome");
   const setActiveWidgetId = (newId: WidgetState["id"] | undefined) =>
     useActiveSendBackWidgetIdStore.setState(newId);
 
@@ -127,13 +129,11 @@ export function SendBack() {
   };
   const eventHandlers = { onMouseOver, onFocus, onMouseOut, onBlur };
   return (
-    <ActionButton
+    <WidgetAction
       icon={<Icon />}
       label={label}
       onClick={onClick}
-      buttonProps={eventHandlers}
-      // TODO: can not pass down event handlers due to iTwinUI type issues.
-      menuProps={eventHandlers as any}
+      {...eventHandlers}
     />
   );
 }

--- a/ui/appui-react/src/appui-react/layout/widget/TabBar.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/TabBar.tsx
@@ -26,6 +26,7 @@ import { useDoubleClick } from "../widget-panels/Grip.js";
 import { useFloatingWidgetId } from "./FloatingWidget.js";
 import { useMaximizedWidgetTabBarHandle } from "../../preview/enable-maximized-widget/useMaximizedWidget.js";
 import { WidgetActions } from "./WidgetActions.js";
+import { ConfigurableUiContext } from "../../configurableui/ConfigurableUiContent.js";
 
 /** @internal */
 export interface WidgetTabBarProps {
@@ -36,6 +37,7 @@ export interface WidgetTabBarProps {
 export function WidgetTabBar(props: WidgetTabBarProps) {
   const dispatch = React.useContext(NineZoneDispatchContext);
   const id = React.useContext(WidgetIdContext);
+  const { widgetActions } = React.useContext(ConfigurableUiContext);
   const floatingWidgetId = useFloatingWidgetId();
   assert(!!id);
   const widgetId = floatingWidgetId === undefined ? id : floatingWidgetId;
@@ -113,7 +115,7 @@ export function WidgetTabBar(props: WidgetTabBarProps) {
     <div ref={containerRef} className={className}>
       <div className={handleClassName} ref={ref} />
       <WidgetTabs />
-      <WidgetActions />
+      {widgetActions ?? <WidgetActions />}
     </div>
   );
 }

--- a/ui/appui-react/src/appui-react/layout/widget/TabBar.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/TabBar.tsx
@@ -20,12 +20,12 @@ import type {
   PointerCaptorEvent,
 } from "../base/usePointerCaptor.js";
 import { usePointerCaptor } from "../base/usePointerCaptor.js";
-import { TabBarButtons } from "./Buttons.js";
 import { WidgetTabs } from "./Tabs.js";
 import { WidgetIdContext } from "./Widget.js";
 import { useDoubleClick } from "../widget-panels/Grip.js";
 import { useFloatingWidgetId } from "./FloatingWidget.js";
 import { useMaximizedWidgetTabBarHandle } from "../../preview/enable-maximized-widget/useMaximizedWidget.js";
+import { WidgetActions } from "./WidgetActions.js";
 
 /** @internal */
 export interface WidgetTabBarProps {
@@ -113,7 +113,7 @@ export function WidgetTabBar(props: WidgetTabBarProps) {
     <div ref={containerRef} className={className}>
       <div className={handleClassName} ref={ref} />
       <WidgetTabs />
-      <TabBarButtons />
+      <WidgetActions />
     </div>
   );
 }

--- a/ui/appui-react/src/appui-react/layout/widget/WidgetAction.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/WidgetAction.tsx
@@ -8,41 +8,41 @@
 
 import * as React from "react";
 import { MenuItem } from "@itwin/itwinui-react";
-import { WidgetActionDropdownContext } from "./MoreButton.js";
-import { TabBarButton } from "../../layout/widget/Button.js";
+import { WidgetActionDropdownContext } from "../../preview/widget-action-dropdown/MoreButton.js";
+import { TabBarButton } from "./Button.js";
+import type { WidgetActions } from "./WidgetActions.js";
 
-interface ActionButtonProps {
-  label?: string;
+interface WidgetActionProps extends React.HTMLAttributes<HTMLElement> {
+  label: string;
   icon: React.JSX.Element;
   onClick?: () => void;
-  menuProps?: React.ComponentProps<typeof MenuItem>;
-  buttonProps?: React.ComponentProps<typeof TabBarButton>;
 }
 
-/** @internal */
-export function ActionButton(props: ActionButtonProps) {
+/**
+ * A widget action rendered in a widget title bar.
+ * Should be used in {@link WidgetActions} component.
+ * @alpha
+ */
+export function WidgetAction(props: WidgetActionProps) {
+  const { label, icon, onClick, ...rest } = props;
   const dropdownContext = React.useContext(WidgetActionDropdownContext);
   if (dropdownContext !== undefined) {
     return (
       <MenuItem
-        icon={props.icon}
+        startIcon={icon}
         onClick={() => {
-          props.onClick?.();
+          onClick?.();
           dropdownContext.onClose();
         }}
-        {...props.menuProps}
+        {...rest}
       >
-        {props.label}
+        {label}
       </MenuItem>
     );
   }
   return (
-    <TabBarButton
-      onClick={props.onClick}
-      label={props.label}
-      {...props.buttonProps}
-    >
-      {props.icon}
+    <TabBarButton onClick={onClick} label={label} {...rest}>
+      {icon}
     </TabBarButton>
   );
 }

--- a/ui/appui-react/src/appui-react/layout/widget/WidgetActions.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/WidgetActions.scss
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-.nz-widget-buttons {
+.nz-widget-widgetActions {
   display: flex;
   align-items: center;
   align-content: center;

--- a/ui/appui-react/src/appui-react/layout/widget/WidgetActions.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/WidgetActions.tsx
@@ -6,7 +6,7 @@
  * @module Widget
  */
 
-import "./Buttons.scss";
+import "./WidgetActions.scss";
 import * as React from "react";
 import { Dock, useDock } from "./Dock.js";
 import { PinToggle, usePinToggle } from "./PinToggle.js";
@@ -18,7 +18,7 @@ import {
 import { SendBack, useSendBack } from "./SendBack.js";
 import {
   MoreButton,
-  useDropdownFeatures,
+  useDropdownActions,
 } from "../../preview/widget-action-dropdown/MoreButton.js";
 import {
   MaximizeToggle,
@@ -44,47 +44,45 @@ const widgetActions = {
   addWidget: AddWidgetButton,
 };
 
-type WidgetActionId = keyof typeof widgetActions;
+/** @internal */
+export type WidgetActionId = keyof typeof widgetActions;
 
-interface WidgetAction {
+interface WidgetActionSpec {
   id: WidgetActionId | (string & {});
   action: React.ComponentType;
 }
 
-interface TabBarButtonsProps {
-  actions?: (defaultActions: WidgetAction[]) => WidgetAction[];
+interface WidgetActionsProps {
+  actions?: (defaultActions: WidgetActionSpec[]) => WidgetActionSpec[];
 }
 
 /** @internal */
-export type WidgetFeature = WidgetActionId;
-
-/** @internal */
-export function TabBarButtons(props: TabBarButtonsProps) {
+export function WidgetActions(props: WidgetActionsProps) {
   const { actions } = props;
-  const features = useWidgetFeatures();
-  const [sortedFeatures, isDropdown] = useDropdownFeatures(features);
+  const defaultActions = useWidgetActions();
+  const [dropdownActions, isDropdown] = useDropdownActions(defaultActions);
   const finalActions = React.useMemo(() => {
-    const knownActions = sortedFeatures.map((feature) => ({
+    const knownActions = dropdownActions.map((feature) => ({
       id: feature,
       action: widgetActions[feature],
     }));
     if (!actions) return knownActions;
     return actions(knownActions);
-  }, [sortedFeatures, actions]);
+  }, [actions, dropdownActions]);
 
   const buttons = finalActions.map(({ id, action: Action }) => {
     return <Action key={id} />;
   });
 
   return (
-    <div className="nz-widget-buttons">
+    <div className="nz-widget-widgetActions">
       {isDropdown ? <MoreButton>{buttons}</MoreButton> : buttons}
     </div>
   );
 }
 
 /** @internal */
-export function useWidgetFeatures(): WidgetFeature[] {
+export function useWidgetActions(): WidgetActionId[] {
   const popoutToggle = usePopoutToggle();
   const maximizeToggle = useMaximizeToggle();
   const sendBack = useSendBack();

--- a/ui/appui-react/src/appui-react/layout/widget/WidgetActions.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/WidgetActions.tsx
@@ -53,12 +53,15 @@ interface WidgetActionSpec {
 }
 
 interface WidgetActionsProps {
-  actions?: (defaultActions: WidgetActionSpec[]) => WidgetActionSpec[];
+  /** Function to modify the default actions. */
+  modifyActions?: (defaultActions: WidgetActionSpec[]) => WidgetActionSpec[];
 }
 
-/** @internal */
+/** Renders widget actions in the widget title bar.
+ * @alpha
+ */
 export function WidgetActions(props: WidgetActionsProps) {
-  const { actions } = props;
+  const { modifyActions } = props;
   const defaultActions = useWidgetActions();
   const [dropdownActions, isDropdown] = useDropdownActions(defaultActions);
   const finalActions = React.useMemo(() => {
@@ -66,9 +69,9 @@ export function WidgetActions(props: WidgetActionsProps) {
       id: feature,
       action: widgetActions[feature],
     }));
-    if (!actions) return knownActions;
-    return actions(knownActions);
-  }, [actions, dropdownActions]);
+    if (!modifyActions) return knownActions;
+    return modifyActions(knownActions);
+  }, [dropdownActions, modifyActions]);
 
   const buttons = finalActions.map(({ id, action: Action }) => {
     return <Action key={id} />;

--- a/ui/appui-react/src/appui-react/layout/widget/WidgetActions.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/WidgetActions.tsx
@@ -32,6 +32,8 @@ import {
   AddWidgetButton,
   useAddTab,
 } from "../../preview/control-widget-visibility/AddWidgetButton.js";
+import type { StandardLayout } from "../../configurableui/ConfigurableUiContent.js";
+import type { WidgetAction } from "./WidgetAction.js";
 
 const widgetActions = {
   popout: PopoutToggle,
@@ -53,11 +55,15 @@ interface WidgetActionSpec {
 }
 
 interface WidgetActionsProps {
-  /** Function to modify the default actions. */
+  /** Function to modify the default widget actions.
+   * Use {@link WidgetAction} component when adding new widget actions.
+   */
   modifyActions?: (defaultActions: WidgetActionSpec[]) => WidgetActionSpec[];
 }
 
-/** Renders widget actions in the widget title bar.
+/**
+ * Renders widget actions in the widget title bar.
+ * Should be used in `widgetActions` prop of {@link StandardLayout} component.
  * @alpha
  */
 export function WidgetActions(props: WidgetActionsProps) {

--- a/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseWidgetButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/control-widget-visibility/CloseWidgetButton.tsx
@@ -8,7 +8,7 @@
 
 import * as React from "react";
 import { SvgCloseSmall } from "@itwin/itwinui-icons-react";
-import { ActionButton } from "../widget-action-dropdown/Button.js";
+import { WidgetAction } from "../../layout/widget/WidgetAction.js";
 import { usePreviewFeatures } from "../PreviewFeatures.js";
 import { useActiveTabId } from "../../layout/widget/Widget.js";
 import { NineZoneDispatchContext } from "../../layout/base/NineZone.js";
@@ -19,7 +19,7 @@ export function CloseWidgetButton() {
   const dispatch = React.useContext(NineZoneDispatchContext);
 
   return (
-    <ActionButton
+    <WidgetAction
       icon={<SvgCloseSmall />}
       label="Close widget"
       onClick={() => {

--- a/ui/appui-react/src/appui-react/preview/enable-maximized-widget/MaximizeToggle.tsx
+++ b/ui/appui-react/src/appui-react/preview/enable-maximized-widget/MaximizeToggle.tsx
@@ -11,7 +11,7 @@ import {
   SvgWindowMaximize,
   SvgWindowMinimize,
 } from "@itwin/itwinui-icons-react";
-import { ActionButton } from "../widget-action-dropdown/Button.js";
+import { WidgetAction } from "../../layout/widget/WidgetAction.js";
 import { WidgetIdContext } from "../../layout/widget/Widget.js";
 import { MaximizedWidgetContext } from "./MaximizedWidget.js";
 import { usePreviewFeatures } from "../PreviewFeatures.js";
@@ -39,7 +39,7 @@ export function MaximizeToggle() {
         };
 
   return (
-    <ActionButton
+    <WidgetAction
       icon={iconSpec}
       label={label}
       onClick={() => {

--- a/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/widget-action-dropdown/MoreButton.tsx
@@ -14,7 +14,7 @@ import { TabBarButton } from "../../layout/widget/Button.js";
 import { usePreviewFeatures } from "../PreviewFeatures.js";
 import { useLayout } from "../../layout/base/LayoutStore.js";
 import { PanelSideContext } from "../../layout/widget-panels/Panel.js";
-import type { WidgetFeature } from "../../layout/widget/Buttons.js";
+import type { WidgetActionId } from "../../layout/widget/WidgetActions.js";
 
 /** @internal */
 export function MoreButton(props: React.PropsWithChildren<object>) {
@@ -62,7 +62,7 @@ function CloseOnPanelCollapse() {
   return null;
 }
 
-const order: WidgetFeature[] = [
+const order: WidgetActionId[] = [
   "pin",
   "maximize",
   "popout",
@@ -72,12 +72,12 @@ const order: WidgetFeature[] = [
 ];
 
 /** @internal */
-export function useDropdownFeatures(features: WidgetFeature[]) {
+export function useDropdownActions(actions: WidgetActionId[]) {
   const { widgetActionDropdown } = usePreviewFeatures();
   const threshold = widgetActionDropdown?.threshold ?? Infinity;
-  const isDropdown = features.length > threshold;
-  if (!isDropdown) return [features, false] as const;
-  const sorted = [...features].sort(
+  const isDropdown = actions.length > threshold;
+  if (!isDropdown) return [actions, false] as const;
+  const sorted = [...actions].sort(
     (a, b) => order.indexOf(a) - order.indexOf(b)
   );
   return [sorted, true] as const;

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -282,15 +282,10 @@ export function useLabels(): NineZoneLabels {
   const { translate } = useTranslation();
 
   return {
-    dockToolSettingsTitle: translate("widget.tooltips.dockToolSettings"),
     moreWidgetsTitle: translate("widget.tooltips.moreWidgets"),
     moreToolSettingsTitle: translate("widget.tooltips.moreToolSettings"),
-    pinPanelTitle: translate("widget.tooltips.pinPanel"),
     resizeGripTitle: translate("widget.tooltips.resizeGrip"),
-    sendWidgetHomeTitle: translate("widget.tooltips.sendHome"),
     toolSettingsHandleTitle: translate("widget.tooltips.toolSettingsHandle"),
-    unpinPanelTitle: translate("widget.tooltips.unpinPanel"),
-    popoutActiveTab: translate("widget.tooltips.popoutActiveTab"),
   };
 }
 

--- a/ui/appui-react/src/test/layout/base/NineZone.test.tsx
+++ b/ui/appui-react/src/test/layout/base/NineZone.test.tsx
@@ -145,9 +145,9 @@ describe("<NineZone />", () => {
 describe("useLabel", () => {
   it("should return label", () => {
     const labels: NineZoneLabels = {
-      dockToolSettingsTitle: "test",
+      moreToolSettingsTitle: "test",
     };
-    const { result } = renderHook(() => useLabel("dockToolSettingsTitle"), {
+    const { result } = renderHook(() => useLabel("moreToolSettingsTitle"), {
       wrapper: (props: object) => (
         <NineZoneLabelsContext.Provider value={labels} {...props} />
       ),

--- a/ui/appui-react/src/test/layout/widget/Dock.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/Dock.test.tsx
@@ -5,10 +5,7 @@
 import { fireEvent, render } from "@testing-library/react";
 import * as React from "react";
 import type { NineZoneDispatch } from "../../../appui-react/layout/base/NineZone.js";
-import {
-  NineZoneDispatchContext,
-  NineZoneLabelsContext,
-} from "../../../appui-react/layout/base/NineZone.js";
+import { NineZoneDispatchContext } from "../../../appui-react/layout/base/NineZone.js";
 import { Dock } from "../../../appui-react/layout/widget/Dock.js";
 
 describe("Dock", () => {
@@ -16,11 +13,7 @@ describe("Dock", () => {
     const dispatch = vi.fn<NineZoneDispatch>();
     const component = render(
       <NineZoneDispatchContext.Provider value={dispatch}>
-        <NineZoneLabelsContext.Provider
-          value={{ dockToolSettingsTitle: "Dock" }}
-        >
-          <Dock />
-        </NineZoneLabelsContext.Provider>
+        <Dock />
       </NineZoneDispatchContext.Provider>
     );
     const button = component.getByRole("button", { name: "Dock" });

--- a/ui/appui-react/src/test/layout/widget/PinToggle.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PinToggle.test.tsx
@@ -14,11 +14,7 @@ import { TestNineZoneProvider } from "../Providers.js";
 describe("PinToggle", () => {
   it("should render in pinned panel", () => {
     const component = render(
-      <TestNineZoneProvider
-        labels={{
-          unpinPanelTitle: "Unpin panel",
-        }}
-      >
+      <TestNineZoneProvider>
         <PanelSideContext.Provider value="bottom">
           <PinToggle />
         </PanelSideContext.Provider>
@@ -33,12 +29,7 @@ describe("PinToggle", () => {
       draft.pinned = false;
     });
     const component = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{
-          pinPanelTitle: "Pin panel",
-        }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <PanelSideContext.Provider value="left">
           <PinToggle />
         </PanelSideContext.Provider>
@@ -51,13 +42,7 @@ describe("PinToggle", () => {
     const dispatch = vi.fn<NineZoneDispatch>();
     const state = createNineZoneState();
     const component = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{
-          unpinPanelTitle: "Unpin panel",
-        }}
-        dispatch={dispatch}
-      >
+      <TestNineZoneProvider defaultState={state} dispatch={dispatch}>
         <PanelSideContext.Provider value="left">
           <PinToggle />
         </PanelSideContext.Provider>

--- a/ui/appui-react/src/test/layout/widget/PopoutToggle.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/PopoutToggle.test.tsx
@@ -19,13 +19,7 @@ describe("PopoutToggle", () => {
     state = addTab(state, "t1");
     state = addPanelWidget(state, "left", "w1", ["t1"]);
     const component = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        dispatch={dispatch}
-        labels={{
-          popoutActiveTab: "Popout",
-        }}
-      >
+      <TestNineZoneProvider defaultState={state} dispatch={dispatch}>
         <WidgetIdContext.Provider value="w1">
           <PopoutToggle />
         </WidgetIdContext.Provider>

--- a/ui/appui-react/src/test/layout/widget/SendBack.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/SendBack.test.tsx
@@ -21,10 +21,7 @@ describe("SendBack", () => {
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
     const component = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{ sendWidgetHomeTitle: "Send back" }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <WidgetIdContext.Provider value="w1">
           <SendBack />
         </WidgetIdContext.Provider>
@@ -39,11 +36,7 @@ describe("SendBack", () => {
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
     const component = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        dispatch={dispatch}
-        labels={{ sendWidgetHomeTitle: "Send back" }}
-      >
+      <TestNineZoneProvider defaultState={state} dispatch={dispatch}>
         <WidgetIdContext.Provider value="w1">
           <SendBack />
         </WidgetIdContext.Provider>
@@ -63,10 +56,7 @@ describe("SendBack", () => {
     state = addTab(state, "t1");
     state = addFloatingWidget(state, "w1", ["t1"]);
     const component = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{ sendWidgetHomeTitle: "Send back" }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <WidgetIdContext.Provider value="w1">
           <SendBack />
         </WidgetIdContext.Provider>

--- a/ui/appui-react/src/test/layout/widget/WidgetActions.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/WidgetActions.test.tsx
@@ -20,10 +20,7 @@ describe("WidgetActions", () => {
     state = addTab(state, "t1", { label: "t1-label" });
     state = addFloatingWidget(state, "fw1", ["t1"]);
     const wrapper = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{ sendWidgetHomeTitle: "Send back" }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <WidgetIdContext.Provider value="fw1">
           <WidgetActions />
         </WidgetIdContext.Provider>
@@ -37,10 +34,7 @@ describe("WidgetActions", () => {
     state = addTab(state, "t1", { label: "t1-label", canPopout: true });
     state = addFloatingWidget(state, "fw1", ["t1"]);
     const wrapper = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{ popoutActiveTab: "Popout" }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <WidgetIdContext.Provider value="fw1">
           <WidgetActions />
         </WidgetIdContext.Provider>
@@ -55,12 +49,7 @@ describe("WidgetActions", () => {
     state = addFloatingWidget(state, "fw1", ["ts"]);
     state = addWidgetToolSettings(state, "ts");
     const wrapper = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{
-          dockToolSettingsTitle: "Dock",
-        }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <WidgetIdContext.Provider value="fw1">
           <WidgetActions />
         </WidgetIdContext.Provider>
@@ -74,10 +63,7 @@ describe("WidgetActions", () => {
     state = addTab(state, "t1", { label: "t1-label", canPopout: false });
     state = addPanelWidget(state, "left", "w1", ["t1"], { activeTabId: "t1" });
     const wrapper = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{ unpinPanelTitle: "Unpin panel" }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
             <WidgetActions />
@@ -93,10 +79,7 @@ describe("WidgetActions", () => {
     state = addTab(state, "t1", { label: "t1-label", canPopout: true });
     state = addPanelWidget(state, "left", "w1", ["t1"], { activeTabId: "t1" });
     const wrapper = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{ popoutActiveTab: "Popout widget" }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
             <WidgetActions />
@@ -112,10 +95,7 @@ describe("WidgetActions", () => {
     state = addTab(state, "t1", { label: "t1-label", canPopout: true });
     state = addPanelWidget(state, "left", "w1", ["t1"], { activeTabId: "t1" });
     const wrapper = render(
-      <TestNineZoneProvider
-        defaultState={state}
-        labels={{ popoutActiveTab: "Popout" }}
-      >
+      <TestNineZoneProvider defaultState={state}>
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
             <WidgetActions />

--- a/ui/appui-react/src/test/layout/widget/WidgetActions.test.tsx
+++ b/ui/appui-react/src/test/layout/widget/WidgetActions.test.tsx
@@ -10,11 +10,11 @@ import { addTab } from "../../../appui-react/layout/state/internal/TabStateHelpe
 import { addWidgetToolSettings } from "../../../appui-react/layout/state/internal/ToolSettingsStateHelpers.js";
 import { addFloatingWidget } from "../../../appui-react/layout/state/internal/WidgetStateHelpers.js";
 import { PanelSideContext } from "../../../appui-react/layout/widget-panels/Panel.js";
-import { TabBarButtons } from "../../../appui-react/layout/widget/Buttons.js";
+import { WidgetActions } from "../../../appui-react/layout/widget/WidgetActions.js";
 import { WidgetIdContext } from "../../../appui-react/layout/widget/Widget.js";
 import { TestNineZoneProvider } from "../Providers.js";
 
-describe("TabBarButtons", () => {
+describe("WidgetActions", () => {
   it("should render SendBack button in a floating widget", () => {
     let state = createNineZoneState();
     state = addTab(state, "t1", { label: "t1-label" });
@@ -25,7 +25,7 @@ describe("TabBarButtons", () => {
         labels={{ sendWidgetHomeTitle: "Send back" }}
       >
         <WidgetIdContext.Provider value="fw1">
-          <TabBarButtons />
+          <WidgetActions />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
@@ -42,7 +42,7 @@ describe("TabBarButtons", () => {
         labels={{ popoutActiveTab: "Popout" }}
       >
         <WidgetIdContext.Provider value="fw1">
-          <TabBarButtons />
+          <WidgetActions />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
@@ -62,7 +62,7 @@ describe("TabBarButtons", () => {
         }}
       >
         <WidgetIdContext.Provider value="fw1">
-          <TabBarButtons />
+          <WidgetActions />
         </WidgetIdContext.Provider>
       </TestNineZoneProvider>
     );
@@ -80,7 +80,7 @@ describe("TabBarButtons", () => {
       >
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
-            <TabBarButtons />
+            <WidgetActions />
           </WidgetIdContext.Provider>
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
@@ -99,7 +99,7 @@ describe("TabBarButtons", () => {
       >
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
-            <TabBarButtons />
+            <WidgetActions />
           </WidgetIdContext.Provider>
         </PanelSideContext.Provider>
       </TestNineZoneProvider>
@@ -118,7 +118,7 @@ describe("TabBarButtons", () => {
       >
         <PanelSideContext.Provider value="left">
           <WidgetIdContext.Provider value="w1">
-            <TabBarButtons />
+            <WidgetActions />
           </WidgetIdContext.Provider>
         </PanelSideContext.Provider>
       </TestNineZoneProvider>


### PR DESCRIPTION
## Changes

This PR adds `widgetActions` prop to `StandardLayout` which when combined with newly exposed `WidgetActions` and `WidgetAction` component allows consumers to add, remove or reorder the default widget actions.
More information and usage examples can be found in `NextVersion.md`

The newly added capability is used in the `widget-api` frontstage of the `test-app` to add an action that restores the frontstage layout.

![Screenshot 2025-03-13 at 17 37 39](https://github.com/user-attachments/assets/fba0e5bf-b85e-4381-a34f-c8a723647e8b)

## Testing

N/A
