### PR TITLE
Fix standard layout for `rsbuild`

### DIFF
--- a/common/changes/@itwin/appui-react/standard-layout-rsbuild_2025-03-30-16-39.json
+++ b/common/changes/@itwin/appui-react/standard-layout-rsbuild_2025-03-30-16-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Simplify grid template definitions of standard layout to avoid CSS issues in `rsbuild` production build.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/common/changes/@itwin/appui-react/standard-layout-rsbuild_2025-03-30-16-39.json
+++ b/common/changes/@itwin/appui-react/standard-layout-rsbuild_2025-03-30-16-39.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@itwin/appui-react",
-      "comment": "Simplify grid template definitions of standard layout to avoid CSS issues in `rsbuild` production build.",
+      "comment": "Simplify grid template definitions of standard layout to avoid CSS issues in `RsBuild` production build.",
       "type": "none"
     }
   ],

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -14,7 +14,7 @@ Table of contents:
 ### Fixes
 
 - Fixed an icon size of a backstage app button when web font icon is used. [#1262](https://github.com/iTwin/appui/pull/1262)
-- Simplify grid template definitions of standard layout to avoid CSS issues in `rsbuild` production build. [#1263](https://github.com/iTwin/appui/pull/1263)
+- Simplify grid template definitions of standard layout to avoid CSS issues in `RsBuild` production build. [#1263](https://github.com/iTwin/appui/pull/1263)
 
 ## @itwin/components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -7,6 +7,12 @@ Table of contents:
 - [@itwin/imodel-components-react](#itwinimodel-components-react)
   - [Additions](#additions-1)
 
+## @itwin/appui-react
+
+### Fixes
+
+- Simplify grid template definitions of standard layout to avoid CSS issues in `rsbuild` production build.
+
 ## @itwin/components-react
 
 ### Additions

--- a/ui/appui-react/src/appui-react/layout/StandardLayout.scss
+++ b/ui/appui-react/src/appui-react/layout/StandardLayout.scss
@@ -10,16 +10,11 @@
     overflow: hidden;
 
     display: grid;
-    grid-template-columns:
-      [lp-start] minmax(0, auto) [lp-end] 1fr [rp-start] minmax(0, auto)
-      [rp-end];
-    grid-template-rows:
-      minmax(0, auto) [ts-end] minmax(0, auto) [tp-end] 1fr [bp-start] minmax(
+    grid-template-columns: minmax(0, auto) 1fr minmax(0, auto);
+    grid-template-rows: minmax(0, auto) minmax(0, auto) 1fr minmax(0, auto) minmax(
         0,
         auto
-      )
-      [bp-end]
-      minmax(0, auto);
+      );
     grid-template-areas:
       "ts ts ts"
       "tp tp tp"


### PR DESCRIPTION
## Changes

This PR fixes #1259 by simplifying the grid template definitions of standard layout to avoid CSS issues in `rsbuild` production build.

## Testing

Tested manually by running `rsbuild` w/ matching CSS rules.
