### PR TITLE
Update `UiItemsManager` to return items for custom layouts

### DIFF
--- a/apps/test-app/src/frontend/appui/frontstages/SpatialFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/SpatialFrontstage.tsx
@@ -107,24 +107,11 @@ export function createSpatialFrontstageProvider(): UiItemsProvider {
         id: "add-widget",
         content: <div>Widget `add` content</div>,
         label: "Add",
-        layouts: {
-          // TODO: should not be necessary to specify the standard layout.
-          standard: {
-            location: StagePanelLocation.Right,
-            section: StagePanelSection.End,
-          },
-        },
       },
       {
         id: "edit-widget",
         content: <div>Widget `edit` content</div>,
         label: "Edit",
-        layouts: {
-          standard: {
-            location: StagePanelLocation.Right,
-            section: StagePanelSection.End,
-          },
-        },
       },
     ],
   };
@@ -304,12 +291,7 @@ function useWidgets() {
     if (!frontstageDef) {
       return [];
     }
-    return UiItemsManager.getWidgets(
-      frontstageDef.id,
-      frontstageDef.usage,
-      StagePanelLocation.Right,
-      StagePanelSection.End
-    );
+    return UiItemsManager.getWidgets(frontstageDef.id, frontstageDef.usage);
   }, [frontstageDef]);
 }
 

--- a/apps/test-app/src/frontend/appui/frontstages/SpatialFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/SpatialFrontstage.tsx
@@ -13,8 +13,6 @@ import {
   isBackstageStageLauncher,
   isToolbarActionItem,
   ProviderItem,
-  StagePanelLocation,
-  StagePanelSection,
   StageUsage,
   StandardContentLayouts,
   ToolbarItem,

--- a/apps/test-app/src/frontend/appui/frontstages/SpatialFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/SpatialFrontstage.tsx
@@ -20,8 +20,6 @@ import {
   ToolbarItem,
   ToolbarItemLayouts,
   ToolbarItemUtilities,
-  ToolbarOrientation,
-  ToolbarUsage,
   UiFramework,
   UiItemsManager,
   UiItemsProvider,
@@ -86,31 +84,22 @@ export function createSpatialFrontstageProvider(): UiItemsProvider {
         icon: <SvgAdd />,
         label: "Add",
         layouts: {
-          // TODO: should not be necessary to specify the standard layout.
-          standard: {
-            usage: ToolbarUsage.ContentManipulation,
-            orientation: ToolbarOrientation.Vertical,
-          },
-          ...createSpatialToolbarItemLayouts({
+          spatial: {
             widgetId: "add-widget",
             location: "content-manipulation",
-          }),
-        },
+          },
+        } satisfies SpatialToolbarItemLayouts,
       }),
       ToolbarItemUtilities.createActionItem({
         id: "edit-tool",
         icon: <SvgEdit />,
         label: "Edit",
         layouts: {
-          standard: {
-            usage: ToolbarUsage.ContentManipulation,
-            orientation: ToolbarOrientation.Vertical,
-          },
-          ...createSpatialToolbarItemLayouts({
+          spatial: {
             widgetId: "edit-widget",
             location: "content-manipulation",
-          }),
-        },
+          },
+        } satisfies SpatialToolbarItemLayouts,
       }),
     ],
     getWidgets: () => [
@@ -149,19 +138,11 @@ interface SpatialLayoutToolbarItem {
   readonly location: "content-manipulation";
 }
 
-interface SpatialToolbarItemLayouts extends ToolbarItemLayouts {
+type SpatialToolbarItemLayouts<
+  T extends ToolbarItemLayouts = ToolbarItemLayouts
+> = T & {
   readonly spatial: SpatialLayoutToolbarItem;
-}
-
-function createSpatialToolbarItemLayouts(
-  args: SpatialLayoutToolbarItem
-): SpatialToolbarItemLayouts {
-  return {
-    spatial: {
-      ...args,
-    },
-  };
-}
+};
 
 type SpatialToolbarItem<T extends ToolbarItem> = T & {
   readonly layouts: SpatialToolbarItemLayouts;
@@ -310,11 +291,9 @@ function useToolbarItems() {
     if (!frontstageDef) {
       return [];
     }
-    return UiItemsManager.getToolbarButtonItems(
+    return UiItemsManager.getToolbarItems(
       frontstageDef.id,
-      frontstageDef.usage,
-      ToolbarUsage.ContentManipulation,
-      ToolbarOrientation.Vertical
+      frontstageDef.usage
     );
   }, [frontstageDef]);
 }

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4758,6 +4758,7 @@ export type ToolbarItem = ToolbarActionItem | ToolbarGroupItem | ToolbarCustomIt
 
 // @public
 export interface ToolbarItemLayouts {
+    readonly [layout: string]: unknown;
     readonly standard?: StandardLayoutToolbarItem;
 }
 
@@ -5193,7 +5194,9 @@ export class UiItemsManager {
     static getBackstageItems(): ReadonlyArray<ProviderItem<BackstageItem>>;
     static getStatusBarItems(stageId: string, stageUsage: string): ReadonlyArray<ProviderItem<StatusBarItem>>;
     static getToolbarButtonItems(stageId: string, stageUsage: string, usage: ToolbarUsage, orientation: ToolbarOrientation): ReadonlyArray<ProviderItem<ToolbarItem>>;
+    static getToolbarItems(stageId: string, stageUsage: string): ReadonlyArray<ProviderItem<ToolbarItem>>;
     static getUiItemsProvider(providerId: string): UiItemsProvider | undefined;
+    static getWidgets(stageId: string, stageUsage: string): ReadonlyArray<ProviderItem<Widget>>;
     static getWidgets(stageId: string, stageUsage: string, location: StagePanelLocation, section?: StagePanelSection): ReadonlyArray<ProviderItem<Widget>>;
     static get hasRegisteredProviders(): boolean;
     static get onUiProviderRegisteredEvent(): BeUiEvent<UiItemsProviderRegisteredEventArgs>;
@@ -5699,6 +5702,7 @@ export class WidgetHost {
 
 // @public
 export interface WidgetLayouts {
+    readonly [layout: string]: unknown;
     readonly standard?: StandardLayoutWidget;
 }
 

--- a/common/changes/@itwin/appui-react/layouts-ui-items-manager_2025-03-14-14-42.json
+++ b/common/changes/@itwin/appui-react/layouts-ui-items-manager_2025-03-14-14-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add additional methods to UiItemsManager that return items for custom layouts.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -663,12 +663,12 @@ export class UiFramework {
     return useGlobalStore.getState().viewState;
   }
 
-  /** @deprecated in 4.17.0. Use {@link @itwin/UiFramework.visibility.isUiVisible} instead. */
+  /** @deprecated in 4.17.0. Use {@link UiFramework.visibility.isUiVisible} instead. */
   public static getIsUiVisible() {
     return UiFramework.visibility.isUiVisible;
   }
 
-  /** @deprecated in 4.17.0. Use {@link @itwin/UiFramework.visibility.isUiVisible} instead. */
+  /** @deprecated in 4.17.0. Use {@link UiFramework.visibility.isUiVisible} instead. */
   public static setIsUiVisible(visible: boolean) {
     UiFramework.visibility.isUiVisible = visible;
   }

--- a/ui/appui-react/src/appui-react/UiFramework.ts
+++ b/ui/appui-react/src/appui-react/UiFramework.ts
@@ -663,12 +663,12 @@ export class UiFramework {
     return useGlobalStore.getState().viewState;
   }
 
-  /** @deprecated in 4.17.0. Use {@link UiFramework.visibility.isUiVisible} instead. */
+  /** @deprecated in 4.17.0. Use `isUiVisible` of {@link UiFramework.visibility} instead. */
   public static getIsUiVisible() {
     return UiFramework.visibility.isUiVisible;
   }
 
-  /** @deprecated in 4.17.0. Use {@link UiFramework.visibility.isUiVisible} instead. */
+  /** @deprecated in 4.17.0. Use `isUiVisible` of {@link UiFramework.visibility} instead. */
   public static setIsUiVisible(visible: boolean) {
     UiFramework.visibility.isUiVisible = visible;
   }

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
@@ -162,6 +162,10 @@ export function isToolbarCustomItem(
 export interface ToolbarItemLayouts {
   /** Toolbar item configuration in a standard layout. */
   readonly standard?: StandardLayoutToolbarItem;
+  /** Allow additional layout specific configurations.
+   * @note Use unique keys to avoid conflicts.
+   */
+  readonly [layout: string]: unknown;
 }
 
 /** Describes toolbar item configuration specific to a standard layout.

--- a/ui/appui-react/src/appui-react/ui-items-provider/AbstractUiItemsManager.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/AbstractUiItemsManager.ts
@@ -78,7 +78,6 @@ export function createAbstractUiItemsManagerAdapter() {
 
 type Target = Pick<
   typeof UiItemsManager,
-  | "getWidgets"
   | "getToolbarButtonItems"
   | "getStatusBarItems"
   | "getBackstageItems"

--- a/ui/appui-react/src/appui-react/ui-items-provider/UiItemsManager.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/UiItemsManager.ts
@@ -159,24 +159,20 @@ export class UiItemsManager {
       return;
     }
 
-    if (this._abstractAdapter) {
-      // Using the same structure to support layout agnostic methods i.e. `getToolbarItems`.
-      UiItemsManager._registeredUiItemsProviders.set(providerId, {
-        provider: uiProvider,
-        overrides,
-      });
-      return this._abstractAdapter.register(uiProvider, overrides);
-    }
-
+    // Using the same structure to support layout agnostic methods i.e. `getToolbarItems`.
     UiItemsManager._registeredUiItemsProviders.set(providerId, {
       provider: uiProvider,
       overrides,
     });
+
+    if (this._abstractAdapter) {
+      return this._abstractAdapter.register(uiProvider, overrides);
+    }
+
     Logger.logInfo(
       UiFramework.loggerCategory("UiItemsManager"),
       `UiItemsProvider '${uiProvider.id}' registered as '${providerId}'`
     );
-
     UiItemsManager.sendRegisteredEvent({ providerId });
   }
 

--- a/ui/appui-react/src/appui-react/ui-items-provider/UiItemsManager.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/UiItemsManager.ts
@@ -91,7 +91,9 @@ export class UiItemsManager {
   /** For use in unit testing
    * @internal */
   public static clearAllProviders() {
-    if (this._abstractAdapter) return this._abstractAdapter.clearAllProviders();
+    if (this._abstractAdapter) {
+      this._abstractAdapter.clearAllProviders();
+    }
 
     UiItemsManager._registeredUiItemsProviders.clear();
   }
@@ -180,18 +182,19 @@ export class UiItemsManager {
 
   /** Unregisters a specific {@link UiItemsProvider}. */
   public static unregister(providerId: string): void {
-    if (this._abstractAdapter)
-      return this._abstractAdapter.unregister(providerId);
-
     const provider = UiItemsManager.getUiItemsProvider(providerId);
     if (!provider) return;
 
-    provider.onUnregister && provider.onUnregister();
-
     UiItemsManager._registeredUiItemsProviders.delete(providerId);
+    if (this._abstractAdapter) {
+      this._abstractAdapter.unregister(providerId);
+    }
+
+    provider.onUnregister?.();
+
     Logger.logInfo(
       UiFramework.loggerCategory("UiItemsManager"),
-      `UiItemsProvider (${providerId}) unloaded`
+      `UiItemsProvider '${providerId}' unregistered`
     );
 
     // trigger a refresh of the ui

--- a/ui/appui-react/src/appui-react/ui-items-provider/UiItemsManager.ts
+++ b/ui/appui-react/src/appui-react/ui-items-provider/UiItemsManager.ts
@@ -286,10 +286,9 @@ export class UiItemsManager {
     return getUniqueItems(items);
   }
 
-  /** Called when the application is populating the statusbar so that any registered UiItemsProvider can add status fields
-   * @param stageId a string identifier of the active stage.
-   * @param stageUsage the StageUsage of the active stage.
-   * @returns An array of CommonStatusBarItem that will be used to create controls for the status bar.
+  /** Returns registered status bar items that match the specified frontstage id and usage.
+   * @note Items registered in `UiItemsManager` of `@itwin/appui-abstract` are returned by this method.
+   * @note Items returned by {@link UiItemsProvider.provideStatusBarItems} are returned by this method.
    */
   public static getStatusBarItems(
     stageId: string,
@@ -319,8 +318,9 @@ export class UiItemsManager {
     return getUniqueItems(items);
   }
 
-  /** Called when the application is populating the statusbar so that any registered UiItemsProvider can add status fields
-   * @returns An array of BackstageItem that will be used to create controls for the backstage menu.
+  /** Returns registered backstage items.
+   * @note Items registered in `UiItemsManager` of `@itwin/appui-abstract` are returned by this method.
+   * @note Items returned by {@link UiItemsProvider.provideBackstageItems} are returned by this method.
    */
   public static getBackstageItems(): ReadonlyArray<
     ProviderItem<BackstageItem>

--- a/ui/appui-react/src/appui-react/widgets/Widget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/Widget.tsx
@@ -86,6 +86,10 @@ export interface Widget {
 export interface WidgetLayouts {
   /** Widget configuration in a standard layout. */
   readonly standard?: StandardLayoutWidget;
+  /** Allow additional layout specific configurations.
+   * @note Use unique keys to avoid conflicts.
+   */
+  readonly [layout: string]: unknown;
 }
 
 /** Describes widget configuration specific to a standard layout.

--- a/ui/appui-react/src/test/ui-items-provider/UiItemsManager.test.tsx
+++ b/ui/appui-react/src/test/ui-items-provider/UiItemsManager.test.tsx
@@ -24,9 +24,9 @@ import {
   UiItemsManager,
 } from "../../appui-react.js";
 
-// @ts-ignore Removed in 4.0
+// @ts-ignore Removed in 5.0. Used to validate use-cases where AppUI is used with @itwin/appui-abstract@4.x
 const AbstractUiItemsManager = abstract.UiItemsManager;
-// @ts-ignore Removed in 4.0
+// @ts-ignore Removed in 5.0
 const AbstractStagePanelLocation = abstract.StagePanelLocation;
 
 function createStatusBarItem(id: string) {
@@ -65,7 +65,7 @@ function createWidget(id: string, overrides?: Partial<Widget>) {
 function describeAbstractAdapter(title: string, fn: () => void) {
   for (const useAbstractAdapter of [true, false]) {
     describe(`${title}${
-      useAbstractAdapter ? " (with abstract adapter)" : ""
+      useAbstractAdapter ? " (abstract adapter)" : ""
     }`, () => {
       beforeEach(() => {
         UiItemsManager.useAbstractAdapter(useAbstractAdapter);
@@ -86,783 +86,252 @@ describe("UiItemsManager", () => {
     UiItemsManager.clearAllProviders();
   });
 
-  it("should register a provider", () => {
-    UiItemsManager.register({
-      id: "provider1",
-    });
-
-    const provider = UiItemsManager.getUiItemsProvider("provider1");
-    expect(provider?.id).toEqual("provider1");
-  });
-
-  it("should provide status bar items", () => {
-    UiItemsManager.register({
-      id: "provider1",
-      provideStatusBarItems: () => [
-        StatusBarItemUtilities.createActionItem(
-          "s1",
-          StatusBarSection.Center,
-          0,
-          "",
-          "",
-          () => {}
-        ),
-      ],
-    });
-
-    const items = UiItemsManager.getStatusBarItems(
-      "stage1",
-      StageUsage.General
-    );
-    expect(items).toEqual([
-      expect.objectContaining({
-        id: "s1",
-      }),
-    ]);
-  });
-
-  it("should provide backstage items", () => {
-    UiItemsManager.register({
-      id: "provider1",
-      provideBackstageItems: () => [
-        BackstageItemUtilities.createActionItem(
-          "b1",
-          0,
-          0,
-          () => {},
-          "b1-label"
-        ),
-        BackstageItemUtilities.createStageLauncher("b2", 0, 0, "b2-label"),
-      ],
-    });
-
-    const items = UiItemsManager.getBackstageItems();
-    expect(items).toEqual([
-      expect.objectContaining({
-        id: "b1",
-      }),
-      expect.objectContaining({
-        id: "b2",
-      }),
-    ]);
-  });
-
-  it("should provide toolbar items", () => {
-    UiItemsManager.register({
-      id: "provider1",
-      provideToolbarItems: () => [{ id: "t1", itemPriority: 0 }],
-    });
-
-    const items = UiItemsManager.getToolbarButtonItems(
-      "stage1",
-      StageUsage.General,
-      ToolbarUsage.ViewNavigation,
-      ToolbarOrientation.Horizontal
-    );
-    expect(items).toEqual([
-      expect.objectContaining({
-        id: "t1",
-      }),
-    ]);
-  });
-
-  it("should provide widgets", () => {
-    UiItemsManager.register({
-      id: "provider1",
-      provideWidgets: () => [{ id: "w1" }],
-    });
-
-    const widgets = UiItemsManager.getWidgets(
-      "stage1",
-      StageUsage.General,
-      StagePanelLocation.Left
-    );
-    expect(widgets).toEqual([
-      expect.objectContaining({
-        id: "w1",
-      }),
-    ]);
-  });
-
-  // Validate use-case where appui-react@4.0 is used with appui-abstract@3.7
-  describe("AbstractUiItemsManager", () => {
-    if (!AbstractUiItemsManager) return;
-
+  describe("register", () => {
     it("should register a provider", () => {
       UiItemsManager.register({
         id: "provider1",
       });
-      AbstractUiItemsManager.register({
-        id: "provider2",
-      });
 
-      {
-        const provider1 = UiItemsManager.getUiItemsProvider("provider1");
-        const provider2 = UiItemsManager.getUiItemsProvider("provider2");
-        expect(provider1?.id).toEqual("provider1");
-        expect(provider2?.id).toEqual("provider2");
-      }
-      {
-        const provider1 =
-          AbstractUiItemsManager.getUiItemsProvider("provider1");
-        const provider2 =
-          AbstractUiItemsManager.getUiItemsProvider("provider2");
-        expect(provider1?.id).toEqual("provider1");
-        expect(provider2?.id).toEqual("provider2");
-      }
+      const provider = UiItemsManager.getUiItemsProvider("provider1");
+      expect(provider?.id).toEqual("provider1");
     });
 
-    it("should un-register a provider", () => {
-      UiItemsManager.register({
-        id: "provider1",
+    describe("AbstractUiItemsManager", () => {
+      it("should register a provider", () => {
+        if (!AbstractUiItemsManager) return;
+
+        UiItemsManager.register({
+          id: "provider1",
+        });
+        AbstractUiItemsManager.register({
+          id: "provider2",
+        });
+
+        {
+          const provider1 = UiItemsManager.getUiItemsProvider("provider1");
+          const provider2 = UiItemsManager.getUiItemsProvider("provider2");
+          expect(provider1?.id).toEqual("provider1");
+          expect(provider2?.id).toEqual("provider2");
+        }
+        {
+          const provider1 =
+            AbstractUiItemsManager.getUiItemsProvider("provider1");
+          const provider2 =
+            AbstractUiItemsManager.getUiItemsProvider("provider2");
+          expect(provider1?.id).toEqual("provider1");
+          expect(provider2?.id).toEqual("provider2");
+        }
       });
-      AbstractUiItemsManager.register({
-        id: "provider2",
-      });
-
-      expect(UiItemsManager.registeredProviderIds).toEqual([
-        "provider1",
-        "provider2",
-      ]);
-      expect(AbstractUiItemsManager.registeredProviderIds).toEqual([
-        "provider1",
-        "provider2",
-      ]);
-
-      UiItemsManager.unregister("provider2");
-      AbstractUiItemsManager.unregister("provider1");
-
-      expect(UiItemsManager.registeredProviderIds).toEqual([]);
-      expect(AbstractUiItemsManager.registeredProviderIds).toEqual([]);
-    });
-
-    it("should emit events", () => {
-      const spy = vi.fn();
-      const abstractSpy = vi.fn();
-      UiItemsManager.onUiProviderRegisteredEvent.addListener(spy);
-      AbstractUiItemsManager.onUiProviderRegisteredEvent.addListener(
-        abstractSpy
-      );
-
-      UiItemsManager.register({
-        id: "provider1",
-      });
-      AbstractUiItemsManager.register({
-        id: "provider2",
-      });
-
-      expect(spy).toHaveBeenCalledTimes(2);
-      expect(abstractSpy).toHaveBeenCalledTimes(2);
-    });
-
-    it("should provide status bar items", () => {
-      const execute2 = vi.fn();
-      const execute4 = vi.fn();
-      UiItemsManager.register({
-        id: "provider1",
-        provideStatusBarItems: () => [
-          StatusBarItemUtilities.createCustomItem(
-            "s1",
-            StatusBarSection.Left,
-            0,
-            <div className="s1-content" />,
-            {
-              badge: abstract.BadgeType.New,
-            }
-          ),
-          StatusBarItemUtilities.createActionItem(
-            "s2",
-            StatusBarSection.Center,
-            0,
-            "",
-            "s2-tooltip",
-            execute2,
-            {
-              icon: <div className="s2-icon" />,
-              badgeKind: "new",
-            }
-          ),
-        ],
-      });
-      AbstractUiItemsManager.register({
-        id: "provider2",
-        provideStatusBarItems: () => {
-          const internalData = new Map();
-          const icon = IconHelper.getIconData(
-            <div className="s4-icon" />,
-            internalData
-          );
-          return [
-            {
-              id: "s3",
-              itemPriority: 0,
-              section: StatusBarSection.Right,
-              isCustom: true,
-              reactNode: <div className="s3-content" />,
-            },
-            {
-              id: "s4",
-              itemPriority: 0,
-              section: StatusBarSection.Right,
-              execute: execute4,
-              icon,
-              internalData,
-              badgeType: abstract.BadgeType.TechnicalPreview,
-            },
-          ];
-        },
-      });
-
-      {
-        const items = UiItemsManager.getStatusBarItems(
-          "stage1",
-          StageUsage.General
-        );
-        expect(items[0]).toEqual(
-          expect.objectContaining({
-            id: "s1",
-            section: StatusBarSection.Left,
-            badge: abstract.BadgeType.New,
-            content: expect.objectContaining({
-              props: {
-                className: "s1-content",
-              },
-            }),
-          })
-        );
-        expect(items[1]).toEqual(
-          expect.objectContaining({
-            id: "s2",
-            section: StatusBarSection.Center,
-            execute: execute2,
-            badgeKind: "new",
-            icon: expect.objectContaining({
-              props: {
-                className: "s2-icon",
-              },
-            }),
-          })
-        );
-        expect(items[2]).toEqual(
-          expect.objectContaining({
-            id: "s3",
-            section: StatusBarSection.Right,
-            content: expect.objectContaining({
-              props: {
-                className: "s3-content",
-              },
-            }),
-          })
-        );
-        expect(items[3]).toEqual(
-          expect.objectContaining({
-            id: "s4",
-            section: StatusBarSection.Right,
-            badge: abstract.BadgeType.TechnicalPreview,
-            execute: execute4,
-            icon: expect.objectContaining({
-              props: {
-                className: "s4-icon",
-              },
-            }),
-          })
-        );
-      }
-      {
-        const items = AbstractUiItemsManager.getStatusBarItems(
-          "stage1",
-          StageUsage.General
-        );
-        expect(items[0]).toEqual(
-          expect.objectContaining({
-            id: "s1",
-            section: StatusBarSection.Left,
-            badgeType: abstract.BadgeType.New,
-            reactNode: expect.objectContaining({
-              props: {
-                className: "s1-content",
-              },
-            }),
-          })
-        );
-        const s2 = items[1];
-        // @ts-ignore Possibly 'any'
-        assert(!!abstract.isAbstractStatusBarActionItem(s2));
-        expect(s2).toEqual(
-          expect.objectContaining({
-            id: "s2",
-            section: StatusBarSection.Center,
-            execute: execute2,
-            badgeType: abstract.BadgeType.New,
-          })
-        );
-        expect(
-          IconHelper.getIconReactNode(s2.icon, s2.internalData)
-        ).toHaveProperty("props.iconSpec.props.className", "s2-icon");
-        expect(items[2]).toEqual(
-          expect.objectContaining({
-            id: "s3",
-            section: StatusBarSection.Right,
-            reactNode: expect.objectContaining({
-              props: {
-                className: "s3-content",
-              },
-            }),
-          })
-        );
-        const s4 = items[3];
-        // @ts-ignore Possibly 'any'
-        assert(!!abstract.isAbstractStatusBarActionItem(s4));
-        expect(s4).toEqual(
-          expect.objectContaining({
-            id: "s4",
-            section: StatusBarSection.Right,
-            badgeType: abstract.BadgeType.TechnicalPreview,
-            execute: execute4,
-          })
-        );
-        expect(
-          IconHelper.getIconReactNode(s4.icon, s4.internalData)
-        ).toHaveProperty("props.iconSpec.props.className", "s4-icon");
-      }
-    });
-
-    it("should provide backstage items", () => {
-      const execute = vi.fn();
-      UiItemsManager.register({
-        id: "provider1",
-        provideBackstageItems: () => [
-          BackstageItemUtilities.createActionItem(
-            "b1",
-            0,
-            0,
-            execute,
-            "b1-label",
-            undefined,
-            undefined,
-            {
-              icon: <div className="b1-icon" />,
-              badge: abstract.BadgeType.New,
-            }
-          ),
-          BackstageItemUtilities.createStageLauncher(
-            "b2",
-            0,
-            0,
-            "b2-label",
-            undefined,
-            undefined,
-            { badgeKind: "technical-preview" }
-          ),
-        ],
-      });
-      AbstractUiItemsManager.register({
-        id: "provider2",
-        provideBackstageItems: () => {
-          const internalData = new Map();
-          const icon = IconHelper.getIconData(
-            <div className="b4-icon" />,
-            internalData
-          );
-          return [
-            // @ts-ignore Possibly 'any'
-            abstract.BackstageItemUtilities.createActionItem(
-              "b3",
-              0,
-              0,
-              execute,
-              "b3-label"
-            ),
-            // @ts-ignore Possibly 'any'
-            abstract.BackstageItemUtilities.createStageLauncher(
-              "b4",
-              0,
-              0,
-              "b4-label",
-              undefined,
-              undefined,
-              {
-                icon,
-                internalData,
-                badgeType: abstract.BadgeType.TechnicalPreview,
-              }
-            ),
-          ];
-        },
-      });
-
-      {
-        const items = UiItemsManager.getBackstageItems();
-        expect(items[0]).toEqual(
-          expect.objectContaining({
-            id: "b1",
-            label: "b1-label",
-            execute,
-            badge: abstract.BadgeType.New,
-          })
-        );
-        expect(items[1]).toEqual(
-          expect.objectContaining({
-            id: "b2",
-            stageId: "b2",
-            badgeKind: "technical-preview",
-          })
-        );
-        expect(items[2]).toEqual(
-          expect.objectContaining({
-            id: "b3",
-            label: "b3-label",
-          })
-        );
-        expect(items[3]).toEqual(
-          expect.objectContaining({
-            id: "b4",
-            badge: abstract.BadgeType.TechnicalPreview,
-            icon: expect.objectContaining({
-              props: {
-                className: "b4-icon",
-              },
-            }),
-          })
-        );
-      }
-      {
-        const items = AbstractUiItemsManager.getBackstageItems();
-        expect(items[0]).toEqual(
-          expect.objectContaining({
-            id: "b1",
-            label: "b1-label",
-            execute,
-            badgeType: abstract.BadgeType.New,
-          })
-        );
-        expect(
-          IconHelper.getIconReactNode(items[0].icon, items[0].internalData)
-        ).toHaveProperty("props.iconSpec.props.className", "b1-icon");
-        expect(items[1]).toEqual(
-          expect.objectContaining({
-            id: "b2",
-            stageId: "b2",
-            badgeType: abstract.BadgeType.TechnicalPreview,
-          })
-        );
-        expect(items[2]).toEqual(
-          expect.objectContaining({
-            id: "b3",
-            label: "b3-label",
-          })
-        );
-        expect(items[3]).toEqual(
-          expect.objectContaining({
-            id: "b4",
-            badgeType: abstract.BadgeType.TechnicalPreview,
-          })
-        );
-        expect(
-          IconHelper.getIconReactNode(items[3].icon, items[3].internalData)
-        ).toHaveProperty("props.iconSpec.props.className", "b4-icon");
-      }
-    });
-
-    it("should provide toolbar items", () => {
-      const execute1 = vi.fn();
-      const execute3 = vi.fn();
-      UiItemsManager.register({
-        id: "provider1",
-        provideToolbarItems: () => [
-          ToolbarItemUtilities.createActionItem(
-            "t1",
-            0,
-            <div className="t1-icon" />,
-            "t1-label",
-            execute1,
-            {
-              badge: abstract.BadgeType.New,
-              parentGroupItemId: "p1",
-            }
-          ),
-        ],
-      });
-      AbstractUiItemsManager.register({
-        id: "provider2",
-        provideToolbarButtonItems: () => {
-          const internalData = new Map();
-          const icon = IconHelper.getIconData(
-            <div className="t3-icon" />,
-            internalData
-          );
-          return [
-            {
-              id: "t2",
-              itemPriority: 0,
-              isCustom: true,
-              badgeType: abstract.BadgeType.TechnicalPreview,
-            },
-            {
-              id: "t3",
-              itemPriority: 0,
-              execute: execute3,
-              label: "t3-label",
-              icon,
-              internalData,
-              parentToolGroupId: "p2",
-            },
-          ];
-        },
-      });
-
-      {
-        const items = UiItemsManager.getToolbarButtonItems(
-          "stage1",
-          StageUsage.General,
-          ToolbarUsage.ViewNavigation,
-          ToolbarOrientation.Horizontal
-        );
-        expect(items[0]).toEqual(
-          expect.objectContaining({
-            id: "t1",
-            badge: abstract.BadgeType.New,
-            label: "t1-label",
-            execute: execute1,
-            parentGroupItemId: "p1",
-            icon: expect.objectContaining({
-              props: {
-                className: "t1-icon",
-              },
-            }),
-          })
-        );
-        expect(items[1]).toEqual(
-          expect.objectContaining({
-            id: "t2",
-            badge: abstract.BadgeType.TechnicalPreview,
-          })
-        );
-        expect(items[2]).toEqual(
-          expect.objectContaining({
-            id: "t3",
-            execute: execute3,
-            parentGroupItemId: "p2",
-            label: "t3-label",
-            icon: expect.objectContaining({
-              props: {
-                className: "t3-icon",
-              },
-            }),
-          })
-        );
-      }
-      {
-        const items = AbstractUiItemsManager.getToolbarButtonItems(
-          "stage1",
-          StageUsage.General,
-          ToolbarUsage.ViewNavigation,
-          ToolbarOrientation.Horizontal
-        );
-        expect(items[0]).toEqual(
-          expect.objectContaining({
-            id: "t1",
-            badgeType: abstract.BadgeType.New,
-            label: "t1-label",
-            execute: execute1,
-            parentToolGroupId: "p1",
-          })
-        );
-        expect(
-          IconHelper.getIconReactNode(items[0].icon, items[0].internalData)
-        ).toHaveProperty("props.iconSpec.props.className", "t1-icon");
-        expect(items[1]).toEqual(
-          expect.objectContaining({
-            id: "t2",
-            badgeType: abstract.BadgeType.TechnicalPreview,
-          })
-        );
-        expect(items[2]).toEqual(
-          expect.objectContaining({
-            id: "t3",
-            execute: execute3,
-            parentToolGroupId: "p2",
-            label: "t3-label",
-          })
-        );
-        expect(
-          IconHelper.getIconReactNode(items[2].icon, items[2].internalData)
-        ).toHaveProperty("props.iconSpec.props.className", "t3-icon");
-      }
-    });
-
-    it("should provide widgets", () => {
-      UiItemsManager.register({
-        id: "provider1",
-        provideWidgets: () => [
-          {
-            id: "w1",
-            allowedPanels: [StagePanelLocation.Left],
-            badge: abstract.BadgeType.New,
-            canFloat: {
-              isResizable: true,
-            },
-            icon: <div className="w1-icon" />,
-            content: <div className="w1-content" />,
-            badgeKind: "deprecated",
-          },
-        ],
-      });
-      AbstractUiItemsManager.register({
-        id: "provider2",
-        provideWidgets: () => {
-          const internalData = new Map();
-          const icon = IconHelper.getIconData(
-            <div className="w2-icon" />,
-            internalData
-          );
-          return [
-            {
-              id: "w2",
-              allowedPanelTargets: ["right"],
-              badgeType: abstract.BadgeType.TechnicalPreview,
-              isFloatingStateWindowResizable: true,
-              canFloat: true,
-              icon,
-              internalData,
-              getWidgetContent: () => <div className="w2-content" />,
-            },
-          ];
-        },
-      });
-      {
-        const widgets = UiItemsManager.getWidgets(
-          "stage1",
-          StageUsage.General,
-          StagePanelLocation.Left
-        );
-        expect(widgets[0]).toEqual(
-          expect.objectContaining({
-            id: "w1",
-            badge: abstract.BadgeType.New,
-            allowedPanels: [StagePanelLocation.Left],
-            content: expect.objectContaining({
-              props: {
-                className: "w1-content",
-              },
-            }),
-            icon: expect.objectContaining({
-              props: {
-                className: "w1-icon",
-              },
-            }),
-            badgeKind: "deprecated",
-          })
-        );
-        expect(widgets[1]).toEqual(
-          expect.objectContaining({
-            id: "w2",
-            badge: abstract.BadgeType.TechnicalPreview,
-            allowedPanels: [StagePanelLocation.Right],
-            content: expect.objectContaining({
-              props: {
-                className: "w2-content",
-              },
-            }),
-            icon: expect.objectContaining({
-              props: {
-                className: "w2-icon",
-              },
-            }),
-          })
-        );
-      }
-      {
-        const widgets = AbstractUiItemsManager.getWidgets(
-          "stage1",
-          StageUsage.General,
-          AbstractStagePanelLocation.Left
-        );
-        expect(widgets[0]).toEqual(
-          expect.objectContaining({
-            id: "w1",
-            badgeType: abstract.BadgeType.New,
-            allowedPanelTargets: ["left"],
-          })
-        );
-        expect(widgets[0].getWidgetContent()).toHaveProperty(
-          "props.className",
-          "w1-content"
-        );
-        expect(
-          IconHelper.getIconReactNode(widgets[0].icon, widgets[0].internalData)
-        ).toHaveProperty("props.iconSpec.props.className", "w1-icon");
-        expect(widgets[1]).toEqual(
-          expect.objectContaining({
-            id: "w2",
-            badgeType: abstract.BadgeType.TechnicalPreview,
-            allowedPanelTargets: ["right"],
-          })
-        );
-        expect(widgets[1].getWidgetContent()).toHaveProperty(
-          "props.className",
-          "w2-content"
-        );
-        expect(
-          IconHelper.getIconReactNode(widgets[1].icon, widgets[1].internalData)
-        ).toHaveProperty("props.iconSpec.props.className", "w2-icon");
-      }
-    });
-
-    it("should provide TopMost widgets", () => {
-      AbstractUiItemsManager.register({
-        id: "provider1",
-        // @ts-ignore Possibly 'any'
-        provideWidgets: (_stageId, _stageUsage, location) => {
-          if (location === AbstractStagePanelLocation.Top) {
-            return [
-              {
-                id: "w1",
-                getWidgetContent: () => null,
-              },
-            ];
-          }
-          if (location === AbstractStagePanelLocation.TopMost) {
-            return [
-              {
-                id: "w2",
-                getWidgetContent: () => null,
-              },
-            ];
-          }
-          return [];
-        },
-      });
-      {
-        const widgets = UiItemsManager.getWidgets(
-          "stage1",
-          StageUsage.General,
-          StagePanelLocation.Top
-        );
-        expect(widgets).toEqual([
-          expect.objectContaining({ id: "w1" }),
-          expect.objectContaining({ id: "w2" }),
-        ]);
-      }
-      {
-        const widgets = AbstractUiItemsManager.getWidgets(
-          "stage1",
-          StageUsage.General,
-          AbstractStagePanelLocation.Top
-        );
-        expect(widgets).toEqual([expect.objectContaining({ id: "w1" })]);
-        const topMostWidgets = AbstractUiItemsManager.getWidgets(
-          "stage1",
-          StageUsage.General,
-          AbstractStagePanelLocation.TopMost
-        );
-        expect(topMostWidgets).toEqual([expect.objectContaining({ id: "w2" })]);
-      }
     });
   });
 
-  describe("UiItemsProvider v2", () => {
-    describeAbstractAdapter("toolbar items", () => {
+  describe("unregister", () => {
+    describe("AbstractUiItemsManager", () => {
+      if (!AbstractUiItemsManager) return;
+
+      it("should un-register a provider", () => {
+        UiItemsManager.register({
+          id: "provider1",
+        });
+        AbstractUiItemsManager.register({
+          id: "provider2",
+        });
+
+        expect(UiItemsManager.registeredProviderIds).toEqual([
+          "provider1",
+          "provider2",
+        ]);
+        expect(AbstractUiItemsManager.registeredProviderIds).toEqual([
+          "provider1",
+          "provider2",
+        ]);
+
+        UiItemsManager.unregister("provider2");
+        AbstractUiItemsManager.unregister("provider1");
+
+        expect(UiItemsManager.registeredProviderIds).toEqual([]);
+        expect(AbstractUiItemsManager.registeredProviderIds).toEqual([]);
+      });
+    });
+  });
+
+  describe("onUiProviderRegisteredEvent", () => {
+    describe("AbstractUiItemsManager", () => {
+      if (!AbstractUiItemsManager) return;
+
+      it("should emit events", () => {
+        const spy = vi.fn();
+        const abstractSpy = vi.fn();
+        UiItemsManager.onUiProviderRegisteredEvent.addListener(spy);
+        AbstractUiItemsManager.onUiProviderRegisteredEvent.addListener(
+          abstractSpy
+        );
+
+        UiItemsManager.register({
+          id: "provider1",
+        });
+        AbstractUiItemsManager.register({
+          id: "provider2",
+        });
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(abstractSpy).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe("getToolbarButtonItems", () => {
+    it("should return items of UiItemsProvider.provideToolbarItems", () => {
+      UiItemsManager.register({
+        id: "provider1",
+        provideToolbarItems: () => [{ id: "t1", itemPriority: 0 }],
+      });
+
+      const items = UiItemsManager.getToolbarButtonItems(
+        "stage1",
+        StageUsage.General,
+        ToolbarUsage.ViewNavigation,
+        ToolbarOrientation.Horizontal
+      );
+      expect(items).toEqual([
+        expect.objectContaining({
+          id: "t1",
+        }),
+      ]);
+    });
+
+    describe("AbstractUiItemsManager", () => {
+      if (!AbstractUiItemsManager) return;
+
+      it("should provide toolbar items", () => {
+        const execute1 = vi.fn();
+        const execute3 = vi.fn();
+        UiItemsManager.register({
+          id: "provider1",
+          provideToolbarItems: () => [
+            ToolbarItemUtilities.createActionItem(
+              "t1",
+              0,
+              <div className="t1-icon" />,
+              "t1-label",
+              execute1,
+              {
+                badge: abstract.BadgeType.New,
+                parentGroupItemId: "p1",
+              }
+            ),
+          ],
+        });
+        AbstractUiItemsManager.register({
+          id: "provider2",
+          provideToolbarButtonItems: () => {
+            const internalData = new Map();
+            const icon = IconHelper.getIconData(
+              <div className="t3-icon" />,
+              internalData
+            );
+            return [
+              {
+                id: "t2",
+                itemPriority: 0,
+                isCustom: true,
+                badgeType: abstract.BadgeType.TechnicalPreview,
+              },
+              {
+                id: "t3",
+                itemPriority: 0,
+                execute: execute3,
+                label: "t3-label",
+                icon,
+                internalData,
+                parentToolGroupId: "p2",
+              },
+            ];
+          },
+        });
+
+        {
+          const items = UiItemsManager.getToolbarButtonItems(
+            "stage1",
+            StageUsage.General,
+            ToolbarUsage.ViewNavigation,
+            ToolbarOrientation.Horizontal
+          );
+          expect(items[0]).toEqual(
+            expect.objectContaining({
+              id: "t1",
+              badge: abstract.BadgeType.New,
+              label: "t1-label",
+              execute: execute1,
+              parentGroupItemId: "p1",
+              icon: expect.objectContaining({
+                props: {
+                  className: "t1-icon",
+                },
+              }),
+            })
+          );
+          expect(items[1]).toEqual(
+            expect.objectContaining({
+              id: "t2",
+              badge: abstract.BadgeType.TechnicalPreview,
+            })
+          );
+          expect(items[2]).toEqual(
+            expect.objectContaining({
+              id: "t3",
+              execute: execute3,
+              parentGroupItemId: "p2",
+              label: "t3-label",
+              icon: expect.objectContaining({
+                props: {
+                  className: "t3-icon",
+                },
+              }),
+            })
+          );
+        }
+        {
+          const items = AbstractUiItemsManager.getToolbarButtonItems(
+            "stage1",
+            StageUsage.General,
+            ToolbarUsage.ViewNavigation,
+            ToolbarOrientation.Horizontal
+          );
+          expect(items[0]).toEqual(
+            expect.objectContaining({
+              id: "t1",
+              badgeType: abstract.BadgeType.New,
+              label: "t1-label",
+              execute: execute1,
+              parentToolGroupId: "p1",
+            })
+          );
+          expect(
+            IconHelper.getIconReactNode(items[0].icon, items[0].internalData)
+          ).toHaveProperty("props.iconSpec.props.className", "t1-icon");
+          expect(items[1]).toEqual(
+            expect.objectContaining({
+              id: "t2",
+              badgeType: abstract.BadgeType.TechnicalPreview,
+            })
+          );
+          expect(items[2]).toEqual(
+            expect.objectContaining({
+              id: "t3",
+              execute: execute3,
+              parentToolGroupId: "p2",
+              label: "t3-label",
+            })
+          );
+          expect(
+            IconHelper.getIconReactNode(items[2].icon, items[2].internalData)
+          ).toHaveProperty("props.iconSpec.props.className", "t3-icon");
+        }
+      });
+    });
+
+    describeAbstractAdapter("UiItemsProvider.getToolbarItems", () => {
       describe("standard layout", () => {
         const provider = {
           id: "provider1",
@@ -988,22 +457,226 @@ describe("UiItemsManager", () => {
           ).lengthOf(1);
         });
       });
+    });
+  });
 
-      describe("all items", () => {
-        it("should provide", () => {
-          UiItemsManager.register({
-            id: "provider1",
-            getToolbarItems: () => [createToolbarItem("item1")],
-          });
+  describe("getToolbarItems", () => {
+    it("should return registered items", () => {
+      UiItemsManager.register({
+        id: "provider1",
+        getToolbarItems: () => [createToolbarItem("item1")],
+      });
 
-          expect(
-            UiItemsManager.getToolbarItems("stage1", StageUsage.General)
-          ).lengthOf(1);
+      expect(
+        UiItemsManager.getToolbarItems("stage1", StageUsage.General)
+      ).lengthOf(1);
+    });
+  });
+
+  describe("getStatusBarItems", () => {
+    it("should return items of UiItemsProvider.provideStatusBarItems", () => {
+      UiItemsManager.register({
+        id: "provider1",
+        provideStatusBarItems: () => [
+          StatusBarItemUtilities.createActionItem(
+            "s1",
+            StatusBarSection.Center,
+            0,
+            "",
+            "",
+            () => {}
+          ),
+        ],
+      });
+
+      const items = UiItemsManager.getStatusBarItems(
+        "stage1",
+        StageUsage.General
+      );
+      expect(items).toEqual([
+        expect.objectContaining({
+          id: "s1",
+        }),
+      ]);
+    });
+
+    describe("AbstractUiItemsManager", () => {
+      if (!AbstractUiItemsManager) return;
+
+      it("should provide status bar items", () => {
+        const execute2 = vi.fn();
+        const execute4 = vi.fn();
+        UiItemsManager.register({
+          id: "provider1",
+          provideStatusBarItems: () => [
+            StatusBarItemUtilities.createCustomItem(
+              "s1",
+              StatusBarSection.Left,
+              0,
+              <div className="s1-content" />,
+              {
+                badge: abstract.BadgeType.New,
+              }
+            ),
+            StatusBarItemUtilities.createActionItem(
+              "s2",
+              StatusBarSection.Center,
+              0,
+              "",
+              "s2-tooltip",
+              execute2,
+              {
+                icon: <div className="s2-icon" />,
+                badgeKind: "new",
+              }
+            ),
+          ],
         });
+        AbstractUiItemsManager.register({
+          id: "provider2",
+          provideStatusBarItems: () => {
+            const internalData = new Map();
+            const icon = IconHelper.getIconData(
+              <div className="s4-icon" />,
+              internalData
+            );
+            return [
+              {
+                id: "s3",
+                itemPriority: 0,
+                section: StatusBarSection.Right,
+                isCustom: true,
+                reactNode: <div className="s3-content" />,
+              },
+              {
+                id: "s4",
+                itemPriority: 0,
+                section: StatusBarSection.Right,
+                execute: execute4,
+                icon,
+                internalData,
+                badgeType: abstract.BadgeType.TechnicalPreview,
+              },
+            ];
+          },
+        });
+
+        {
+          const items = UiItemsManager.getStatusBarItems(
+            "stage1",
+            StageUsage.General
+          );
+          expect(items[0]).toEqual(
+            expect.objectContaining({
+              id: "s1",
+              section: StatusBarSection.Left,
+              badge: abstract.BadgeType.New,
+              content: expect.objectContaining({
+                props: {
+                  className: "s1-content",
+                },
+              }),
+            })
+          );
+          expect(items[1]).toEqual(
+            expect.objectContaining({
+              id: "s2",
+              section: StatusBarSection.Center,
+              execute: execute2,
+              badgeKind: "new",
+              icon: expect.objectContaining({
+                props: {
+                  className: "s2-icon",
+                },
+              }),
+            })
+          );
+          expect(items[2]).toEqual(
+            expect.objectContaining({
+              id: "s3",
+              section: StatusBarSection.Right,
+              content: expect.objectContaining({
+                props: {
+                  className: "s3-content",
+                },
+              }),
+            })
+          );
+          expect(items[3]).toEqual(
+            expect.objectContaining({
+              id: "s4",
+              section: StatusBarSection.Right,
+              badge: abstract.BadgeType.TechnicalPreview,
+              execute: execute4,
+              icon: expect.objectContaining({
+                props: {
+                  className: "s4-icon",
+                },
+              }),
+            })
+          );
+        }
+        {
+          const items = AbstractUiItemsManager.getStatusBarItems(
+            "stage1",
+            StageUsage.General
+          );
+          expect(items[0]).toEqual(
+            expect.objectContaining({
+              id: "s1",
+              section: StatusBarSection.Left,
+              badgeType: abstract.BadgeType.New,
+              reactNode: expect.objectContaining({
+                props: {
+                  className: "s1-content",
+                },
+              }),
+            })
+          );
+          const s2 = items[1];
+          // @ts-ignore Possibly 'any'
+          assert(!!abstract.isAbstractStatusBarActionItem(s2));
+          expect(s2).toEqual(
+            expect.objectContaining({
+              id: "s2",
+              section: StatusBarSection.Center,
+              execute: execute2,
+              badgeType: abstract.BadgeType.New,
+            })
+          );
+          expect(
+            IconHelper.getIconReactNode(s2.icon, s2.internalData)
+          ).toHaveProperty("props.iconSpec.props.className", "s2-icon");
+          expect(items[2]).toEqual(
+            expect.objectContaining({
+              id: "s3",
+              section: StatusBarSection.Right,
+              reactNode: expect.objectContaining({
+                props: {
+                  className: "s3-content",
+                },
+              }),
+            })
+          );
+          const s4 = items[3];
+          // @ts-ignore Possibly 'any'
+          assert(!!abstract.isAbstractStatusBarActionItem(s4));
+          expect(s4).toEqual(
+            expect.objectContaining({
+              id: "s4",
+              section: StatusBarSection.Right,
+              badgeType: abstract.BadgeType.TechnicalPreview,
+              execute: execute4,
+            })
+          );
+          expect(
+            IconHelper.getIconReactNode(s4.icon, s4.internalData)
+          ).toHaveProperty("props.iconSpec.props.className", "s4-icon");
+        }
       });
     });
 
-    describeAbstractAdapter("status bar items", () => {
+    describeAbstractAdapter("UiItemsProvider.getStatusBarItems", () => {
       const provider = {
         id: "provider1",
         getStatusBarItems: () => {
@@ -1055,8 +728,177 @@ describe("UiItemsManager", () => {
         );
       });
     });
+  });
 
-    describeAbstractAdapter("backstage items", () => {
+  describe("getBackstageItems", () => {
+    it("should return items of UiItemsProvider.provideBackstageItems", () => {
+      UiItemsManager.register({
+        id: "provider1",
+        provideBackstageItems: () => [
+          BackstageItemUtilities.createActionItem(
+            "b1",
+            0,
+            0,
+            () => {},
+            "b1-label"
+          ),
+          BackstageItemUtilities.createStageLauncher("b2", 0, 0, "b2-label"),
+        ],
+      });
+
+      const items = UiItemsManager.getBackstageItems();
+      expect(items).toEqual([
+        expect.objectContaining({
+          id: "b1",
+        }),
+        expect.objectContaining({
+          id: "b2",
+        }),
+      ]);
+    });
+
+    describe("AbstractUiItemsManager", () => {
+      if (!AbstractUiItemsManager) return;
+
+      it("should provide backstage items", () => {
+        const execute = vi.fn();
+        UiItemsManager.register({
+          id: "provider1",
+          provideBackstageItems: () => [
+            BackstageItemUtilities.createActionItem(
+              "b1",
+              0,
+              0,
+              execute,
+              "b1-label",
+              undefined,
+              undefined,
+              {
+                icon: <div className="b1-icon" />,
+                badge: abstract.BadgeType.New,
+              }
+            ),
+            BackstageItemUtilities.createStageLauncher(
+              "b2",
+              0,
+              0,
+              "b2-label",
+              undefined,
+              undefined,
+              { badgeKind: "technical-preview" }
+            ),
+          ],
+        });
+        AbstractUiItemsManager.register({
+          id: "provider2",
+          provideBackstageItems: () => {
+            const internalData = new Map();
+            const icon = IconHelper.getIconData(
+              <div className="b4-icon" />,
+              internalData
+            );
+            return [
+              // @ts-ignore Possibly 'any'
+              abstract.BackstageItemUtilities.createActionItem(
+                "b3",
+                0,
+                0,
+                execute,
+                "b3-label"
+              ),
+              // @ts-ignore Possibly 'any'
+              abstract.BackstageItemUtilities.createStageLauncher(
+                "b4",
+                0,
+                0,
+                "b4-label",
+                undefined,
+                undefined,
+                {
+                  icon,
+                  internalData,
+                  badgeType: abstract.BadgeType.TechnicalPreview,
+                }
+              ),
+            ];
+          },
+        });
+
+        {
+          const items = UiItemsManager.getBackstageItems();
+          expect(items[0]).toEqual(
+            expect.objectContaining({
+              id: "b1",
+              label: "b1-label",
+              execute,
+              badge: abstract.BadgeType.New,
+            })
+          );
+          expect(items[1]).toEqual(
+            expect.objectContaining({
+              id: "b2",
+              stageId: "b2",
+              badgeKind: "technical-preview",
+            })
+          );
+          expect(items[2]).toEqual(
+            expect.objectContaining({
+              id: "b3",
+              label: "b3-label",
+            })
+          );
+          expect(items[3]).toEqual(
+            expect.objectContaining({
+              id: "b4",
+              badge: abstract.BadgeType.TechnicalPreview,
+              icon: expect.objectContaining({
+                props: {
+                  className: "b4-icon",
+                },
+              }),
+            })
+          );
+        }
+        {
+          const items = AbstractUiItemsManager.getBackstageItems();
+          expect(items[0]).toEqual(
+            expect.objectContaining({
+              id: "b1",
+              label: "b1-label",
+              execute,
+              badgeType: abstract.BadgeType.New,
+            })
+          );
+          expect(
+            IconHelper.getIconReactNode(items[0].icon, items[0].internalData)
+          ).toHaveProperty("props.iconSpec.props.className", "b1-icon");
+          expect(items[1]).toEqual(
+            expect.objectContaining({
+              id: "b2",
+              stageId: "b2",
+              badgeType: abstract.BadgeType.TechnicalPreview,
+            })
+          );
+          expect(items[2]).toEqual(
+            expect.objectContaining({
+              id: "b3",
+              label: "b3-label",
+            })
+          );
+          expect(items[3]).toEqual(
+            expect.objectContaining({
+              id: "b4",
+              badgeType: abstract.BadgeType.TechnicalPreview,
+            })
+          );
+          expect(
+            IconHelper.getIconReactNode(items[3].icon, items[3].internalData)
+          ).toHaveProperty("props.iconSpec.props.className", "b4-icon");
+        }
+      });
+    });
+
+    describeAbstractAdapter("UiItemsProvider.getBackstageItems", () => {
       const provider = {
         id: "provider1",
         getBackstageItems: () => {
@@ -1081,137 +923,334 @@ describe("UiItemsManager", () => {
         expect(items[0].id).toEqual("item1");
       });
     });
+  });
 
-    describeAbstractAdapter("widgets", () => {
-      describe("standard layout", () => {
-        const provider = {
-          id: "provider1",
-          getWidgets: () => {
-            return [
-              createWidget("item1", {
-                layouts: {
-                  standard: {
-                    location: StagePanelLocation.Bottom,
-                    section: StagePanelSection.End,
-                  },
-                },
-              }),
-            ];
-          },
-        } satisfies UiItemsProvider;
-
-        it("should provide", () => {
-          UiItemsManager.register(provider);
-
-          expect(
-            UiItemsManager.getWidgets(
-              "stage1",
-              StageUsage.General,
-              StagePanelLocation.Bottom,
-              StagePanelSection.End
-            )
-          ).lengthOf(1);
-        });
-
-        it("should not provide w/o location", () => {
-          UiItemsManager.register({
-            id: "provider1",
-            getWidgets: () => [createWidget("w1")],
-          });
-
-          expect(
-            UiItemsManager.getWidgets(
-              "stage1",
-              StageUsage.General,
-              StagePanelLocation.Left,
-              StagePanelSection.Start
-            )
-          ).lengthOf(0);
-        });
-
-        it("should not provide for different location/section", () => {
-          UiItemsManager.register(provider);
-
-          expect(
-            UiItemsManager.getWidgets(
-              "stage1",
-              StageUsage.General,
-              StagePanelLocation.Top,
-              StagePanelSection.End
-            )
-          ).lengthOf(0);
-          expect(
-            UiItemsManager.getWidgets(
-              "stage1",
-              StageUsage.General,
-              StagePanelLocation.Top,
-              StagePanelSection.Start
-            )
-          ).lengthOf(0);
-          expect(
-            UiItemsManager.getWidgets(
-              "stage1",
-              StageUsage.General,
-              StagePanelLocation.Bottom,
-              StagePanelSection.Start
-            )
-          ).lengthOf(0);
-        });
-
-        it("should only provide for specified stage ids", () => {
-          UiItemsManager.register(provider, { stageIds: ["stage2"] });
-
-          expect(
-            UiItemsManager.getWidgets(
-              "stage1",
-              StageUsage.General,
-              StagePanelLocation.Bottom,
-              StagePanelSection.End
-            )
-          ).lengthOf(0);
-          expect(
-            UiItemsManager.getWidgets(
-              "stage2",
-              StageUsage.General,
-              StagePanelLocation.Bottom,
-              StagePanelSection.End
-            )
-          ).lengthOf(1);
-        });
-
-        it("should only provide for specified stage usages", () => {
-          UiItemsManager.register(provider, { stageUsages: ["custom"] });
-
-          expect(
-            UiItemsManager.getWidgets(
-              "stage1",
-              StageUsage.General,
-              StagePanelLocation.Bottom,
-              StagePanelSection.End
-            )
-          ).lengthOf(0);
-          expect(
-            UiItemsManager.getWidgets(
-              "stage1",
-              "custom",
-              StagePanelLocation.Bottom,
-              StagePanelSection.End
-            )
-          ).lengthOf(1);
-        });
+  describe("getWidgets", () => {
+    it("should return widgets of UiItemsProvider.provideWidgets", () => {
+      UiItemsManager.register({
+        id: "provider1",
+        provideWidgets: () => [{ id: "w1" }],
       });
 
-      describe("all widgets", () => {
-        it("should provide", () => {
-          UiItemsManager.register({
-            id: "provider1",
-            getWidgets: () => [createWidget("w1")],
-          });
+      const widgets = UiItemsManager.getWidgets(
+        "stage1",
+        StageUsage.General,
+        StagePanelLocation.Left
+      );
+      expect(widgets).toEqual([
+        expect.objectContaining({
+          id: "w1",
+        }),
+      ]);
+    });
 
-          expect(
-            UiItemsManager.getWidgets("stage1", StageUsage.General)
-          ).lengthOf(1);
+    it("overload should return all widgets", () => {
+      UiItemsManager.register({
+        id: "provider1",
+        getWidgets: () => [createWidget("w1")],
+      });
+
+      expect(UiItemsManager.getWidgets("stage1", StageUsage.General)).lengthOf(
+        1
+      );
+    });
+
+    describe("AbstractUiItemsManager", () => {
+      if (!AbstractUiItemsManager) return;
+
+      it("should provide widgets", () => {
+        UiItemsManager.register({
+          id: "provider1",
+          provideWidgets: () => [
+            {
+              id: "w1",
+              allowedPanels: [StagePanelLocation.Left],
+              badge: abstract.BadgeType.New,
+              canFloat: {
+                isResizable: true,
+              },
+              icon: <div className="w1-icon" />,
+              content: <div className="w1-content" />,
+              badgeKind: "deprecated",
+            },
+          ],
         });
+        AbstractUiItemsManager.register({
+          id: "provider2",
+          provideWidgets: () => {
+            const internalData = new Map();
+            const icon = IconHelper.getIconData(
+              <div className="w2-icon" />,
+              internalData
+            );
+            return [
+              {
+                id: "w2",
+                allowedPanelTargets: ["right"],
+                badgeType: abstract.BadgeType.TechnicalPreview,
+                isFloatingStateWindowResizable: true,
+                canFloat: true,
+                icon,
+                internalData,
+                getWidgetContent: () => <div className="w2-content" />,
+              },
+            ];
+          },
+        });
+        {
+          const widgets = UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Left
+          );
+          expect(widgets[0]).toEqual(
+            expect.objectContaining({
+              id: "w1",
+              badge: abstract.BadgeType.New,
+              allowedPanels: [StagePanelLocation.Left],
+              content: expect.objectContaining({
+                props: {
+                  className: "w1-content",
+                },
+              }),
+              icon: expect.objectContaining({
+                props: {
+                  className: "w1-icon",
+                },
+              }),
+              badgeKind: "deprecated",
+            })
+          );
+          expect(widgets[1]).toEqual(
+            expect.objectContaining({
+              id: "w2",
+              badge: abstract.BadgeType.TechnicalPreview,
+              allowedPanels: [StagePanelLocation.Right],
+              content: expect.objectContaining({
+                props: {
+                  className: "w2-content",
+                },
+              }),
+              icon: expect.objectContaining({
+                props: {
+                  className: "w2-icon",
+                },
+              }),
+            })
+          );
+        }
+        {
+          const widgets = AbstractUiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            AbstractStagePanelLocation.Left
+          );
+          expect(widgets[0]).toEqual(
+            expect.objectContaining({
+              id: "w1",
+              badgeType: abstract.BadgeType.New,
+              allowedPanelTargets: ["left"],
+            })
+          );
+          expect(widgets[0].getWidgetContent()).toHaveProperty(
+            "props.className",
+            "w1-content"
+          );
+          expect(
+            IconHelper.getIconReactNode(
+              widgets[0].icon,
+              widgets[0].internalData
+            )
+          ).toHaveProperty("props.iconSpec.props.className", "w1-icon");
+          expect(widgets[1]).toEqual(
+            expect.objectContaining({
+              id: "w2",
+              badgeType: abstract.BadgeType.TechnicalPreview,
+              allowedPanelTargets: ["right"],
+            })
+          );
+          expect(widgets[1].getWidgetContent()).toHaveProperty(
+            "props.className",
+            "w2-content"
+          );
+          expect(
+            IconHelper.getIconReactNode(
+              widgets[1].icon,
+              widgets[1].internalData
+            )
+          ).toHaveProperty("props.iconSpec.props.className", "w2-icon");
+        }
+      });
+
+      it("should provide TopMost widgets", () => {
+        AbstractUiItemsManager.register({
+          id: "provider1",
+          // @ts-ignore Possibly 'any'
+          provideWidgets: (_stageId, _stageUsage, location) => {
+            if (location === AbstractStagePanelLocation.Top) {
+              return [
+                {
+                  id: "w1",
+                  getWidgetContent: () => null,
+                },
+              ];
+            }
+            if (location === AbstractStagePanelLocation.TopMost) {
+              return [
+                {
+                  id: "w2",
+                  getWidgetContent: () => null,
+                },
+              ];
+            }
+            return [];
+          },
+        });
+        {
+          const widgets = UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Top
+          );
+          expect(widgets).toEqual([
+            expect.objectContaining({ id: "w1" }),
+            expect.objectContaining({ id: "w2" }),
+          ]);
+        }
+        {
+          const widgets = AbstractUiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            AbstractStagePanelLocation.Top
+          );
+          expect(widgets).toEqual([expect.objectContaining({ id: "w1" })]);
+          const topMostWidgets = AbstractUiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            AbstractStagePanelLocation.TopMost
+          );
+          expect(topMostWidgets).toEqual([
+            expect.objectContaining({ id: "w2" }),
+          ]);
+        }
+      });
+    });
+
+    describeAbstractAdapter("UiItemsProvider.getWidgets", () => {
+      const provider = {
+        id: "provider1",
+        getWidgets: () => {
+          return [
+            createWidget("item1", {
+              layouts: {
+                standard: {
+                  location: StagePanelLocation.Bottom,
+                  section: StagePanelSection.End,
+                },
+              },
+            }),
+          ];
+        },
+      } satisfies UiItemsProvider;
+
+      it("should provide", () => {
+        UiItemsManager.register(provider);
+
+        expect(
+          UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Bottom,
+            StagePanelSection.End
+          )
+        ).lengthOf(1);
+      });
+
+      it("should not provide w/o location", () => {
+        UiItemsManager.register({
+          id: "provider1",
+          getWidgets: () => [createWidget("w1")],
+        });
+
+        expect(
+          UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Left,
+            StagePanelSection.Start
+          )
+        ).lengthOf(0);
+      });
+
+      it("should not provide for different location/section", () => {
+        UiItemsManager.register(provider);
+
+        expect(
+          UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Top,
+            StagePanelSection.End
+          )
+        ).lengthOf(0);
+        expect(
+          UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Top,
+            StagePanelSection.Start
+          )
+        ).lengthOf(0);
+        expect(
+          UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Bottom,
+            StagePanelSection.Start
+          )
+        ).lengthOf(0);
+      });
+
+      it("should only provide for specified stage ids", () => {
+        UiItemsManager.register(provider, { stageIds: ["stage2"] });
+
+        expect(
+          UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Bottom,
+            StagePanelSection.End
+          )
+        ).lengthOf(0);
+        expect(
+          UiItemsManager.getWidgets(
+            "stage2",
+            StageUsage.General,
+            StagePanelLocation.Bottom,
+            StagePanelSection.End
+          )
+        ).lengthOf(1);
+      });
+
+      it("should only provide for specified stage usages", () => {
+        UiItemsManager.register(provider, { stageUsages: ["custom"] });
+
+        expect(
+          UiItemsManager.getWidgets(
+            "stage1",
+            StageUsage.General,
+            StagePanelLocation.Bottom,
+            StagePanelSection.End
+          )
+        ).lengthOf(0);
+        expect(
+          UiItemsManager.getWidgets(
+            "stage1",
+            "custom",
+            StagePanelLocation.Bottom,
+            StagePanelSection.End
+          )
+        ).lengthOf(1);
       });
     });
   });


### PR DESCRIPTION
## Changes

This PR adds `UiItemsManager.getToolbarItems` method and `UiItemsManager.getWidgets` method overload to return registered items that are not configured for the standard layout. This is useful when implementing custom layouts, since standard layout specific definitions, like `ToolbarUsage` can be omitted.

Usage examples are available in `NextVersion.md`

## Testing

Added additional unit tests.
