### PR TITLE
Editor show status message

### DIFF
--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -596,7 +596,7 @@ export interface EditorProps<TMetadata = ValueMetadata, TValue = Value> {
 }
 
 // @beta
-export function EditorRenderer(props: EditorProps): React_3.JSX.Element | null;
+export function EditorRenderer({ statusMessage, ...editorProps }: EditorRendererProps): React_3.JSX.Element | null;
 
 // @beta
 export interface EditorSpec {
@@ -2114,6 +2114,7 @@ export function PropertyFilterBuilderRuleValue(props: PropertyFilterBuilderRuleV
 
 // @beta
 export interface PropertyFilterBuilderRuleValueProps {
+    editorSystem?: "legacy" | "new";
     onChange: (value: PropertyValue) => void;
     property: PropertyDescription;
     value?: PropertyValue;

--- a/common/changes/@itwin/components-react/editor-show-status-message_2025-04-24-10-13.json
+++ b/common/changes/@itwin/components-react/editor-show-status-message_2025-04-24-10-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Added ability to render status message in `EditorRenderer`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/common/changes/@itwin/components-react/editor-show-status-message_2025-04-24-10-18.json
+++ b/common/changes/@itwin/components-react/editor-show-status-message_2025-04-24-10-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/components-react",
+      "comment": "Added ability to opt in to using new editors system in `FilterBuilder` component.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/components-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -10,4 +10,34 @@ Table of contents:
 ### Additions
 
 - Added ability to opt in to using new editors system in `FilterBuilder` component. [#1288](https://github.com/iTwin/appui/pull/1288)
+
+  ```tsx
+  return (
+    <FilterBuilder
+      {...props}
+      ruleValueRenderer={React.useCallback(
+        (valueProps) => (
+          <PropertyFilterBuilderRuleValue {...valueProps} editorSystem="new" />
+        ),
+        []
+      )}
+    />
+  );
+  ```
+
 - Added ability to render status message in `EditorRenderer`. [#1288](https://github.com/iTwin/appui/pull/1288)
+
+  ```tsx
+  return <EditorRenderer {...props} statusMessage="Negative status message" />;
+  ```
+
+  ```tsx
+  return (
+    <EditorRenderer
+      {...props}
+      statusMessage={
+        <StatusMessage status="positive">Custom status message</StatusMessage>
+      }
+    />
+  );
+  ```

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,13 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/components-react](#itwincomponents-react)
+  - [Additions](#additions)
+
+## @itwin/components-react
+
+### Additions
+
+- Added ability to opt in to using new editors system in `FilterBuilder` component. [#1288](https://github.com/iTwin/appui/pull/1288)
+- Added ability to render status message in `EditorRenderer`. [#1288](https://github.com/iTwin/appui/pull/1288)

--- a/docs/storybook/src/components/FilterBuilder.stories.tsx
+++ b/docs/storybook/src/components/FilterBuilder.stories.tsx
@@ -39,6 +39,14 @@ export const WithInitialFilter: Story = {
   },
 };
 
+export const WithNewEditorSystem: Story = {
+  args: {
+    initialFilter: createInitialFilter(),
+    properties: createProperties(),
+    editorSystem: "new",
+  },
+};
+
 function createProperties(): PropertyDescription[] {
   return [
     {

--- a/docs/storybook/src/components/FilterBuilder.tsx
+++ b/docs/storybook/src/components/FilterBuilder.tsx
@@ -7,6 +7,7 @@ import { UiFramework } from "@itwin/appui-react";
 import {
   PropertyFilterBuilderProps,
   PropertyFilterBuilderRenderer,
+  PropertyFilterBuilderRuleValue,
   usePropertyFilterBuilder,
 } from "@itwin/components-react";
 import { IModelApp } from "@itwin/core-frontend";
@@ -24,10 +25,13 @@ export function FilterBuilderStory(props: FilterBuilderComponentProps) {
 type FilterBuilderComponentProps = Pick<
   PropertyFilterBuilderProps,
   "properties" | "initialFilter"
->;
+> & {
+  editorSystem: "new" | "legacy";
+};
 
 function FilterBuilderComponent({
   initialFilter,
+  editorSystem,
   ...props
 }: FilterBuilderComponentProps) {
   const { rootGroup, actions, buildFilter } = usePropertyFilterBuilder({
@@ -53,6 +57,15 @@ function FilterBuilderComponent({
         {...props}
         actions={actions}
         rootGroup={rootGroup}
+        ruleValueRenderer={React.useCallback(
+          (valueProps) => (
+            <PropertyFilterBuilderRuleValue
+              {...valueProps}
+              editorSystem={editorSystem}
+            />
+          ),
+          [editorSystem]
+        )}
       />
       <Button onClick={() => buildFilter()}>Validate</Button>
     </div>

--- a/ui/components-react/src/components-react/filter-builder/FilterBuilderRule.tsx
+++ b/ui/components-react/src/components-react/filter-builder/FilterBuilderRule.tsx
@@ -9,8 +9,7 @@
 import "./FilterBuilderRule.scss";
 import * as React from "react";
 import type { PropertyDescription, PropertyValue } from "@itwin/appui-abstract";
-import { SvgStatusError } from "@itwin/itwinui-icons-react";
-import { Flex, Text } from "@itwin/itwinui-react";
+import { Flex, StatusMessage } from "@itwin/itwinui-react";
 import {
   PropertyFilterBuilderContext,
   PropertyFilterBuilderRuleRenderingContext,
@@ -147,10 +146,9 @@ export function PropertyFilterBuilderRuleRenderer(
           <div className="fb-property-value">
             {valueRenderer(property, operator)}
             {rule.errorMessage ? (
-              <Flex>
-                <SvgStatusError />
-                <Text>{rule.errorMessage}</Text>
-              </Flex>
+              <StatusMessage status="negative">
+                {rule.errorMessage}
+              </StatusMessage>
             ) : null}
           </div>
         ) : null}

--- a/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleValue.tsx
+++ b/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleValue.tsx
@@ -15,6 +15,7 @@ import { Flex, Text } from "@itwin/itwinui-react";
 import { PropertyFilterBuilderRuleRangeValue } from "./FilterBuilderRangeValue.js";
 import type { PropertyFilterBuilderRuleOperator } from "./Operators.js";
 import { useTranslation } from "../l10n/useTranslation.js";
+import { PropertyRecordEditor } from "../../components-react.js";
 
 /**
  * Props for [[PropertyFilterBuilderRuleValue]] component.
@@ -27,6 +28,12 @@ export interface PropertyFilterBuilderRuleValueProps {
   property: PropertyDescription;
   /** Callback that is invoked when value changes. */
   onChange: (value: PropertyValue) => void;
+  /**
+   * Specifies which editors system should be used: legacy or the new one.
+   * @default "legacy"
+   * @beta
+   */
+  editorSystem?: "legacy" | "new";
 }
 
 /**
@@ -59,6 +66,7 @@ function FilterBuilderRulePrimitiveValueRenderer({
   property,
   value,
   onChange,
+  editorSystem,
 }: PropertyFilterBuilderRuleValueProps) {
   const propertyRecord = React.useMemo(() => {
     return new PropertyRecord(
@@ -75,12 +83,12 @@ function FilterBuilderRulePrimitiveValueRenderer({
   );
 
   return (
-    <EditorContainer
+    <PropertyRecordEditor
       propertyRecord={propertyRecord}
       onCancel={() => {}}
       onCommit={onValueChange}
-      setFocus={false}
-      shouldCommitOnChange={false}
+      size="small"
+      editorSystem={editorSystem}
     />
   );
 }

--- a/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleValue.tsx
+++ b/ui/components-react/src/components-react/filter-builder/FilterBuilderRuleValue.tsx
@@ -15,7 +15,7 @@ import { Flex, Text } from "@itwin/itwinui-react";
 import { PropertyFilterBuilderRuleRangeValue } from "./FilterBuilderRangeValue.js";
 import type { PropertyFilterBuilderRuleOperator } from "./Operators.js";
 import { useTranslation } from "../l10n/useTranslation.js";
-import { PropertyRecordEditor } from "../../components-react.js";
+import { PropertyRecordEditor } from "../new-editors/interop/PropertyRecordEditor.js";
 
 /**
  * Props for [[PropertyFilterBuilderRuleValue]] component.

--- a/ui/components-react/src/components-react/new-editors/EditorRenderer.tsx
+++ b/ui/components-react/src/components-react/new-editors/EditorRenderer.tsx
@@ -9,18 +9,39 @@
 import * as React from "react";
 import type { EditorProps } from "./Types.js";
 import { useEditor } from "./editors-registry/UseEditor.js";
+import { StatusMessage } from "@itwin/itwinui-react";
+
+interface EditorRendererProps extends EditorProps {
+  /**
+   * Status message shown under editor. If `string` is passed it will be rendered as `negative`
+   * status message. To render different type of status message custom react component can be provided.
+   */
+  statusMessage?: React.ReactNode | string;
+}
 
 /**
  * Editor component that renders an editor based on the metadata and value.
  * @beta
  */
-export function EditorRenderer(props: EditorProps) {
-  const { metadata, value } = props;
+export function EditorRenderer({
+  statusMessage,
+  ...editorProps
+}: EditorRendererProps) {
+  const { metadata, value } = editorProps;
   const TypeEditor = useEditor(metadata, value);
 
   if (!TypeEditor) {
     return null;
   }
 
-  return <TypeEditor {...props} />;
+  return (
+    <>
+      <TypeEditor {...editorProps} />
+      {statusMessage && typeof statusMessage === "string" ? (
+        <StatusMessage status="negative">{statusMessage}</StatusMessage>
+      ) : (
+        statusMessage
+      )}
+    </>
+  );
 }

--- a/ui/components-react/src/components-react/new-editors/editors/NumericEditor.tsx
+++ b/ui/components-react/src/components-react/new-editors/editors/NumericEditor.tsx
@@ -25,12 +25,15 @@ export function NumericEditor({
   return (
     <Input
       value={currentValue.displayValue}
-      onChange={(e) =>
+      onChange={(e) => {
+        const parsedValue = parseFloat(e.target.value);
         onChange({
-          rawValue: parseFloat(e.target.value),
+          rawValue: Number.isNaN(parsedValue)
+            ? undefined
+            : parseFloat(e.target.value),
           displayValue: e.target.value,
-        })
-      }
+        });
+      }}
       size={size}
       disabled={disabled}
     />

--- a/ui/components-react/src/test/new-editors/EditorRenderer.test.tsx
+++ b/ui/components-react/src/test/new-editors/EditorRenderer.test.tsx
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, it } from "vitest";
+import { EditorRenderer } from "../../components-react.js";
+
+describe("EditorRenderer", () => {
+  it("renders status message", () => {
+    const { queryByText } = render(
+      <EditorRenderer
+        metadata={{ type: "string" }}
+        value={{ value: "test" }}
+        onChange={() => {}}
+        statusMessage="Test message"
+      />
+    );
+
+    expect(queryByText("Test message")).not.toBeNull();
+  });
+
+  it("renders custom status message component", () => {
+    const { queryByText } = render(
+      <EditorRenderer
+        metadata={{ type: "string" }}
+        value={{ value: "test" }}
+        onChange={() => {}}
+        statusMessage={
+          <div>
+            <div>Multiline</div>
+            <div>Test message</div>
+          </div>
+        }
+      />
+    );
+
+    expect(queryByText("Multiline Test message")).toBeNull();
+    expect(queryByText("Multiline")).not.toBeNull();
+    expect(queryByText("Test message")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Closes https://github.com/iTwin/appui/issues/1219. Added ability to show status message along size editor. 

Didn't change `FilterBuilder` to use this new approach when using new editors system to have better backwards compatibility. 

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Added unit tests.