### PR TITLE
Add `visibleToolSettings` prop to `<StandardLayout>`

### DIFF
--- a/common/changes/@itwin/appui-react/tool-settings-widget_2025-03-30-20-45.json
+++ b/common/changes/@itwin/appui-react/tool-settings-widget_2025-03-30-20-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Added `visibleToolSettings` prop to `StandardLayout` component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -11,7 +11,7 @@ Table of contents:
 
 ### Additions
 
-- Added `visibleToolSettings` prop to `StandardLayout` component which when enabled keeps the tool settings visible to the end user. This is especially useful when the tool settings is undocked as a regular widget as changing a tool or it's tool settings will show the tool settings widget via the `WidgetDef.show()` API.
+- Added `visibleToolSettings` prop to `StandardLayout` component which when enabled keeps the tool settings visible to the end user. This is especially useful when the tool settings is undocked as a regular widget as changing a tool or it's tool settings will show the tool settings widget via the `WidgetDef.show()` API. [#1266](https://github.com/iTwin/appui/pull/1266)
 
   ```tsx
   UiFramework.frontstages.addFrontstage({

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -7,6 +7,19 @@ Table of contents:
 - [@itwin/imodel-components-react](#itwinimodel-components-react)
   - [Additions](#additions-1)
 
+## @itwin/appui-react
+
+### Additions
+
+- Added `visibleToolSettings` prop to `StandardLayout` component which when enabled keeps the tool settings visible to the end user. This is especially useful when the tool settings is undocked as a regular widget as changing a tool or it's tool settings will show the tool settings widget via the `WidgetDef.show()` API.
+
+  ```tsx
+  UiFramework.frontstages.addFrontstage({
+    // ...
+    layout: <StandardLayout visibleToolSettings />,
+  });
+  ```
+
 ## @itwin/components-react
 
 ### Additions

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -108,15 +108,21 @@ export function ConfigurableUiContent(props: ConfigurableUiContentProps) {
 interface StandardLayoutProps {
   /** Overrides widget specific actions displayed in the title bar area.
    * Use {@link WidgetActions} component to customize widget actions.
+   * @alpha
    */
   widgetActions?: React.ReactNode;
+  /** When enabled keeps the tool settings visible to the end user.
+   * This is especially useful when the tool settings is undocked as a regular widget.
+   * @alpha
+   */
+  visibleToolSettings?: boolean;
 }
 
 /** The standard widget based layout used as a default layout for all frontstages.
  * @alpha
  */
 export function StandardLayout(props: StandardLayoutProps) {
-  const { widgetActions } = props;
+  const { widgetActions, visibleToolSettings = false } = props;
   const context = React.useContext(ConfigurableUiContext);
   const {
     appBackstage,
@@ -144,6 +150,7 @@ export function StandardLayout(props: StandardLayoutProps) {
       InternalConfigurableUiManager.activityTracker.terminate();
     };
   }, [idleTimeout, intervalTimeout]);
+  useVisibleToolSettings(visibleToolSettings);
 
   const setContentHovered = useCursorInformationStore(
     (state) => state.setContentHovered
@@ -259,4 +266,16 @@ function useToolbarOpacity(
       document.documentElement.style.removeProperty("--buic-toolbar-opacity");
     };
   }, [opacity]);
+}
+
+function useVisibleToolSettings(enabled: boolean) {
+  React.useEffect(() => {
+    if (!enabled) return;
+    return UiFramework.frontstages.onToolSettingsReloadEvent.addListener(() => {
+      const frontstage = UiFramework.frontstages.activeFrontstageDef;
+      const toolSettings = frontstage?.toolSettings;
+      if (!toolSettings) return;
+      toolSettings.show();
+    });
+  }, [enabled]);
 }


### PR DESCRIPTION
## Changes

This PR fixes #1227 by adding `visibleToolSettings` prop to `StandardLayout` component which when enabled keeps the tool settings visible to the end user. This is especially useful when the tool settings is undocked as a regular widget as changing a tool or it's tool settings will show the tool settings widget via the `WidgetDef.show()` API.

## Testing

Tested manually via test-app.
