### PR TITLE
Fix `onItemExecuted` of the `<Toolbar>` component

### DIFF
--- a/common/changes/@itwin/appui-react/on-item-executed_2025-03-31-08-16.json
+++ b/common/changes/@itwin/appui-react/on-item-executed_2025-03-31-08-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fixed `onItemExecuted` prop of the `Toolbar` component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -11,7 +11,7 @@ Table of contents:
 
 ### Fixes
 
-- Fixed `onItemExecuted` prop of the `Toolbar` component which was omitted from the initial implementation of the updated toolbar.
+- Fixed `onItemExecuted` prop of the `Toolbar` component which was omitted from the initial implementation of the updated toolbar. [#1264](https://github.com/iTwin/appui/pull/1264)
 
 ## @itwin/components-react
 

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -7,6 +7,12 @@ Table of contents:
 - [@itwin/imodel-components-react](#itwinimodel-components-react)
   - [Additions](#additions-1)
 
+## @itwin/appui-react
+
+### Fixes
+
+- Fixed `onItemExecuted` prop of the `Toolbar` component which was omitted from the initial implementation of the updated toolbar.
+
 ## @itwin/components-react
 
 ### Additions

--- a/docs/storybook/src/components/ToolbarPopup.stories.tsx
+++ b/docs/storybook/src/components/ToolbarPopup.stories.tsx
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import type { Meta, StoryObj } from "@storybook/react";
+import { ToolbarPopupStory } from "./ToolbarPopup";
+import { ToolbarItemUtilities } from "@itwin/appui-react";
+import {
+  SvgCut,
+  SvgInfo,
+  SvgSave,
+  SvgSaveAs,
+  SvgSaveSettings,
+  SvgSaveUpdate,
+} from "@itwin/itwinui-icons-react";
+import { action } from "@storybook/addon-actions";
+
+const meta = {
+  title: "Components/ToolbarPopup",
+  component: ToolbarPopupStory,
+  tags: ["autodocs"],
+  args: {
+    title: "Platform ABC123",
+    location: {
+      x: 100,
+      y: 100,
+    },
+    offset: {
+      x: 0,
+      y: 0,
+    },
+    toolbarProps: {
+      items: [
+        ToolbarItemUtilities.createActionItem(
+          "item1",
+          100,
+          <SvgInfo />,
+          "Item 1",
+          action("Item 1")
+        ),
+        ToolbarItemUtilities.createActionItem(
+          "item2",
+          100,
+          <SvgCut />,
+          "Item 2",
+          action("Item 2")
+        ),
+        ToolbarItemUtilities.createGroupItem(
+          "item3",
+          100,
+          <SvgSaveSettings />,
+          "Item 3",
+          [
+            ToolbarItemUtilities.createActionItem(
+              "item3_1",
+              100,
+              <SvgSave />,
+              "Item 3_1",
+              action("Item 3_1")
+            ),
+            ToolbarItemUtilities.createActionItem(
+              "item3_2",
+              100,
+              <SvgSaveAs />,
+              "Item 3_2",
+              action("Item 3_2")
+            ),
+            ToolbarItemUtilities.createActionItem(
+              "item3_3",
+              100,
+              <SvgSaveUpdate />,
+              "Item 3_3",
+              action("Item 3_3")
+            ),
+          ]
+        ),
+      ],
+    },
+    placement: "right-start",
+  },
+} satisfies Meta<typeof ToolbarPopupStory>;
+
+export default meta;
+type Story = StoryObj<typeof ToolbarPopupStory>;
+
+export const Basic: Story = {};

--- a/docs/storybook/src/components/ToolbarPopup.tsx
+++ b/docs/storybook/src/components/ToolbarPopup.tsx
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { action } from "@storybook/addon-actions";
+import { UiFramework } from "@itwin/appui-react";
+import { AppUiStory } from "../AppUiStory";
+
+type ShowToolbarParams = Parameters<typeof UiFramework.showToolbar>;
+
+export interface CardPopupStoryProps {
+  title?: string;
+  toolbarProps: ShowToolbarParams[0];
+  location: ShowToolbarParams[1];
+  offset: ShowToolbarParams[2];
+  placement: ShowToolbarParams[5];
+}
+
+/** [showCard](https://www.itwinjs.org/reference/appui-react/admin/frameworkuiadmin/showcard/) API can be used to show a card-at-cursor popup. */
+export function ToolbarPopupStory({
+  toolbarProps,
+  location,
+  offset,
+  placement,
+}: CardPopupStoryProps) {
+  return (
+    <AppUiStory
+      onInitialize={async () => {
+        UiFramework.showToolbar(
+          toolbarProps,
+          location,
+          offset,
+          action("onItemExecuted"),
+          action("onCancel"),
+          placement
+        );
+      }}
+    />
+  );
+}

--- a/docs/storybook/src/components/ToolbarPopup.tsx
+++ b/docs/storybook/src/components/ToolbarPopup.tsx
@@ -16,7 +16,7 @@ export interface CardPopupStoryProps {
   placement: ShowToolbarParams[5];
 }
 
-/** [showCard](https://www.itwinjs.org/reference/appui-react/admin/frameworkuiadmin/showcard/) API can be used to show a card-at-cursor popup. */
+/** [UiFramework.showToolbar()](https://www.itwinjs.org/reference/appui-react/utilities/uiframework/showtoolbarstatic/) API can be used to show a toolbar popup. */
 export function ToolbarPopupStory({
   toolbarProps,
   location,

--- a/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/Toolbar.tsx
@@ -50,13 +50,18 @@ export interface ToolbarProps extends CommonProps, NoChildrenProps {
  * @beta
  */
 export function Toolbar(props: ToolbarProps) {
-  const expandsTo = toDirection(props.expandsTo);
-  const panelAlignment = toPanelAlignment(props.panelAlignment);
+  const {
+    expandsTo: expandsToProp,
+    panelAlignment: panelAlignmentProp,
+    ...rest
+  } = props;
+  const expandsTo = toDirection(expandsToProp);
+  const panelAlignment = toPanelAlignment(panelAlignmentProp);
   return (
     <ToolGroupToolbar
       expandsTo={expandsTo}
       panelAlignment={panelAlignment}
-      items={props.items}
+      {...rest}
     />
   );
 }

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/ActionItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/ActionItem.tsx
@@ -11,6 +11,7 @@ import type { ToolbarActionItem } from "../../toolbar/ToolbarItem.js";
 import { ToolGroupOverflowContext } from "./OverflowButton.js";
 import { Item } from "./Item.js";
 import { GroupMenuItem } from "./GroupItem.js";
+import { ToolbarContext } from "./Toolbar.js";
 
 /** @internal */
 export interface ActionItemProps {
@@ -20,6 +21,7 @@ export interface ActionItemProps {
 /** @internal */
 export const ActionItem = React.forwardRef<HTMLButtonElement, ActionItemProps>(
   function ActionItem({ item }, ref) {
+    const { onItemExecuted } = React.useContext(ToolbarContext) ?? {};
     const overflowContext = React.useContext(ToolGroupOverflowContext);
     if (overflowContext) {
       return <GroupMenuItem item={item} onClose={overflowContext.onClose} />;
@@ -30,6 +32,7 @@ export const ActionItem = React.forwardRef<HTMLButtonElement, ActionItemProps>(
         item={item}
         onClick={() => {
           item.execute();
+          onItemExecuted?.(item);
         }}
       />
     );

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
@@ -71,6 +71,7 @@ interface GroupMenuItemProps {
 
 /** @internal */
 export function GroupMenuItem({ item, onClose }: GroupMenuItemProps) {
+  const { onItemExecuted } = React.useContext(ToolbarContext) ?? {};
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const iconSpec = useConditionalProp(item.icon);
   const label = useConditionalProp(item.label);
@@ -97,6 +98,7 @@ export function GroupMenuItem({ item, onClose }: GroupMenuItemProps) {
       onClick={() => {
         if (isToolbarActionItem(item)) {
           item.execute();
+          onItemExecuted?.(item);
           onClose?.();
         }
       }}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Toolbar.tsx
@@ -14,8 +14,12 @@ import {
   isToolbarGroupItem,
 } from "../../toolbar/ToolbarItem.js";
 import { ToolGroup } from "./ToolGroup.js";
+import type { ToolbarProps as OldToolbarProps } from "../Toolbar.js";
 
-interface ToolbarProps {
+/** These exist for backwards compatibility only. */
+type ToolbarInternalProps = Pick<OldToolbarProps, "onItemExecuted">;
+
+interface ToolbarProps extends ToolbarInternalProps {
   /** Definitions for items of the toolbar. */
   items: ToolbarItem[];
   /** Describes direction to which the panels are expanded. Orientation of the toolbar is determined based on this prop. Defaults to `bottom`.  */
@@ -29,16 +33,21 @@ export function Toolbar({
   items,
   expandsTo = "bottom",
   panelAlignment = "start",
+  onItemExecuted,
 }: ToolbarProps) {
   const [popoverOpen, setPopoverOpen] = React.useState(false);
   return (
     <ToolbarContext.Provider
-      value={{
-        expandsTo,
-        panelAlignment,
-        popoverOpen,
-        setPopoverOpen,
-      }}
+      value={React.useMemo(
+        () => ({
+          expandsTo,
+          panelAlignment,
+          popoverOpen,
+          setPopoverOpen,
+          onItemExecuted,
+        }),
+        [expandsTo, panelAlignment, popoverOpen, setPopoverOpen, onItemExecuted]
+      )}
     >
       <ToolGroup>
         {items.map((item) => {
@@ -59,7 +68,8 @@ export function Toolbar({
 }
 
 interface ToolbarContextProps
-  extends Pick<Required<ToolbarProps>, "expandsTo" | "panelAlignment"> {
+  extends Pick<Required<ToolbarProps>, "expandsTo" | "panelAlignment">,
+    Pick<ToolbarProps, "onItemExecuted"> {
   popoverOpen: boolean;
   setPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }


### PR DESCRIPTION
## Changes

This PR fixes #1234 by correctly invoking `onItemExecuted` prop of the `Toolbar` component which was omitted from the initial implementation of the updated toolbar

## Testing

Added additional story.