### PR TITLE
Tool settings location

### DIFF
--- a/apps/test-app/src/frontend/appui/frontstages/TestToolSettingsFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/TestToolSettingsFrontstage.tsx
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+import {
+  StagePanelLocation,
+  StagePanelSection,
+  StandardLayout,
+} from "@itwin/appui-react";
+import { createTestFrontstage } from "./createTestFrontstage";
+
+type StandardLayoutProps = React.ComponentProps<typeof StandardLayout>;
+
+/** Used in e2e tests to test different tool settings configurations. */
+export const createTestToolSettingsFrontstage = () => {
+  {
+    const urlParams = new URLSearchParams(window.location.search);
+    const defaultLocation = getDefaultLocation(urlParams);
+
+    const frontstage = createTestFrontstage({
+      id: "test-tool-settings",
+      version: Math.random(),
+      layout: (
+        <StandardLayout
+          toolSettings={{
+            defaultLocation,
+          }}
+        />
+      ),
+      toolSettings: {
+        id: "toolSettings",
+      },
+    });
+
+    return frontstage;
+  }
+};
+
+function getDefaultLocation(
+  params: URLSearchParams
+): Required<StandardLayoutProps>["toolSettings"]["defaultLocation"] {
+  const locationParam = params.get("location");
+  const location = toStagePanelLocation(locationParam ?? "");
+  const section = params.get("section");
+  if (!location || !section) {
+    return undefined;
+  }
+  return {
+    location,
+    section: Number(section) as StagePanelSection,
+  };
+}
+
+function toStagePanelLocation(side: string) {
+  switch (side) {
+    case "bottom":
+      return StagePanelLocation.Bottom;
+    case "left":
+      return StagePanelLocation.Left;
+    case "right":
+      return StagePanelLocation.Right;
+    case "top":
+      return StagePanelLocation.Top;
+  }
+  return undefined;
+}

--- a/apps/test-app/src/frontend/registerFrontstages.tsx
+++ b/apps/test-app/src/frontend/registerFrontstages.tsx
@@ -55,6 +55,7 @@ import {
   createSpatialFrontstage,
   createSpatialFrontstageProvider,
 } from "./appui/frontstages/SpatialFrontstage";
+import { createTestToolSettingsFrontstage } from "./appui/frontstages/TestToolSettingsFrontstage";
 
 interface RegisterFrontstagesArgs {
   iModelConnection?: IModelConnection;
@@ -80,6 +81,7 @@ export function registerFrontstages({
     createTestPanelFrontstage(),
     createTestWidgetFrontstage(),
     createTestPopoutFrontstage(),
+    createTestToolSettingsFrontstage(),
     createWidgetApiFrontstage(),
     createCustomContentFrontstage(),
     createContentLayoutFrontstage(),

--- a/common/changes/@itwin/appui-react/master_2025-04-16-15-54.json
+++ b/common/changes/@itwin/appui-react/master_2025-04-16-15-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Add `toolSettings.defaultLocation` to `StandardLayout` component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -78,6 +78,19 @@ Table of contents:
   }
   ```
 
+- Added `toolSettings.defaultLocation` prop to the `StandardLayout` component which allows consumers to specify the initial tool settings location as a docked widget. [#1268](https://github.com/iTwin/appui/pull/1268)
+
+  ```tsx
+  <StandardLayout
+    toolSettings={{
+      defaultLocation: {
+        location: StagePanelLocation.Right,
+        section: StagePanelSection.Start,
+      },
+    }}
+  />
+  ```
+
 ### Changes
 
 - Converted `CursorPopupRenderer` from a class component to a functional component. [#1277](https://github.com/iTwin/appui/pull/1277)

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -35,13 +35,16 @@ import type { ContentProps } from "../content/ContentGroup.js";
 import { ChildWindowRenderer } from "../childwindow/ChildWindowRenderer.js";
 import { useActiveFrontstageDef } from "../frontstage/FrontstageDef.js";
 import type { WidgetActions } from "../layout/widget/WidgetActions.js";
+import type { StagePanelSection } from "../stagepanels/StagePanelSection.js";
+import type { StagePanelLocation } from "../stagepanels/StagePanelLocation.js";
 
 /** @internal */
 export const ConfigurableUiContext = React.createContext<
   /* eslint-disable-next-line @typescript-eslint/no-deprecated */
   ConfigurableUiContentProps & {
     contentElementRef?: React.RefObject<HTMLElement>;
-    widgetActions?: React.ReactNode;
+    widgetActions?: StandardLayoutProps["widgetActions"];
+    toolSettings?: StandardLayoutProps["toolSettings"];
   }
 >({});
 
@@ -102,6 +105,11 @@ export function ConfigurableUiContent(props: ConfigurableUiContentProps) {
   );
 }
 
+interface ToolSettingsLocation {
+  section: StagePanelSection;
+  location: StagePanelLocation;
+}
+
 interface StandardLayoutProps {
   /** Overrides widget specific actions displayed in the title bar area.
    * Use {@link WidgetActions} component to customize widget actions.
@@ -113,13 +121,22 @@ interface StandardLayoutProps {
    * @alpha
    */
   visibleToolSettings?: boolean;
+  /** Tool settings related configuration.
+   * @alpha
+   */
+  toolSettings?: {
+    /** The default location of the tool settings. Only used when initializing the layout and ignored when restoring a saved layout.
+     * @alpha
+     */
+    defaultLocation?: ToolSettingsLocation;
+  };
 }
 
 /** The standard widget based layout used as a default layout for all frontstages.
  * @alpha
  */
 export function StandardLayout(props: StandardLayoutProps) {
-  const { widgetActions, visibleToolSettings = false } = props;
+  const { widgetActions, visibleToolSettings = false, toolSettings } = props;
   const context = React.useContext(ConfigurableUiContext);
   const {
     appBackstage,
@@ -156,8 +173,9 @@ export function StandardLayout(props: StandardLayoutProps) {
           ...context,
           contentElementRef,
           widgetActions,
+          toolSettings,
         }),
-        [context, widgetActions]
+        [context, widgetActions, toolSettings]
       )}
     >
       <main

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
@@ -335,6 +335,7 @@ export interface WidgetDefAddToolSettingsAction {
   readonly type: "WIDGET_DEF_ADD_TOOL_SETTINGS";
   readonly id: TabState["id"];
   readonly overrides?: Partial<TabState>;
+  readonly panelSection?: WidgetDefAddAction["panelSection"];
 }
 
 /** @internal */


### PR DESCRIPTION
## Changes

This PR closes #1268 by introducing `toolSettings.defaultLocation` prop to `StandardLayout` component.

## Testing

Added additional frontstage to the `test-app` to test tool settings specific wokrflows `?frontstageId=test-tool-settings&location=right&section=0`.