### PR TITLE
Fix `iconNode` rendering of `CursorMenuItemProps`

### DIFF
--- a/apps/test-providers/src/tools/SampleTool.tsx
+++ b/apps/test-providers/src/tools/SampleTool.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-
+import * as React from "react";
 import {
   AngleDescription,
   BeButtonEvent,
@@ -40,6 +40,7 @@ import {
 } from "@itwin/appui-react";
 import { AppUiTestProviders } from "../AppUiTestProviders.js";
 import sampleToolSvg from "./SampleTool.svg";
+import { SvgPlaceholder } from "@itwin/itwinui-icons-react";
 
 enum ToolOptions {
   Red,
@@ -465,11 +466,11 @@ export class SampleTool extends PrimitiveTool {
         id: "entry1",
         item: {
           label: "Label1",
-          icon: "icon-placeholder",
           execute: () => {
             this.showInfoFromCursorMenu("hello from entry1");
           },
         },
+        iconNode: <SvgPlaceholder />,
       });
       menuItems.push({
         id: "entry2",

--- a/apps/test-providers/src/tools/SampleTool.tsx
+++ b/apps/test-providers/src/tools/SampleTool.tsx
@@ -464,18 +464,17 @@ export class SampleTool extends PrimitiveTool {
       const menuItems: CursorMenuItemProps[] = [];
       menuItems.push({
         id: "entry1",
-        item: {
-          label: "Label1",
-          execute: () => {
-            this.showInfoFromCursorMenu("hello from entry1");
-          },
-        },
+        label: "Label1",
         iconNode: <SvgPlaceholder />,
+        execute: () => {
+          this.showInfoFromCursorMenu("hello from entry1");
+        },
       });
       menuItems.push({
         id: "entry2",
         item: {
           label: "Label2",
+          icon: "icon-placeholder",
           execute: () => {
             this.showInfoFromCursorMenu("hello from entry2");
           },
@@ -485,11 +484,21 @@ export class SampleTool extends PrimitiveTool {
         id: "entry3",
         item: {
           label: "Label3",
-          icon: "icon-placeholder",
           execute: () => {
             this.showInfoFromCursorMenu("hello from entry3");
           },
         },
+        iconRight: "icon-placeholder",
+      });
+      menuItems.push({
+        id: "entry4",
+        item: {
+          label: "Label4",
+          execute: () => {
+            this.showInfoFromCursorMenu("hello from entry4");
+          },
+        },
+        iconRightNode: <SvgPlaceholder />,
       });
 
       UiFramework.openCursorMenu({

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -1398,7 +1398,9 @@ export interface CursorMenuItemProps extends CommonProps {
     // @deprecated
     icon?: IconSpec;
     iconNode?: React_2.ReactNode;
+    // @deprecated
     iconRight?: string | ConditionalStringValue;
+    iconRightNode?: React_2.ReactNode;
     // @deprecated
     iconSpec?: IconSpec;
     id: string;
@@ -1469,17 +1471,7 @@ export class CursorPopupManager {
 }
 
 // @alpha
-export class CursorPopupMenu extends React_2.PureComponent<CommonProps, // eslint-disable-line @typescript-eslint/no-deprecated
-CursorPopupMenuState> {
-    // (undocumented)
-    componentDidMount(): void;
-    // (undocumented)
-    componentWillUnmount(): void;
-    // (undocumented)
-    render(): React_2.ReactNode;
-    // (undocumented)
-    readonly state: CursorPopupMenuState;
-}
+export function CursorPopupMenu(props: CommonProps): React_2.JSX.Element;
 
 // @public
 export interface CursorPopupOptions {

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -212,7 +212,7 @@ public;interface;CursorMenuPayload
 public;class;CursorPopup
 public;function;CursorPopupContent
 public;class;CursorPopupManager
-alpha;class;CursorPopupMenu
+alpha;function;CursorPopupMenu
 public;interface;CursorPopupOptions
 public;type;CursorPopupProps
 public;class;CursorPopupRenderer

--- a/common/changes/@itwin/appui-react/cursor-menu-fix_2025-03-31-09-19.json
+++ b/common/changes/@itwin/appui-react/cursor-menu-fix_2025-03-31-09-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Fixed `iconNode` property rendering of `CursorMenuItemProps` interface in `CursorPopupMenu` component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -7,6 +7,32 @@ Table of contents:
 - [@itwin/imodel-components-react](#itwinimodel-components-react)
   - [Additions](#additions-1)
 
+## @itwin/appui-react
+
+### Deprecations
+
+- Deprecated `iconRight` property of `CursorMenuItemProps` interface. Consumers should use newly added `iconRightNode` instead.
+
+  ```tsx
+  // Before
+  const item: CursorMenuItemProps = {
+    iconRight: "icon-placeholder",
+  };
+
+  // After
+  const item: CursorMenuItemProps = {
+    iconRightNode: <SvgPlaceholder />,
+  };
+  ```
+
+### Additions
+
+- Added `iconRightNode` property to `CursorMenuItemProps` which replaces deprecated web font icon specific `iconRight` property.
+
+### Fixes
+
+- Fixed `iconNode` property rendering of `CursorMenuItemProps` interface in `CursorPopupMenu` component.
+
 ## @itwin/components-react
 
 ### Additions

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -11,7 +11,7 @@ Table of contents:
 
 ### Deprecations
 
-- Deprecated `iconRight` property of `CursorMenuItemProps` interface. Consumers should use newly added `iconRightNode` instead.
+- Deprecated `iconRight` property of `CursorMenuItemProps` interface. Consumers should use newly added `iconRightNode` instead. [#1265](https://github.com/iTwin/appui/pull/1265)
 
   ```tsx
   // Before
@@ -27,11 +27,11 @@ Table of contents:
 
 ### Additions
 
-- Added `iconRightNode` property to `CursorMenuItemProps` which replaces deprecated web font icon specific `iconRight` property.
+- Added `iconRightNode` property to `CursorMenuItemProps` which replaces deprecated web font icon specific `iconRight` property. [#1265](https://github.com/iTwin/appui/pull/1265)
 
 ### Fixes
 
-- Fixed `iconNode` property rendering of `CursorMenuItemProps` interface in `CursorPopupMenu` component.
+- Fixed `iconNode` property rendering of `CursorMenuItemProps` interface in `CursorPopupMenu` component. [#1265](https://github.com/iTwin/appui/pull/1265)
 
 ## @itwin/components-react
 

--- a/ui/appui-react/src/appui-react/shared/MenuItem.tsx
+++ b/ui/appui-react/src/appui-react/shared/MenuItem.tsx
@@ -47,8 +47,11 @@ export interface CursorMenuItemProps extends CommonProps {
   submenu?: CursorMenuItemProps[];
   /** Icon to display on right side of the menu item.
    * Name of icon WebFont entry or if specifying an imported SVG symbol use "webSvg:" prefix  to imported symbol Id.
+   * @deprecated in 5.4.0. Use {@link CursorMenuItemProps.iconRightNode} instead.
    */
   iconRight?: string | ConditionalStringValue;
+  /** Icon to display on right side of the menu item. */
+  iconRightNode?: React.ReactNode;
 
   // #region "ItemProps" properties previously extended from deprecated type.
 
@@ -121,11 +124,8 @@ export class MenuItem extends ItemDefBase {
 
     if (props.item) {
       this._actionItem = new CommandItemDef(props.item);
-      this._actionItem.iconElement = props.iconNode;
 
       // Copy over icon, label & badgeType from the item
-      if (!this.iconSpec) this.iconSpec = this._actionItem.iconSpec;
-      if (!this.iconElement) this.iconElement = this._actionItem.iconElement;
       if (!this.label) this.setLabel(this._actionItem.label);
       if (!this.badgeType) this.badgeType = this._actionItem.badgeType;
       if (!this.badgeKind) this.badgeKind = this._actionItem.badgeKind;
@@ -133,7 +133,7 @@ export class MenuItem extends ItemDefBase {
     } else if (props.execute) {
       this._execute = props.execute;
     } else if (props.submenu) {
-      props.submenu.forEach((childProps: CursorMenuItemProps) => {
+      props.submenu.forEach((childProps) => {
         const childItem = new MenuItem(childProps, onSelection);
         this._submenu.push(childItem);
       });
@@ -145,7 +145,8 @@ export class MenuItem extends ItemDefBase {
       );
     }
 
-    this.iconRightSpec = props.iconRight;
+    this.iconSpec = props.iconNode ?? props.icon ?? this._actionItem?.iconSpec;
+    this.iconRightSpec = props.iconRightNode ?? props.iconRight;
   }
 
   public get id(): string {
@@ -182,7 +183,7 @@ export class MenuItemHelpers {
     onSelection?: () => void
   ): MenuItem[] {
     const menuItems = new Array<MenuItem>();
-    itemPropsList.forEach((itemProps: CursorMenuItemProps) => {
+    itemPropsList.forEach((itemProps) => {
       menuItems.push(new MenuItem(itemProps, onSelection));
     });
     return menuItems;
@@ -204,7 +205,7 @@ export class MenuItemHelpers {
     index: number
   ): React.ReactNode {
     const label = item.label;
-    const iconSpec = item.iconElement ?? item.iconSpec;
+    const iconSpec = item.iconSpec;
     const iconRightSpec = item.iconRightSpec;
     const badgeType = item.badgeType;
     const badgeKind = item.badgeKind;

--- a/ui/appui-react/src/appui-react/shared/MenuItem.tsx
+++ b/ui/appui-react/src/appui-react/shared/MenuItem.tsx
@@ -121,9 +121,11 @@ export class MenuItem extends ItemDefBase {
 
     if (props.item) {
       this._actionItem = new CommandItemDef(props.item);
+      this._actionItem.iconElement = props.iconNode;
 
       // Copy over icon, label & badgeType from the item
       if (!this.iconSpec) this.iconSpec = this._actionItem.iconSpec;
+      if (!this.iconElement) this.iconElement = this._actionItem.iconElement;
       if (!this.label) this.setLabel(this._actionItem.label);
       if (!this.badgeType) this.badgeType = this._actionItem.badgeType;
       if (!this.badgeKind) this.badgeKind = this._actionItem.badgeKind;
@@ -202,7 +204,7 @@ export class MenuItemHelpers {
     index: number
   ): React.ReactNode {
     const label = item.label;
-    const iconSpec = item.iconSpec;
+    const iconSpec = item.iconElement ?? item.iconSpec;
     const iconRightSpec = item.iconRightSpec;
     const badgeType = item.badgeType;
     const badgeKind = item.badgeKind;


### PR DESCRIPTION
## Changes

This PR fixes #1235 by correctly rendering an icon specified via `iconNode` property of `CursorMenuItemProps` interface in `CursorPopupMenu` component.

Additionally, `iconRight` property of `CursorMenuItemProps` is deprecated and replaced by newly introduced `iconRightNode`.

`CursorPopupMenu` component is converted from a class component to a functional one.

## Testing

Tested manually via test-app (alt+click when "SampleTool" is active).
