### PR TITLE
Fix Firefox specific style loading issue in widget popouts

### DIFF
--- a/apps/test-app/README.md
+++ b/apps/test-app/README.md
@@ -38,6 +38,7 @@ _Optionally_ used to load an application in a specific configuration:
 - `menu` - allows disabling the rendering of menus if `0` is specified, i.e. <http://localhost:3000/?menu=0>.
 - `frontstageId` - opens a frontstage by specified frontstage id, uses a blank connection, i.e. <http://localhost:3000/blank?frontstageId=widget-api>.
 - `themeBridge` - enables the iTwinUI v5 theme bridge if `1` is specified, i.e. <http://localhost:3000/?themeBridge=1>.
+- `useDefaultPopoutUrl` - disables the default `/iTwinPopup.html` URL for popout widgets if `0` is specified, i.e. <http://localhost:3000/?useDefaultPopoutUrl=0>.
 
 Preview features:
 

--- a/common/changes/@itwin/appui-react/fix-1239_2025-03-19-15-50.json
+++ b/common/changes/@itwin/appui-react/fix-1239_2025-03-19-15-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fix Firefox specific style loading issue of widget popouts.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/InternalChildWindowManager.tsx
@@ -40,6 +40,15 @@ function addChildHTML(window: Window) {
   `;
   doc.head.appendChild(style);
 
+  // Fixes a FF specific issue where document.baseURI is "about:blank"
+  const opener: Window | undefined = window.opener;
+  const baseURI = opener?.document.baseURI;
+  if (doc.baseURI === "about:blank" && baseURI) {
+    const base = doc.createElement("base");
+    base.href = baseURI;
+    doc.head.appendChild(base);
+  }
+
   const noScript = doc.createElement("noscript");
   noScript.textContent = "You need to enable JavaScript to run this app.";
   doc.body.appendChild(noScript);


### PR DESCRIPTION
## Changes

This PR fixes #1239 which is reproducible in Firefox only. The main cause for the issue was style loading failure in https://github.com/iTwin/appui/blob/28181ab49f89b4e8d3162c7324b648e32077637b/ui/appui-react/src/appui-react/childwindow/CopyStyles.ts#L11

Reason for failure:
- https://developer.mozilla.org/en-US/docs/Web/API/Window/open is used to open a new blank page (empty string is used for url param)
  - `window.location.href` of new window equals to `about:blank`
  - `window.document.baseURI` of new window equals to the `baseURI` of the `opener` (main window), i.e. `http://localhost:3000/blank?frontstageId=widget-api&useDefaultPopoutUrl=0` when ran locally.
  - **[Firefox only]** `window.document.baseURI` of new window equals to `about:blank`
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link element is used to load the stylesheet with a relative `href` which fails to resolve on Firefox (copied from main window)

Suggested fix uses [`base` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) to conditionally override the [`baseURI`](https://developer.mozilla.org/en-US/docs/Web/API/Node/baseURI) of the opened window.

## Testing

- Add `styles.css` to `test-app/public`
- Load `styles.css` in `test-app/index.html` using a relative href i.e.: 
  `<link rel="stylesheet" type="text/css" href="/styles.css" />`
- Open the test-app w/o the default popout URL: `http://localhost:3000/blank?frontstageId=widget-api&useDefaultPopoutUrl=0`
- Click one of `Popout active widget tab` buttons
