### PR TITLE
Remove redundant spacing between toolbars

### DIFF
--- a/common/changes/@itwin/appui-react/fix-1231_2025-03-19-10-06.json
+++ b/common/changes/@itwin/appui-react/fix-1231_2025-03-19-10-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Remove redundant spacing between toolbars when the app button or navigation aid is not displayed.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/layout/widget/NavigationArea.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/NavigationArea.scss
@@ -12,10 +12,12 @@
   box-sizing: border-box;
   height: 100%;
   grid-gap: 6px;
-  grid-template-columns: 1fr minmax($mls-navigation-aid-width, auto);
-  grid-template-rows: minmax($mls-navigation-aid-width, auto) 1fr;
+  grid-template-areas:
+    "htools button"
+    ". vtools";
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto 1fr;
   justify-items: end;
-  grid-template-areas: "htools button" ". vtools";
 
   &.nz-hidden {
     opacity: 0;
@@ -23,24 +25,34 @@
   }
 
   > .nz-navigation-aid-container {
+    grid-area: button;
+
+    min-width: $mls-navigation-aid-width;
+    min-height: $mls-navigation-aid-height;
+
     margin-bottom: 6px;
     pointer-events: auto;
-    grid-area: button;
 
     @include nz-widget-opacity;
   }
 
   > .nz-vertical-toolbar-container {
     grid-area: vtools;
+
     height: calc(100% - 60px);
     display: inline-flex;
     flex-direction: column;
     align-items: flex-end;
     @include nz-widget-opacity;
+
+    &.nz-span {
+      grid-row: button / vtools;
+    }
   }
 
   > .nz-horizontal-toolbar-container {
     grid-area: htools;
+
     width: 100%;
     display: flex;
     flex-direction: row;

--- a/ui/appui-react/src/appui-react/layout/widget/NavigationArea.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/NavigationArea.tsx
@@ -31,8 +31,7 @@ export interface NavigationAreaProps extends CommonProps, NoChildrenProps {
   onMouseLeave?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
-/** NavigationArea widget is used in NavigationArea (Zone 1) and Navigation (Zone 3???) zones of 9-Zone UI.
- * @note Should be placed in [[Zone]] component.
+/** A component that renders toolbars in the top right corner of standard layout.
  * @internal
  */
 export function NavigationArea(props: NavigationAreaProps) {
@@ -56,7 +55,10 @@ export function NavigationArea(props: NavigationAreaProps) {
         </div>
       )}
       <div
-        className="nz-vertical-toolbar-container"
+        className={classnames(
+          "nz-vertical-toolbar-container",
+          !props.navigationAid && "nz-span"
+        )}
         onMouseEnter={props.onMouseEnter}
         onMouseLeave={props.onMouseLeave}
       >

--- a/ui/appui-react/src/appui-react/layout/widget/ToolsArea.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/ToolsArea.scss
@@ -13,9 +13,11 @@
 
   display: grid;
   grid-gap: 6px;
-  grid-template:
-    "appButton htools" auto
-    "vtools ." 1fr / auto 1fr;
+  grid-template-areas:
+    "button htools"
+    "vtools .";
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
   align-items: start;
   justify-items: start;
 
@@ -25,7 +27,7 @@
   }
 
   > .nz-app-button {
-    grid-area: appButton;
+    grid-area: button;
 
     pointer-events: auto;
     @include nz-widget-opacity;
@@ -38,6 +40,10 @@
     display: inline-flex;
     flex-direction: column;
     @include nz-widget-opacity;
+
+    &.nz-span {
+      grid-row: button / vtools;
+    }
   }
 
   > .nz-horizontal-toolbar-container {

--- a/ui/appui-react/src/appui-react/layout/widget/ToolsArea.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/ToolsArea.tsx
@@ -32,8 +32,7 @@ export interface ToolsAreaProps extends CommonProps, NoChildrenProps {
   onMouseLeave?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
-/** ToolsArea widget is used in ToolsArea (top left) and Navigation (top right) zones of 9-Zone UI.
- * @note Should be placed in [[Zone]] component.
+/** A component that renders toolbars in the top left corner of standard layout.
  * @internal
  */
 export class ToolsArea extends React.PureComponent<ToolsAreaProps> {
@@ -53,7 +52,10 @@ export class ToolsArea extends React.PureComponent<ToolsAreaProps> {
           {button}
         </div>
         <div
-          className="nz-vertical-toolbar-container"
+          className={classnames(
+            "nz-vertical-toolbar-container",
+            !button && "nz-span"
+          )}
           onMouseEnter={this.props.onMouseEnter}
           onMouseLeave={this.props.onMouseLeave}
         >


### PR DESCRIPTION
## Changes

This PR fixes #1231 by removing redundant spacing between toolbars of tools area when the app button is not displayed. This issue was introduced by https://github.com/iTwin/appui/pull/1078

Additionally, the gap between toolbars is removed from navigation area when navigation aid is not displayed.

![Screenshot 2025-03-19 at 13 18 51](https://github.com/user-attachments/assets/10710153-baae-4227-8134-3b8f923eb661)

## Testing

N/A
