### PR TITLE
Add ability to render prompt at cursor in child windows

### DIFF
--- a/apps/test-app/src/frontend/App.tsx
+++ b/apps/test-app/src/frontend/App.tsx
@@ -46,5 +46,9 @@ export function App({ featureOverrides }: AppProps) {
 
 // Load iTwinUI v2 styles in popout widgets.
 function ChildWindow(props: React.PropsWithChildren<object>) {
-  return <IUI2_ThemeProvider>{props.children}</IUI2_ThemeProvider>;
+  return (
+    <IUI2_ThemeProvider style={{ height: "100%" }}>
+      {props.children}
+    </IUI2_ThemeProvider>
+  );
 }

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -168,12 +168,7 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
       }),
       StatusBarItemUtilities.createCustomItem({
         id: "ToolAssistance",
-        content: (
-          <ToolAssistanceField
-            cursorPromptTimeout={99999999}
-            promptAtContent={true}
-          />
-        ),
+        content: <ToolAssistanceField />,
       }),
     ];
   }

--- a/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
+++ b/apps/test-providers/src/ui/providers/ContentLayoutStageUiItemsProvider.tsx
@@ -10,6 +10,7 @@ import {
   StagePanelSection,
   StatusBarItem,
   StatusBarItemUtilities,
+  ToolAssistanceField,
   ToolbarItem,
   ToolbarItemUtilities,
   ToolbarOrientation,
@@ -164,6 +165,15 @@ export class ContentLayoutStageUiItemsProvider implements UiItemsProvider {
         id: "DisplayStyle",
         itemPriority: 400,
         content: <DisplayStyleField />,
+      }),
+      StatusBarItemUtilities.createCustomItem({
+        id: "ToolAssistance",
+        content: (
+          <ToolAssistanceField
+            cursorPromptTimeout={99999999}
+            promptAtContent={true}
+          />
+        ),
       }),
     ];
   }

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -1367,12 +1367,13 @@ export class CursorInformation {
     // @internal
     static clearCursorDirections(): void;
     static get cursorDirection(): CursorDirection;
+    static get cursorDocument(): Document | undefined;
     static get cursorPosition(): XAndY;
     static set cursorPosition(pt: XAndY);
     static get cursorX(): number;
     static get cursorY(): number;
     static getRelativePositionFromCursorDirection(cursorDirection: CursorDirection): RelativePosition;
-    static handleMouseMove(point: XAndY): void;
+    static handleMouseMove(point: XAndY, document?: Document): void;
     static readonly onCursorUpdatedEvent: CursorUpdatedEvent;
 }
 
@@ -1461,13 +1462,13 @@ export class CursorPopupManager {
     static readonly onCursorPopupUpdatePositionEvent: BeUiEvent<{
         pt: XAndY;
     }>;
-    static open(id: string, content: React_2.ReactNode, pt: XAndY, offset: XAndY, relativePosition: RelativePosition, priority?: number, options?: CursorPopupOptions): void;
+    static open(id: string, content: React_2.ReactNode, pt: XAndY, offset: XAndY, relativePosition: RelativePosition, priority?: number, options?: CursorPopupOptions, targetDocument?: Document): void;
     // (undocumented)
     static get popupCount(): number;
     // (undocumented)
     static get popups(): CursorPopupInfo[];
-    static update(id: string, content: React_2.ReactNode, pt: XAndY, offset: XAndY, relativePosition: RelativePosition, priority?: number): void;
-    static updatePosition(pt: XAndY): void;
+    static update(id: string, content: React_2.ReactNode, pt: XAndY, offset: XAndY, relativePosition: RelativePosition, priority?: number, targetDocument?: Document): void;
+    static updatePosition(pt: XAndY, targetDocument?: Document): void;
 }
 
 // @alpha
@@ -1497,15 +1498,7 @@ RequireAtLeastOne<{
 }>;
 
 // @public
-export class CursorPopupRenderer extends React_2.Component<any, CursorPopupRendererState> {
-    constructor(props: any);
-    // (undocumented)
-    componentDidMount(): void;
-    // (undocumented)
-    componentWillUnmount(): void;
-    // (undocumented)
-    render(): React_2.ReactNode;
-}
+export function CursorPopupRenderer(): React_2.JSX.Element | undefined;
 
 // @public @deprecated
 export class CursorUpdatedEvent extends UiEvent<CursorUpdatedEventArgs> {
@@ -2166,6 +2159,7 @@ export class FrameworkUiAdmin extends UiAdmin {
 // @public
 export interface FrameworkVisibility {
     autoHideUi: boolean;
+    handleContentMouseLeave(_event?: React.MouseEvent<HTMLElement, MouseEvent>): void;
     handleContentMouseMove(_event?: React.MouseEvent<HTMLElement, MouseEvent>): void;
     handleFrontstageReady(): void;
     handleWidgetMouseEnter(_event?: React.MouseEvent<HTMLElement, MouseEvent>): void;

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -215,7 +215,7 @@ public;class;CursorPopupManager
 alpha;function;CursorPopupMenu
 public;interface;CursorPopupOptions
 public;type;CursorPopupProps
-public;class;CursorPopupRenderer
+public;function;CursorPopupRenderer
 public;class;CursorUpdatedEvent
 deprecated;class;CursorUpdatedEvent
 public;interface;CursorUpdatedEventArgs

--- a/common/changes/@itwin/appui-react/prompt-at-cursor_2025-04-11-11-26.json
+++ b/common/changes/@itwin/appui-react/prompt-at-cursor_2025-04-11-11-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Display prompt at cursor in child windows.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -41,6 +41,42 @@ Table of contents:
   });
   ```
 
+- Added `cursorDocument` getter to `CursorInformation` class. Added `targetDocument` optional argument to `updatePosition`, `update` and `open` methods of `CursorPopupManager` class. Added `targetDocument` property to `CursorPopupInfo` interface. These additions are used to support cursor based functionality in child windows and popout widgets by specifying a window document. [#1277](https://github.com/iTwin/appui/pull/1277)
+- Added `handleContentMouseLeave` property to `FrameworkVisibility` interface available via `UiFramework.visibility`. This new method together with existing `handleContentMouseMove` allows consumers to mark when cursor is interacting with the main content of the application - usually a viewport. These APIs are currently used by UI auto hide feature and `promptAtContent` feature of `ToolAssistanceField` component. [#1277](https://github.com/iTwin/appui/pull/1277)
+
+  By default content mouse events are handled by:
+
+  - `ContentOverlay` component
+  - `FloatingViewportContentWrapper` component
+  - When using `contentGroup` APIs of `Frontstage`
+
+  Consumers that want to display tool assistance cursor prompt in a widget or a widget popout should render `ContentOverlay` component:
+
+  ```tsx
+  function MyWidget() {
+    return (
+      <ContentOverlay>
+        <Viewport />
+      </ContentOverlay>
+    );
+  }
+  ```
+
+  Alternatively, to handle content mouse events manually:
+
+  ```tsx
+  function MyWidget() {
+    return (
+      <div
+        onMouseMove={UiFramework.visibility.handleContentMouseMove}
+        onMouseLeave={UiFramework.visibility.handleContentMouseLeave}
+      >
+        <Viewport />
+      </div>
+    );
+  }
+  ```
+
 ### Fixes
 
 - Fixed an icon size of a backstage app button when web font icon is used. [#1262](https://github.com/iTwin/appui/pull/1262)

--- a/ui/appui-react/src/appui-react/childwindow/ChildWindowRenderer.tsx
+++ b/ui/appui-react/src/appui-react/childwindow/ChildWindowRenderer.tsx
@@ -21,6 +21,7 @@ import { ModelessDialogRenderer } from "../dialog/ModelessDialogManager.js";
 import { CursorPopupMenu } from "../cursor/cursormenu/CursorMenu.js";
 import { copyStyles } from "./CopyStyles.js";
 import { ConfigurableUiContext } from "../configurableui/ConfigurableUiContent.js";
+import { CursorPopupRenderer } from "../../appui-react.js";
 
 interface ChildWindowRendererProps {
   windowManager: InternalChildWindowManager;
@@ -77,22 +78,25 @@ function ChildWindow({ content, tabId, window }: ChildWindowProps) {
 
   const ChildWindowWrapper = childWindow ?? DefaultChildWindowWrapper;
   return ReactDOM.createPortal(
-    <TabIdContext.Provider value={tabId}>
-      <ThemeManager>
-        <ChildWindowWrapper>
-          <div className="uifw-child-window-container-host">
-            <PopupRenderer />
-            <ModalDialogRenderer />
-            <ModelessDialogRenderer />
-            <CursorPopupMenu />
-            <div className="uifw-child-window-container nz-widget-widget">
-              {content}
+    <ChildWindowContext.Provider value={window}>
+      <TabIdContext.Provider value={tabId}>
+        <ThemeManager>
+          <ChildWindowWrapper>
+            <div className="uifw-child-window-container-host">
+              <PopupRenderer />
+              <ModalDialogRenderer />
+              <ModelessDialogRenderer />
+              <CursorPopupMenu />
+              <div className="uifw-child-window-container nz-widget-widget">
+                {content}
+              </div>
+              <CursorPopupRenderer />
             </div>
-          </div>
-          <div className="uifw-childwindow-internalChildWindowManager_portalContainer" />
-        </ChildWindowWrapper>
-      </ThemeManager>
-    </TabIdContext.Provider>,
+            <div className="uifw-childwindow-internalChildWindowManager_portalContainer" />
+          </ChildWindowWrapper>
+        </ThemeManager>
+      </TabIdContext.Provider>
+    </ChildWindowContext.Provider>,
     container
   );
 }
@@ -119,3 +123,8 @@ const stylesUtils = (() => {
 function DefaultChildWindowWrapper(props: React.PropsWithChildren) {
   return <>{props.children}</>;
 }
+
+/** @internal */
+export const ChildWindowContext = React.createContext<Window | undefined>(
+  undefined
+);

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -11,10 +11,7 @@ import * as React from "react";
 import type { CommonProps } from "@itwin/core-react";
 import { Point } from "@itwin/core-react/internal";
 import { ThemeProvider } from "@itwin/itwinui-react";
-import {
-  CursorInformation,
-  useCursorInformationStore,
-} from "../cursor/CursorInformation.js";
+import { CursorInformation } from "../cursor/CursorInformation.js";
 import { CursorPopupMenu } from "../cursor/cursormenu/CursorMenu.js";
 import { CursorPopupRenderer } from "../cursor/cursorpopup/CursorPopupManager.js";
 import { ModalDialogRenderer } from "../dialog/ModalDialogManager.js";
@@ -152,9 +149,6 @@ export function StandardLayout(props: StandardLayoutProps) {
   }, [idleTimeout, intervalTimeout]);
   useVisibleToolSettings(visibleToolSettings);
 
-  const setContentHovered = useCursorInformationStore(
-    (state) => state.setContentHovered
-  );
   return (
     <ConfigurableUiContext.Provider
       value={React.useMemo(
@@ -174,13 +168,6 @@ export function StandardLayout(props: StandardLayoutProps) {
         onMouseMove={(e) => {
           const point = new Point(e.pageX, e.pageY);
           CursorInformation.handleMouseMove(point, e.view.document);
-
-          if (!(e.target instanceof Node)) return;
-          const contentHovered = contentElementRef.current?.contains(e.target);
-          setContentHovered(contentHovered ?? false);
-        }}
-        onMouseLeave={() => {
-          setContentHovered(false);
         }}
         ref={(el) => setMainElement(el ?? undefined)}
       >

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -173,7 +173,7 @@ export function StandardLayout(props: StandardLayoutProps) {
         style={context.style}
         onMouseMove={(e) => {
           const point = new Point(e.pageX, e.pageY);
-          CursorInformation.handleMouseMove(point);
+          CursorInformation.handleMouseMove(point, e.view.document);
 
           if (!(e.target instanceof Node)) return;
           const contentHovered = contentElementRef.current?.contains(e.target);

--- a/ui/appui-react/src/appui-react/content/ContentLayout.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.tsx
@@ -253,7 +253,6 @@ class SingleContentContainer extends React.Component<SingleContentProps> {
         )}
         style={this.props.style}
         data-testid="single-content-container"
-        onMouseMove={UiFramework.visibility.handleContentMouseMove}
       >
         <ContentWrapper
           content={this.props.content}
@@ -660,29 +659,27 @@ export function ContentLayout(props: ContentLayoutComponentProps) {
     contentNodes,
     true
   );
-  if (contentContainer) {
-    return (
-      <div
-        id="uifw-contentlayout-div"
-        className={props.className}
-        style={props.style}
-        key={`${contentGroupId}-${contentLayoutDef.id}`}
-        onMouseDown={() => {
-          UiFramework.content.setMouseDown(true);
-        }}
-        onMouseUp={() => {
-          UiFramework.content.setMouseDown(false);
-        }}
-        role="presentation"
-      >
-        <ContentLayoutContext.Provider value={contentGroup}>
-          {contentContainer}
-        </ContentLayoutContext.Provider>
-      </div>
-    );
-  }
+  if (!contentContainer) return null;
 
-  return null;
+  return (
+    <div
+      id="uifw-contentlayout-div"
+      className={props.className}
+      style={props.style}
+      key={`${contentGroupId}-${contentLayoutDef.id}`}
+      onMouseDown={() => {
+        UiFramework.content.setMouseDown(true);
+      }}
+      onMouseUp={() => {
+        UiFramework.content.setMouseDown(false);
+      }}
+      role="presentation"
+    >
+      <ContentLayoutContext.Provider value={contentGroup}>
+        {contentContainer}
+      </ContentLayoutContext.Provider>
+    </div>
+  );
 }
 
 const ContentLayoutContext = React.createContext<ContentGroup | undefined>(

--- a/ui/appui-react/src/appui-react/content/ContentLayout.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.tsx
@@ -129,8 +129,6 @@ export function ContentWrapper(props: ContentWrapperProps) {
       style={props.style}
       active={active}
       onMouseDown={handleMouseDown}
-      onMouseMove={UiFramework.visibility.handleContentMouseMove}
-      onMouseLeave={UiFramework.visibility.handleContentMouseLeave}
       role="presentation"
     >
       {content}

--- a/ui/appui-react/src/appui-react/content/ContentLayout.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentLayout.tsx
@@ -130,6 +130,7 @@ export function ContentWrapper(props: ContentWrapperProps) {
       active={active}
       onMouseDown={handleMouseDown}
       onMouseMove={UiFramework.visibility.handleContentMouseMove}
+      onMouseLeave={UiFramework.visibility.handleContentMouseLeave}
       role="presentation"
     >
       {content}

--- a/ui/appui-react/src/appui-react/content/ContentOverlay.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentOverlay.tsx
@@ -14,6 +14,7 @@ import { useOptionalLayout } from "../layout/base/LayoutStore.js";
 import { getWidgetState } from "../widgets/WidgetDef.js";
 import { TabIdContext } from "../layout/widget/ContentRenderer.js";
 import { WidgetState } from "../widgets/WidgetState.js";
+import { UiFramework } from "../UiFramework.js";
 
 /** Returns the number of content overlays.
  * @internal
@@ -38,6 +39,8 @@ export function ContentOverlay({
   return (
     <div
       className={classnames("uifw-content-contentOverlay", className)}
+      onMouseMove={UiFramework.visibility.handleContentMouseMove}
+      onMouseLeave={UiFramework.visibility.handleContentMouseLeave}
       {...other}
     >
       {children}

--- a/ui/appui-react/src/appui-react/content/ContentOverlay.tsx
+++ b/ui/appui-react/src/appui-react/content/ContentOverlay.tsx
@@ -27,6 +27,7 @@ interface ContentOverlayProps extends React.ComponentProps<"div"> {
 }
 
 /** Overlay used to identify active content views.
+ * This component is treated as part of the application content and integrates with the `UiFramework.visibility` system to handle mouse events appropriately.
  * @beta
  */
 export function ContentOverlay({

--- a/ui/appui-react/src/appui-react/content/FloatingViewportContent.tsx
+++ b/ui/appui-react/src/appui-react/content/FloatingViewportContent.tsx
@@ -15,7 +15,7 @@ import { FloatingViewportContentControl } from "./ViewportContentControl.js";
 import { ContentWrapper } from "./ContentLayout.js";
 import { UiFramework } from "../UiFramework.js";
 import { useRefs } from "@itwin/core-react/internal";
-import { ContentOverlay } from "./ContentOverlay.js";
+import type { ContentOverlay } from "./ContentOverlay.js";
 
 /* eslint-disable @typescript-eslint/no-deprecated */
 
@@ -64,8 +64,6 @@ export function FloatingViewportContentWrapper({
 }: FloatingViewportContentWrapperProps) {
   return (
     <div
-      onMouseMove={UiFramework.visibility.handleContentMouseMove}
-      onMouseLeave={UiFramework.visibility.handleContentMouseLeave}
       className="uifw-dialog-imodel-content"
       style={{ height: "100%", position: "relative" }}
     >

--- a/ui/appui-react/src/appui-react/content/FloatingViewportContent.tsx
+++ b/ui/appui-react/src/appui-react/content/FloatingViewportContent.tsx
@@ -65,6 +65,7 @@ export function FloatingViewportContentWrapper({
   return (
     <div
       onMouseMove={UiFramework.visibility.handleContentMouseMove}
+      onMouseLeave={UiFramework.visibility.handleContentMouseLeave}
       className="uifw-dialog-imodel-content"
       style={{ height: "100%", position: "relative" }}
     >

--- a/ui/appui-react/src/appui-react/cursor/CursorInformation.ts
+++ b/ui/appui-react/src/appui-react/cursor/CursorInformation.ts
@@ -59,6 +59,7 @@ export class CursorUpdatedEvent extends UiEvent<CursorUpdatedEventArgs> {}
  */
 export class CursorInformation {
   private static _cursorPosition: Point = new Point();
+  private static _cursorDocument: Document | undefined;
   private static _cursorDirection: CursorDirection =
     CursorDirection.BottomRight;
 
@@ -86,12 +87,17 @@ export class CursorInformation {
     return this._cursorDirection;
   }
 
+  /** Gets the cursor document. */
+  public static get cursorDocument(): Document | undefined {
+    return this._cursorDocument;
+  }
+
   /** Gets the [[CursorUpdatedEvent]]. */
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   public static readonly onCursorUpdatedEvent = new CursorUpdatedEvent();
 
   /** Handles the mouse movement.  Sets the cursor position and direction and emits onCursorUpdatedEvent. */
-  public static handleMouseMove(point: XAndY): void {
+  public static handleMouseMove(point: XAndY, document?: Document): void {
     const oldPt = CursorInformation.cursorPosition;
     const direction = this._determineMostFrequentDirection(
       this._cursorDirections,
@@ -100,6 +106,7 @@ export class CursorInformation {
     );
 
     this.cursorPosition = point;
+    this._cursorDocument = document;
     this._cursorDirection = direction;
 
     this.onCursorUpdatedEvent.emit({ oldPt, newPt: point, direction });

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
@@ -226,6 +226,14 @@ export class CursorPopupManager {
     targetDocument: Document | undefined
   ) {
     CursorPopupManager.popups.forEach((popupInfo) => {
+      if (
+        popupInfo.cancelFadeOut &&
+        popupInfo.targetDocument !== targetDocument
+      ) {
+        // Popup if fading out - do not change target document.
+        return;
+      }
+
       popupInfo.renderRelativePosition = popupInfo.relativePosition;
       popupInfo.targetDocument = targetDocument;
 

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
@@ -143,7 +143,8 @@ export class CursorPopupManager {
     pt: XAndY,
     offset: XAndY,
     relativePosition: RelativePosition,
-    priority: number = 0
+    priority: number = 0,
+    targetDocument?: Document
   ) {
     const popupInfo = CursorPopupManager._popups.find(
       (info: CursorPopupInfo) => id === info.id
@@ -154,6 +155,7 @@ export class CursorPopupManager {
       popupInfo.relativePosition = relativePosition;
       popupInfo.renderRelativePosition = relativePosition;
       popupInfo.priority = priority;
+      popupInfo.targetDocument = targetDocument;
     } else {
       Logger.logError(
         UiFramework.loggerCategory("CursorPopupManager"),

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
@@ -112,7 +112,7 @@ export class CursorPopupManager {
       popupInfo.priority = priority;
       popupInfo.options = options;
       popupInfo.targetDocument = targetDocument;
-      CursorPopupManager.updatePosition(pt);
+      CursorPopupManager.updatePosition(pt, targetDocument);
 
       if (popupInfo.cancelFadeOut) {
         popupInfo.cancelFadeOut();
@@ -132,7 +132,7 @@ export class CursorPopupManager {
       targetDocument,
     };
     CursorPopupManager.pushPopup(newPopupInfo);
-    CursorPopupManager.updatePosition(pt);
+    CursorPopupManager.updatePosition(pt, targetDocument);
   }
 
   /** Called to update popup with a new set of properties
@@ -375,12 +375,17 @@ export function CursorPopupRenderer() {
 
   React.useEffect(() => {
     return CursorPopupManager.onCursorPopupsChangedEvent.addListener(() => {
-      setPopups([...CursorPopupManager.popups]);
+      const allPopups = CursorPopupManager.popups;
+      const newPopups = allPopups.map((p) => ({ ...p }));
+      setPopups(newPopups);
     });
   }, []);
   React.useEffect(() => {
     return CursorPopupManager.onCursorPopupUpdatePositionEvent.addListener(
       (args) => {
+        const allPopups = CursorPopupManager.popups;
+        const newPopups = allPopups.map((p) => ({ ...p }));
+        setPopups(newPopups);
         setPoint(Point.create(args.pt));
       }
     );

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopupManager.tsx
@@ -32,7 +32,9 @@ export interface CursorPopupOptions {
   shadow?: boolean;
 }
 
-/** Information maintained by CursorPopupManager about a CursorPopup. */
+/** Information maintained by CursorPopupManager about a CursorPopup.
+ * @public
+ */
 interface CursorPopupInfo {
   id: string;
   content: React.ReactNode;

--- a/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.tsx
@@ -41,7 +41,10 @@ export class CursorPrompt {
     if (!this._removeListeners) {
       const listeners = [
         CursorInformation.onCursorUpdatedEvent.addListener((args) => {
-          CursorPopupManager.updatePosition(args.newPt);
+          CursorPopupManager.updatePosition(
+            args.newPt,
+            CursorInformation.cursorDocument
+          );
         }),
         useCursorInformationStore.subscribe((state) => {
           if (!promptAtContent) return;
@@ -109,7 +112,8 @@ export class CursorPrompt {
       new Point(20, 20),
       RelativePosition.BottomRight,
       0,
-      { shadow: true }
+      { shadow: true },
+      CursorInformation.cursorDocument
     );
   }
 

--- a/ui/appui-react/src/appui-react/framework/FrameworkVisibility.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkVisibility.ts
@@ -41,6 +41,11 @@ export interface FrameworkVisibility {
     _event?: React.MouseEvent<HTMLElement, MouseEvent>
   ): void;
 
+  /** Handler for when the mouse moves over the content area */
+  handleContentMouseLeave(
+    _event?: React.MouseEvent<HTMLElement, MouseEvent>
+  ): void;
+
   /** Handler for when the mouse enters a widget */
   handleWidgetMouseEnter(
     _event?: React.MouseEvent<HTMLElement, MouseEvent>

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
@@ -85,7 +85,12 @@ export class StandardStatusbarUiItemsProvider implements UiItemsProvider {
           id: "uifw.ToolAssistance",
           section: StatusBarSection.Left,
           itemPriority: 20,
-          content: <ToolAssistanceField />,
+          content: (
+            <ToolAssistanceField
+              cursorPromptTimeout={99999999}
+              promptAtContent={true}
+            />
+          ),
         })
       );
 

--- a/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
+++ b/ui/appui-react/src/appui-react/ui-items-provider/StandardStatusbarUiItemsProvider.tsx
@@ -85,12 +85,7 @@ export class StandardStatusbarUiItemsProvider implements UiItemsProvider {
           id: "uifw.ToolAssistance",
           section: StatusBarSection.Left,
           itemPriority: 20,
-          content: (
-            <ToolAssistanceField
-              cursorPromptTimeout={99999999}
-              promptAtContent={true}
-            />
-          ),
+          content: <ToolAssistanceField />,
         })
       );
 

--- a/ui/appui-react/src/appui-react/utils/InternalUiShowHideManager.ts
+++ b/ui/appui-react/src/appui-react/utils/InternalUiShowHideManager.ts
@@ -6,6 +6,7 @@
  * @module Utilities
  */
 
+import { useCursorInformationStore } from "../cursor/CursorInformation.js";
 import {
   SyncUiEventDispatcher,
   SyncUiEventId,
@@ -209,8 +210,16 @@ export class InternalUiShowHideManager {
   public static handleContentMouseMove(
     _event?: React.MouseEvent<HTMLElement, MouseEvent>
   ) {
+    useCursorInformationStore.getState().setContentHovered(true);
     if (!InternalUiShowHideManager._autoHideUi) return;
     InternalUiShowHideManager.showUiAndResetTimer();
+  }
+
+  /** Handler for when the mouse leaves the content area */
+  public static handleContentMouseLeave(
+    _event?: React.MouseEvent<HTMLElement, MouseEvent>
+  ) {
+    useCursorInformationStore.getState().setContentHovered(false);
   }
 
   /** Handler for when the mouse enters a widget */

--- a/ui/appui-react/src/test/configurableui/ConfigurableUiContent.test.tsx
+++ b/ui/appui-react/src/test/configurableui/ConfigurableUiContent.test.tsx
@@ -10,7 +10,6 @@ import { Key } from "ts-key-enum";
 import TestUtils from "../TestUtils.js";
 import { ConfigurableUiContent } from "../../appui-react/configurableui/ConfigurableUiContent.js";
 import { FrameworkToolAdmin } from "../../appui-react/tools/FrameworkToolAdmin.js";
-import { userEvent } from "@testing-library/user-event";
 import {
   CursorInformation,
   ThemeManager,
@@ -18,11 +17,6 @@ import {
 } from "../../appui-react.js";
 
 describe("ConfigurableUiContent", () => {
-  let theUserTo: ReturnType<typeof userEvent.setup>;
-  beforeEach(() => {
-    theUserTo = userEvent.setup();
-  });
-
   it("key presses should be handled", async () => {
     render(
       <Provider store={TestUtils.store}>
@@ -54,18 +48,14 @@ describe("ConfigurableUiContent", () => {
       </Provider>
     );
 
-    await theUserTo.pointer({
-      target: screen.getByRole("main"),
-      coords: { x: 10, y: 10 },
+    const ev = new MouseEvent("mousemove", {
+      clientX: 10,
+      clientY: 10,
+      bubbles: true,
     });
-
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        oldPt: expect.anything(),
-        newPt: expect.anything(),
-        direction: expect.anything(),
-      })
-    );
+    vi.spyOn(ev, "view", "get").mockImplementation(() => ({} as Window));
+    screen.getByRole("main").dispatchEvent(ev);
+    expect(spy).toHaveBeenCalledOnce();
 
     removeListener();
   });

--- a/ui/appui-react/src/test/frontstage/FrontstageManager.test.tsx
+++ b/ui/appui-react/src/test/frontstage/FrontstageManager.test.tsx
@@ -395,37 +395,19 @@ describe("FrontstageManager", () => {
 
       vi.advanceTimersByTime(200);
 
-      divContainer.dispatchEvent(
-        new MouseEvent("mousemove", {
-          bubbles: true,
-          cancelable: true,
-          buttons: 1,
-        })
-      );
-      divContainer.dispatchEvent(
-        new MouseEvent("mousemove", {
-          bubbles: true,
-          cancelable: true,
-          buttons: 1,
-        })
-      );
+      const ev = new MouseEvent("mousemove", {
+        bubbles: true,
+        cancelable: true,
+        buttons: 1,
+      });
+      vi.spyOn(ev, "view", "get").mockImplementation(() => ({} as Window));
+      divContainer.dispatchEvent(ev);
+      divContainer.dispatchEvent(ev);
 
       vi.advanceTimersByTime(200);
 
-      divContainer.dispatchEvent(
-        new MouseEvent("mousemove", {
-          bubbles: true,
-          cancelable: true,
-          buttons: 1,
-        })
-      );
-      divContainer.dispatchEvent(
-        new MouseEvent("mousemove", {
-          bubbles: true,
-          cancelable: true,
-          buttons: 1,
-        })
-      );
+      divContainer.dispatchEvent(ev);
+      divContainer.dispatchEvent(ev);
 
       await InternalFrontstageManager.deactivateFrontstageDef();
       expect(InternalFrontstageManager.activeFrontstageDef).toEqual(undefined);

--- a/ui/appui-react/src/test/utils/UiShowHideManager.test.tsx
+++ b/ui/appui-react/src/test/utils/UiShowHideManager.test.tsx
@@ -198,7 +198,9 @@ describe("UiShowHideManager localStorage Wrapper", () => {
             contentLayout={myContentLayout}
           />
         );
-        const container = component.getByTestId("single-content-container");
+        const container = component
+          .getByTestId("single-content-container")
+          .getElementsByClassName("uifw-content-contentOverlay")[0];
         container.dispatchEvent(
           new MouseEvent("mousemove", {
             bubbles: true,


### PR DESCRIPTION
## Changes

This PR closes #1242 by adding capability to display prompt at cursor in child windows and popout widgets. Tool assistance prompt at cursor is one such use case, available with `ToolAssistanceField`. Additional information and usage guidance is available in `NextVersion.md`.

Additionally, `CursorPopupRenderer` class component is converted to a functional component.

Future work involves refactoring of `ToolAssistanceField` and will be done in subsequent PRs. Known issues:
- Cursor prompt is displayed when dragging a widget container or a widget tab
- Cursor prompt is rendered below floating widgets
- Cursor prompt timing issues, where timeout is not respected if prompt is re-shown when fading out

## Testing

N/A
