### PR TITLE
Fix issues with tool assistance prompt

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -105,7 +105,6 @@ import type { Store } from 'redux';
 import type { StringGetter } from '@itwin/appui-abstract';
 import { Tool } from '@itwin/core-frontend';
 import { ToolAdmin } from '@itwin/core-frontend';
-import type { ToolAssistanceInstruction } from '@itwin/core-frontend';
 import type { ToolAssistanceInstructions } from '@itwin/core-frontend';
 import type { ToolbarOpacitySetting } from '@itwin/components-react';
 import { ToolbarPanelAlignment } from '@itwin/components-react';
@@ -117,7 +116,7 @@ import type { UiDataProvider } from '@itwin/appui-abstract';
 import { UiEvent } from '@itwin/appui-abstract';
 import { UiLayoutDataProvider } from '@itwin/appui-abstract';
 import { UiStateEntry } from '@itwin/core-react';
-import { UiStateStorage as UiStateStorage_2 } from '@itwin/core-react';
+import type { UiStateStorage as UiStateStorage_2 } from '@itwin/core-react';
 import type { UiStateStorageResult as UiStateStorageResult_2 } from '@itwin/core-react';
 import { UiStateStorageStatus as UiStateStorageStatus_2 } from '@itwin/core-react';
 import type { UnitSystemKey } from '@itwin/core-quantity';
@@ -4644,25 +4643,7 @@ export interface ToolAssistanceChangedEventArgs {
 }
 
 // @public
-export class ToolAssistanceField extends React_2.Component<ToolAssistanceFieldProps, ToolAssistanceFieldState> {
-    constructor(p: ToolAssistanceFieldProps);
-    // (undocumented)
-    componentDidMount(): Promise<void>;
-    // @internal (undocumented)
-    componentDidUpdate(): void;
-    // (undocumented)
-    componentWillUnmount(): void;
-    // @internal (undocumented)
-    context: React_2.ContextType<typeof UiStateStorageContext>;
-    // @internal (undocumented)
-    static contextType: React_2.Context<UiStateStorage_2>;
-    // (undocumented)
-    static readonly defaultProps: Pick<ToolAssistanceFieldProps, "includePromptAtCursor" | "uiStateStorage" | "cursorPromptTimeout" | "fadeOutCursorPrompt" | "defaultPromptAtCursor">;
-    // @internal (undocumented)
-    static getInstructionImage(instruction: ToolAssistanceInstruction): React_2.ReactNode;
-    // (undocumented)
-    render(): React_2.ReactNode;
-}
+export function ToolAssistanceField(props: Props): React_2.JSX.Element;
 
 // @public
 export interface ToolAssistanceFieldProps extends CommonProps {

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -674,7 +674,7 @@ public;class;ToolAssistanceChangedEvent
 deprecated;class;ToolAssistanceChangedEvent
 public;interface;ToolAssistanceChangedEventArgs
 deprecated;interface;ToolAssistanceChangedEventArgs
-public;class;ToolAssistanceField
+public;function;ToolAssistanceField
 public;interface;ToolAssistanceFieldProps
 beta;function;Toolbar
 public;const;TOOLBAR_OPACITY_DEFAULT

--- a/common/changes/@itwin/appui-react/tool-assistance-prompt_2025-04-15-15-41.json
+++ b/common/changes/@itwin/appui-react/tool-assistance-prompt_2025-04-15-15-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Changed `ToolAssistanceField` from class to functional component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -5,6 +5,7 @@ Table of contents:
 - [@itwin/appui-react](#itwinappui-react)
   - [Deprecations](#deprecations)
   - [Additions](#additions)
+  - [Changes](#changes)
   - [Fixes](#fixes)
 - [@itwin/components-react](#itwincomponents-react)
   - [Additions](#additions-1)
@@ -77,12 +78,18 @@ Table of contents:
   }
   ```
 
+### Changes
+
+- Converted `CursorPopupRenderer` from a class component to a functional component. [#1277](https://github.com/iTwin/appui/pull/1277)
+- Converted `ToolAssistanceField` from a class component to a functional component to resolve timing issues with prompt fade-out. Additionally, the tool assistance cursor prompt is no longer displayed when dragging a widget container or widget tab if `promptAtContent` is enabled. [#1283](https://github.com/iTwin/appui/pull/1283)
+
 ### Fixes
 
 - Fixed an icon size of a backstage app button when web font icon is used. [#1262](https://github.com/iTwin/appui/pull/1262)
 - Simplify grid template definitions of standard layout to avoid CSS issues in `RsBuild` production build. [#1263](https://github.com/iTwin/appui/pull/1263)
 - Fixed `onItemExecuted` prop of the `Toolbar` component which was omitted from the initial implementation of the updated toolbar. [#1264](https://github.com/iTwin/appui/pull/1264)
 - Fixed `iconNode` property rendering of `CursorMenuItemProps` interface in `CursorPopupMenu` component. [#1265](https://github.com/iTwin/appui/pull/1265)
+- Fixed tool assistance cursor prompt stacking to correctly rendered above floating widgets. [#1283](https://github.com/iTwin/appui/pull/1283)
 
 ## @itwin/components-react
 

--- a/e2e-tests/tests/notification/tool-assistance-field.test.ts
+++ b/e2e-tests/tests/notification/tool-assistance-field.test.ts
@@ -12,7 +12,7 @@ test("tool assistance field test", async ({ page, baseURL }) => {
 
   await page
     .getByRole("button", {
-      name: "Measure Distance > Click for more information",
+      name: "Measure Distance Click for more information",
     })
     .click();
 

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -179,7 +179,6 @@ export function StandardLayout(props: StandardLayoutProps) {
             {appBackstage}
             <WidgetPanelsFrontstage />
 
-            <ElementTooltip />
             <PointerMessage />
             {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
             <KeyboardShortcutMenu />
@@ -188,6 +187,7 @@ export function StandardLayout(props: StandardLayoutProps) {
             <CursorPopupMenu />
             <CursorPopupRenderer />
             <PopupRenderer />
+            <ElementTooltip />
             <MessageRenderer />
             <ChildWindowRenderer windowManager={appUi.windowManager} />
             <div

--- a/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.scss
+++ b/ui/appui-react/src/appui-react/cursor/cursorpopup/CursorPopup.scss
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+@use "~@itwin/core-react/lib/core-react/z-index" as *;
 @use "../../variables" as *;
 
 .uifw-cursorpopup {
@@ -17,6 +18,8 @@
   height: fit-content;
   width: fit-content;
   transition: opacity 500ms;
+
+  @include uicore-z-index(tooltip);
 
   > .uifw-cursorpopup-title {
     min-height: $uifw-popup-title-bar-min-height;

--- a/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursorprompt/CursorPrompt.tsx
@@ -9,6 +9,7 @@
 import "./CursorPrompt.scss";
 import * as React from "react";
 import { RelativePosition } from "@itwin/appui-abstract";
+import { Logger } from "@itwin/core-bentley";
 import { Icon, Timer } from "@itwin/core-react";
 import { Point } from "@itwin/core-react/internal";
 import { Text } from "@itwin/itwinui-react";
@@ -17,97 +18,66 @@ import {
   useCursorInformationStore,
 } from "../CursorInformation.js";
 import { CursorPopupManager } from "../cursorpopup/CursorPopupManager.js";
+import { UiFramework } from "../../UiFramework.js";
+
+interface UseCursorPromptArgs {
+  show: boolean;
+  timeout: number;
+  iconSpec: string;
+  instruction: string | undefined;
+  fadeOut: boolean;
+  promptAtContent: boolean;
+}
+
+const popupId = "cursor-prompt";
+const category = UiFramework.loggerCategory("useCursorPrompt");
 
 /** @internal */
-export class CursorPrompt {
-  private _popupId = "cursor-prompt";
+export function useCursorPrompt(args: UseCursorPromptArgs) {
+  const { show, timeout, instruction, iconSpec, promptAtContent } = args;
+  const lastArgsRef = React.useRef(args);
+  React.useEffect(() => {
+    lastArgsRef.current = args;
+  }, [args]);
+
+  const [isOpen, setIsOpen] = React.useState(false);
   // eslint-disable-next-line @typescript-eslint/no-deprecated
-  private _timer: Timer | undefined;
-  private _removeListeners: (() => void) | undefined;
+  const timerRef = React.useRef<Timer | undefined>();
 
-  public open({
-    timeout,
-    fadeout,
-    iconSpec,
-    instruction,
-    promptAtContent,
-  }: {
-    timeout: number;
-    fadeout: boolean;
-    iconSpec: string;
-    instruction: string;
-    promptAtContent: boolean;
-  }) {
-    if (!this._removeListeners) {
-      const listeners = [
-        CursorInformation.onCursorUpdatedEvent.addListener((args) => {
-          CursorPopupManager.updatePosition(
-            args.newPt,
-            CursorInformation.cursorDocument
-          );
-        }),
-        useCursorInformationStore.subscribe((state) => {
-          if (!promptAtContent) return;
-          if (state.contentHovered) {
-            this.show({
-              iconSpec,
-              instruction,
-            });
-            return;
-          }
+  const contentHovered = useCursorInformationStore(
+    (state) => state.contentHovered
+  );
 
-          this.hide(fadeout);
-        }),
-      ];
-      this._removeListeners = () => {
-        listeners.forEach((remove) => remove());
-      };
-    }
+  const shouldOpen = React.useMemo(() => {
+    if (!show) return false;
+    if (!isOpen) return false;
+    if (promptAtContent && !contentHovered) return false;
+    return true;
+  }, [show, isOpen, promptAtContent, contentHovered]);
 
-    this.show({ iconSpec, instruction });
-
+  React.useEffect(() => {
     if (timeout === Number.POSITIVE_INFINITY) return;
 
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const timer = new Timer(timeout);
-    timer.setOnExecute(() => this.close(fadeout));
-    timer.start();
-    this._timer = timer;
-  }
+    timer.setOnExecute(() => {
+      Logger.logTrace(category, "timer expired");
+      setIsOpen(false);
+    });
+    timer.delay = timeout;
+    timerRef.current = timer;
+    return () => {
+      timer.stop();
+    };
+  }, [timeout]);
+  React.useEffect(() => {
+    if (!shouldOpen) return;
+    if (!instruction) return;
 
-  public close(fadeout: boolean) {
-    this._timer?.stop();
-    this._timer = undefined;
-    this._removeListeners?.();
-    this._removeListeners = undefined;
-
-    this.hide(fadeout);
-  }
-
-  private show({
-    iconSpec,
-    instruction,
-  }: {
-    iconSpec: string;
-    instruction: string;
-  }) {
-    const promptElement = (
-      <div className="uifw-cursor-prompt">
-        {iconSpec && (
-          <span className="uifw-cursor-prompt-icon">
-            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-            <Icon iconSpec={iconSpec} />
-          </span>
-        )}
-        <Text variant="body" className="uifw-cursor-prompt-text">
-          {instruction}
-        </Text>
-      </div>
-    );
-
+    Logger.logTrace(category, "open");
     CursorPopupManager.open(
-      this._popupId,
-      promptElement,
+      popupId,
+      <CursorPrompt iconSpec={iconSpec} instruction={instruction} />,
       CursorInformation.cursorPosition,
       new Point(20, 20),
       RelativePosition.BottomRight,
@@ -115,9 +85,47 @@ export class CursorPrompt {
       { shadow: true },
       CursorInformation.cursorDocument
     );
-  }
+    return () => {
+      Logger.logTrace(category, "close");
+      CursorPopupManager.close(popupId, false, lastArgsRef.current.fadeOut);
+    };
+  }, [shouldOpen, instruction, iconSpec]);
+  React.useEffect(() => {
+    return CursorInformation.onCursorUpdatedEvent.addListener((args) => {
+      CursorPopupManager.updatePosition(
+        args.newPt,
+        CursorInformation.cursorDocument
+      );
+    });
+  }, []);
 
-  private hide(fadeout: boolean) {
-    CursorPopupManager.close(this._popupId, false, fadeout);
-  }
+  const open = React.useCallback(() => {
+    Logger.logTrace(category, "request open");
+    setIsOpen(true);
+    timerRef.current?.start();
+  }, []);
+
+  return { open };
+}
+
+function CursorPrompt({
+  iconSpec,
+  instruction,
+}: {
+  iconSpec: string;
+  instruction: string;
+}) {
+  return (
+    <div className="uifw-cursor-prompt">
+      {iconSpec && (
+        <span className="uifw-cursor-prompt-icon">
+          {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
+          <Icon iconSpec={iconSpec} />
+        </span>
+      )}
+      <Text variant="body" className="uifw-cursor-prompt-text">
+        {instruction}
+      </Text>
+    </div>
+  );
 }

--- a/ui/appui-react/src/appui-react/hooks/useActiveTool.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useActiveTool.tsx
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Hooks
+ */
+
+import { useSyncExternalStore } from "react";
+import { IModelApp } from "@itwin/core-frontend";
+import type { InteractiveTool } from "@itwin/core-frontend";
+
+const subscribe = (onStoreChange: () => void) => {
+  return IModelApp.toolAdmin.activeToolChanged.addListener(onStoreChange);
+};
+
+const getSnapshot = () => {
+  return IModelApp.toolAdmin.activeTool;
+};
+
+/** React hook that maintains the active tool.
+ * @internal
+ */
+export function useActiveTool(): InteractiveTool | undefined {
+  const activeTool = useSyncExternalStore(subscribe, getSnapshot);
+  return activeTool;
+}

--- a/ui/appui-react/src/appui-react/layout/base/DragManager.tsx
+++ b/ui/appui-react/src/appui-react/layout/base/DragManager.tsx
@@ -471,25 +471,21 @@ export function useDragItem<T extends DragItem>(args: UseDragItemArgs<T>) {
 /** @internal */
 export function useDraggedItem() {
   const dragManager = React.useContext(DragManagerContext);
-  const [draggedItem, setDraggedItem] = React.useState<DragItem | undefined>(
-    dragManager.draggedItem?.item
+  const subscribe = React.useCallback(
+    (onStoreChange: () => void) => {
+      const listeners = [
+        dragManager.onDragStart.addListener(onStoreChange),
+        dragManager.onDragUpdate.addListener(onStoreChange),
+        dragManager.onDragEnd.addListener(onStoreChange),
+      ];
+      return () => listeners.forEach((l) => l());
+    },
+    [dragManager]
   );
-  React.useEffect(() => {
-    return dragManager.onDragStart.addListener((item) => {
-      setDraggedItem(item);
-    });
+  const getSnapshot = React.useCallback(() => {
+    return dragManager.draggedItem?.item;
   }, [dragManager]);
-  React.useEffect(() => {
-    return dragManager.onDragUpdate.addListener((item) => {
-      setDraggedItem(item);
-    });
-  }, [dragManager]);
-  React.useEffect(() => {
-    return dragManager.onDragEnd.addListener(() => {
-      setDraggedItem(undefined);
-    });
-  }, [dragManager]);
-  return draggedItem;
+  return React.useSyncExternalStore(subscribe, getSnapshot);
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -19,7 +19,6 @@ import {
   ToolAssistanceInputMethod,
 } from "@itwin/core-frontend";
 import type { CommonProps } from "@itwin/core-react";
-import type { ListenerType } from "@itwin/core-react/internal";
 import { FillCentered, Icon, UiStateEntry } from "@itwin/core-react";
 import { Button, Tabs, ToggleSwitch } from "@itwin/itwinui-react";
 import classnames from "classnames";
@@ -53,12 +52,10 @@ import mouseWheelClickIcon from "./mouse-click-wheel.svg";
 import touchCursorDragIcon from "./touch-cursor-pan.svg";
 import touchCursorTapIcon from "./touch-cursor-point.svg";
 import { StatusBarPopover } from "../../statusbar/popup/StatusBarPopover.js";
-import type { UiStateStorageResult } from "../../uistate/UiStateStorage.js";
 import {
   type UiStateStorage,
   UiStateStorageStatus,
 } from "../../uistate/UiStateStorage.js";
-import { LocalStateStorage } from "../../uistate/LocalStateStorage.js";
 
 /** Properties of [[ToolAssistanceField]] component.
  * @public
@@ -81,6 +78,20 @@ export interface ToolAssistanceFieldProps extends CommonProps {
   promptAtContent?: boolean;
 }
 
+interface Props
+  extends Omit<
+    ToolAssistanceFieldProps,
+    | "includePromptAtCursor"
+    | "cursorPromptTimeout"
+    | "fadeOutCursorPrompt"
+    | "defaultPromptAtCursor"
+  > {
+  includePromptAtCursor?: ToolAssistanceFieldProps["includePromptAtCursor"];
+  cursorPromptTimeout?: ToolAssistanceFieldProps["cursorPromptTimeout"];
+  fadeOutCursorPrompt?: ToolAssistanceFieldProps["fadeOutCursorPrompt"];
+  defaultPromptAtCursor?: ToolAssistanceFieldProps["defaultPromptAtCursor"];
+}
+
 interface ToolAssistanceFieldState {
   instructions: ToolAssistanceInstructions | undefined;
   toolIconSpec: string;
@@ -95,55 +106,32 @@ interface ToolAssistanceFieldState {
   isOpen: boolean;
 }
 
+const toolAssistanceKey = "ToolAssistance";
+const showPromptAtCursorKey = "showPromptAtCursor";
+const mouseTouchTabIndexKey = "mouseTouchTabIndex";
+
 /** Tool Assistance Field React component.
  * @public
  * @note Tool assistance field will only display 30 characters in the status bar. Any additional text will be hidden. The full text will always be shown in the opened popover.
  */
-export class ToolAssistanceField extends React.Component<
-  ToolAssistanceFieldProps,
-  ToolAssistanceFieldState
-> {
-  /** @internal */
-  public static override contextType = UiStateStorageContext;
-  /** @internal */
-  public declare context: React.ContextType<typeof UiStateStorageContext>;
-
-  private static _toolAssistanceKey = "ToolAssistance";
-  private static _showPromptAtCursorKey = "showPromptAtCursor";
-  private static _mouseTouchTabIndexKey = "mouseTouchTabIndex";
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  private _showPromptAtCursorSetting: UiStateEntry<boolean>;
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  private _mouseTouchTabIndexSetting: UiStateEntry<number>;
-  private _indicator = React.createRef<HTMLButtonElement>();
-  private _cursorPrompt: CursorPrompt;
-  private _isMounted = false;
-  private _uiSettingsStorage: UiStateStorage;
-
-  public static readonly defaultProps: Pick<
-    ToolAssistanceFieldProps,
-    | "includePromptAtCursor"
-    | "uiStateStorage"
-    | "cursorPromptTimeout"
-    | "fadeOutCursorPrompt"
-    | "defaultPromptAtCursor"
-  > = {
-    includePromptAtCursor: true,
-    cursorPromptTimeout: 5000,
-    fadeOutCursorPrompt: true,
-    defaultPromptAtCursor: false,
-  };
-
-  constructor(p: ToolAssistanceFieldProps) {
-    super(p);
-
-    const mobile = ProcessDetector.isMobileBrowser;
-
-    this.state = {
+export function ToolAssistanceField(props: Props) {
+  const {
+    includePromptAtCursor = true,
+    cursorPromptTimeout = 5000,
+    fadeOutCursorPrompt = true,
+    defaultPromptAtCursor = false,
+    uiStateStorage: uiStateStorageProp,
+  } = props;
+  const uiStateStorageCtx = React.useContext(UiStateStorageContext);
+  const uiStateStorage = uiStateStorageProp ?? uiStateStorageCtx;
+  const _cursorPrompt = React.useRef(new CursorPrompt());
+  const [state, setState] = React.useState<ToolAssistanceFieldState>(() => {
+    const isMobileBrowser = ProcessDetector.isMobileBrowser;
+    return {
       instructions: undefined,
       toolIconSpec: "",
-      showPromptAtCursor: p.defaultPromptAtCursor,
-      includeMouseInstructions: !mobile,
+      showPromptAtCursor: defaultPromptAtCursor,
+      includeMouseInstructions: !isMobileBrowser,
       includeTouchInstructions: true,
       showMouseTouchTabs: false,
       showMouseInstructions: false,
@@ -152,669 +140,366 @@ export class ToolAssistanceField extends React.Component<
       isPinned: false,
       isOpen: false,
     };
+  });
 
-    this._uiSettingsStorage = new LocalStateStorage();
-    this._cursorPrompt = new CursorPrompt();
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    this._showPromptAtCursorSetting = new UiStateEntry(
-      ToolAssistanceField._toolAssistanceKey,
-      ToolAssistanceField._showPromptAtCursorKey,
-      () => this.state.showPromptAtCursor
-    );
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    this._mouseTouchTabIndexSetting = new UiStateEntry(
-      ToolAssistanceField._toolAssistanceKey,
-      ToolAssistanceField._mouseTouchTabIndexKey,
-      () => this.state.mouseTouchTabIndex
-    );
-  }
-
-  public override async componentDidMount() {
-    this._isMounted = true;
-    MessageManager.onToolAssistanceChangedEvent.addListener(
-      this._handleToolAssistanceChangedEvent
-    );
-    UiFramework.frontstages.onToolIconChangedEvent.addListener(
-      this._handleToolIconChangedEvent
-    );
-
-    if (this.props.uiStateStorage)
-      this._uiSettingsStorage = this.props.uiStateStorage;
-    else if (this.context) this._uiSettingsStorage = this.context;
-
-    await this.restoreSettings();
-  }
-
-  /** @internal */
-  public override componentDidUpdate() {
-    if (!this.state.showPromptAtCursor)
-      this._cursorPrompt.close(this.props.fadeOutCursorPrompt);
-  }
-
-  public override componentWillUnmount() {
-    this._isMounted = false;
-    this._cursorPrompt.close(this.props.fadeOutCursorPrompt);
-    MessageManager.onToolAssistanceChangedEvent.removeListener(
-      this._handleToolAssistanceChangedEvent
-    );
-    UiFramework.frontstages.onToolIconChangedEvent.removeListener(
-      this._handleToolIconChangedEvent
-    );
-  }
-
-  private async restoreSettings() {
-    let getShowPromptAtCursor: Promise<UiStateStorageResult> | undefined;
-    if (this.props.includePromptAtCursor) {
-      getShowPromptAtCursor = this._showPromptAtCursorSetting.getSetting(
-        this._uiSettingsStorage
-      );
+  const setIsOpen = (isOpen: boolean) => {
+    let newState = {
+      isOpen,
+    };
+    if (!isOpen && state.isPinned) {
+      newState = { ...newState, ...{ isPinned: false } };
     }
-    const getMouseTouchTabIndex = this._mouseTouchTabIndexSetting.getSetting(
-      this._uiSettingsStorage
-    );
-    const [showPromptAtCursorResult, mouseTouchTabIndexResult] =
-      await Promise.all([getShowPromptAtCursor, getMouseTouchTabIndex]);
-
-    if (
-      showPromptAtCursorResult !== undefined &&
-      showPromptAtCursorResult.status === UiStateStorageStatus.Success
-    ) {
-      if (this._isMounted)
-        this.setState({ showPromptAtCursor: showPromptAtCursorResult.setting });
-    }
-
-    if (mouseTouchTabIndexResult.status === UiStateStorageStatus.Success) {
-      if (this._isMounted)
-        this.setState({ mouseTouchTabIndex: mouseTouchTabIndexResult.setting });
-    }
-  }
-
-  private _handleToolAssistanceChangedEvent: ListenerType<
-    typeof MessageManager.onToolAssistanceChangedEvent
-  > = (args) => {
-    let showMouseTouchTabs = false;
-    let showMouseInstructions = false;
-    let showTouchInstructions = false;
-
-    if (args.instructions && args.instructions.sections) {
-      const hasMouseInstructions = args.instructions.sections.some(
-        (section: ToolAssistanceSection) => {
-          return section.instructions.some(
-            (instruction: ToolAssistanceInstruction) =>
-              this._isMouseInstruction(instruction)
-          );
-        }
-      );
-      const hasTouchInstructions = args.instructions.sections.some(
-        (section: ToolAssistanceSection) => {
-          return section.instructions.some(
-            (instruction: ToolAssistanceInstruction) =>
-              this._isTouchInstruction(instruction)
-          );
-        }
-      );
-
-      if (
-        this.state.includeMouseInstructions &&
-        this.state.includeTouchInstructions &&
-        hasMouseInstructions &&
-        hasTouchInstructions
-      ) {
-        showMouseTouchTabs = true;
-        showMouseInstructions = this.state.mouseTouchTabIndex === 0;
-        showTouchInstructions = this.state.mouseTouchTabIndex === 1;
-      } else {
-        if (this.state.includeMouseInstructions && hasMouseInstructions)
-          showMouseInstructions = true;
-        else if (this.state.includeTouchInstructions && hasTouchInstructions)
-          showTouchInstructions = true;
-      }
-    }
-
-    if (this._isMounted)
-      this.setState(
-        {
-          instructions: args.instructions,
-          showMouseTouchTabs,
-          showMouseInstructions,
-          showTouchInstructions,
-        },
-        () => {
-          this._showCursorPrompt();
-        }
-      );
+    setState((prev) => ({ ...prev, ...newState }));
   };
 
-  private _isBothInstruction = (instruction: ToolAssistanceInstruction) => {
-    return (
-      instruction.inputMethod === undefined ||
-      instruction.inputMethod === ToolAssistanceInputMethod.Both
-    );
-  };
-
-  private _isMouseInstruction = (instruction: ToolAssistanceInstruction) =>
-    instruction.inputMethod === ToolAssistanceInputMethod.Mouse;
-
-  private _isTouchInstruction = (instruction: ToolAssistanceInstruction) =>
-    instruction.inputMethod === ToolAssistanceInputMethod.Touch;
-
-  private _handleToolIconChangedEvent: ListenerType<
-    typeof UiFramework.frontstages.onToolIconChangedEvent
-  > = (args) => {
-    if (this._isMounted)
-      this.setState(
-        {
-          toolIconSpec: args.iconSpec,
-        },
-        () => {
-          this._showCursorPrompt();
-        }
-      );
-  };
-
-  private _showCursorPrompt() {
-    const instruction = this.state.instructions?.mainInstruction.text;
-    if (!this.state.showPromptAtCursor || !instruction) {
-      this._cursorPrompt.close(this.props.fadeOutCursorPrompt);
-      return;
-    }
-
-    this._cursorPrompt.open({
-      timeout: this.props.cursorPromptTimeout,
-      fadeout: this.props.fadeOutCursorPrompt,
-      iconSpec: this.state.toolIconSpec,
-      instruction,
-      promptAtContent: this.props.promptAtContent ?? false,
-    });
-  }
-
-  private _sectionHasDisplayableInstructions(
+  const sectionHasDisplayableInstructions = (
     section: ToolAssistanceSection
-  ): boolean {
-    const displayableInstructions = this._getDisplayableInstructions(section);
+  ) => {
+    const displayableInstructions = getDisplayableInstructions(section);
     return displayableInstructions.length > 0;
-  }
-
-  private _getDisplayableInstructions(
-    section: ToolAssistanceSection
-  ): ToolAssistanceInstruction[] {
+  };
+  const getDisplayableInstructions = (section: ToolAssistanceSection) => {
     const displayableInstructions = section.instructions.filter(
-      (instruction: ToolAssistanceInstruction) => {
+      (instruction) => {
         return (
-          this._isBothInstruction(instruction) ||
-          (this.state.showMouseInstructions &&
-            this._isMouseInstruction(instruction)) ||
-          (this.state.showTouchInstructions &&
-            this._isTouchInstruction(instruction))
+          isBothInstruction(instruction) ||
+          (state.showMouseInstructions && isMouseInstruction(instruction)) ||
+          (state.showTouchInstructions && isTouchInstruction(instruction))
         );
       }
     );
     return displayableInstructions;
-  }
+  };
+  // const showCursorPrompt = () => {
+  //   const instruction = state.instructions?.mainInstruction.text;
+  //   if (!state.showPromptAtCursor || !instruction) {
+  //     this._cursorPrompt.close(fadeOutCursorPrompt);
+  //     return;
+  //   }
 
-  private _handleMouseTouchTab = async (index: number) => {
-    const showMouseInstructions = index === 0;
-    const showTouchInstructions = index === 1;
+  //   this._cursorPrompt.open({
+  //     timeout: cursorPromptTimeout,
+  //     fadeout: fadeOutCursorPrompt,
+  //     iconSpec: state.toolIconSpec,
+  //     instruction,
+  //     promptAtContent: props.promptAtContent ?? false,
+  //   });
+  // }
 
-    if (this._isMounted)
-      this.setState(
-        {
-          mouseTouchTabIndex: index,
+  React.useEffect(() => {
+    void (async () => {
+      const result = await uiStateStorage.getSetting(
+        toolAssistanceKey,
+        showPromptAtCursorKey
+      );
+
+      if (result.status !== UiStateStorageStatus.Success) return;
+      setState((prev) => ({
+        ...prev,
+        showPromptAtCursor: result.setting,
+      }));
+    })();
+  }, [uiStateStorage]);
+  React.useEffect(() => {
+    void (async () => {
+      const result = await uiStateStorage.getSetting(
+        toolAssistanceKey,
+        mouseTouchTabIndexKey
+      );
+
+      if (result.status !== UiStateStorageStatus.Success) return;
+      setState((prev) => ({
+        ...prev,
+        mouseTouchTabIndex: result.setting,
+      }));
+    })();
+  }, [uiStateStorage]);
+  React.useEffect(() => {
+    return MessageManager.onToolAssistanceChangedEvent.addListener((args) => {
+      let showMouseTouchTabs = false;
+      let showMouseInstructions = false;
+      let showTouchInstructions = false;
+
+      if (args.instructions && args.instructions.sections) {
+        const hasMouseInstructions = args.instructions.sections.some(
+          (section) => {
+            return section.instructions.some((instruction) =>
+              isMouseInstruction(instruction)
+            );
+          }
+        );
+        const hasTouchInstructions = args.instructions.sections.some(
+          (section) => {
+            return section.instructions.some((instruction) =>
+              isTouchInstruction(instruction)
+            );
+          }
+        );
+
+        if (
+          state.includeMouseInstructions &&
+          state.includeTouchInstructions &&
+          hasMouseInstructions &&
+          hasTouchInstructions
+        ) {
+          showMouseTouchTabs = true;
+          showMouseInstructions = state.mouseTouchTabIndex === 0;
+          showTouchInstructions = state.mouseTouchTabIndex === 1;
+        } else {
+          if (state.includeMouseInstructions && hasMouseInstructions)
+            showMouseInstructions = true;
+          else if (state.includeTouchInstructions && hasTouchInstructions)
+            showTouchInstructions = true;
+        }
+      }
+
+      setState(
+        (prev) => ({
+          ...prev,
+          instructions: args.instructions,
+          showMouseTouchTabs,
           showMouseInstructions,
           showTouchInstructions,
-        },
-        async () => {
-          await this._mouseTouchTabIndexSetting.saveSetting(
-            this._uiSettingsStorage
-          );
-        }
+        })
+        // () => {
+        //   this._showCursorPrompt();
+        // }
       );
-  };
-
-  public override render(): React.ReactNode {
-    const { instructions } = this.state;
-    const dialogTitle = IModelApp.toolAdmin.activeTool
-      ? IModelApp.toolAdmin.activeTool.flyover
-      : UiFramework.translate("toolAssistance.title");
-    const mouseLabel = UiFramework.translate("toolAssistance.mouse");
-    const touchLabel = UiFramework.translate("toolAssistance.touch");
-    let prompt = "";
-    let tooltip = "";
-    let toolIcon: React.ReactNode;
-    let dialogContent: React.ReactNode;
-
-    if (instructions) {
-      prompt = instructions.mainInstruction.text;
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      toolIcon = <Icon iconSpec={this.state.toolIconSpec} />;
-
-      let displayableSections: ToolAssistanceSection[] | undefined;
-      if (instructions.sections) {
-        displayableSections = instructions.sections.filter(
-          (section: ToolAssistanceSection) =>
-            this._sectionHasDisplayableInstructions(section)
+    });
+  }, [
+    state.includeMouseInstructions,
+    state.includeTouchInstructions,
+    state.mouseTouchTabIndex,
+  ]);
+  React.useEffect(() => {
+    return UiFramework.frontstages.onToolIconChangedEvent.addListener(
+      (args) => {
+        setState(
+          (prev) => ({
+            ...prev,
+            toolIconSpec: args.iconSpec,
+          })
+          // () => {
+          //   this._showCursorPrompt();
+          // }
         );
       }
-
-      dialogContent = (
-        <div>
-          {this.state.showMouseTouchTabs && (
-            <Tabs.Wrapper
-              type="pill"
-              value={String(this.state.mouseTouchTabIndex)}
-            >
-              <Tabs.TabList className="uifw-toolAssistance-tabs">
-                {[mouseLabel, touchLabel].map((label, index) => (
-                  <Tabs.Tab
-                    key={index}
-                    className="uifw-tab"
-                    value={String(index)}
-                    label={label}
-                    onClick={async () => this._handleMouseTouchTab(index)}
-                  />
-                ))}
-              </Tabs.TabList>
-            </Tabs.Wrapper>
-          )}
-
-          <div className="uifw-toolAssistance-content">
-            <NZ_ToolAssistanceInstruction
-              key="main"
-              image={ToolAssistanceField.getInstructionImage(
-                instructions.mainInstruction
-              )}
-              text={instructions.mainInstruction.text}
-              isNew={instructions.mainInstruction.isNew}
-            />
-
-            {displayableSections &&
-              displayableSections.map(
-                (section: ToolAssistanceSection, index1: number) => {
-                  return (
-                    <React.Fragment key={index1.toString()}>
-                      <ToolAssistanceSeparator key={index1.toString()}>
-                        {section.label}
-                      </ToolAssistanceSeparator>
-                      {this._getDisplayableInstructions(section).map(
-                        (
-                          instruction: ToolAssistanceInstruction,
-                          index2: number
-                        ) => {
-                          return (
-                            <NZ_ToolAssistanceInstruction
-                              key={`${index1.toString()}-${index2.toString()}`}
-                              image={ToolAssistanceField.getInstructionImage(
-                                instruction
-                              )}
-                              text={instruction.text}
-                              isNew={instruction.isNew}
-                            />
-                          );
-                        }
-                      )}
-                    </React.Fragment>
-                  );
-                }
-              )}
-
-            {this.props.includePromptAtCursor && (
-              <>
-                <ToolAssistanceSeparator key="prompt-sep" />
-                <ToolAssistanceItem key="prompt-item">
-                  <ToggleSwitch
-                    label={UiFramework.translate(
-                      "toolAssistance.promptAtCursor"
-                    )}
-                    labelPosition="right"
-                    checked={this.state.showPromptAtCursor}
-                    onChange={this._onPromptAtCursorChange}
-                  />
-                </ToolAssistanceItem>
-              </>
-            )}
-          </div>
-        </div>
-      );
-    }
-
-    if (prompt) tooltip = prompt;
-
-    if (IModelApp.toolAdmin.activeTool)
-      tooltip = `${IModelApp.toolAdmin.activeTool.flyover} > ${tooltip}  `;
-
-    if (tooltip) {
-      const lineBreak = "\u000d\u000a";
-      tooltip = tooltip + lineBreak;
-    }
-
-    tooltip += UiFramework.translate("toolAssistance.moreInfo");
-
-    return (
-      <StatusBarPopover
-        visible={this.state.isOpen}
-        onVisibleChange={(visible) => {
-          this.setIsOpen(visible);
-        }}
-        closeOnOutsideClick={!this.state.isPinned}
-        content={
-          <ToolAssistanceDialog
-            buttons={
-              <>
-                {!this.state.isPinned && (
-                  <StatusBarDialog.TitleBarButton
-                    onClick={this._handlePinButtonClick}
-                    title={UiFramework.translate("toolAssistance.pin")}
-                  >
-                    <SvgPin />
-                  </StatusBarDialog.TitleBarButton>
-                )}
-                {this.state.isPinned && (
-                  <StatusBarDialog.TitleBarButton
-                    onClick={this._handleCloseButtonClick}
-                    title={UiFramework.translate("dialog.close")}
-                  >
-                    <SvgClose />
-                  </StatusBarDialog.TitleBarButton>
-                )}
-              </>
-            }
-            title={dialogTitle}
-          >
-            {dialogContent}
-          </ToolAssistanceDialog>
-        }
-      >
-        <Button
-          styleType="borderless"
-          startIcon={<>{toolIcon}</>}
-          className={classnames(
-            "uifw-statusFields-toolAssistance-toolAssistanceField",
-            this.props.className
-          )}
-          title={tooltip}
-          style={this.props.style}
-          ref={this._indicator}
-          labelProps={{ className: "prompt" }}
-        >
-          {prompt}
-          <StatusBarPopover.ExpandIndicator />
-        </Button>
-      </StatusBarPopover>
     );
-  }
-
-  private _onPromptAtCursorChange = async (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    if (this._isMounted)
-      this.setState(
-        {
-          showPromptAtCursor: e.target.checked,
-        },
-        async () => {
-          await this._showPromptAtCursorSetting.saveSetting(
-            this._uiSettingsStorage
-          );
-        }
-      );
-  };
-
-  private _handlePinButtonClick = () => {
-    if (this._isMounted) this.setState({ isPinned: true });
-  };
-
-  private _handleCloseButtonClick = () => {
-    this.setIsOpen(false);
-  };
-
-  private setIsOpen(isOpen: boolean) {
-    let newState = {
-      isOpen,
+  }, []);
+  React.useEffect(() => {
+    const cursorPrompt = _cursorPrompt.current;
+    return () => {
+      cursorPrompt.close(fadeOutCursorPrompt);
     };
-    if (!isOpen && this.state.isPinned && this._isMounted) {
-      newState = { ...newState, ...{ isPinned: false } };
-    }
-    this.setState(newState);
-  }
+  });
+  React.useEffect(() => {
+    if (!state.showPromptAtCursor)
+      _cursorPrompt.current.close(fadeOutCursorPrompt);
+  }, [fadeOutCursorPrompt, state.showPromptAtCursor]);
 
-  /** @internal */
-  public static getInstructionImage(
-    instruction: ToolAssistanceInstruction
-  ): React.ReactNode {
-    let image: React.ReactNode;
+  const { instructions } = state;
+  const dialogTitle = IModelApp.toolAdmin.activeTool
+    ? IModelApp.toolAdmin.activeTool.flyover
+    : UiFramework.translate("toolAssistance.title");
+  const mouseLabel = UiFramework.translate("toolAssistance.mouse");
+  const touchLabel = UiFramework.translate("toolAssistance.touch");
+  let prompt = "";
+  let tooltip = "";
+  let toolIcon: React.ReactNode;
+  let dialogContent: React.ReactNode;
 
-    if (
-      (typeof instruction.image === "string" ||
-        instruction.image !== ToolAssistanceImage.Keyboard) &&
-      instruction.keyboardInfo
-    ) {
-      if (
-        instruction.keyboardInfo.keys.length === 1 &&
-        !instruction.keyboardInfo.bottomKeys
-      ) {
-        const key = instruction.keyboardInfo.keys[0];
-        const rightImage =
-          typeof instruction.image === "string" ? (
-            <div className="uifw-toolassistance-icon-medium">
-              {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-              <Icon iconSpec={instruction.image} />
-            </div>
-          ) : (
-            this.getInstructionSvgImage(instruction, true)
-          );
+  if (instructions) {
+    prompt = instructions.mainInstruction.text;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    toolIcon = <Icon iconSpec={state.toolIconSpec} />;
 
-        image = (
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          <FillCentered>
-            {ToolAssistanceField.getKeyNode(
-              key,
-              0,
-              "uifw-toolassistance-key-modifier"
-            )}
-            {rightImage}
-          </FillCentered>
-        );
-      } else {
-        Logger.logError(
-          UiFramework.loggerCategory("ToolAssistanceField"),
-          `getInstructionImage: Invalid keyboardInfo provided with image`
-        );
-      }
-    } else if (typeof instruction.image === "string") {
-      if (instruction.image.length > 0) {
-        const svgSource = getWebComponentSource(instruction.image);
-        const className =
-          svgSource !== undefined
-            ? "uifw-toolassistance-svg"
-            : "uifw-toolassistance-icon-large";
-        image = (
-          <div className={className}>
-            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-            <Icon iconSpec={svgSource ?? instruction.image} />
-          </div>
-        );
-      }
-    } else if (instruction.image === ToolAssistanceImage.Keyboard) {
-      if (instruction.keyboardInfo) {
-        image = ToolAssistanceField.getInstructionKeyboardImage(
-          instruction.keyboardInfo
-        );
-      } else {
-        Logger.logError(
-          UiFramework.loggerCategory("ToolAssistanceField"),
-          `getInstructionImage: ToolAssistanceImage.Keyboard specified but no keyboardInfo provided`
-        );
-      }
-    } else {
-      image = this.getInstructionSvgImage(instruction, false);
-    }
-
-    return image;
-  }
-
-  private static getInstructionSvgImage(
-    instruction: ToolAssistanceInstruction,
-    mediumSize: boolean
-  ): React.ReactNode {
-    let image: React.ReactNode;
-    let className = mediumSize
-      ? "uifw-toolassistance-svg-medium"
-      : "uifw-toolassistance-svg";
-
-    if (
-      typeof instruction.image !== "string" &&
-      instruction.image !== ToolAssistanceImage.Keyboard
-    ) {
-      const toolAssistanceImage: ToolAssistanceImage = instruction.image;
-      let svgImage = "";
-
-      switch (toolAssistanceImage) {
-        case ToolAssistanceImage.AcceptPoint:
-          svgImage = acceptPointIcon;
-          break;
-        case ToolAssistanceImage.CursorClick:
-          svgImage = cursorClickIcon;
-          break;
-        case ToolAssistanceImage.LeftClick:
-          svgImage = clickLeftIcon;
-          break;
-        case ToolAssistanceImage.RightClick:
-          svgImage = clickRightIcon;
-          break;
-        case ToolAssistanceImage.MouseWheel:
-          svgImage = mouseWheelClickIcon;
-          break;
-        case ToolAssistanceImage.LeftClickDrag:
-          svgImage = clickLeftDragIcon;
-          className = mediumSize
-            ? "uifw-toolassistance-svg-medium-wide"
-            : "uifw-toolassistance-svg-wide";
-          break;
-        case ToolAssistanceImage.RightClickDrag:
-          svgImage = clickRightDragIcon;
-          className = mediumSize
-            ? "uifw-toolassistance-svg-medium-wide"
-            : "uifw-toolassistance-svg-wide";
-          break;
-        case ToolAssistanceImage.MouseWheelClickDrag:
-          svgImage = clickMouseWheelDragIcon;
-          className = mediumSize
-            ? "uifw-toolassistance-svg-medium-wide"
-            : "uifw-toolassistance-svg-wide";
-          break;
-        case ToolAssistanceImage.OneTouchTap:
-          svgImage = oneTouchTapIcon;
-          break;
-        case ToolAssistanceImage.OneTouchDoubleTap:
-          svgImage = oneTouchDoubleTapIcon;
-          break;
-        case ToolAssistanceImage.OneTouchDrag:
-          svgImage = oneTouchDragIcon;
-          break;
-        case ToolAssistanceImage.TwoTouchTap:
-          svgImage = twoTouchTapIcon;
-          break;
-        case ToolAssistanceImage.TwoTouchDrag:
-          svgImage = twoTouchDragIcon;
-          break;
-        case ToolAssistanceImage.TwoTouchPinch:
-          svgImage = twoTouchPinchIcon;
-          break;
-        case ToolAssistanceImage.TouchCursorTap:
-          svgImage = touchCursorTapIcon;
-          break;
-        case ToolAssistanceImage.TouchCursorDrag:
-          svgImage = touchCursorDragIcon;
-          className = mediumSize
-            ? "uifw-toolassistance-svg-medium-wide"
-            : "uifw-toolassistance-svg-wide";
-          break;
-      }
-
-      image = (
-        <div className={className}>
-          {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-          {svgImage && <Icon iconSpec={svgImage} />}
-        </div>
+    let displayableSections: ToolAssistanceSection[] | undefined;
+    if (instructions.sections) {
+      displayableSections = instructions.sections.filter((section) =>
+        sectionHasDisplayableInstructions(section)
       );
     }
 
-    return image;
-  }
+    dialogContent = (
+      <div>
+        {state.showMouseTouchTabs && (
+          <Tabs.Wrapper type="pill" value={String(state.mouseTouchTabIndex)}>
+            <Tabs.TabList className="uifw-toolAssistance-tabs">
+              {[mouseLabel, touchLabel].map((label, index) => (
+                <Tabs.Tab
+                  key={index}
+                  className="uifw-tab"
+                  value={String(index)}
+                  label={label}
+                  onClick={async () => {
+                    const showMouseInstructions = index === 0;
+                    const showTouchInstructions = index === 1;
 
-  private static getInstructionKeyboardImage(
-    keyboardInfo: ToolAssistanceKeyboardInfo
-  ): React.ReactNode {
-    let image: React.ReactNode;
+                    setState(
+                      (prev) => ({
+                        ...prev,
+                        mouseTouchTabIndex: index,
+                        showMouseInstructions,
+                        showTouchInstructions,
+                      })
+                      // async () => {
+                      //   await this._mouseTouchTabIndexSetting.saveSetting(
+                      //     uiStateStorage
+                      //   );
+                      // }
+                    );
+                  }}
+                />
+              ))}
+            </Tabs.TabList>
+          </Tabs.Wrapper>
+        )}
 
-    if (keyboardInfo.bottomKeys !== undefined) {
-      image = (
-        <div className="uifw-toolassistance-key-group">
-          <span className="row1">
-            {keyboardInfo.keys.map((key: string, index1: number) => {
-              return ToolAssistanceField.getKeyNode(
-                key,
-                index1,
-                "uifw-toolassistance-key-small"
+        <div className="uifw-toolAssistance-content">
+          <NZ_ToolAssistanceInstruction
+            key="main"
+            image={
+              <InstructionImage instruction={instructions.mainInstruction} />
+            }
+            text={instructions.mainInstruction.text}
+            isNew={instructions.mainInstruction.isNew}
+          />
+
+          {displayableSections &&
+            displayableSections.map((section, index) => {
+              return (
+                <React.Fragment key={index.toString()}>
+                  <ToolAssistanceSeparator>
+                    {section.label}
+                  </ToolAssistanceSeparator>
+                  {getDisplayableInstructions(section).map(
+                    (instruction, index1) => {
+                      return (
+                        <NZ_ToolAssistanceInstruction
+                          key={`${index1.toString()}-${index.toString()}`}
+                          image={<InstructionImage instruction={instruction} />}
+                          text={instruction.text}
+                          isNew={instruction.isNew}
+                        />
+                      );
+                    }
+                  )}
+                </React.Fragment>
               );
             })}
-          </span>
-          <br />
-          <span className="row2">
-            {keyboardInfo.bottomKeys.map((key: string, index2: number) => {
-              return ToolAssistanceField.getKeyNode(
-                key,
-                index2,
-                "uifw-toolassistance-key-small"
-              );
-            })}
-          </span>
+
+          {includePromptAtCursor && (
+            <>
+              <ToolAssistanceSeparator key="prompt-sep" />
+              <ToolAssistanceItem key="prompt-item">
+                <ToggleSwitch
+                  label={UiFramework.translate("toolAssistance.promptAtCursor")}
+                  labelPosition="right"
+                  checked={state.showPromptAtCursor}
+                  onChange={(e) => {
+                    setState(
+                      (prev) => ({
+                        ...prev,
+                        showPromptAtCursor: e.target.checked,
+                      })
+                      // async () => {
+                      //   await this._showPromptAtCursorSetting.saveSetting(
+                      //     uiStateStorage
+                      //   );
+                      // }
+                    );
+                  }}
+                />
+              </ToolAssistanceItem>
+            </>
+          )}
         </div>
-      );
-    } else if (keyboardInfo.keys.length === 2) {
-      image = (
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        <FillCentered>
-          {keyboardInfo.keys.map((key: string, index3: number) => {
-            let className = "uifw-toolassistance-key-medium";
-            if (key.length > 1) className = "uifw-toolassistance-key-modifier";
-            return ToolAssistanceField.getKeyNode(key, index3, className);
-          })}
-        </FillCentered>
-      );
-    } else if (keyboardInfo.keys[0]) {
-      if (keyboardInfo.keys[0].length > 1)
-        image = ToolAssistanceField.getKeyNode(
-          keyboardInfo.keys[0],
-          0,
-          "uifw-toolassistance-key-large"
-        );
-      else image = ToolAssistanceField.getKeyNode(keyboardInfo.keys[0], 0);
-    } else {
-      Logger.logError(
-        UiFramework.loggerCategory("ToolAssistanceField"),
-        `ToolAssistanceImage.Keyboard specified but ToolAssistanceKeyboardInfo not valid`
-      );
-    }
-
-    return image;
-  }
-
-  private static getKeyNode(
-    key: string,
-    index: number,
-    className?: string
-  ): React.ReactNode {
-    return (
-      <div
-        key={index.toString()}
-        className={classnames("uifw-toolassistance-key", className)}
-      >
-        {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
-        <FillCentered>{key}</FillCentered>
       </div>
     );
   }
+
+  if (prompt) tooltip = prompt;
+
+  if (IModelApp.toolAdmin.activeTool)
+    tooltip = `${IModelApp.toolAdmin.activeTool.flyover} > ${tooltip}  `;
+
+  if (tooltip) {
+    const lineBreak = "\u000d\u000a";
+    tooltip = tooltip + lineBreak;
+  }
+
+  tooltip += UiFramework.translate("toolAssistance.moreInfo");
+
+  return (
+    <StatusBarPopover
+      visible={state.isOpen}
+      onVisibleChange={(visible) => {
+        setIsOpen(visible);
+      }}
+      closeOnOutsideClick={!state.isPinned}
+      content={
+        <ToolAssistanceDialog
+          buttons={
+            <>
+              {!state.isPinned && (
+                <StatusBarDialog.TitleBarButton
+                  onClick={() => {
+                    setState((prev) => ({ ...prev, isPinned: true }));
+                  }}
+                  title={UiFramework.translate("toolAssistance.pin")}
+                >
+                  <SvgPin />
+                </StatusBarDialog.TitleBarButton>
+              )}
+              {state.isPinned && (
+                <StatusBarDialog.TitleBarButton
+                  onClick={() => {
+                    setIsOpen(false);
+                  }}
+                  title={UiFramework.translate("dialog.close")}
+                >
+                  <SvgClose />
+                </StatusBarDialog.TitleBarButton>
+              )}
+            </>
+          }
+          title={dialogTitle}
+        >
+          {dialogContent}
+        </ToolAssistanceDialog>
+      }
+    >
+      <Button
+        styleType="borderless"
+        startIcon={<>{toolIcon}</>}
+        className={classnames(
+          "uifw-statusFields-toolAssistance-toolAssistanceField",
+          props.className
+        )}
+        title={tooltip}
+        style={props.style}
+        labelProps={{ className: "prompt" }}
+      >
+        {prompt}
+        <StatusBarPopover.ExpandIndicator />
+      </Button>
+    </StatusBarPopover>
+  );
+}
+
+function isBothInstruction(instruction: ToolAssistanceInstruction) {
+  return (
+    instruction.inputMethod === undefined ||
+    instruction.inputMethod === ToolAssistanceInputMethod.Both
+  );
+}
+
+function isMouseInstruction(instruction: ToolAssistanceInstruction) {
+  return instruction.inputMethod === ToolAssistanceInputMethod.Mouse;
+}
+
+function isTouchInstruction(instruction: ToolAssistanceInstruction) {
+  return instruction.inputMethod === ToolAssistanceInputMethod.Touch;
 }
 
 function getWebComponentSource(iconSpec: string): string | undefined {
@@ -823,4 +508,256 @@ function getWebComponentSource(iconSpec: string): string | undefined {
   }
 
   return undefined;
+}
+
+function InstructionImage({
+  instruction,
+}: {
+  instruction: ToolAssistanceInstruction;
+}) {
+  let image: React.ReactNode;
+
+  if (
+    (typeof instruction.image === "string" ||
+      instruction.image !== ToolAssistanceImage.Keyboard) &&
+    instruction.keyboardInfo
+  ) {
+    if (
+      instruction.keyboardInfo.keys.length === 1 &&
+      !instruction.keyboardInfo.bottomKeys
+    ) {
+      const key = instruction.keyboardInfo.keys[0];
+      const rightImage =
+        typeof instruction.image === "string" ? (
+          <div className="uifw-toolassistance-icon-medium">
+            {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
+            <Icon iconSpec={instruction.image} />
+          </div>
+        ) : (
+          <InstructionSvgImage instruction={instruction} mediumSize={true} />
+        );
+
+      image = (
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        <FillCentered>
+          <KeyNode
+            keyboardKey={key}
+            className="uifw-toolassistance-key-modifier"
+          />
+          {rightImage}
+        </FillCentered>
+      );
+    } else {
+      Logger.logError(
+        UiFramework.loggerCategory("ToolAssistanceField"),
+        `getInstructionImage: Invalid keyboardInfo provided with image`
+      );
+    }
+  } else if (typeof instruction.image === "string") {
+    if (instruction.image.length > 0) {
+      const svgSource = getWebComponentSource(instruction.image);
+      const className =
+        svgSource !== undefined
+          ? "uifw-toolassistance-svg"
+          : "uifw-toolassistance-icon-large";
+      image = (
+        <div className={className}>
+          {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
+          <Icon iconSpec={svgSource ?? instruction.image} />
+        </div>
+      );
+    }
+  } else if (instruction.image === ToolAssistanceImage.Keyboard) {
+    if (instruction.keyboardInfo) {
+      image = (
+        <InstructionKeyboardImage keyboardInfo={instruction.keyboardInfo} />
+      );
+    } else {
+      Logger.logError(
+        UiFramework.loggerCategory("ToolAssistanceField"),
+        `getInstructionImage: ToolAssistanceImage.Keyboard specified but no keyboardInfo provided`
+      );
+    }
+  } else {
+    image = (
+      <InstructionSvgImage instruction={instruction} mediumSize={false} />
+    );
+  }
+
+  return image;
+}
+
+function InstructionSvgImage({
+  instruction,
+  mediumSize,
+}: {
+  instruction: ToolAssistanceInstruction;
+  mediumSize: boolean;
+}) {
+  let image: React.ReactNode;
+  let className = mediumSize
+    ? "uifw-toolassistance-svg-medium"
+    : "uifw-toolassistance-svg";
+
+  if (
+    typeof instruction.image !== "string" &&
+    instruction.image !== ToolAssistanceImage.Keyboard
+  ) {
+    const toolAssistanceImage: ToolAssistanceImage = instruction.image;
+    let svgImage = "";
+
+    switch (toolAssistanceImage) {
+      case ToolAssistanceImage.AcceptPoint:
+        svgImage = acceptPointIcon;
+        break;
+      case ToolAssistanceImage.CursorClick:
+        svgImage = cursorClickIcon;
+        break;
+      case ToolAssistanceImage.LeftClick:
+        svgImage = clickLeftIcon;
+        break;
+      case ToolAssistanceImage.RightClick:
+        svgImage = clickRightIcon;
+        break;
+      case ToolAssistanceImage.MouseWheel:
+        svgImage = mouseWheelClickIcon;
+        break;
+      case ToolAssistanceImage.LeftClickDrag:
+        svgImage = clickLeftDragIcon;
+        className = mediumSize
+          ? "uifw-toolassistance-svg-medium-wide"
+          : "uifw-toolassistance-svg-wide";
+        break;
+      case ToolAssistanceImage.RightClickDrag:
+        svgImage = clickRightDragIcon;
+        className = mediumSize
+          ? "uifw-toolassistance-svg-medium-wide"
+          : "uifw-toolassistance-svg-wide";
+        break;
+      case ToolAssistanceImage.MouseWheelClickDrag:
+        svgImage = clickMouseWheelDragIcon;
+        className = mediumSize
+          ? "uifw-toolassistance-svg-medium-wide"
+          : "uifw-toolassistance-svg-wide";
+        break;
+      case ToolAssistanceImage.OneTouchTap:
+        svgImage = oneTouchTapIcon;
+        break;
+      case ToolAssistanceImage.OneTouchDoubleTap:
+        svgImage = oneTouchDoubleTapIcon;
+        break;
+      case ToolAssistanceImage.OneTouchDrag:
+        svgImage = oneTouchDragIcon;
+        break;
+      case ToolAssistanceImage.TwoTouchTap:
+        svgImage = twoTouchTapIcon;
+        break;
+      case ToolAssistanceImage.TwoTouchDrag:
+        svgImage = twoTouchDragIcon;
+        break;
+      case ToolAssistanceImage.TwoTouchPinch:
+        svgImage = twoTouchPinchIcon;
+        break;
+      case ToolAssistanceImage.TouchCursorTap:
+        svgImage = touchCursorTapIcon;
+        break;
+      case ToolAssistanceImage.TouchCursorDrag:
+        svgImage = touchCursorDragIcon;
+        className = mediumSize
+          ? "uifw-toolassistance-svg-medium-wide"
+          : "uifw-toolassistance-svg-wide";
+        break;
+    }
+
+    image = (
+      <div className={className}>
+        {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
+        {svgImage && <Icon iconSpec={svgImage} />}
+      </div>
+    );
+  }
+
+  return image;
+}
+
+function InstructionKeyboardImage({
+  keyboardInfo,
+}: {
+  keyboardInfo: ToolAssistanceKeyboardInfo;
+}) {
+  let image: React.ReactNode;
+
+  if (keyboardInfo.bottomKeys !== undefined) {
+    image = (
+      <div className="uifw-toolassistance-key-group">
+        <span className="row1">
+          {keyboardInfo.keys.map((key, index) => {
+            return (
+              <KeyNode
+                key={index}
+                keyboardKey={key}
+                className="uifw-toolassistance-key-small"
+              />
+            );
+          })}
+        </span>
+        <br />
+        <span className="row2">
+          {keyboardInfo.bottomKeys.map((key, index) => {
+            return (
+              <KeyNode
+                key={index}
+                keyboardKey={key}
+                className="uifw-toolassistance-key-small"
+              />
+            );
+          })}
+        </span>
+      </div>
+    );
+  } else if (keyboardInfo.keys.length === 2) {
+    image = (
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      <FillCentered>
+        {keyboardInfo.keys.map((key, index) => {
+          let className = "uifw-toolassistance-key-medium";
+          if (key.length > 1) className = "uifw-toolassistance-key-modifier";
+          return (
+            <KeyNode key={index} keyboardKey={key} className={className} />
+          );
+        })}
+      </FillCentered>
+    );
+  } else if (keyboardInfo.keys[0]) {
+    if (keyboardInfo.keys[0].length > 1)
+      image = (
+        <KeyNode
+          keyboardKey={keyboardInfo.keys[0]}
+          className="uifw-toolassistance-key-large"
+        />
+      );
+    else image = <KeyNode keyboardKey={keyboardInfo.keys[0]} />;
+  } else {
+    Logger.logError(
+      UiFramework.loggerCategory("ToolAssistanceField"),
+      `ToolAssistanceImage.Keyboard specified but ToolAssistanceKeyboardInfo not valid`
+    );
+  }
+
+  return image;
+}
+
+function KeyNode({
+  keyboardKey,
+  className,
+}: {
+  keyboardKey: string;
+  className?: string;
+}) {
+  return (
+    <div className={classnames("uifw-toolassistance-key", className)}>
+      {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
+      <FillCentered>{keyboardKey}</FillCentered>
+    </div>
+  );
 }

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -100,10 +100,6 @@ interface ToolAssistanceFieldState {
   instructions: ToolAssistanceInstructions | undefined;
   toolIconSpec: string;
   showPromptAtCursor: boolean;
-  includeMouseInstructions: boolean;
-  includeTouchInstructions: boolean;
-  showMouseInstructions: boolean;
-  showTouchInstructions: boolean;
   mouseTouchTabIndex: number;
   isPinned: boolean;
   isOpen: boolean;
@@ -130,15 +126,10 @@ export function ToolAssistanceField(props: Props) {
   const uiStateStorage = uiStateStorageProp ?? uiStateStorageCtx;
 
   const [state, setState] = React.useState<ToolAssistanceFieldState>(() => {
-    const isMobileBrowser = ProcessDetector.isMobileBrowser;
     return {
       instructions: undefined,
       toolIconSpec: "",
       showPromptAtCursor: defaultPromptAtCursor,
-      includeMouseInstructions: !isMobileBrowser,
-      includeTouchInstructions: true,
-      showMouseInstructions: false,
-      showTouchInstructions: false,
       mouseTouchTabIndex: 0,
       isPinned: false,
       isOpen: false,
@@ -177,8 +168,8 @@ export function ToolAssistanceField(props: Props) {
       (instruction) => {
         return (
           isBothInstruction(instruction) ||
-          (state.showMouseInstructions && isMouseInstruction(instruction)) ||
-          (state.showTouchInstructions && isTouchInstruction(instruction))
+          (showMouseInstructions && isMouseInstruction(instruction)) ||
+          (showTouchInstructions && isTouchInstruction(instruction))
         );
       }
     );
@@ -259,11 +250,13 @@ export function ToolAssistanceField(props: Props) {
       );
     }
   );
-  const showMouseTouchTabs =
-    state.showMouseInstructions &&
-    state.showTouchInstructions &&
-    hasMouseInstructions &&
-    hasTouchInstructions;
+
+  const isMobileBrowser = React.useMemo(() => {
+    return ProcessDetector.isMobileBrowser;
+  }, []);
+  const showMouseInstructions = !isMobileBrowser && hasMouseInstructions;
+  const showTouchInstructions = hasTouchInstructions;
+  const showMouseTouchTabs = showMouseInstructions && hasTouchInstructions;
 
   if (instructions) {
     prompt = instructions.mainInstruction.text;
@@ -289,14 +282,9 @@ export function ToolAssistanceField(props: Props) {
                   value={String(index)}
                   label={label}
                   onClick={async () => {
-                    const showMouseInstructions = index === 0;
-                    const showTouchInstructions = index === 1;
-
                     setState((prev) => ({
                       ...prev,
                       mouseTouchTabIndex: index,
-                      showMouseInstructions,
-                      showTouchInstructions,
                     }));
                     void uiStateStorage.saveSetting(
                       toolAssistanceKey,

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -164,14 +164,16 @@ export function ToolAssistanceField(props: Props) {
   const getDisplayableInstructions = (section: ToolAssistanceSection) => {
     const displayableInstructions = section.instructions.filter(
       (instruction) => {
+        const includeMouseInstructions = showMouseTouchTabs
+          ? mouseTouchTabIndex === 0 && showMouseInstructions
+          : showMouseInstructions;
+        const includeTouchInstructions = showMouseTouchTabs
+          ? mouseTouchTabIndex === 1 && showTouchInstructions
+          : showTouchInstructions;
         return (
           isBothInstruction(instruction) ||
-          (showMouseInstructions &&
-            mouseTouchTabIndex === 0 &&
-            isMouseInstruction(instruction)) ||
-          (showTouchInstructions &&
-            mouseTouchTabIndex === 1 &&
-            isTouchInstruction(instruction))
+          (includeMouseInstructions && isMouseInstruction(instruction)) ||
+          (includeTouchInstructions && isTouchInstruction(instruction))
         );
       }
     );

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -56,6 +56,7 @@ import {
   type UiStateStorage,
   UiStateStorageStatus,
 } from "../../uistate/UiStateStorage.js";
+import { useTranslation } from "../../hooks/useTranslation.js";
 
 /** Properties of [[ToolAssistanceField]] component.
  * @public
@@ -124,6 +125,7 @@ export function ToolAssistanceField(props: Props) {
   } = props;
   const uiStateStorageCtx = React.useContext(UiStateStorageContext);
   const uiStateStorage = uiStateStorageProp ?? uiStateStorageCtx;
+  const { translate } = useTranslation();
 
   const [state, setState] = React.useState<ToolAssistanceFieldState>(() => {
     return {
@@ -212,7 +214,7 @@ export function ToolAssistanceField(props: Props) {
       }));
       open();
     });
-  }, [open, state.toolIconSpec]);
+  }, [open]);
   React.useEffect(() => {
     return UiFramework.frontstages.onToolIconChangedEvent.addListener(
       (args) => {
@@ -223,14 +225,14 @@ export function ToolAssistanceField(props: Props) {
         open();
       }
     );
-  }, [open, state.instructions]);
+  }, [open]);
 
   const { instructions } = state;
   const dialogTitle = IModelApp.toolAdmin.activeTool
     ? IModelApp.toolAdmin.activeTool.flyover
-    : UiFramework.translate("toolAssistance.title");
-  const mouseLabel = UiFramework.translate("toolAssistance.mouse");
-  const touchLabel = UiFramework.translate("toolAssistance.touch");
+    : translate("toolAssistance.title");
+  const mouseLabel = translate("toolAssistance.mouse");
+  const touchLabel = translate("toolAssistance.touch");
   let prompt = "";
   let tooltip = "";
   let toolIcon: React.ReactNode;
@@ -263,12 +265,9 @@ export function ToolAssistanceField(props: Props) {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     toolIcon = <Icon iconSpec={state.toolIconSpec} />;
 
-    let displayableSections: ToolAssistanceSection[] | undefined;
-    if (instructions.sections) {
-      displayableSections = instructions.sections.filter((section) =>
-        sectionHasDisplayableInstructions(section)
-      );
-    }
+    const displayableSections = instructions.sections?.filter((section) =>
+      sectionHasDisplayableInstructions(section)
+    );
 
     dialogContent = (
       <div>
@@ -336,7 +335,7 @@ export function ToolAssistanceField(props: Props) {
               <ToolAssistanceSeparator key="prompt-sep" />
               <ToolAssistanceItem key="prompt-item">
                 <ToggleSwitch
-                  label={UiFramework.translate("toolAssistance.promptAtCursor")}
+                  label={translate("toolAssistance.promptAtCursor")}
                   labelPosition="right"
                   checked={state.showPromptAtCursor}
                   onChange={(e) => {
@@ -370,7 +369,7 @@ export function ToolAssistanceField(props: Props) {
     tooltip = tooltip + lineBreak;
   }
 
-  tooltip += UiFramework.translate("toolAssistance.moreInfo");
+  tooltip += translate("toolAssistance.moreInfo");
 
   return (
     <StatusBarPopover
@@ -388,7 +387,7 @@ export function ToolAssistanceField(props: Props) {
                   onClick={() => {
                     setState((prev) => ({ ...prev, isPinned: true }));
                   }}
-                  title={UiFramework.translate("toolAssistance.pin")}
+                  title={translate("toolAssistance.pin")}
                 >
                   <SvgPin />
                 </StatusBarDialog.TitleBarButton>
@@ -398,7 +397,7 @@ export function ToolAssistanceField(props: Props) {
                   onClick={() => {
                     setIsOpen(false);
                   }}
-                  title={UiFramework.translate("dialog.close")}
+                  title={translate("dialog.close")}
                 >
                   <SvgClose />
                 </StatusBarDialog.TitleBarButton>

--- a/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
+++ b/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.tsx
@@ -229,12 +229,6 @@ export function ToolAssistanceField(props: Props) {
     );
   }, [open]);
 
-  const dialogTitle = activeTool?.flyover ?? translate("toolAssistance.title");
-  const tabs = [
-    translate("toolAssistance.mouse"),
-    translate("toolAssistance.touch"),
-  ];
-
   const hasMouseInstructions = !!instructions?.sections?.some((section) => {
     return section.instructions.some((instruction) =>
       isMouseInstruction(instruction)
@@ -271,9 +265,7 @@ export function ToolAssistanceField(props: Props) {
     const moreInfo = translate("toolAssistance.moreInfo");
     const postfix = `${lineBreak}${moreInfo}`;
     if (activeTool) {
-      return `${activeTool.flyover}${
-        prompt ? ` > ${prompt}` : undefined
-      }${postfix}`;
+      return `${activeTool.flyover}${prompt ? ` > ${prompt}` : ""}${postfix}`;
     }
     if (prompt) {
       return `${prompt}${postfix}`;
@@ -281,6 +273,11 @@ export function ToolAssistanceField(props: Props) {
     return moreInfo;
   }, [prompt, activeTool, translate]);
 
+  const dialogTitle = activeTool?.flyover ?? translate("toolAssistance.title");
+  const tabs = [
+    translate("toolAssistance.mouse"),
+    translate("toolAssistance.touch"),
+  ];
   return (
     <StatusBarPopover
       visible={state.isOpen}

--- a/ui/appui-react/src/test/statusfields/toolassistance/ToolAssistanceField.test.tsx
+++ b/ui/appui-react/src/test/statusfields/toolassistance/ToolAssistanceField.test.tsx
@@ -18,6 +18,7 @@ import {
   UiFramework,
 } from "../../../appui-react.js";
 import { selectorMatches, storageMock, userEvent } from "../../TestUtils.js";
+import { DragManagerProvider } from "../../layout/Providers.js";
 
 describe(`ToolAssistanceField`, () => {
   let theUserTo: ReturnType<typeof userEvent.setup>;
@@ -40,7 +41,9 @@ describe(`ToolAssistanceField`, () => {
   } as Window);
 
   it("ToolAssistanceField should mount", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     notifications.outputPrompt("Hello World!");
@@ -55,7 +58,10 @@ describe(`ToolAssistanceField`, () => {
 
   it("ToolAssistanceField should display prompt", async () => {
     const wrapper = render(
-      <ToolAssistanceField uiStateStorage={uiSettingsStorage} />
+      <ToolAssistanceField uiStateStorage={uiSettingsStorage} />,
+      {
+        wrapper: DragManagerProvider,
+      }
     );
 
     const notifications = new AppNotificationManager();
@@ -66,7 +72,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("dialog should open and close on click", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     notifications.outputPrompt("Hello World!");
@@ -83,7 +91,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("passing isNew:true should use newDot", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -123,7 +133,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("ToolAssistanceImage.Keyboard with a single key should generate key image", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -148,7 +160,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("should support known icons and multiple sections", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -270,7 +284,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("ToolAssistanceImage.Keyboard with a key containing multiple chars should use large key", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -298,7 +314,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("ToolAssistanceImage.Keyboard with 2 keys should use medium keys", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -326,7 +344,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("ToolAssistanceImage.Keyboard with a modifier key should a medium modifier key & medium key", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -357,7 +377,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("ToolAssistanceImage.Keyboard with bottomRow should use small keys", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -386,7 +408,9 @@ describe(`ToolAssistanceField`, () => {
 
   it("ToolAssistanceImage.Keyboard but keyboardInfo should log error", async () => {
     const spy = vi.spyOn(Logger, "logError");
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -394,8 +418,9 @@ describe(`ToolAssistanceField`, () => {
       "Press a key" /* No keyboardInfo */
     );
     const instructions = ToolAssistance.createInstructions(mainInstruction);
-
     notifications.setToolAssistance(instructions);
+
+    await theUserTo.click(screen.getByRole("button"));
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalled();
@@ -404,7 +429,9 @@ describe(`ToolAssistanceField`, () => {
 
   it("ToolAssistanceImage.Keyboard with invalid keyboardInfo should log error", async () => {
     const spy = vi.spyOn(Logger, "logError");
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createKeyboardInstruction(
@@ -412,8 +439,9 @@ describe(`ToolAssistanceField`, () => {
       "Press key"
     );
     const instructions = ToolAssistance.createInstructions(mainInstruction);
-
     notifications.setToolAssistance(instructions);
+
+    await theUserTo.click(screen.getByRole("button"));
 
     await waitFor(() => {
       expect(spy).toHaveBeenCalled();
@@ -421,7 +449,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("createModifierKeyInstruction should generate valid instruction", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -483,7 +513,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("should support svg icons in string-based instruction.image", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -508,7 +540,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("should support webfont icons in string-based instruction.image", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -536,7 +570,9 @@ describe(`ToolAssistanceField`, () => {
 
   it("invalid modifier key info along with image should log error", async () => {
     const spy = vi.spyOn(Logger, "logError");
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -549,6 +585,8 @@ describe(`ToolAssistanceField`, () => {
     const instructions = ToolAssistance.createInstructions(mainInstruction);
     notifications.setToolAssistance(instructions);
 
+    await theUserTo.click(screen.getByRole("button"));
+
     await waitFor(() => {
       expect(spy).toHaveBeenCalled();
     });
@@ -559,7 +597,10 @@ describe(`ToolAssistanceField`, () => {
       <>
         <div data-testid={"outside"} />
         <ToolAssistanceField uiStateStorage={uiSettingsStorage} />
-      </>
+      </>,
+      {
+        wrapper: DragManagerProvider,
+      }
     );
 
     await theUserTo.click(screen.getByRole("button"));
@@ -576,7 +617,10 @@ describe(`ToolAssistanceField`, () => {
       <>
         <div data-testid={"outside"} />
         <ToolAssistanceField uiStateStorage={uiSettingsStorage} />
-      </>
+      </>,
+      {
+        wrapper: DragManagerProvider,
+      }
     );
 
     await theUserTo.click(screen.getByRole("button"));
@@ -589,7 +633,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("dialog should open and close on click, even if pinned", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const helloWorld = "Hello World!";
     const notifications = new AppNotificationManager();
@@ -605,7 +651,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("should set showPromptAtCursor on toggle click", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
     await theUserTo.click(screen.getByRole("button"));
 
     const notifications = new AppNotificationManager();
@@ -629,7 +677,10 @@ describe(`ToolAssistanceField`, () => {
       <ToolAssistanceField
         uiStateStorage={uiSettingsStorage}
         defaultPromptAtCursor={true}
-      />
+      />,
+      {
+        wrapper: DragManagerProvider,
+      }
     );
 
     const spy = vi.fn();
@@ -656,7 +707,10 @@ describe(`ToolAssistanceField`, () => {
       <ToolAssistanceField
         uiStateStorage={uiSettingsStorage}
         defaultPromptAtCursor={true}
-      />
+      />,
+      {
+        wrapper: DragManagerProvider,
+      }
     );
 
     const spy = vi.fn();
@@ -693,7 +747,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("mouse & touch instructions should generate tabs", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const mainInstruction = ToolAssistance.createInstruction(
       ToolAssistanceImage.CursorClick,
@@ -738,7 +794,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("touch instructions should show", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const notifications = new AppNotificationManager();
     const mainInstruction = ToolAssistance.createInstruction(
@@ -765,7 +823,9 @@ describe(`ToolAssistanceField`, () => {
   });
 
   it("dialog should open, pin and close on click", async () => {
-    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />);
+    render(<ToolAssistanceField uiStateStorage={uiSettingsStorage} />, {
+      wrapper: DragManagerProvider,
+    });
 
     const helloWorld = "Hello World!";
     const notifications = new AppNotificationManager();


### PR DESCRIPTION
## Changes

Follow up to _#1277_

This PR fixes following issues with tool assistance cursor prompt:
- Displayed when dragging a widget container or a widget tab (when `promptAtContent` is enabled)
- Rendered below floating widgets
- Timing issues, where timeout is not respected if prompt is re-shown when fading out

Additionally, `ToolAssistanceField` is refactored from class to functional component.

Internal changes:
- Added `useActiveTool` (currently marked as internal), although this could be exposed as well.
- `useDraggedItem` is now using `useSyncExternalStore` to avoid weird timing/rendering issues between React state and `zustand` store.

## Testing

N/A
