### PR TITLE
[preview-feature]: New editors system in tool settings

### DIFF
--- a/apps/test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
+++ b/apps/test-providers/src/ui/providers/PreviewFeaturesToggleProvider.tsx
@@ -49,6 +49,9 @@ const availableFeatures: AvailableFeatures = {
   enableColorlessAccuDrawInputFields: {
     label: "Enable colorless AccuDraw input fields",
   },
+  toolSettingsNewEditors: {
+    label: "Enable new tool settings editors",
+  },
 };
 
 function PreviewFeatureList() {

--- a/common/changes/@itwin/appui-react/new-editors-in-tool-settings_2025-04-24-13-36.json
+++ b/common/changes/@itwin/appui-react/new-editors-in-tool-settings_2025-04-24-13-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@itwin/appui-react",
+      "comment": "Added preview feature for enabling new editors system in tool settings.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@itwin/appui-react"
+}

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -9,4 +9,4 @@ Table of contents:
 
 ### Additions
 
-- Added preview feature for enabling new editors system in tool settings. #PR
+- Added preview feature for enabling new editors system in tool settings. [#1289](https://github.com/iTwin/appui/pull/1289)

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -1,1 +1,12 @@
 # NextVersion <!-- omit from toc -->
+
+Table of contents:
+
+- [@itwin/appui-react](#itwinappui-react)
+  - [Additions](#additions)
+
+## @itwin/appui-react
+
+### Additions
+
+- Added preview feature for enabling new editors system in tool settings. #PR

--- a/docs/changehistory/NextVersion.md
+++ b/docs/changehistory/NextVersion.md
@@ -9,4 +9,4 @@ Table of contents:
 
 ### Additions
 
-- Added preview feature for enabling new editors system in tool settings. [#1289](https://github.com/iTwin/appui/pull/1289)
+- Added `toolSettingsNewEditors` preview feature for enabling new editors system in tool settings. [#1289](https://github.com/iTwin/appui/pull/1289)

--- a/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
+++ b/ui/appui-react/src/appui-react/preview/PreviewFeatures.tsx
@@ -62,6 +62,11 @@ interface KnownPreviewFeatures {
    * Discuss or upvote this feature: https://github.com/iTwin/appui/discussions/859
    */
   controlWidgetVisibility: boolean | WidgetDef["id"][];
+  /**
+   * If `true`, the tool settings will be using the new editor API. The new system delivers same default editors as the old one.
+   * However, in order to use custom editors they need to be provided using `EditorsRegistryProvider` component.
+   */
+  toolSettingsNewEditors: boolean;
 }
 
 /** Object used trim to only known features at runtime.
@@ -76,6 +81,7 @@ const knownFeaturesObject: Record<keyof KnownPreviewFeatures, undefined> = {
   allowBearingLettersInAccuDrawInputFields: undefined,
   reparentPopoutWidgets: undefined,
   controlWidgetVisibility: undefined,
+  toolSettingsNewEditors: undefined,
 };
 
 /** List of preview features that can be enabled/disabled.

--- a/ui/appui-react/src/appui-react/preview/tool-settings-new-editors/useToolsSettingsNewEditors.ts
+++ b/ui/appui-react/src/appui-react/preview/tool-settings-new-editors/useToolsSettingsNewEditors.ts
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { usePreviewFeatures } from "../PreviewFeatures.js";
+
+/**  If `true`, tool settings will use editors based on the new editors system.
+ * @internal
+ */
+export function useToolSettingsNewEditors() {
+  const { toolSettingsNewEditors } = usePreviewFeatures();
+  return toolSettingsNewEditors;
+}

--- a/ui/appui-react/src/appui-react/uiprovider/ComponentGenerator.tsx
+++ b/ui/appui-react/src/appui-react/uiprovider/ComponentGenerator.tsx
@@ -21,10 +21,12 @@ import {
   UiLayoutDataProvider,
 } from "@itwin/appui-abstract";
 import type { PropertyUpdatedArgs } from "@itwin/components-react";
+import { PropertyRecordEditor } from "@itwin/components-react";
 import { EditorContainer } from "@itwin/components-react";
 import type { ToolSettingsEntry } from "../widget-panels/ToolSettings.js";
 import { assert, Logger } from "@itwin/core-bentley";
 import { Label } from "@itwin/itwinui-react";
+import { useToolSettingsNewEditors } from "../preview/tool-settings-new-editors/useToolsSettingsNewEditors.js";
 
 function EditorLabel({
   uiDataProvider,
@@ -187,15 +189,29 @@ function PropertyEditor({
   );
   const handleCancel = () => {};
 
+  const useNewEditors = useToolSettingsNewEditors();
+
   return (
     <div key={initialItem.property.name} className={className}>
-      <EditorContainer
-        key={initialItem.property.name}
-        propertyRecord={propertyRecord}
-        setFocus={setFocus}
-        onCommit={handleCommit}
-        onCancel={onCancel ?? handleCancel}
-      />
+      {useNewEditors ? (
+        <PropertyRecordEditor
+          key={initialItem.property.name}
+          propertyRecord={propertyRecord}
+          setFocus={setFocus}
+          onCommit={handleCommit}
+          onCancel={onCancel ?? handleCancel}
+          editorSystem="new"
+          size="small"
+        />
+      ) : (
+        <EditorContainer
+          key={initialItem.property.name}
+          propertyRecord={propertyRecord}
+          setFocus={setFocus}
+          onCommit={handleCommit}
+          onCancel={onCancel ?? handleCancel}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Closes https://github.com/iTwin/appui/issues/1223. Added preview feature for enabling usage of the new editors system in tool settings.

Tool settings with legacy editors system:
![image](https://github.com/user-attachments/assets/9720428a-291c-42ea-9c95-4bc01c06f751)
![image](https://github.com/user-attachments/assets/93b5d543-ac7d-4c88-b25f-f2cedecd008a)

Tool settings with new editors system:
![image](https://github.com/user-attachments/assets/0f3dd8ce-2231-469d-ab73-2cb9700bf190)
![image](https://github.com/user-attachments/assets/b8646238-8c63-40fc-9289-09c616bf6fea)



## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
