### PR TITLE
`useCommittableValue`: Avoid committing on same value

### DIFF
--- a/common/changes/@itwin/components-react/editors-avoid-commiting-on-same-value_2025-03-31-14-52.json
+++ b/common/changes/@itwin/components-react/editors-avoid-commiting-on-same-value_2025-03-31-14-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "`useCommittableValue`: Avoid invoking `commit` if value is the same as the initial.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -278,6 +278,8 @@ Table of contents:
 
   The new system removes all the code that was associated with class components and accessing values through editor `ref`. It is not clear if that was used/useful so the chosen approach is to add something similar later if that is still needed. Majority of that was used by `EditorContainer` that is replaced by `useCommittableValue` hook in the new system.
 
+- `useCommittableValue`: Avoid invoking `commit` if value is the same as the initial.
+
 ## @itwin/imodel-components-react
 
 ### Additions

--- a/ui/components-react/src/components-react/new-editors/UseCommittableValue.tsx
+++ b/ui/components-react/src/components-react/new-editors/UseCommittableValue.tsx
@@ -8,6 +8,7 @@
 
 import * as React from "react";
 import type { Value } from "./values/Values.js";
+import { areEqual } from "./values/ValueUtilities.js";
 
 interface UseCommittableValueProps {
   initialValue?: Value;
@@ -52,6 +53,7 @@ export function useCommittableValue({
   onCancel,
   onCommit,
 }: UseCommittableValueProps) {
+  const initialValueRef = React.useRef(initialValue);
   const [currentValue, setCurrentValue] = React.useState<Value | undefined>(
     initialValue
   );
@@ -69,7 +71,10 @@ export function useCommittableValue({
   };
 
   const handleCommit = () => {
-    if (currentValueRef.current.state === "changed") {
+    if (
+      currentValueRef.current.state === "changed" &&
+      !areEqual(currentValueRef.current.value, initialValueRef.current)
+    ) {
       onCommit(currentValueRef.current.value);
       return;
     }

--- a/ui/components-react/src/components-react/new-editors/values/ValueUtilities.ts
+++ b/ui/components-react/src/components-react/new-editors/values/ValueUtilities.ts
@@ -63,3 +63,42 @@ export function isEnum(value: Value): value is EnumValue {
 export function isInstanceKey(value: Value): value is InstanceKeyValue {
   return "key" in value && "id" in value.key && "className" in value.key;
 }
+
+/**
+ * Checks if two values are equal.
+ * @beta
+ */
+export function areEqual(
+  lhs: Value | undefined,
+  rhs: Value | undefined
+): boolean {
+  if (lhs === undefined && rhs === undefined) {
+    return true;
+  }
+  if (lhs === undefined) {
+    return false;
+  }
+  if (rhs === undefined) {
+    return false;
+  }
+
+  if (isNumeric(lhs) && isNumeric(rhs)) {
+    return lhs.rawValue === rhs.rawValue;
+  }
+  if (isText(lhs) && isText(rhs)) {
+    return lhs.value === rhs.value;
+  }
+  if (isBoolean(lhs) && isBoolean(rhs)) {
+    return lhs.value === rhs.value;
+  }
+  if (isDate(lhs) && isDate(rhs)) {
+    return lhs.value === rhs.value;
+  }
+  if (isInstanceKey(lhs) && isInstanceKey(rhs)) {
+    return lhs.key.id === rhs.key.id && lhs.key.className === rhs.key.className;
+  }
+  if (isEnum(lhs) && isEnum(rhs)) {
+    return lhs.choice === rhs.choice;
+  }
+  return false;
+}

--- a/ui/components-react/src/test/new-editors/Values.test.ts
+++ b/ui/components-react/src/test/new-editors/Values.test.ts
@@ -13,6 +13,7 @@ import type {
   TextValue,
 } from "../../components-react/new-editors/values/Values.js";
 import {
+  areEqual,
   isBoolean,
   isDate,
   isEnum,
@@ -84,5 +85,97 @@ describe("ValueUtilities", () => {
     expect(isInstanceKey(dateValue)).toBe(false);
     expect(isInstanceKey(enumValue)).toBe(false);
     expect(isInstanceKey(instanceKeyValue)).toBe(true);
+  });
+
+  describe("areEqual", () => {
+    it("compares `undefined` value", () => {
+      expect(areEqual(undefined, undefined)).toBe(true);
+      expect(areEqual(undefined, { value: "text" })).toBe(false);
+      expect(areEqual({ value: "text" }, undefined)).toBe(false);
+    });
+
+    it("compares text values", () => {
+      expect(areEqual({ value: "text" }, { value: "text" })).toBe(true);
+      expect(areEqual({ value: "text" }, { value: "different-text" })).toBe(
+        false
+      );
+      expect(areEqual({ value: "different-text" }, { value: "text" })).toBe(
+        false
+      );
+    });
+
+    it("compares numeric values", () => {
+      expect(
+        areEqual(
+          { rawValue: 1, displayValue: "1" },
+          { rawValue: 1, displayValue: "1" }
+        )
+      ).toBe(true);
+      expect(
+        areEqual(
+          { rawValue: 1, displayValue: "1" },
+          { rawValue: 2, displayValue: "2" }
+        )
+      ).toBe(false);
+      expect(
+        areEqual(
+          { rawValue: 2, displayValue: "2" },
+          { rawValue: 1, displayValue: "1" }
+        )
+      ).toBe(false);
+    });
+
+    it("compares boolean values", () => {
+      expect(areEqual({ value: true }, { value: true })).toBe(true);
+      expect(areEqual({ value: true }, { value: false })).toBe(false);
+      expect(areEqual({ value: false }, { value: true })).toBe(false);
+    });
+
+    it("compares date values", () => {
+      const date = new Date("2025-01-01T00:00:00Z");
+      const differentDate = new Date("2025-02-01T00:00:00Z");
+      expect(areEqual({ value: date }, { value: date })).toBe(true);
+      expect(areEqual({ value: date }, { value: differentDate })).toBe(false);
+      expect(areEqual({ value: differentDate }, { value: date })).toBe(false);
+    });
+
+    it("compares enum values", () => {
+      expect(areEqual({ choice: 1 }, { choice: 1 })).toBe(true);
+      expect(areEqual({ choice: 1 }, { choice: 2 })).toBe(false);
+      expect(areEqual({ choice: 2 }, { choice: 1 })).toBe(false);
+    });
+
+    it("compares instance key values", () => {
+      expect(
+        areEqual(
+          { key: { id: "0x1", className: "Schema.Class" } },
+          { key: { id: "0x1", className: "Schema.Class" } }
+        )
+      ).toBe(true);
+      expect(
+        areEqual(
+          { key: { id: "0x1", className: "Schema.Class" } },
+          { key: { id: "0x2", className: "Schema.Class" } }
+        )
+      ).toBe(false);
+      expect(
+        areEqual(
+          { key: { id: "0x2", className: "Schema.Class" } },
+          { key: { id: "0x1", className: "Schema.Class" } }
+        )
+      ).toBe(false);
+      expect(
+        areEqual(
+          { key: { id: "0x1", className: "Schema.Class" } },
+          { key: { id: "0x1", className: "Schema.DifferentClass" } }
+        )
+      ).toBe(false);
+      expect(
+        areEqual(
+          { key: { id: "0x1", className: "Schema.DifferentClass" } },
+          { key: { id: "0x1", className: "Schema.Class" } }
+        )
+      ).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Closes https://github.com/iTwin/appui/issues/1220. Added check to the `useCommittableValue` for value equality to make sure that `commit` is not invoked if value is the same as the initial.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Added unit tests.