### PR TITLE
Retry release

### DIFF
--- a/.changeset/big-dogs-think.md
+++ b/.changeset/big-dogs-think.md
@@ -1,0 +1,24 @@
+---
+"@itwin/components-react": minor
+---
+
+Deprecated `dispose` method of `FilteringPropertyDataProvider` and `TreeEventHandler` classes which is defined in now deprecated `IDisposable` interface from `@itwin/core-bentley` package.
+
+In version `5.2`, TypeScript [introduced](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management) `Disposable` type and `using` declarations (from the upcoming [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) feature in ECMAScript).
+
+Consumers should use `Symbol.dispose` instead, which is polyfilled by the AppUI package.
+
+```ts
+// Before #1
+const handler = new TreeEventHandler();
+handler.dispose();
+
+// Before #2 when using `using` utility from `@itwin/core-bentley`
+using(new TreeEventHandler(), (handler) => {
+  // Do something with handler, it'll get disposed when the callback returns
+});
+
+// After
+using handler = new TreeEventHandler();
+// Do something with handler, it'll get disposed when it goes out of scope
+```

--- a/.changeset/clean-games-raise.md
+++ b/.changeset/clean-games-raise.md
@@ -1,0 +1,8 @@
+---
+"@itwin/imodel-components-react": minor
+"@itwin/components-react": minor
+"@itwin/appui-react": minor
+"@itwin/core-react": minor
+---
+
+Updated peer dependencies to support iTwin.js core v5 packages.

--- a/.changeset/deep-llamas-sell.md
+++ b/.changeset/deep-llamas-sell.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Added `toolSettingsNewEditors` preview feature for enabling new editors system in tool settings. [#1289](https://github.com/iTwin/appui/pull/1289)

--- a/.changeset/twenty-bobcats-shine.md
+++ b/.changeset/twenty-bobcats-shine.md
@@ -1,0 +1,36 @@
+---
+"@itwin/components-react": minor
+---
+
+Added ability to opt in to using new editors system in `FilterBuilder` component. [#1288](https://github.com/iTwin/appui/pull/1288)
+
+```tsx
+return (
+  <FilterBuilder
+    {...props}
+    ruleValueRenderer={React.useCallback(
+      (valueProps) => (
+        <PropertyFilterBuilderRuleValue {...valueProps} editorSystem="new" />
+      ),
+      []
+    )}
+  />
+);
+```
+
+Added ability to render status message in `EditorRenderer`.
+
+```tsx
+return <EditorRenderer {...props} statusMessage="Negative status message" />;
+```
+
+```tsx
+return (
+  <EditorRenderer
+    {...props}
+    statusMessage={
+      <StatusMessage status="positive">Custom status message</StatusMessage>
+    }
+  />
+);
+```

--- a/.github/workflows/changeset-release.yaml
+++ b/.github/workflows/changeset-release.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org/
           cache: "pnpm"
 
       - run: pnpm install

--- a/ui/appui-react/CHANGELOG.md
+++ b/ui/appui-react/CHANGELOG.md
@@ -1,23 +1,6 @@
 # Change Log - @itwin/appui-react
 
-## 5.5.0
-
-### Minor Changes
-
-- c619667: Updated peer dependencies to support iTwin.js core v5 packages.
-- a69108d: Added `toolSettingsNewEditors` preview feature for enabling new editors system in tool settings. [#1289](https://github.com/iTwin/appui/pull/1289)
-
-### Patch Changes
-
-- Updated dependencies [c619667]
-- Updated dependencies [c619667]
-- Updated dependencies [a69108d]
-  - @itwin/components-react@5.5.0
-  - @itwin/imodel-components-react@5.5.0
-  - @itwin/core-react@5.5.0
-
 ## 5.4.0
-
 Thu, 17 Apr 2025 09:55:41 GMT
 
 ### Updates
@@ -31,7 +14,6 @@ Thu, 17 Apr 2025 09:55:41 GMT
 - Added `visibleToolSettings` prop to `StandardLayout` component.
 
 ## 5.3.1
-
 Thu, 20 Mar 2025 11:10:28 GMT
 
 ### Updates
@@ -40,7 +22,6 @@ Thu, 20 Mar 2025 11:10:28 GMT
 - Fix Firefox specific style loading issue of widget popouts.
 
 ## 5.3.0
-
 Fri, 14 Mar 2025 17:37:48 GMT
 
 ### Updates
@@ -50,7 +31,6 @@ Fri, 14 Mar 2025 17:37:48 GMT
 - Add `widgetActions` prop to `StandardLayout` component.
 
 ## 5.2.0
-
 Thu, 27 Feb 2025 08:07:36 GMT
 
 ### Updates
@@ -60,7 +40,6 @@ Thu, 27 Feb 2025 08:07:36 GMT
 - Add `useSavedState` to `Widget` interface.
 
 ## 5.1.0
-
 Thu, 30 Jan 2025 09:15:23 GMT
 
 ### Updates
@@ -71,7 +50,6 @@ Thu, 30 Jan 2025 09:15:23 GMT
 - Fixed some AccuDraw behaviors that where working incorrectly, like input highlight, focus and update. Improved typing Bearing angles.
 
 ## 5.0.5
-
 Tue, 21 Jan 2025 11:38:58 GMT
 
 ### Updates
@@ -79,7 +57,6 @@ Tue, 21 Jan 2025 11:38:58 GMT
 - Update `react-error-boundary` version.
 
 ## 5.0.4
-
 Fri, 17 Jan 2025 14:12:03 GMT
 
 ### Updates
@@ -87,7 +64,6 @@ Fri, 17 Jan 2025 14:12:03 GMT
 - Fixed `module 'lodash' does not provide an export named...` error when running in Node.js.
 
 ## 5.0.3
-
 Fri, 17 Jan 2025 11:42:02 GMT
 
 ### Updates
@@ -95,7 +71,6 @@ Fri, 17 Jan 2025 11:42:02 GMT
 - Fix popout widget issue when `useDefaultPopoutUrl` is not enabled.
 
 ## 5.0.2
-
 Thu, 16 Jan 2025 12:04:12 GMT
 
 ### Updates
@@ -103,7 +78,6 @@ Thu, 16 Jan 2025 12:04:12 GMT
 - Use import attributes for json imports.
 
 ## 5.0.1
-
 Wed, 15 Jan 2025 11:47:00 GMT
 
 ### Updates
@@ -111,7 +85,6 @@ Wed, 15 Jan 2025 11:47:00 GMT
 - Fix `useWidget` hook issue when used in a popout widget.
 
 ## 5.0.0
-
 Mon, 16 Dec 2024 11:43:27 GMT
 
 ### Updates
@@ -147,7 +120,6 @@ Mon, 16 Dec 2024 11:43:27 GMT
 - Replace buic variables with iTwinUI CSS variables.
 
 ## 4.17.6
-
 Wed, 20 Nov 2024 14:27:46 GMT
 
 ### Updates
@@ -155,7 +127,6 @@ Wed, 20 Nov 2024 14:27:46 GMT
 - Update `MessageManager.addMessage` to ignore messages that are already active.
 
 ## 4.17.5
-
 Thu, 14 Nov 2024 08:22:04 GMT
 
 ### Updates
@@ -163,7 +134,6 @@ Thu, 14 Nov 2024 08:22:04 GMT
 - Fix styling of alert dialog used by notification APIs.
 
 ## 4.17.4
-
 Fri, 08 Nov 2024 14:41:23 GMT
 
 ### Updates
@@ -171,7 +141,6 @@ Fri, 08 Nov 2024 14:41:23 GMT
 - Fix localization of StandardMessageBox component.
 
 ## 4.17.3
-
 Wed, 06 Nov 2024 09:04:20 GMT
 
 ### Updates
@@ -180,13 +149,11 @@ Wed, 06 Nov 2024 09:04:20 GMT
 - Fix an issue where restore frontstage layout would require an active frontstage.
 
 ## 4.17.2
-
 Wed, 30 Oct 2024 14:46:15 GMT
 
 _Version update only_
 
 ## 4.17.1
-
 Wed, 09 Oct 2024 10:50:47 GMT
 
 ### Updates
@@ -195,7 +162,6 @@ Wed, 09 Oct 2024 10:50:47 GMT
 - Add `-webkit` prefix to `user-select` CSS property to fix selection issues on Safari.
 
 ## 4.17.0
-
 Thu, 19 Sep 2024 12:50:53 GMT
 
 ### Updates
@@ -216,7 +182,6 @@ Thu, 19 Sep 2024 12:50:53 GMT
 - Added `UiFramework.onIModelConnectionChanged` event to get notified whenever the iModel connection returned by `UiFramework.getIModelConnection()` is changed.
 
 ## 4.16.5
-
 Tue, 10 Sep 2024 16:40:45 GMT
 
 ### Updates
@@ -228,7 +193,6 @@ Tue, 10 Sep 2024 16:40:45 GMT
 - Fix `undefined` property access within `StatusBarComposer` component.
 
 ## 4.16.4
-
 Wed, 04 Sep 2024 08:10:19 GMT
 
 ### Updates
@@ -236,7 +200,6 @@ Wed, 04 Sep 2024 08:10:19 GMT
 - Fix link style load timing issue in window popups.
 
 ## 4.16.3
-
 Tue, 03 Sep 2024 14:32:22 GMT
 
 ### Updates
@@ -244,7 +207,6 @@ Tue, 03 Sep 2024 14:32:22 GMT
 - Render `MenuItem` without `item` or `submenu` props.
 
 ## 4.16.2
-
 Wed, 28 Aug 2024 06:32:12 GMT
 
 ### Updates
@@ -254,7 +216,6 @@ Wed, 28 Aug 2024 06:32:12 GMT
 - Increased margins of `SelectionCountField` component.
 
 ## 4.16.1
-
 Fri, 16 Aug 2024 08:18:13 GMT
 
 ### Updates
@@ -264,7 +225,6 @@ Fri, 16 Aug 2024 08:18:13 GMT
 - Fix `useActiveViewport` to correctly return the active viewport.
 
 ## 4.16.0
-
 Wed, 07 Aug 2024 12:38:32 GMT
 
 ### Updates
@@ -284,7 +244,6 @@ Wed, 07 Aug 2024 12:38:32 GMT
 - Removed transitions when toggling themes. This fixes the unintentional "flying-in" of floating elements like Tooltips and ComboBox menus when the page first loads.
 
 ## 4.15.5
-
 Wed, 24 Jul 2024 16:09:26 GMT
 
 ### Updates
@@ -292,7 +251,6 @@ Wed, 24 Jul 2024 16:09:26 GMT
 - Fix `UiFramework.visibility.autoHideUi` to reset UI visibility.
 
 ## 4.15.4
-
 Mon, 22 Jul 2024 21:27:52 GMT
 
 ### Updates
@@ -302,13 +260,11 @@ Mon, 22 Jul 2024 21:27:52 GMT
 - Fixed popout widget changing position on a secondary monitor.
 
 ## 4.15.3
-
 Mon, 15 Jul 2024 12:12:00 GMT
 
 _Version update only_
 
 ## 4.15.2
-
 Wed, 10 Jul 2024 11:54:56 GMT
 
 ### Updates
@@ -316,13 +272,11 @@ Wed, 10 Jul 2024 11:54:56 GMT
 - Fix `FrontstageDef.create()` if a non-instance `FrontstageProvider` is used.
 
 ## 4.15.1
-
 Tue, 09 Jul 2024 09:23:12 GMT
 
 _Version update only_
 
 ## 4.15.0
-
 Fri, 28 Jun 2024 09:09:37 GMT
 
 ### Updates
@@ -337,7 +291,6 @@ Fri, 28 Jun 2024 09:09:37 GMT
 - Deprecated `StandardMessageBox` component.
 
 ## 4.14.2
-
 Mon, 22 Jul 2024 21:23:09 GMT
 
 ### Updates
@@ -347,7 +300,6 @@ Mon, 22 Jul 2024 21:23:09 GMT
 - Fixed popout widget changing position on a secondary monitor.
 
 ## 4.14.1
-
 Tue, 11 Jun 2024 15:58:29 GMT
 
 ### Updates
@@ -356,7 +308,6 @@ Tue, 11 Jun 2024 15:58:29 GMT
 - Re-open popout widgets when switching frontstages in an electron app.
 
 ## 4.14.0
-
 Thu, 06 Jun 2024 08:24:21 GMT
 
 ### Updates
@@ -368,7 +319,6 @@ Thu, 06 Jun 2024 08:24:21 GMT
 - Use iTwinUI components for `StatusBar` field components.
 
 ## 4.13.4
-
 Tue, 21 May 2024 08:21:34 GMT
 
 ### Updates
@@ -376,7 +326,6 @@ Tue, 21 May 2024 08:21:34 GMT
 - Fix save and restore of frontstage layout for react 18 strict mode.
 
 ## 4.13.3
-
 Fri, 17 May 2024 09:43:31 GMT
 
 ### Updates
@@ -384,7 +333,6 @@ Fri, 17 May 2024 09:43:31 GMT
 - upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x
 
 ## 4.13.2
-
 Wed, 08 May 2024 08:24:46 GMT
 
 ### Updates
@@ -392,13 +340,11 @@ Wed, 08 May 2024 08:24:46 GMT
 - Fixed `StatusBar` and `ToolSettings` not being visible when `contentAlwaysMaxSize` preview feature is enabled.
 
 ## 4.13.1
-
 Tue, 07 May 2024 15:01:46 GMT
 
 _Version update only_
 
 ## 4.13.0
-
 Tue, 07 May 2024 08:44:06 GMT
 
 ### Updates
@@ -415,7 +361,6 @@ Tue, 07 May 2024 08:44:06 GMT
 - Bump `FloatingViewportContentWrapper` to `@public`.
 
 ## 4.12.0
-
 Fri, 05 Apr 2024 09:55:35 GMT
 
 ### Updates
@@ -425,7 +370,6 @@ Fri, 05 Apr 2024 09:55:35 GMT
 - Replace `process.env.NODE_ENV === "development"` check in preview features with `Logger.logWarning()`.
 
 ## 4.11.0
-
 Thu, 21 Mar 2024 16:38:04 GMT
 
 ### Updates
@@ -443,7 +387,6 @@ Thu, 21 Mar 2024 16:38:04 GMT
 - Removed memoization for translated strings in components.
 
 ## 4.10.0
-
 Mon, 26 Feb 2024 15:50:45 GMT
 
 ### Updates
@@ -454,7 +397,6 @@ Mon, 26 Feb 2024 15:50:45 GMT
 - Add `enableMaximizedPanelWidget` preview feature.
 
 ## 4.9.0
-
 Tue, 06 Feb 2024 08:56:40 GMT
 
 ### Updates
@@ -469,7 +411,6 @@ Tue, 06 Feb 2024 08:56:40 GMT
 - Updated buttons on widget panels.
 
 ## 4.8.3
-
 Tue, 30 Jan 2024 09:04:27 GMT
 
 ### Updates
@@ -477,19 +418,16 @@ Tue, 30 Jan 2024 09:04:27 GMT
 - Position root container element.
 
 ## 4.8.2
-
 Wed, 24 Jan 2024 12:37:03 GMT
 
 _Version update only_
 
 ## 4.8.1
-
 Thu, 11 Jan 2024 13:05:42 GMT
 
 _Version update only_
 
 ## 4.8.0
-
 Thu, 21 Dec 2023 14:08:42 GMT
 
 ### Updates
@@ -498,11 +436,10 @@ Thu, 21 Dec 2023 14:08:42 GMT
 - Keep widget content unmounted while widget state is set to WidgetState.Unloaded.
 - Localize popout error text
 - Fixed bug where popouts would get incrementally smaller or larger each time opened
-- Promote `FrameworkToolAdmin` to _beta_.
+- Promote `FrameworkToolAdmin` to *beta*.
 - Fix `RestoreLayout` tool.
 
 ## 4.7.2
-
 Wed, 20 Dec 2023 23:11:37 GMT
 
 ### Updates
@@ -510,7 +447,6 @@ Wed, 20 Dec 2023 23:11:37 GMT
 - Revert Popout reparenting strategy.
 
 ## 4.7.1
-
 Thu, 07 Dec 2023 19:40:17 GMT
 
 ### Updates
@@ -518,7 +454,6 @@ Thu, 07 Dec 2023 19:40:17 GMT
 - Now support `null` Content (allow delay rendering on specific cases)
 
 ## 4.7.0
-
 Fri, 01 Dec 2023 20:01:16 GMT
 
 ### Updates
@@ -545,7 +480,6 @@ Fri, 01 Dec 2023 20:01:16 GMT
 - Fixed reference error in case `applicationData` is not provided for `IModelViewportControl`.
 
 ## 4.6.3
-
 Wed, 25 Oct 2023 09:39:22 GMT
 
 ### Updates
@@ -555,7 +489,6 @@ Wed, 25 Oct 2023 09:39:22 GMT
 - Correctly enable `isResizable` flag for every floating widget unless it is disabled explicitly.
 
 ## 4.6.2
-
 Tue, 17 Oct 2023 19:16:23 GMT
 
 ### Updates
@@ -563,7 +496,6 @@ Tue, 17 Oct 2023 19:16:23 GMT
 - Unmount childWindowManager whenever window is closed
 
 ## 4.6.1
-
 Thu, 12 Oct 2023 16:59:20 GMT
 
 ### Updates
@@ -571,7 +503,6 @@ Thu, 12 Oct 2023 16:59:20 GMT
 - Fix an issue where `onWidgetStateChangedEvent` is not emitted for a hidden widget.
 
 ## 4.6.0
-
 Wed, 04 Oct 2023 18:05:34 GMT
 
 ### Updates
@@ -584,7 +515,6 @@ Wed, 04 Oct 2023 18:05:34 GMT
 - React to core/appui-abstract deprecations
 
 ## 4.5.1
-
 Fri, 08 Sep 2023 16:10:53 GMT
 
 ### Updates
@@ -592,7 +522,6 @@ Fri, 08 Sep 2023 16:10:53 GMT
 - Fix an issue with `useSpecificWidgetDef` to correctly return re-created WidgetDef.
 
 ## 4.5.0
-
 Wed, 06 Sep 2023 17:29:22 GMT
 
 ### Updates
@@ -603,7 +532,6 @@ Wed, 06 Sep 2023 17:29:22 GMT
 - Bump `rxjs` dependency to `7.8.1`.
 
 ## 4.4.0
-
 Tue, 15 Aug 2023 18:02:09 GMT
 
 ### Updates
@@ -617,7 +545,6 @@ Tue, 15 Aug 2023 18:02:09 GMT
 - `Toolbar` now correctly handles `Conditional` properties and support `enableOverflow` prop.
 
 ## 4.3.0
-
 Mon, 17 Jul 2023 10:16:20 GMT
 
 ### Updates
@@ -631,7 +558,6 @@ Mon, 17 Jul 2023 10:16:20 GMT
 - Add missing `isMounted` check to fix a warning message while running tests.
 
 ## 4.2.0
-
 Tue, 27 Jun 2023 14:50:22 GMT
 
 ### Updates
@@ -643,7 +569,6 @@ Tue, 27 Jun 2023 14:50:22 GMT
 - Update `@itwin/itwinui-react` version to 2.11.6.
 
 ## 4.1.0
-
 Mon, 29 May 2023 14:05:04 GMT
 
 ### Updates
@@ -657,7 +582,6 @@ Mon, 29 May 2023 14:05:04 GMT
 - Errors thrown during rendering of widget content are now caught by `ErrorBoundary`. A fallback UI is rendered instead.
 
 ## 4.0.1
-
 Fri, 19 May 2023 12:24:30 GMT
 
 ### Updates
@@ -665,7 +589,6 @@ Fri, 19 May 2023 12:24:30 GMT
 - ToolAssistanceField: Display as class if image is not svg (IE: webfont class image)
 
 ## 4.0.0
-
 Mon, 01 May 2023 13:32:16 GMT
 
 ### Updates
@@ -713,19 +636,16 @@ Mon, 01 May 2023 13:32:16 GMT
 - Remove webfont icons from components.
 
 ## 3.7.2
-
 Wed, 12 Apr 2023 13:12:42 GMT
 
 _Version update only_
 
 ## 3.7.1
-
 Mon, 03 Apr 2023 15:15:36 GMT
 
 _Version update only_
 
 ## 3.7.0
-
 Wed, 29 Mar 2023 15:02:27 GMT
 
 ### Updates
@@ -736,13 +656,11 @@ Wed, 29 Mar 2023 15:02:27 GMT
 - update @deprecated comments.
 
 ## 3.6.3
-
 Mon, 27 Mar 2023 16:26:47 GMT
 
 _Version update only_
 
 ## 3.6.2
-
 Fri, 17 Mar 2023 17:52:32 GMT
 
 ### Updates
@@ -750,7 +668,6 @@ Fri, 17 Mar 2023 17:52:32 GMT
 - Add search functionality to ViewSelector
 
 ## 3.6.1
-
 Fri, 24 Feb 2023 22:00:48 GMT
 
 ### Updates
@@ -759,7 +676,6 @@ Fri, 24 Feb 2023 22:00:48 GMT
 - Fix `@itwin/itwinui-icons-react` dependency version
 
 ## 3.6.0
-
 Wed, 08 Feb 2023 14:58:39 GMT
 
 ### Updates
@@ -775,19 +691,16 @@ Wed, 08 Feb 2023 14:58:39 GMT
 - Fix floating widget offset issue.
 
 ## 3.5.6
-
 Fri, 24 Feb 2023 16:02:47 GMT
 
 _Version update only_
 
 ## 3.5.5
-
 Thu, 26 Jan 2023 22:53:27 GMT
 
 _Version update only_
 
 ## 3.5.4
-
 Wed, 18 Jan 2023 15:27:15 GMT
 
 ### Updates
@@ -795,13 +708,11 @@ Wed, 18 Jan 2023 15:27:15 GMT
 - Issue #4879: Make sure floating viewports properly set their content as active and display the active view highlight bar.
 
 ## 3.5.3
-
 Fri, 13 Jan 2023 17:23:07 GMT
 
 _Version update only_
 
 ## 3.5.2
-
 Wed, 11 Jan 2023 16:46:30 GMT
 
 ### Updates
@@ -809,13 +720,11 @@ Wed, 11 Jan 2023 16:46:30 GMT
 - Fix detailed output message on a new line in toasts.
 
 ## 3.5.1
-
 Thu, 15 Dec 2022 16:38:28 GMT
 
 _Version update only_
 
 ## 3.5.0
-
 Wed, 07 Dec 2022 19:12:36 GMT
 
 ### Updates
@@ -836,13 +745,11 @@ Wed, 07 Dec 2022 19:12:36 GMT
 - Update WidgetDef to pass the optional prop allowedPanelTargets to createTab wh
 
 ## 3.4.7
-
 Wed, 30 Nov 2022 14:28:19 GMT
 
 _Version update only_
 
 ## 3.4.6
-
 Tue, 22 Nov 2022 14:24:19 GMT
 
 ### Updates
@@ -850,37 +757,31 @@ Tue, 22 Nov 2022 14:24:19 GMT
 - Maintain widget panel location after frontstage is changed.
 
 ## 3.4.5
-
 Thu, 17 Nov 2022 21:32:49 GMT
 
 _Version update only_
 
 ## 3.4.4
-
 Thu, 10 Nov 2022 19:32:17 GMT
 
 _Version update only_
 
 ## 3.4.3
-
 Fri, 28 Oct 2022 13:34:57 GMT
 
 _Version update only_
 
 ## 3.4.2
-
 Mon, 24 Oct 2022 13:23:45 GMT
 
 _Version update only_
 
 ## 3.4.1
-
 Mon, 17 Oct 2022 20:06:51 GMT
 
 _Version update only_
 
 ## 3.4.0
-
 Thu, 13 Oct 2022 20:24:47 GMT
 
 ### Updates
@@ -898,25 +799,21 @@ Thu, 13 Oct 2022 20:24:47 GMT
 - Make sure FloatingViewportContent specifies controlId to FloatingViewport. Make sure FloatingViewportContent updates whenever the ViewState changes.
 
 ## 3.3.5
-
 Tue, 27 Sep 2022 11:50:59 GMT
 
 _Version update only_
 
 ## 3.3.4
-
 Thu, 08 Sep 2022 19:00:04 GMT
 
 _Version update only_
 
 ## 3.3.3
-
 Tue, 06 Sep 2022 20:54:19 GMT
 
 _Version update only_
 
 ## 3.3.2
-
 Thu, 01 Sep 2022 14:37:22 GMT
 
 ### Updates
@@ -924,13 +821,11 @@ Thu, 01 Sep 2022 14:37:22 GMT
 - Update camera icon and make camera tooltip conditional on the camera's on/off state.
 
 ## 3.3.1
-
 Fri, 26 Aug 2022 15:40:02 GMT
 
 _Version update only_
 
 ## 3.3.0
-
 Thu, 18 Aug 2022 19:08:01 GMT
 
 ### Updates
@@ -956,55 +851,46 @@ Thu, 18 Aug 2022 19:08:01 GMT
 - Update iTwinUI-react to 1.38.1
 
 ## 3.2.9
-
 Fri, 26 Aug 2022 14:21:40 GMT
 
 _Version update only_
 
 ## 3.2.8
-
 Tue, 09 Aug 2022 15:52:41 GMT
 
 _Version update only_
 
 ## 3.2.7
-
 Mon, 01 Aug 2022 13:36:56 GMT
 
 _Version update only_
 
 ## 3.2.6
-
 Fri, 15 Jul 2022 19:04:43 GMT
 
 _Version update only_
 
 ## 3.2.5
-
 Wed, 13 Jul 2022 15:45:52 GMT
 
 _Version update only_
 
 ## 3.2.4
-
 Tue, 21 Jun 2022 18:06:33 GMT
 
 _Version update only_
 
 ## 3.2.3
-
 Fri, 17 Jun 2022 15:18:39 GMT
 
 _Version update only_
 
 ## 3.2.2
-
 Fri, 10 Jun 2022 16:11:36 GMT
 
 _Version update only_
 
 ## 3.2.1
-
 Tue, 07 Jun 2022 15:02:56 GMT
 
 ### Updates
@@ -1015,7 +901,6 @@ Tue, 07 Jun 2022 15:02:56 GMT
 - Remove cached frontstageDef if associated FrontstageProvider is re-registered.
 
 ## 3.2.0
-
 Fri, 20 May 2022 13:10:54 GMT
 
 ### Updates
@@ -1033,25 +918,21 @@ Fri, 20 May 2022 13:10:54 GMT
 - Fix checkbox alignment in visibility trees.
 
 ## 3.1.3
-
 Fri, 15 Apr 2022 13:49:25 GMT
 
 _Version update only_
 
 ## 3.1.2
-
 Wed, 06 Apr 2022 22:27:56 GMT
 
 _Version update only_
 
 ## 3.1.1
-
 Thu, 31 Mar 2022 15:55:48 GMT
 
 _Version update only_
 
 ## 3.1.0
-
 Tue, 29 Mar 2022 20:53:46 GMT
 
 ### Updates
@@ -1068,13 +949,11 @@ Tue, 29 Mar 2022 20:53:46 GMT
 - Update to latest itwinui-react - requires new compile option allowSyntheticDefaultImports=true.
 
 ## 3.0.3
-
 Fri, 25 Mar 2022 15:10:01 GMT
 
 _Version update only_
 
 ## 3.0.2
-
 Thu, 10 Mar 2022 21:18:13 GMT
 
 ### Updates
@@ -1083,7 +962,6 @@ Thu, 10 Mar 2022 21:18:13 GMT
 - Make fix to displaying a custom view overlay.
 
 ## 3.0.1
-
 Thu, 24 Feb 2022 15:26:55 GMT
 
 ### Updates
@@ -1097,7 +975,6 @@ Thu, 24 Feb 2022 15:26:55 GMT
 - Remove unnecessary dependency on itwin/browser-authorization
 
 ## 3.0.0
-
 Mon, 24 Jan 2022 14:00:52 GMT
 
 ### Updates
@@ -1127,7 +1004,7 @@ Mon, 24 Jan 2022 14:00:52 GMT
 - Remove UserInfo completely
 - Update snapshots
 - Replaced ContextRegistry with generalized ITwinAccess interface
-- Renamed an iModel's parent container to iTwin
+-  Renamed an iModel's parent container to iTwin
 - Removed references to the deleted config-loader package
 - tool.run and tool.parseAndRun are now async methods
 - Support for TypeDoc v0.22.7. Fix various broken docs links.
@@ -1180,7 +1057,7 @@ Mon, 24 Jan 2022 14:00:52 GMT
 - Update Tool Setting for UI 1.0 to fix refresh bug.
 - BaseUiItemsProvider class and refactor "standard" providers to subclass it.
 - Undeprecate necessary UI 1.0 classes/interfaces
-- Update standard UI item providers to require a providerId so more than one instance may be used within an app. Usually by different packages providing stages.
+- Update standard UI item providers to require a providerId so more than one instance may be used within an app.  Usually by different packages providing stages.
 - Replaced ui-core Slider with one from iTwinUi-react. Update DefaultViewOverlay to opt-in to display of view overlays.
 - Update to latest types/react package
 - reset to use overflow hidden in floating widgets as it messes up auto-sizing and re-sizing.
@@ -1191,93 +1068,78 @@ Mon, 24 Jan 2022 14:00:52 GMT
 - Hide widgets with Hidden defaultState when frontstage is activated.
 
 ## 2.19.28
-
 Wed, 12 Jan 2022 14:52:38 GMT
 
 _Version update only_
 
 ## 2.19.27
-
 Wed, 05 Jan 2022 20:07:20 GMT
 
 _Version update only_
 
 ## 2.19.26
-
 Wed, 08 Dec 2021 20:54:53 GMT
 
 _Version update only_
 
 ## 2.19.25
-
 Fri, 03 Dec 2021 20:05:49 GMT
 
 _Version update only_
 
 ## 2.19.24
-
 Mon, 29 Nov 2021 18:44:31 GMT
 
 _Version update only_
 
 ## 2.19.23
-
 Mon, 22 Nov 2021 20:41:40 GMT
 
 _Version update only_
 
 ## 2.19.22
-
 Wed, 17 Nov 2021 01:23:26 GMT
 
 _Version update only_
 
 ## 2.19.21
-
 Wed, 10 Nov 2021 10:58:24 GMT
 
 _Version update only_
 
 ## 2.19.20
-
 Fri, 29 Oct 2021 16:14:22 GMT
 
 _Version update only_
 
 ## 2.19.19
-
 Mon, 25 Oct 2021 16:16:25 GMT
 
 ### Updates
 
-- Drop unnecessary dep on @bentley/react-scripts; add a \*.d.ts file for svg?sprite loader syntax
+- Drop unnecessary dep on @bentley/react-scripts; add a *.d.ts file for svg?sprite loader syntax
 
 ## 2.19.18
-
 Thu, 21 Oct 2021 20:59:44 GMT
 
 _Version update only_
 
 ## 2.19.17
-
 Thu, 14 Oct 2021 21:19:43 GMT
 
 _Version update only_
 
 ## 2.19.16
-
 Mon, 11 Oct 2021 17:37:46 GMT
 
 _Version update only_
 
 ## 2.19.15
-
 Fri, 08 Oct 2021 16:44:23 GMT
 
 _Version update only_
 
 ## 2.19.14
-
 Fri, 01 Oct 2021 13:07:03 GMT
 
 ### Updates
@@ -1285,13 +1147,11 @@ Fri, 01 Oct 2021 13:07:03 GMT
 - Force Tool Settings to render when the active tool is reloaded.
 
 ## 2.19.13
-
 Tue, 21 Sep 2021 21:06:40 GMT
 
 _Version update only_
 
 ## 2.19.12
-
 Wed, 15 Sep 2021 18:06:47 GMT
 
 ### Updates
@@ -1299,25 +1159,21 @@ Wed, 15 Sep 2021 18:06:47 GMT
 - Fix calc function that is causing an error in the latest dart-sass version
 
 ## 2.19.11
-
 Thu, 09 Sep 2021 21:04:58 GMT
 
 _Version update only_
 
 ## 2.19.10
-
 Wed, 08 Sep 2021 14:36:01 GMT
 
 _Version update only_
 
 ## 2.19.9
-
 Wed, 25 Aug 2021 15:36:01 GMT
 
 _Version update only_
 
 ## 2.19.8
-
 Mon, 23 Aug 2021 13:23:13 GMT
 
 ### Updates
@@ -1325,49 +1181,41 @@ Mon, 23 Aug 2021 13:23:13 GMT
 - Backport change to clear hide/isolate/emphasis of models and categories.
 
 ## 2.19.7
-
 Fri, 20 Aug 2021 17:47:22 GMT
 
 _Version update only_
 
 ## 2.19.6
-
 Tue, 17 Aug 2021 20:34:29 GMT
 
 _Version update only_
 
 ## 2.19.5
-
 Fri, 13 Aug 2021 21:48:09 GMT
 
 _Version update only_
 
 ## 2.19.4
-
 Thu, 12 Aug 2021 13:09:26 GMT
 
 _Version update only_
 
 ## 2.19.3
-
 Wed, 04 Aug 2021 20:29:34 GMT
 
 _Version update only_
 
 ## 2.19.2
-
 Tue, 03 Aug 2021 18:26:23 GMT
 
 _Version update only_
 
 ## 2.19.1
-
 Thu, 29 Jul 2021 20:01:11 GMT
 
 _Version update only_
 
 ## 2.19.0
-
 Mon, 26 Jul 2021 12:21:25 GMT
 
 ### Updates
@@ -1377,25 +1225,21 @@ Mon, 26 Jul 2021 12:21:25 GMT
 - Add useActiveStageId to barrel file so it is properly exported.
 
 ## 2.18.4
-
 Tue, 10 Aug 2021 19:35:13 GMT
 
 _Version update only_
 
 ## 2.18.3
-
 Wed, 28 Jul 2021 17:16:30 GMT
 
 _Version update only_
 
 ## 2.18.2
-
 Mon, 26 Jul 2021 16:18:31 GMT
 
 _Version update only_
 
 ## 2.18.1
-
 Fri, 16 Jul 2021 17:45:09 GMT
 
 ### Updates
@@ -1403,7 +1247,6 @@ Fri, 16 Jul 2021 17:45:09 GMT
 - Add test for the iModelConnection being blank to avoid asserts when setting up for new iModel.
 
 ## 2.18.0
-
 Fri, 09 Jul 2021 18:11:24 GMT
 
 ### Updates
@@ -1418,25 +1261,21 @@ Fri, 09 Jul 2021 18:11:24 GMT
 - Add ability to provide widgets to zones via UiItemsProvider when using AppUI version 1.
 
 ## 2.17.3
-
 Mon, 26 Jul 2021 16:08:36 GMT
 
 _Version update only_
 
 ## 2.17.2
-
 Thu, 08 Jul 2021 15:23:00 GMT
 
 _Version update only_
 
 ## 2.17.1
-
 Fri, 02 Jul 2021 15:38:31 GMT
 
 _Version update only_
 
 ## 2.17.0
-
 Mon, 28 Jun 2021 16:20:11 GMT
 
 ### Updates
@@ -1450,67 +1289,56 @@ Mon, 28 Jun 2021 16:20:11 GMT
 - Refactor SolarTimeline and ScheduleAnimationProvider to use new TimelineComponent iteration.
 
 ## 2.16.10
-
 Thu, 22 Jul 2021 20:23:45 GMT
 
 _Version update only_
 
 ## 2.16.9
-
 Tue, 06 Jul 2021 22:08:34 GMT
 
 _Version update only_
 
 ## 2.16.8
-
 Fri, 02 Jul 2021 17:40:46 GMT
 
 _Version update only_
 
 ## 2.16.7
-
 Mon, 28 Jun 2021 18:13:04 GMT
 
 _Version update only_
 
 ## 2.16.6
-
 Mon, 28 Jun 2021 13:12:55 GMT
 
 _Version update only_
 
 ## 2.16.5
-
 Fri, 25 Jun 2021 16:03:01 GMT
 
 _Version update only_
 
 ## 2.16.4
-
 Wed, 23 Jun 2021 17:09:07 GMT
 
 _Version update only_
 
 ## 2.16.3
-
 Wed, 16 Jun 2021 20:29:32 GMT
 
 _Version update only_
 
 ## 2.16.2
-
 Thu, 03 Jun 2021 18:08:11 GMT
 
 _Version update only_
 
 ## 2.16.1
-
 Thu, 27 May 2021 20:04:22 GMT
 
 _Version update only_
 
 ## 2.16.0
-
 Mon, 24 May 2021 15:58:39 GMT
 
 ### Updates
@@ -1523,13 +1351,11 @@ Mon, 24 May 2021 15:58:39 GMT
 - Update to latest classnames package
 
 ## 2.15.6
-
 Wed, 26 May 2021 15:55:19 GMT
 
 _Version update only_
 
 ## 2.15.5
-
 Thu, 20 May 2021 15:06:26 GMT
 
 ### Updates
@@ -1537,13 +1363,11 @@ Thu, 20 May 2021 15:06:26 GMT
 - Remove framework version condition from floatWidget and dockWidget. This was causing problems in the sample showcase.
 
 ## 2.15.4
-
 Tue, 18 May 2021 21:59:07 GMT
 
 _Version update only_
 
 ## 2.15.3
-
 Mon, 17 May 2021 13:31:38 GMT
 
 ### Updates
@@ -1551,19 +1375,16 @@ Mon, 17 May 2021 13:31:38 GMT
 - Clean up styling in StatusBar.css
 
 ## 2.15.2
-
 Wed, 12 May 2021 18:08:13 GMT
 
 _Version update only_
 
 ## 2.15.1
-
 Wed, 05 May 2021 13:18:31 GMT
 
 _Version update only_
 
 ## 2.15.0
-
 Fri, 30 Apr 2021 12:36:58 GMT
 
 ### Updates
@@ -1576,7 +1397,6 @@ Fri, 30 Apr 2021 12:36:58 GMT
 - Publish APIs used bu iTwinViewer.
 
 ## 2.14.4
-
 Thu, 22 Apr 2021 21:07:34 GMT
 
 ### Updates
@@ -1584,7 +1404,6 @@ Thu, 22 Apr 2021 21:07:34 GMT
 - Update to get activeViewPort by monitoring ContentViewManager.onActiveContentChangedEvent this eliminates issue where ViewManager active viewport changes occur before all UI components are mounted and listening.
 
 ## 2.14.3
-
 Thu, 15 Apr 2021 15:13:16 GMT
 
 ### Updates
@@ -1592,7 +1411,6 @@ Thu, 15 Apr 2021 15:13:16 GMT
 - Cleanup statusbar styling to ensure items are centered and do not overflow area.
 
 ## 2.14.2
-
 Thu, 08 Apr 2021 14:30:09 GMT
 
 ### Updates
@@ -1600,13 +1418,11 @@ Thu, 08 Apr 2021 14:30:09 GMT
 - Avoid getting into infinite render loop in CategoriesTree
 
 ## 2.14.1
-
 Mon, 05 Apr 2021 16:28:00 GMT
 
 _Version update only_
 
 ## 2.14.0
-
 Fri, 02 Apr 2021 13:18:42 GMT
 
 ### Updates
@@ -1624,14 +1440,13 @@ Fri, 02 Apr 2021 13:18:42 GMT
 - Fix ViewSelector so it reloads list of views when iModel prop is updated.
 
 ## 2.13.0
-
 Tue, 09 Mar 2021 20:28:13 GMT
 
 ### Updates
 
 - Add functions to clear the Hide/Isolate for Models and Categories
 - Upgrade react-resize-detector to avoid lodash security vulnerability
-- Fix solar timeline component so that sunTime is properly set for project location.
+-  Fix solar timeline component so that sunTime is properly set for project location.
 - Document uiSettings in ToolAssistanceField
 - Fix stateFunction for clear hide/isolate/emphasize tool that is used in UI 1.0.
 - Updated to use TypeScript 4.1
@@ -1644,25 +1459,21 @@ Tue, 09 Mar 2021 20:28:13 GMT
 - begin rename project from iModel.js to iTwin.js
 
 ## 2.12.3
-
 Mon, 08 Mar 2021 15:32:00 GMT
 
 _Version update only_
 
 ## 2.12.2
-
 Wed, 03 Mar 2021 18:48:53 GMT
 
 _Version update only_
 
 ## 2.12.1
-
 Tue, 23 Feb 2021 20:54:45 GMT
 
 _Version update only_
 
 ## 2.12.0
-
 Thu, 18 Feb 2021 22:10:13 GMT
 
 ### Updates
@@ -1678,13 +1489,11 @@ Thu, 18 Feb 2021 22:10:13 GMT
 - Update remaining syncEventId checks to be case insensitive.
 
 ## 2.11.2
-
 Thu, 18 Feb 2021 02:50:59 GMT
 
 _Version update only_
 
 ## 2.11.1
-
 Thu, 04 Feb 2021 17:22:41 GMT
 
 ### Updates
@@ -1692,7 +1501,6 @@ Thu, 04 Feb 2021 17:22:41 GMT
 - Updated ModelsTree rulesets to better handle updates.
 
 ## 2.11.0
-
 Thu, 28 Jan 2021 13:39:27 GMT
 
 ### Updates
@@ -1709,25 +1517,21 @@ Thu, 28 Jan 2021 13:39:27 GMT
 - Update to latest react-dnd version.
 
 ## 2.10.3
-
 Fri, 08 Jan 2021 18:34:03 GMT
 
 _Version update only_
 
 ## 2.10.2
-
 Fri, 08 Jan 2021 14:52:02 GMT
 
 _Version update only_
 
 ## 2.10.1
-
 Tue, 22 Dec 2020 00:53:38 GMT
 
 _Version update only_
 
 ## 2.10.0
-
 Fri, 18 Dec 2020 18:24:01 GMT
 
 ### Updates
@@ -1740,55 +1544,46 @@ Fri, 18 Dec 2020 18:24:01 GMT
 - Disable pointer events in overlay of default view overlay.
 
 ## 2.9.9
-
 Sun, 13 Dec 2020 19:00:03 GMT
 
 _Version update only_
 
 ## 2.9.8
-
 Fri, 11 Dec 2020 02:57:36 GMT
 
 _Version update only_
 
 ## 2.9.7
-
 Wed, 09 Dec 2020 20:58:23 GMT
 
 _Version update only_
 
 ## 2.9.6
-
 Mon, 07 Dec 2020 18:40:48 GMT
 
 _Version update only_
 
 ## 2.9.5
-
 Sat, 05 Dec 2020 01:55:56 GMT
 
 _Version update only_
 
 ## 2.9.4
-
 Wed, 02 Dec 2020 20:55:40 GMT
 
 _Version update only_
 
 ## 2.9.3
-
 Mon, 23 Nov 2020 20:57:56 GMT
 
 _Version update only_
 
 ## 2.9.2
-
 Mon, 23 Nov 2020 15:33:50 GMT
 
 _Version update only_
 
 ## 2.9.1
-
 Thu, 19 Nov 2020 17:03:42 GMT
 
 ### Updates
@@ -1796,7 +1591,6 @@ Thu, 19 Nov 2020 17:03:42 GMT
 - Revert width change to EnumEditor component instead set width to auto only for docked tool settings.
 
 ## 2.9.0
-
 Wed, 18 Nov 2020 16:01:50 GMT
 
 ### Updates
@@ -1813,13 +1607,11 @@ Wed, 18 Nov 2020 16:01:50 GMT
 - Respect WidgetState.Hidden when rendering widget tabs.
 
 ## 2.8.1
-
 Tue, 03 Nov 2020 00:33:56 GMT
 
 _Version update only_
 
 ## 2.8.0
-
 Fri, 23 Oct 2020 17:04:02 GMT
 
 ### Updates
@@ -1829,43 +1621,36 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Upgraded react-split-pane to 0.1.92
 
 ## 2.7.6
-
 Wed, 11 Nov 2020 16:28:23 GMT
 
 _Version update only_
 
 ## 2.7.5
-
 Fri, 23 Oct 2020 16:23:51 GMT
 
 _Version update only_
 
 ## 2.7.4
-
 Mon, 19 Oct 2020 17:57:02 GMT
 
 _Version update only_
 
 ## 2.7.3
-
 Wed, 14 Oct 2020 17:00:59 GMT
 
 _Version update only_
 
 ## 2.7.2
-
 Tue, 13 Oct 2020 18:20:39 GMT
 
 _Version update only_
 
 ## 2.7.1
-
 Thu, 08 Oct 2020 13:04:35 GMT
 
 _Version update only_
 
 ## 2.7.0
-
 Fri, 02 Oct 2020 18:03:32 GMT
 
 ### Updates
@@ -1880,13 +1665,11 @@ Fri, 02 Oct 2020 18:03:32 GMT
 - Add telemetry to ui-framework.
 
 ## 2.6.5
-
 Sat, 26 Sep 2020 16:06:34 GMT
 
 _Version update only_
 
 ## 2.6.4
-
 Tue, 22 Sep 2020 17:40:07 GMT
 
 ### Updates
@@ -1894,25 +1677,21 @@ Tue, 22 Sep 2020 17:40:07 GMT
 - Do not render empty stage panel when frontstage changes.
 
 ## 2.6.3
-
 Mon, 21 Sep 2020 14:47:10 GMT
 
 _Version update only_
 
 ## 2.6.2
-
 Mon, 21 Sep 2020 13:07:45 GMT
 
 _Version update only_
 
 ## 2.6.1
-
 Fri, 18 Sep 2020 13:15:09 GMT
 
 _Version update only_
 
 ## 2.6.0
-
 Thu, 17 Sep 2020 13:16:12 GMT
 
 ### Updates
@@ -1937,7 +1716,6 @@ Thu, 17 Sep 2020 13:16:12 GMT
 - Deny tool settings tab from docking to top panel target.
 
 ## 2.5.5
-
 Wed, 02 Sep 2020 17:42:23 GMT
 
 ### Updates
@@ -1945,7 +1723,6 @@ Wed, 02 Sep 2020 17:42:23 GMT
 - Update rxjs dependency version to `^6.6.2`
 
 ## 2.5.4
-
 Fri, 28 Aug 2020 15:34:16 GMT
 
 ### Updates
@@ -1953,25 +1730,21 @@ Fri, 28 Aug 2020 15:34:16 GMT
 - Show duplicate target partitions in ModelsTree
 
 ## 2.5.3
-
 Wed, 26 Aug 2020 11:46:00 GMT
 
 _Version update only_
 
 ## 2.5.2
-
 Tue, 25 Aug 2020 22:09:08 GMT
 
 _Version update only_
 
 ## 2.5.1
-
 Mon, 24 Aug 2020 18:13:04 GMT
 
 _Version update only_
 
 ## 2.5.0
-
 Thu, 20 Aug 2020 20:57:10 GMT
 
 ### Updates
@@ -1991,13 +1764,11 @@ Thu, 20 Aug 2020 20:57:10 GMT
 - Update to @bentley/react-scripts@3.4.2
 
 ## 2.4.2
-
 Fri, 14 Aug 2020 16:34:09 GMT
 
 _Version update only_
 
 ## 2.4.1
-
 Fri, 07 Aug 2020 19:57:43 GMT
 
 ### Updates
@@ -2005,7 +1776,6 @@ Fri, 07 Aug 2020 19:57:43 GMT
 - add missing rbac-client dep
 
 ## 2.4.0
-
 Tue, 28 Jul 2020 16:26:24 GMT
 
 ### Updates
@@ -2019,25 +1789,21 @@ Tue, 28 Jul 2020 16:26:24 GMT
 - Remove not found widget tabs when restoring layout.
 
 ## 2.3.3
-
 Thu, 23 Jul 2020 12:57:15 GMT
 
 _Version update only_
 
 ## 2.3.2
-
 Tue, 14 Jul 2020 23:50:36 GMT
 
 _Version update only_
 
 ## 2.3.1
-
 Mon, 13 Jul 2020 18:50:14 GMT
 
 _Version update only_
 
 ## 2.3.0
-
 Fri, 10 Jul 2020 17:23:14 GMT
 
 ### Updates
@@ -2053,7 +1819,6 @@ Fri, 10 Jul 2020 17:23:14 GMT
 - Enable WidgetDef.setLabel() in 2.0 mode.
 
 ## 2.2.1
-
 Tue, 07 Jul 2020 14:44:52 GMT
 
 ### Updates
@@ -2061,7 +1826,6 @@ Tue, 07 Jul 2020 14:44:52 GMT
 - Fix setWidgetState edge case where widget stays open w/o active tab.
 
 ## 2.2.0
-
 Fri, 19 Jun 2020 14:10:03 GMT
 
 ### Updates
@@ -2083,7 +1847,6 @@ Fri, 19 Jun 2020 14:10:03 GMT
 - Added ViewStateProp & support for obtaining ViewState from function in ViewportComponent and IModelViewportControl
 
 ## 2.1.0
-
 Thu, 28 May 2020 22:48:59 GMT
 
 ### Updates
@@ -2105,7 +1868,6 @@ Thu, 28 May 2020 22:48:59 GMT
 - Do not display camera tool if 3D view does not support camera.
 
 ## 2.0.0
-
 Wed, 06 May 2020 13:17:49 GMT
 
 ### Updates
@@ -2120,7 +1882,7 @@ Wed, 06 May 2020 13:17:49 GMT
 - Removed @deprecated APIs from ui-framework & ui-core and updated NextVersion.md
 - Rename some new widget classes and deprecate classes we don't want user to continue to use.
 - Fix to properly initialize enable/disable state of toolsettings editor based on lock property.
-- Fix bug where toolbar buttons did not show expand arrow on custom button when not in 'DragInteraction' mode. Fix display of key-in browser 1.0 UI.
+- Fix bug where toolbar buttons did not show expand arrow on custom button when not in 'DragInteraction' mode.  Fix display of key-in browser 1.0 UI.
 - Call FrontstageDef.setActiveViewFromViewport when viewport is available to ensure activeContent is properly set.
 - Ensure ui-abstract is listed as peer dependency and not just a dev dependency.
 - Fix type in ToolSettingsGridProps name
@@ -2146,7 +1908,7 @@ Wed, 06 May 2020 13:17:49 GMT
 - Added API in MessageManager to display either a Toast or Sticky message using React components.
 - react to new clients packages from imodeljs-clients
 - Remove comment text shown in render function.
-- Updates to remove need for svg-sprite-loader, use default CRA svgr loader instead.
+-  Updates to remove need for svg-sprite-loader, use default CRA svgr loader instead.
 - For consistency add reactNode getters/setters and deprecate use of reactElement.
 - Revert back to using svg-sprite-loader and sprite resourceQuery.
 - Upgrade to Rush 5.23.2
@@ -2199,13 +1961,11 @@ Wed, 06 May 2020 13:17:49 GMT
 - Add support for Horizontal Tool Settings container
 
 ## 1.14.1
-
 Wed, 22 Apr 2020 19:04:00 GMT
 
 _Version update only_
 
 ## 1.14.0
-
 Tue, 31 Mar 2020 15:44:19 GMT
 
 ### Updates
@@ -2213,7 +1973,6 @@ Tue, 31 Mar 2020 15:44:19 GMT
 - Models Tree: Fix non-geometric models being used when changing subject's display
 
 ## 1.13.0
-
 Wed, 04 Mar 2020 16:16:31 GMT
 
 ### Updates
@@ -2223,7 +1982,6 @@ Wed, 04 Mar 2020 16:16:31 GMT
 - Updated ModelTree ruleset to use RelationshipPathSpecification
 
 ## 1.12.0
-
 Wed, 12 Feb 2020 17:45:50 GMT
 
 ### Updates
@@ -2234,7 +1992,6 @@ Wed, 12 Feb 2020 17:45:50 GMT
 - Added UiAdmin.showHTMLElement to show information & graphics for markers
 
 ## 1.11.0
-
 Wed, 22 Jan 2020 19:24:12 GMT
 
 ### Updates
@@ -2244,7 +2001,6 @@ Wed, 22 Jan 2020 19:24:12 GMT
 - Cube navigation aid touch events fix.
 
 ## 1.10.0
-
 Tue, 07 Jan 2020 19:44:01 GMT
 
 ### Updates
@@ -2256,7 +2012,6 @@ Tue, 07 Jan 2020 19:44:01 GMT
 - Fix for nine-zone sample app not displaying backstage items.
 
 ## 1.9.0
-
 Tue, 10 Dec 2019 18:08:56 GMT
 
 ### Updates
@@ -2290,7 +2045,6 @@ Tue, 10 Dec 2019 18:08:56 GMT
 - Added ConditionalField and FooterModeField components. StatusBar responsive changes.
 
 ## 1.8.0
-
 Fri, 22 Nov 2019 14:03:34 GMT
 
 ### Updates
@@ -2313,7 +2067,6 @@ Fri, 22 Nov 2019 14:03:34 GMT
 - Update TileRendering StatusField width.
 
 ## 1.7.0
-
 Fri, 01 Nov 2019 13:28:37 GMT
 
 ### Updates
@@ -2343,7 +2096,6 @@ Fri, 01 Nov 2019 13:28:37 GMT
 - Removed unused package
 
 ## 1.6.0
-
 Wed, 09 Oct 2019 20:28:43 GMT
 
 ### Updates
@@ -2357,7 +2109,6 @@ Wed, 09 Oct 2019 20:28:43 GMT
 - Ignore widgetDef state in WidgetContentRenderer of tool settings.
 
 ## 1.5.0
-
 Mon, 30 Sep 2019 22:28:48 GMT
 
 ### Updates
@@ -2390,7 +2141,6 @@ Mon, 30 Sep 2019 22:28:48 GMT
 - Make components aware of safe area insets.
 
 ## 1.4.0
-
 Tue, 10 Sep 2019 12:09:49 GMT
 
 ### Updates
@@ -2406,7 +2156,6 @@ Tue, 10 Sep 2019 12:09:49 GMT
 - Visibility Component: Preserve active tree state by saving and restoring scroll position
 
 ## 1.3.0
-
 Tue, 13 Aug 2019 20:25:53 GMT
 
 ### Updates
@@ -2440,7 +2189,6 @@ Tue, 13 Aug 2019 20:25:53 GMT
 - Update to latest icon package version.
 
 ## 1.2.0
-
 Wed, 24 Jul 2019 11:47:26 GMT
 
 ### Updates
@@ -2466,7 +2214,6 @@ Wed, 24 Jul 2019 11:47:26 GMT
 - React to ui-ninezone changes.
 
 ## 1.1.0
-
 Mon, 01 Jul 2019 19:04:29 GMT
 
 ### Updates
@@ -2482,7 +2229,7 @@ Mon, 01 Jul 2019 19:04:29 GMT
 - Removed 4 dangerouslySetInnerHtml usages to help with Security audit; 3 remain on purpose.
 - Save & Restore View Layouts
 - Force toolsettings to refresh when a tool is started even if new toolId is same as active toolId.
-- Added \*.svg to .npmignore file
+- Added *.svg to .npmignore file
 - Fix issue where cached tool settings values in UI would get out of sync with actual values in tool.
 - Update to TypeScript 3.5
 - Fix model selector view sync problem
@@ -2498,7 +2245,6 @@ Mon, 01 Jul 2019 19:04:29 GMT
 - Added ViewSelector.updateShowSettings to control which view types are displayed
 
 ## 1.0.0
-
 Mon, 03 Jun 2019 18:09:39 GMT
 
 ### Updates
@@ -2530,7 +2276,6 @@ Mon, 03 Jun 2019 18:09:39 GMT
 - Added ViewSelectorChangedEvent
 
 ## 0.191.0
-
 Mon, 13 May 2019 15:52:05 GMT
 
 ### Updates
@@ -2572,7 +2317,7 @@ Mon, 13 May 2019 15:52:05 GMT
 - Move timeline components from ui-test-app to ui-components package
 - Tool Settings: removed minimize tab, added min to title bar, styled title
 - Auto close popups when clicking outside.
-- Return ruleset promises in Category/Model picker \_initialize()
+- Return ruleset promises in Category/Model picker _initialize()
 - Use GlobalContextMenu in category picker and modify to better follow UX standards.
 - Added ui-framework release tags and common/api/ui-framework.api.md
 - UI documentation - added to Learning section
@@ -2601,7 +2346,6 @@ Mon, 13 May 2019 15:52:05 GMT
 - Changed props for CubeRotationChangeEvents
 
 ## 0.190.0
-
 Thu, 14 Mar 2019 14:26:49 GMT
 
 ### Updates
@@ -2616,7 +2360,6 @@ Thu, 14 Mar 2019 14:26:49 GMT
 - Add models visibility tree
 
 ## 0.189.0
-
 Wed, 06 Mar 2019 15:41:22 GMT
 
 ### Updates
@@ -2663,19 +2406,16 @@ Wed, 06 Mar 2019 15:41:22 GMT
 - WIP: ViewportComponent unit tests. Removed imodeljs-clients-backend dependency from ui-framework
 
 ## 0.188.0
-
 Wed, 16 Jan 2019 16:36:09 GMT
 
 _Version update only_
 
 ## 0.187.0
-
 Tue, 15 Jan 2019 15:18:59 GMT
 
 _Version update only_
 
 ## 0.186.0
-
 Mon, 14 Jan 2019 23:09:10 GMT
 
 ### Updates
@@ -2684,13 +2424,11 @@ Mon, 14 Jan 2019 23:09:10 GMT
 - Add Status Field to show selection count
 
 ## 0.185.0
-
 Fri, 11 Jan 2019 18:29:00 GMT
 
 _Version update only_
 
 ## 0.184.0
-
 Thu, 10 Jan 2019 22:46:17 GMT
 
 ### Updates
@@ -2702,13 +2440,11 @@ Thu, 10 Jan 2019 22:46:17 GMT
 - Renamed connection getter to imodel
 
 ## 0.183.0
-
 Mon, 07 Jan 2019 21:49:21 GMT
 
 _Version update only_
 
 ## 0.182.0
-
 Mon, 07 Jan 2019 13:31:34 GMT
 
 ### Updates
@@ -2716,7 +2452,6 @@ Mon, 07 Jan 2019 13:31:34 GMT
 - Do not show SubCategory if it has no siblings
 
 ## 0.181.0
-
 Fri, 04 Jan 2019 13:02:40 GMT
 
 ### Updates
@@ -2724,13 +2459,11 @@ Fri, 04 Jan 2019 13:02:40 GMT
 - Add SyncUi support for ConfigurableUi controls.
 
 ## 0.180.0
-
 Wed, 02 Jan 2019 15:18:23 GMT
 
 _Version update only_
 
 ## 0.179.0
-
 Wed, 19 Dec 2018 18:26:14 GMT
 
 ### Updates
@@ -2740,7 +2473,6 @@ Wed, 19 Dec 2018 18:26:14 GMT
 - Fix model selector to only show non-private spatial models
 
 ## 0.178.0
-
 Thu, 13 Dec 2018 22:06:10 GMT
 
 ### Updates
@@ -2749,7 +2481,6 @@ Thu, 13 Dec 2018 22:06:10 GMT
 - Fix tool panel alignment issue.
 
 ## 0.177.0
-
 Wed, 12 Dec 2018 17:21:32 GMT
 
 ### Updates
@@ -2758,19 +2489,16 @@ Wed, 12 Dec 2018 17:21:32 GMT
 - Improved speed & smoothness of CubeNavigationAid. Made class names unique to fix documentation. UI Tree doc fixes.
 
 ## 0.176.0
-
 Mon, 10 Dec 2018 21:19:45 GMT
 
 _Version update only_
 
 ## 0.175.0
-
 Mon, 10 Dec 2018 17:08:55 GMT
 
 _Version update only_
 
 ## 0.174.0
-
 Mon, 10 Dec 2018 13:24:09 GMT
 
 ### Updates
@@ -2778,7 +2506,6 @@ Mon, 10 Dec 2018 13:24:09 GMT
 - Add SignIn and SignOut to the index file
 
 ## 0.173.0
-
 Thu, 06 Dec 2018 22:03:29 GMT
 
 ### Updates
@@ -2788,7 +2515,6 @@ Thu, 06 Dec 2018 22:03:29 GMT
 - Custom imodelJs noDirectImport lint rule implemented, noDuplicateImport lint rule turned on.
 
 ## 0.172.0
-
 Tue, 04 Dec 2018 17:24:39 GMT
 
 ### Updates
@@ -2796,7 +2522,6 @@ Tue, 04 Dec 2018 17:24:39 GMT
 - Changed index file name to match package name, eliminate subdirectory index files, decrease usage of default exports, change imports to use other packages' index file.
 
 ## 0.171.0
-
 Mon, 03 Dec 2018 18:52:58 GMT
 
 ### Updates
@@ -2805,7 +2530,6 @@ Mon, 03 Dec 2018 18:52:58 GMT
 - Removed ConfigurableUiManager.addFrontstageDef and other unused/old methods and components
 
 ## 0.170.0
-
 Mon, 26 Nov 2018 19:38:42 GMT
 
 ### Updates
@@ -2813,7 +2537,6 @@ Mon, 26 Nov 2018 19:38:42 GMT
 - Fix to OIDC browser client.
 
 ## 0.169.0
-
 Tue, 20 Nov 2018 16:17:15 GMT
 
 ### Updates
@@ -2821,7 +2544,6 @@ Tue, 20 Nov 2018 16:17:15 GMT
 - Include presentation rulesets in package
 
 ## 0.168.0
-
 Sat, 17 Nov 2018 14:20:11 GMT
 
 ### Updates
@@ -2829,7 +2551,6 @@ Sat, 17 Nov 2018 14:20:11 GMT
 - Fixed OidcBrowserClient comparison of redirect path.
 
 ## 0.167.0
-
 Fri, 16 Nov 2018 21:45:44 GMT
 
 ### Updates
@@ -2842,19 +2563,16 @@ Fri, 16 Nov 2018 21:45:44 GMT
 - ui-framework unit tests & docs
 
 ## 0.166.0
-
 Mon, 12 Nov 2018 16:42:10 GMT
 
 _Version update only_
 
 ## 0.165.0
-
 Mon, 12 Nov 2018 15:47:00 GMT
 
 _Version update only_
 
 ## 0.164.0
-
 Thu, 08 Nov 2018 17:59:21 GMT
 
 ### Updates
@@ -2865,7 +2583,6 @@ Thu, 08 Nov 2018 17:59:21 GMT
 - Zone & Widget initial state, more ui-core unit tests, cleaned up ui-framework index.ts files.
 
 ## 0.163.0
-
 Wed, 31 Oct 2018 20:55:37 GMT
 
 ### Updates
@@ -2874,7 +2591,6 @@ Wed, 31 Oct 2018 20:55:37 GMT
 - Fixed ui-framework unit test
 
 ## 0.162.0
-
 Wed, 24 Oct 2018 19:20:07 GMT
 
 ### Updates
@@ -2883,35 +2599,30 @@ Wed, 24 Oct 2018 19:20:07 GMT
 - Tooltips, ToolAdmin.activeToolChanged support, SheetNavigationAid/SheetsModalFrontstage improvements.
 - Ui Documentation
 - Vertical PropertyGrid layout improvements. PropertyGrid background color. Setting the widget state.
-- Added NotificationManager.isToolTipSupported so that we can avoid asking for tooltip message when \_showToolTip isn't implemented by application.
+- Added NotificationManager.isToolTipSupported so that we can avoid asking for tooltip message when _showToolTip isn't implemented by application.
 - Adding SyncUiEventDispatcher
 
 ## 0.161.0
-
 Fri, 19 Oct 2018 13:04:14 GMT
 
 _Version update only_
 
 ## 0.160.0
-
 Wed, 17 Oct 2018 18:18:38 GMT
 
 _Version update only_
 
 ## 0.159.0
-
 Tue, 16 Oct 2018 14:09:09 GMT
 
 _Version update only_
 
 ## 0.158.0
-
 Mon, 15 Oct 2018 19:36:09 GMT
 
 _Version update only_
 
 ## 0.157.0
-
 Sun, 14 Oct 2018 17:20:06 GMT
 
 ### Updates
@@ -2919,9 +2630,9 @@ Sun, 14 Oct 2018 17:20:06 GMT
 - Fixing scripts for linux
 
 ## 0.156.0
-
 Fri, 12 Oct 2018 23:00:10 GMT
 
 ### Updates
 
 - Initial release
+

--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/appui-react",
-  "version": "5.5.0",
+  "version": "5.4.0",
   "description": "A react component library for AppUI framework",
   "type": "module",
   "types": "./lib/appui-react.d.ts",
@@ -60,7 +60,7 @@
     "@itwin/core-frontend": "^4.0.0 || ^5.0.0",
     "@itwin/core-geometry": "^4.0.0 || ^5.0.0",
     "@itwin/core-quantity": "^4.0.0 || ^5.0.0",
-    "@itwin/core-react": "workspace:^5.5.0",
+    "@itwin/core-react": "workspace:^5.5.0-dev.0",
     "@itwin/imodel-components-react": "workspace:*",
     "@itwin/itwinui-react": "^3.15.0",
     "react": "^18.0.0",

--- a/ui/components-react/CHANGELOG.md
+++ b/ui/components-react/CHANGELOG.md
@@ -1,71 +1,6 @@
 # Change Log - @itwin/components-react
 
-## 5.5.0
-
-### Minor Changes
-
-- c619667: Deprecated `dispose` method of `FilteringPropertyDataProvider` and `TreeEventHandler` classes which is defined in now deprecated `IDisposable` interface from `@itwin/core-bentley` package.
-
-  In version `5.2`, TypeScript [introduced](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management) `Disposable` type and `using` declarations (from the upcoming [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) feature in ECMAScript).
-
-  Consumers should use `Symbol.dispose` instead, which is polyfilled by the AppUI package.
-
-  ```ts
-  // Before #1
-  const handler = new TreeEventHandler();
-  handler.dispose();
-
-  // Before #2 when using `using` utility from `@itwin/core-bentley`
-  using(new TreeEventHandler(), (handler) => {
-    // Do something with handler, it'll get disposed when the callback returns
-  });
-
-  // After
-  using handler = new TreeEventHandler();
-  // Do something with handler, it'll get disposed when it goes out of scope
-  ```
-
-- c619667: Updated peer dependencies to support iTwin.js core v5 packages.
-- a69108d: Added ability to opt in to using new editors system in `FilterBuilder` component. [#1288](https://github.com/iTwin/appui/pull/1288)
-
-  ```tsx
-  return (
-    <FilterBuilder
-      {...props}
-      ruleValueRenderer={React.useCallback(
-        (valueProps) => (
-          <PropertyFilterBuilderRuleValue {...valueProps} editorSystem="new" />
-        ),
-        []
-      )}
-    />
-  );
-  ```
-
-  Added ability to render status message in `EditorRenderer`.
-
-  ```tsx
-  return <EditorRenderer {...props} statusMessage="Negative status message" />;
-  ```
-
-  ```tsx
-  return (
-    <EditorRenderer
-      {...props}
-      statusMessage={
-        <StatusMessage status="positive">Custom status message</StatusMessage>
-      }
-    />
-  );
-  ```
-
-### Patch Changes
-
-- Updated dependencies [c619667]
-  - @itwin/core-react@5.5.0
-
 ## 5.4.0
-
 Thu, 17 Apr 2025 09:55:41 GMT
 
 ### Updates
@@ -74,19 +9,16 @@ Thu, 17 Apr 2025 09:55:41 GMT
 - Added new system for rendering property value editor components.
 
 ## 5.3.1
-
 Thu, 20 Mar 2025 11:10:28 GMT
 
 _Version update only_
 
 ## 5.3.0
-
 Fri, 14 Mar 2025 17:37:48 GMT
 
 _Version update only_
 
 ## 5.2.0
-
 Thu, 27 Feb 2025 08:07:36 GMT
 
 ### Updates
@@ -94,7 +26,6 @@ Thu, 27 Feb 2025 08:07:36 GMT
 - Fix an issue which prevented tabbing through editor containers.
 
 ## 5.1.0
-
 Thu, 30 Jan 2025 09:15:23 GMT
 
 ### Updates
@@ -102,13 +33,11 @@ Thu, 30 Jan 2025 09:15:23 GMT
 - cSpell fixes
 
 ## 5.0.5
-
 Tue, 21 Jan 2025 11:38:58 GMT
 
 _Version update only_
 
 ## 5.0.4
-
 Fri, 17 Jan 2025 14:12:03 GMT
 
 ### Updates
@@ -116,13 +45,11 @@ Fri, 17 Jan 2025 14:12:03 GMT
 - Fixed `module 'lodash' does not provide an export named...` error when running in Node.js.
 
 ## 5.0.3
-
 Fri, 17 Jan 2025 11:42:02 GMT
 
 _Version update only_
 
 ## 5.0.2
-
 Thu, 16 Jan 2025 12:04:12 GMT
 
 ### Updates
@@ -130,13 +57,11 @@ Thu, 16 Jan 2025 12:04:12 GMT
 - Use import attributes for json imports.
 
 ## 5.0.1
-
 Wed, 15 Jan 2025 11:47:00 GMT
 
 _Version update only_
 
 ## 5.0.0
-
 Mon, 16 Dec 2024 11:43:27 GMT
 
 ### Updates
@@ -157,31 +82,26 @@ Mon, 16 Dec 2024 11:43:27 GMT
 - Replace buic variables with iTwinUI CSS variables.
 
 ## 4.17.6
-
 Wed, 20 Nov 2024 14:27:46 GMT
 
 _Version update only_
 
 ## 4.17.5
-
 Thu, 14 Nov 2024 08:22:04 GMT
 
 _Version update only_
 
 ## 4.17.4
-
 Fri, 08 Nov 2024 14:41:23 GMT
 
 _Version update only_
 
 ## 4.17.3
-
 Wed, 06 Nov 2024 09:04:20 GMT
 
 _Version update only_
 
 ## 4.17.2
-
 Wed, 30 Oct 2024 14:46:15 GMT
 
 ### Updates
@@ -189,7 +109,6 @@ Wed, 30 Oct 2024 14:46:15 GMT
 - Fixed `pw:` links handling in property grid.
 
 ## 4.17.1
-
 Wed, 09 Oct 2024 10:50:47 GMT
 
 ### Updates
@@ -197,7 +116,6 @@ Wed, 09 Oct 2024 10:50:47 GMT
 - Update FilterBuilder UI according to UX team's new specs
 
 ## 4.17.0
-
 Thu, 19 Sep 2024 12:50:53 GMT
 
 ### Updates
@@ -206,37 +124,31 @@ Thu, 19 Sep 2024 12:50:53 GMT
 - Add support for allowing last rule to be deleted in FilterBuilder
 
 ## 4.16.5
-
 Tue, 10 Sep 2024 16:40:46 GMT
 
 _Version update only_
 
 ## 4.16.4
-
 Wed, 04 Sep 2024 08:10:19 GMT
 
 _Version update only_
 
 ## 4.16.3
-
 Tue, 03 Sep 2024 14:32:22 GMT
 
 _Version update only_
 
 ## 4.16.2
-
 Wed, 28 Aug 2024 06:32:12 GMT
 
 _Version update only_
 
 ## 4.16.1
-
 Fri, 16 Aug 2024 08:18:14 GMT
 
 _Version update only_
 
 ## 4.16.0
-
 Wed, 07 Aug 2024 12:38:32 GMT
 
 ### Updates
@@ -251,37 +163,31 @@ Wed, 07 Aug 2024 12:38:32 GMT
 - Updated `VirtualizedPropertyGrid` to automatically close property editors when data changes.
 
 ## 4.15.5
-
 Wed, 24 Jul 2024 16:09:26 GMT
 
 _Version update only_
 
 ## 4.15.4
-
 Mon, 22 Jul 2024 21:27:52 GMT
 
 _Version update only_
 
 ## 4.15.3
-
 Mon, 15 Jul 2024 12:12:00 GMT
 
 _Version update only_
 
 ## 4.15.2
-
 Wed, 10 Jul 2024 11:54:56 GMT
 
 _Version update only_
 
 ## 4.15.1
-
 Tue, 09 Jul 2024 09:23:12 GMT
 
 _Version update only_
 
 ## 4.15.0
-
 Fri, 28 Jun 2024 09:09:37 GMT
 
 ### Updates
@@ -290,19 +196,16 @@ Fri, 28 Jun 2024 09:09:37 GMT
 - Portal editors to the same container used to portal other components.
 
 ## 4.14.2
-
 Mon, 22 Jul 2024 21:23:09 GMT
 
 _Version update only_
 
 ## 4.14.1
-
 Tue, 11 Jun 2024 15:58:29 GMT
 
 _Version update only_
 
 ## 4.14.0
-
 Thu, 06 Jun 2024 08:24:21 GMT
 
 ### Updates
@@ -312,13 +215,11 @@ Thu, 06 Jun 2024 08:24:21 GMT
 - Update PropertyGrid to allow browser context menu and user selection.
 
 ## 4.13.4
-
 Tue, 21 May 2024 08:21:34 GMT
 
 _Version update only_
 
 ## 4.13.3
-
 Fri, 17 May 2024 09:43:31 GMT
 
 ### Updates
@@ -326,13 +227,11 @@ Fri, 17 May 2024 09:43:31 GMT
 - upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x
 
 ## 4.13.2
-
 Wed, 08 May 2024 08:24:46 GMT
 
 _Version update only_
 
 ## 4.13.1
-
 Tue, 07 May 2024 15:01:46 GMT
 
 ### Updates
@@ -340,7 +239,6 @@ Tue, 07 May 2024 15:01:46 GMT
 - Fixed `VirtualizedPropertyGrid` not rendering primitive property display value and instead always trying to convert raw value into string.
 
 ## 4.13.0
-
 Tue, 07 May 2024 08:44:06 GMT
 
 ### Updates
@@ -351,7 +249,6 @@ Tue, 07 May 2024 08:44:06 GMT
 - Fixed spacing between categories in `VirtualizedPropertyGrid`.
 
 ## 4.12.0
-
 Fri, 05 Apr 2024 09:55:35 GMT
 
 ### Updates
@@ -359,7 +256,6 @@ Fri, 05 Apr 2024 09:55:35 GMT
 - Added note to `PropertyFilterRuleOperator` that `Like` operator should be handled as a contains operator.
 
 ## 4.11.0
-
 Thu, 21 Mar 2024 16:38:04 GMT
 
 ### Patches
@@ -373,7 +269,6 @@ Thu, 21 Mar 2024 16:38:04 GMT
 - Removed memoization for translated strings in components.
 
 ## 4.10.0
-
 Mon, 26 Feb 2024 15:50:45 GMT
 
 ### Updates
@@ -382,7 +277,6 @@ Mon, 26 Feb 2024 15:50:45 GMT
 - Use iTwinUI 3.x.
 
 ## 4.9.0
-
 Tue, 06 Feb 2024 08:56:40 GMT
 
 ### Patches
@@ -397,25 +291,21 @@ Tue, 06 Feb 2024 08:56:40 GMT
 - Polish UI for FilterBuilder
 
 ## 4.8.3
-
 Tue, 30 Jan 2024 09:04:27 GMT
 
 _Version update only_
 
 ## 4.8.2
-
 Wed, 24 Jan 2024 12:37:03 GMT
 
 _Version update only_
 
 ## 4.8.1
-
 Thu, 11 Jan 2024 13:05:42 GMT
 
 _Version update only_
 
 ## 4.8.0
-
 Thu, 21 Dec 2023 14:08:42 GMT
 
 ### Patches
@@ -424,13 +314,11 @@ Thu, 21 Dec 2023 14:08:42 GMT
 - Ensure correct initial property orientation in `PropertyGrid`
 
 ## 4.7.2
-
 Wed, 20 Dec 2023 23:11:37 GMT
 
 _Version update only_
 
 ## 4.7.1
-
 Thu, 07 Dec 2023 19:40:17 GMT
 
 ### Minor changes
@@ -442,7 +330,6 @@ Thu, 07 Dec 2023 19:40:17 GMT
 - Set filterText to lowercase in constructors of filterers.
 
 ## 4.7.0
-
 Fri, 01 Dec 2023 20:01:16 GMT
 
 ### Minor changes
@@ -459,25 +346,21 @@ Fri, 01 Dec 2023 20:01:16 GMT
 - Fixed `useAsyncValue` hook to work in React 18 strict mode.
 
 ## 4.6.3
-
 Wed, 25 Oct 2023 09:39:22 GMT
 
 _Version update only_
 
 ## 4.6.2
-
 Tue, 17 Oct 2023 19:16:23 GMT
 
 _Version update only_
 
 ## 4.6.1
-
 Thu, 12 Oct 2023 16:59:20 GMT
 
 _Version update only_
 
 ## 4.6.0
-
 Wed, 04 Oct 2023 18:05:34 GMT
 
 ### Updates
@@ -485,13 +368,11 @@ Wed, 04 Oct 2023 18:05:34 GMT
 - Fix `useTreeModel` missing tree model changes that happen after render until `useTreeModel` subscribes to `TreeModelSource.onModelChanged` event.
 
 ## 4.5.1
-
 Fri, 08 Sep 2023 16:10:53 GMT
 
 _Version update only_
 
 ## 4.5.0
-
 Wed, 06 Sep 2023 17:29:22 GMT
 
 ### Updates
@@ -504,7 +385,6 @@ Wed, 06 Sep 2023 17:29:22 GMT
 - `ControlledTree`: Fixed range selection over nodes that are not loaded causing browser to hang.
 
 ## 4.4.0
-
 Tue, 15 Aug 2023 18:02:09 GMT
 
 ### Updates
@@ -515,7 +395,6 @@ Tue, 15 Aug 2023 18:02:09 GMT
 - Promote `PropertyFilterBuilderRuleOperatorProps`, `PropertyFilterBuilderRuleValueProps`, `PropertyFilterBuilderRuleValue` to beta, create interface `PropertyFilterBuilderRuleValueRendererProps` which extends `PropertyFilterBuilderRuleValueProps`, pass `PropertyFilterRuleOperator` to custom `PropertyFilterBuilderRuleValue` renderer.
 
 ## 4.3.0
-
 Mon, 17 Jul 2023 10:16:20 GMT
 
 ### Updates
@@ -524,7 +403,6 @@ Mon, 17 Jul 2023 10:16:20 GMT
 - Added `useControlledTreeLayoutStorage` and `useVirtualizedPropertyGridLayoutStorage` hooks
 
 ## 4.2.0
-
 Tue, 27 Jun 2023 14:50:22 GMT
 
 ### Updates
@@ -540,7 +418,6 @@ Tue, 27 Jun 2023 14:50:22 GMT
 - Update `@itwin/itwinui-react` version to 2.11.6.
 
 ## 4.1.0
-
 Mon, 29 May 2023 14:05:04 GMT
 
 ### Updates
@@ -549,13 +426,11 @@ Mon, 29 May 2023 14:05:04 GMT
 - Fix tree flickering without keeping the horizontal scrollbar
 
 ## 4.0.1
-
 Fri, 19 May 2023 12:24:31 GMT
 
 _Version update only_
 
 ## 4.0.0
-
 Mon, 01 May 2023 13:32:16 GMT
 
 ### Updates
@@ -581,19 +456,16 @@ Mon, 01 May 2023 13:32:16 GMT
 - Remove webfont icons from components.
 
 ## 3.7.2
-
 Wed, 12 Apr 2023 13:12:42 GMT
 
 _Version update only_
 
 ## 3.7.1
-
 Mon, 03 Apr 2023 15:15:36 GMT
 
 _Version update only_
 
 ## 3.7.0
-
 Wed, 29 Mar 2023 15:02:27 GMT
 
 ### Updates
@@ -601,19 +473,16 @@ Wed, 29 Mar 2023 15:02:27 GMT
 - Update @deprecated comments.
 
 ## 3.6.3
-
 Mon, 27 Mar 2023 16:26:47 GMT
 
 _Version update only_
 
 ## 3.6.2
-
 Fri, 17 Mar 2023 17:52:32 GMT
 
 _Version update only_
 
 ## 3.6.1
-
 Fri, 24 Feb 2023 22:00:48 GMT
 
 ### Updates
@@ -621,7 +490,6 @@ Fri, 24 Feb 2023 22:00:48 GMT
 - Update `@itwin/itwinui-icons-react` dependency to version `^1.15`
 
 ## 3.6.0
-
 Wed, 08 Feb 2023 14:58:39 GMT
 
 ### Updates
@@ -635,43 +503,36 @@ Wed, 08 Feb 2023 14:58:39 GMT
 - Fixed 'FilteringInput' placeholder text localization
 
 ## 3.5.6
-
 Fri, 24 Feb 2023 16:02:47 GMT
 
 _Version update only_
 
 ## 3.5.5
-
 Thu, 26 Jan 2023 22:53:27 GMT
 
 _Version update only_
 
 ## 3.5.4
-
 Wed, 18 Jan 2023 15:27:15 GMT
 
 _Version update only_
 
 ## 3.5.3
-
 Fri, 13 Jan 2023 17:23:07 GMT
 
 _Version update only_
 
 ## 3.5.2
-
 Wed, 11 Jan 2023 16:46:30 GMT
 
 _Version update only_
 
 ## 3.5.1
-
 Thu, 15 Dec 2022 16:38:28 GMT
 
 _Version update only_
 
 ## 3.5.0
-
 Wed, 07 Dec 2022 19:12:36 GMT
 
 ### Updates
@@ -684,49 +545,41 @@ Wed, 07 Dec 2022 19:12:36 GMT
 - Use --buic-toolbar-opacity to set the opacity of toolbar items.
 
 ## 3.4.7
-
 Wed, 30 Nov 2022 14:28:19 GMT
 
 _Version update only_
 
 ## 3.4.6
-
 Tue, 22 Nov 2022 14:24:19 GMT
 
 _Version update only_
 
 ## 3.4.5
-
 Thu, 17 Nov 2022 21:32:50 GMT
 
 _Version update only_
 
 ## 3.4.4
-
 Thu, 10 Nov 2022 19:32:17 GMT
 
 _Version update only_
 
 ## 3.4.3
-
 Fri, 28 Oct 2022 13:34:57 GMT
 
 _Version update only_
 
 ## 3.4.2
-
 Mon, 24 Oct 2022 13:23:45 GMT
 
 _Version update only_
 
 ## 3.4.1
-
 Mon, 17 Oct 2022 20:06:51 GMT
 
 _Version update only_
 
 ## 3.4.0
-
 Thu, 13 Oct 2022 20:24:47 GMT
 
 ### Updates
@@ -738,31 +591,26 @@ Thu, 13 Oct 2022 20:24:47 GMT
 - `MutableTreeModel`: Accept initial `TreeModel` in the constructor.
 
 ## 3.3.5
-
 Tue, 27 Sep 2022 11:50:59 GMT
 
 _Version update only_
 
 ## 3.3.4
-
 Thu, 08 Sep 2022 19:00:04 GMT
 
 _Version update only_
 
 ## 3.3.3
-
 Tue, 06 Sep 2022 20:54:19 GMT
 
 _Version update only_
 
 ## 3.3.2
-
 Thu, 01 Sep 2022 14:37:22 GMT
 
 _Version update only_
 
 ## 3.3.1
-
 Fri, 26 Aug 2022 15:40:02 GMT
 
 ### Updates
@@ -770,7 +618,6 @@ Fri, 26 Aug 2022 15:40:02 GMT
 - Updated desktop toolbar width and height to 40px
 
 ## 3.3.0
-
 Thu, 18 Aug 2022 19:08:02 GMT
 
 ### Updates
@@ -786,49 +633,41 @@ Thu, 18 Aug 2022 19:08:02 GMT
 - Update iTwinUI-react to 1.38.1
 
 ## 3.2.9
-
 Fri, 26 Aug 2022 14:21:40 GMT
 
 _Version update only_
 
 ## 3.2.8
-
 Tue, 09 Aug 2022 15:52:41 GMT
 
 _Version update only_
 
 ## 3.2.7
-
 Mon, 01 Aug 2022 13:36:56 GMT
 
 _Version update only_
 
 ## 3.2.6
-
 Fri, 15 Jul 2022 19:04:43 GMT
 
 _Version update only_
 
 ## 3.2.5
-
 Wed, 13 Jul 2022 15:45:52 GMT
 
 _Version update only_
 
 ## 3.2.4
-
 Tue, 21 Jun 2022 18:06:33 GMT
 
 _Version update only_
 
 ## 3.2.3
-
 Fri, 17 Jun 2022 15:18:39 GMT
 
 _Version update only_
 
 ## 3.2.2
-
 Fri, 10 Jun 2022 16:11:36 GMT
 
 ### Updates
@@ -836,13 +675,11 @@ Fri, 10 Jun 2022 16:11:36 GMT
 - Fix `useTreeModel` returning stale model for the given model source
 
 ## 3.2.1
-
 Tue, 07 Jun 2022 15:02:56 GMT
 
 _Version update only_
 
 ## 3.2.0
-
 Fri, 20 May 2022 13:10:54 GMT
 
 ### Updates
@@ -851,25 +688,21 @@ Fri, 20 May 2022 13:10:54 GMT
 - Update UI to new UX design to allow only 2 sections of widgets per panel.
 
 ## 3.1.3
-
 Fri, 15 Apr 2022 13:49:25 GMT
 
 _Version update only_
 
 ## 3.1.2
-
 Wed, 06 Apr 2022 22:27:56 GMT
 
 _Version update only_
 
 ## 3.1.1
-
 Thu, 31 Mar 2022 15:55:48 GMT
 
 _Version update only_
 
 ## 3.1.0
-
 Tue, 29 Mar 2022 20:53:47 GMT
 
 ### Updates
@@ -880,19 +713,16 @@ Tue, 29 Mar 2022 20:53:47 GMT
 - Update to latest itwinui-react.
 
 ## 3.0.3
-
 Fri, 25 Mar 2022 15:10:01 GMT
 
 _Version update only_
 
 ## 3.0.2
-
 Thu, 10 Mar 2022 21:18:13 GMT
 
 _Version update only_
 
 ## 3.0.1
-
 Thu, 24 Feb 2022 15:26:55 GMT
 
 ### Updates
@@ -900,7 +730,6 @@ Thu, 24 Feb 2022 15:26:55 GMT
 - Use ToolbarAutoHidePopupContext to monitor widgets' autoHidden state.
 
 ## 3.0.0
-
 Mon, 24 Jan 2022 14:00:52 GMT
 
 ### Updates
@@ -926,7 +755,7 @@ Mon, 24 Jan 2022 14:00:52 GMT
 - Clean up deprecated FilteringInput and PropertyGrid props
 - Make `width` and `height` props required for `VirtualizedPropertyGrid` and `VirtualizedPropertyGridWithDataProvider`
 - Update CustomNumberEditor resetting of bad values.
-- update immer to fix security warning
+-  update immer to fix security warning
 - Deprecated Breadcrumb component
 - Deprecate and promote apis
 - Deprecate Table component.
@@ -957,97 +786,81 @@ Mon, 24 Jan 2022 14:00:52 GMT
 - Lock down and update version numbers so docs will build.
 
 ## 2.19.28
-
 Wed, 12 Jan 2022 14:52:38 GMT
 
 _Version update only_
 
 ## 2.19.27
-
 Wed, 05 Jan 2022 20:07:20 GMT
 
 _Version update only_
 
 ## 2.19.26
-
 Wed, 08 Dec 2021 20:54:53 GMT
 
 _Version update only_
 
 ## 2.19.25
-
 Fri, 03 Dec 2021 20:05:49 GMT
 
 _Version update only_
 
 ## 2.19.24
-
 Mon, 29 Nov 2021 18:44:31 GMT
 
 _Version update only_
 
 ## 2.19.23
-
 Mon, 22 Nov 2021 20:41:40 GMT
 
 _Version update only_
 
 ## 2.19.22
-
 Wed, 17 Nov 2021 01:23:26 GMT
 
 _Version update only_
 
 ## 2.19.21
-
 Wed, 10 Nov 2021 10:58:24 GMT
 
 _Version update only_
 
 ## 2.19.20
-
 Fri, 29 Oct 2021 16:14:22 GMT
 
 _Version update only_
 
 ## 2.19.19
-
 Mon, 25 Oct 2021 16:16:25 GMT
 
 _Version update only_
 
 ## 2.19.18
-
 Thu, 21 Oct 2021 20:59:44 GMT
 
 _Version update only_
 
 ## 2.19.17
-
 Thu, 14 Oct 2021 21:19:43 GMT
 
 _Version update only_
 
 ## 2.19.16
-
 Mon, 11 Oct 2021 17:37:46 GMT
 
 _Version update only_
 
 ## 2.19.15
-
 Fri, 08 Oct 2021 16:44:23 GMT
 
 _Version update only_
 
 ## 2.19.14
-
 Fri, 01 Oct 2021 13:07:03 GMT
 
 _Version update only_
 
 ## 2.19.13
-
 Tue, 21 Sep 2021 21:06:40 GMT
 
 ### Updates
@@ -1055,7 +868,6 @@ Tue, 21 Sep 2021 21:06:40 GMT
 - 'PropertyValueRendererManager': use merged MergedPropertyValueRenderer before looking for typename specific renderer if property is merged.
 
 ## 2.19.12
-
 Wed, 15 Sep 2021 18:06:47 GMT
 
 ### Updates
@@ -1063,67 +875,56 @@ Wed, 15 Sep 2021 18:06:47 GMT
 - `TreeRenderer`: Fix last call to `scrollToNode` being repeated on each render.
 
 ## 2.19.11
-
 Thu, 09 Sep 2021 21:04:58 GMT
 
 _Version update only_
 
 ## 2.19.10
-
 Wed, 08 Sep 2021 14:36:01 GMT
 
 _Version update only_
 
 ## 2.19.9
-
 Wed, 25 Aug 2021 15:36:01 GMT
 
 _Version update only_
 
 ## 2.19.8
-
 Mon, 23 Aug 2021 13:23:13 GMT
 
 _Version update only_
 
 ## 2.19.7
-
 Fri, 20 Aug 2021 17:47:22 GMT
 
 _Version update only_
 
 ## 2.19.6
-
 Tue, 17 Aug 2021 20:34:29 GMT
 
 _Version update only_
 
 ## 2.19.5
-
 Fri, 13 Aug 2021 21:48:09 GMT
 
 _Version update only_
 
 ## 2.19.4
-
 Thu, 12 Aug 2021 13:09:26 GMT
 
 _Version update only_
 
 ## 2.19.3
-
 Wed, 04 Aug 2021 20:29:34 GMT
 
 _Version update only_
 
 ## 2.19.2
-
 Tue, 03 Aug 2021 18:26:23 GMT
 
 _Version update only_
 
 ## 2.19.1
-
 Thu, 29 Jul 2021 20:01:11 GMT
 
 ### Updates
@@ -1131,7 +932,6 @@ Thu, 29 Jul 2021 20:01:11 GMT
 - `ControlledTree`: Fix tree background not being rendered.
 
 ## 2.19.0
-
 Mon, 26 Jul 2021 12:21:25 GMT
 
 ### Updates
@@ -1144,13 +944,11 @@ Mon, 26 Jul 2021 12:21:25 GMT
 - Add option prop to set time zone offset for date and time display in the TimelineComponent.
 
 ## 2.18.4
-
 Tue, 10 Aug 2021 19:35:13 GMT
 
 _Version update only_
 
 ## 2.18.3
-
 Wed, 28 Jul 2021 17:16:30 GMT
 
 ### Updates
@@ -1158,7 +956,6 @@ Wed, 28 Jul 2021 17:16:30 GMT
 - Fixed scrolling in Table component
 
 ## 2.18.2
-
 Mon, 26 Jul 2021 16:18:31 GMT
 
 ### Updates
@@ -1167,13 +964,11 @@ Mon, 26 Jul 2021 16:18:31 GMT
 - Workaround for react-data-grid blank grid after scroll and update
 
 ## 2.18.1
-
 Fri, 16 Jul 2021 17:45:09 GMT
 
 _Version update only_
 
 ## 2.18.0
-
 Fri, 09 Jul 2021 18:11:24 GMT
 
 ### Updates
@@ -1187,7 +982,6 @@ Fri, 09 Jul 2021 18:11:24 GMT
 - Add props to the TimelineComponent that will allow apps to pass a set of items to be prefixed, appended, or to replace the context menu entries.
 
 ## 2.17.3
-
 Mon, 26 Jul 2021 16:08:36 GMT
 
 ### Updates
@@ -1195,19 +989,16 @@ Mon, 26 Jul 2021 16:08:36 GMT
 - Workaround for react-data-grid blank grid after scroll and update
 
 ## 2.17.2
-
 Thu, 08 Jul 2021 15:23:00 GMT
 
 _Version update only_
 
 ## 2.17.1
-
 Fri, 02 Jul 2021 15:38:31 GMT
 
 _Version update only_
 
 ## 2.17.0
-
 Mon, 28 Jun 2021 16:20:11 GMT
 
 ### Updates
@@ -1225,7 +1016,6 @@ Mon, 28 Jun 2021 16:20:11 GMT
 - `VirtualizedPropertyGridWithDataProvider`: Fix loading animation overflowing its parent container.
 
 ## 2.16.10
-
 Thu, 22 Jul 2021 20:23:45 GMT
 
 ### Updates
@@ -1233,61 +1023,51 @@ Thu, 22 Jul 2021 20:23:45 GMT
 - Workaround for react-data-grid blank grid after scroll and update
 
 ## 2.16.9
-
 Tue, 06 Jul 2021 22:08:34 GMT
 
 _Version update only_
 
 ## 2.16.8
-
 Fri, 02 Jul 2021 17:40:46 GMT
 
 _Version update only_
 
 ## 2.16.7
-
 Mon, 28 Jun 2021 18:13:04 GMT
 
 _Version update only_
 
 ## 2.16.6
-
 Mon, 28 Jun 2021 13:12:55 GMT
 
 _Version update only_
 
 ## 2.16.5
-
 Fri, 25 Jun 2021 16:03:01 GMT
 
 _Version update only_
 
 ## 2.16.4
-
 Wed, 23 Jun 2021 17:09:07 GMT
 
 _Version update only_
 
 ## 2.16.3
-
 Wed, 16 Jun 2021 20:29:32 GMT
 
 _Version update only_
 
 ## 2.16.2
-
 Thu, 03 Jun 2021 18:08:11 GMT
 
 _Version update only_
 
 ## 2.16.1
-
 Thu, 27 May 2021 20:04:22 GMT
 
 _Version update only_
 
 ## 2.16.0
-
 Mon, 24 May 2021 15:58:39 GMT
 
 ### Updates
@@ -1301,13 +1081,11 @@ Mon, 24 May 2021 15:58:39 GMT
 - Update to latest classnames package
 
 ## 2.15.6
-
 Wed, 26 May 2021 15:55:19 GMT
 
 _Version update only_
 
 ## 2.15.5
-
 Thu, 20 May 2021 15:06:26 GMT
 
 ### Updates
@@ -1315,31 +1093,26 @@ Thu, 20 May 2021 15:06:26 GMT
 - Fixed getting distinct values when Table rows are updated
 
 ## 2.15.4
-
 Tue, 18 May 2021 21:59:07 GMT
 
 _Version update only_
 
 ## 2.15.3
-
 Mon, 17 May 2021 13:31:38 GMT
 
 _Version update only_
 
 ## 2.15.2
-
 Wed, 12 May 2021 18:08:13 GMT
 
 _Version update only_
 
 ## 2.15.1
-
 Wed, 05 May 2021 13:18:31 GMT
 
 _Version update only_
 
 ## 2.15.0
-
 Fri, 30 Apr 2021 12:36:58 GMT
 
 ### Updates
@@ -1354,31 +1127,26 @@ Fri, 30 Apr 2021 12:36:58 GMT
 - Fix a crash when clicking on a `ControlledTree` node when the tree contains placeholder nodes and using `SelectionMode.Multiple`
 
 ## 2.14.4
-
 Thu, 22 Apr 2021 21:07:33 GMT
 
 _Version update only_
 
 ## 2.14.3
-
 Thu, 15 Apr 2021 15:13:16 GMT
 
 _Version update only_
 
 ## 2.14.2
-
 Thu, 08 Apr 2021 14:30:09 GMT
 
 _Version update only_
 
 ## 2.14.1
-
 Mon, 05 Apr 2021 16:28:00 GMT
 
 _Version update only_
 
 ## 2.14.0
-
 Fri, 02 Apr 2021 13:18:42 GMT
 
 ### Updates
@@ -1397,7 +1165,6 @@ Fri, 02 Apr 2021 13:18:42 GMT
 - Better support for Escape key to Home position
 
 ## 2.13.0
-
 Tue, 09 Mar 2021 20:28:13 GMT
 
 ### Updates
@@ -1414,25 +1181,21 @@ Tue, 09 Mar 2021 20:28:13 GMT
 - begin rename project from iModel.js to iTwin.js
 
 ## 2.12.3
-
 Mon, 08 Mar 2021 15:32:00 GMT
 
 _Version update only_
 
 ## 2.12.2
-
 Wed, 03 Mar 2021 18:48:53 GMT
 
 _Version update only_
 
 ## 2.12.1
-
 Tue, 23 Feb 2021 20:54:45 GMT
 
 _Version update only_
 
 ## 2.12.0
-
 Thu, 18 Feb 2021 22:10:13 GMT
 
 ### Updates
@@ -1443,19 +1206,16 @@ Thu, 18 Feb 2021 22:10:13 GMT
 - Update TimelineComponent.tsx to properly respond to changed props.
 
 ## 2.11.2
-
 Thu, 18 Feb 2021 02:50:59 GMT
 
 _Version update only_
 
 ## 2.11.1
-
 Thu, 04 Feb 2021 17:22:41 GMT
 
 _Version update only_
 
 ## 2.11.0
-
 Thu, 28 Jan 2021 13:39:27 GMT
 
 ### Updates
@@ -1476,25 +1236,21 @@ Thu, 28 Jan 2021 13:39:27 GMT
 - Always clone the ViewState for a ViewportComponent to avoid attaching the same ViewState to multiple viewPorts.
 
 ## 2.10.3
-
 Fri, 08 Jan 2021 18:34:03 GMT
 
 _Version update only_
 
 ## 2.10.2
-
 Fri, 08 Jan 2021 14:52:02 GMT
 
 _Version update only_
 
 ## 2.10.1
-
 Tue, 22 Dec 2020 00:53:38 GMT
 
 _Version update only_
 
 ## 2.10.0
-
 Fri, 18 Dec 2020 18:24:01 GMT
 
 ### Updates
@@ -1511,55 +1267,46 @@ Fri, 18 Dec 2020 18:24:01 GMT
 - Fix issue where entries in ButtonGroup would not properly disable/enable.
 
 ## 2.9.9
-
 Sun, 13 Dec 2020 19:00:03 GMT
 
 _Version update only_
 
 ## 2.9.8
-
 Fri, 11 Dec 2020 02:57:36 GMT
 
 _Version update only_
 
 ## 2.9.7
-
 Wed, 09 Dec 2020 20:58:23 GMT
 
 _Version update only_
 
 ## 2.9.6
-
 Mon, 07 Dec 2020 18:40:48 GMT
 
 _Version update only_
 
 ## 2.9.5
-
 Sat, 05 Dec 2020 01:55:56 GMT
 
 _Version update only_
 
 ## 2.9.4
-
 Wed, 02 Dec 2020 20:55:40 GMT
 
 _Version update only_
 
 ## 2.9.3
-
 Mon, 23 Nov 2020 20:57:56 GMT
 
 _Version update only_
 
 ## 2.9.2
-
 Mon, 23 Nov 2020 15:33:50 GMT
 
 _Version update only_
 
 ## 2.9.1
-
 Thu, 19 Nov 2020 17:03:42 GMT
 
 ### Updates
@@ -1568,7 +1315,6 @@ Thu, 19 Nov 2020 17:03:42 GMT
 - Revert width change to EnumEditor component instead set width to auto only for docked tool settings.
 
 ## 2.9.0
-
 Wed, 18 Nov 2020 16:01:50 GMT
 
 ### Updates
@@ -1582,13 +1328,11 @@ Wed, 18 Nov 2020 16:01:50 GMT
 - Update EditorContainer tests in attempt to fix sporadic test failures.
 
 ## 2.8.1
-
 Tue, 03 Nov 2020 00:33:56 GMT
 
 _Version update only_
 
 ## 2.8.0
-
 Fri, 23 Oct 2020 17:04:02 GMT
 
 ### Updates
@@ -1601,43 +1345,36 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Added jsdoc ESLint rule for UI packages
 
 ## 2.7.6
-
 Wed, 11 Nov 2020 16:28:23 GMT
 
 _Version update only_
 
 ## 2.7.5
-
 Fri, 23 Oct 2020 16:23:51 GMT
 
 _Version update only_
 
 ## 2.7.4
-
 Mon, 19 Oct 2020 17:57:02 GMT
 
 _Version update only_
 
 ## 2.7.3
-
 Wed, 14 Oct 2020 17:00:59 GMT
 
 _Version update only_
 
 ## 2.7.2
-
 Tue, 13 Oct 2020 18:20:39 GMT
 
 _Version update only_
 
 ## 2.7.1
-
 Thu, 08 Oct 2020 13:04:35 GMT
 
 _Version update only_
 
 ## 2.7.0
-
 Fri, 02 Oct 2020 18:03:32 GMT
 
 ### Updates
@@ -1645,44 +1382,38 @@ Fri, 02 Oct 2020 18:03:32 GMT
 - Update boolean type editors to allow component to be disabled.
 - Add support for a DatePicker control.
 - Update editor to use fixed focus trap.
-- Added Table cell editor activation via keyboard when using row selection. Added Tree cell editor activation via keyboard.
+-  Added Table cell editor activation via keyboard when using row selection. Added Tree cell editor activation via keyboard.
 - Fixed react-axe initialization. Improved ui-components test coverage.
 - Table cell editing via keyboard
 - Add multiline text property support to property grid.
 - TreeRenderer: Add ability to scroll to a specific node
 
 ## 2.6.5
-
 Sat, 26 Sep 2020 16:06:34 GMT
 
 _Version update only_
 
 ## 2.6.4
-
 Tue, 22 Sep 2020 17:40:07 GMT
 
 _Version update only_
 
 ## 2.6.3
-
 Mon, 21 Sep 2020 14:47:10 GMT
 
 _Version update only_
 
 ## 2.6.2
-
 Mon, 21 Sep 2020 13:07:44 GMT
 
 _Version update only_
 
 ## 2.6.1
-
 Fri, 18 Sep 2020 13:15:09 GMT
 
 _Version update only_
 
 ## 2.6.0
-
 Thu, 17 Sep 2020 13:16:12 GMT
 
 ### Updates
@@ -1696,7 +1427,6 @@ Thu, 17 Sep 2020 13:16:12 GMT
 - Add ThemedEnumEditor for DialogItems and ToolSettings, using the ThemedSelect component.
 
 ## 2.5.5
-
 Wed, 02 Sep 2020 17:42:23 GMT
 
 ### Updates
@@ -1704,31 +1434,26 @@ Wed, 02 Sep 2020 17:42:23 GMT
 - Update rxjs dependency version to `^6.6.2`
 
 ## 2.5.4
-
 Fri, 28 Aug 2020 15:34:15 GMT
 
 _Version update only_
 
 ## 2.5.3
-
 Wed, 26 Aug 2020 11:46:00 GMT
 
 _Version update only_
 
 ## 2.5.2
-
 Tue, 25 Aug 2020 22:09:08 GMT
 
 _Version update only_
 
 ## 2.5.1
-
 Mon, 24 Aug 2020 18:13:04 GMT
 
 _Version update only_
 
 ## 2.5.0
-
 Thu, 20 Aug 2020 20:57:10 GMT
 
 ### Updates
@@ -1746,19 +1471,16 @@ Thu, 20 Aug 2020 20:57:10 GMT
 - Tree keyboard node selection & expansion
 
 ## 2.4.2
-
 Fri, 14 Aug 2020 16:34:09 GMT
 
 _Version update only_
 
 ## 2.4.1
-
 Fri, 07 Aug 2020 19:57:43 GMT
 
 _Version update only_
 
 ## 2.4.0
-
 Tue, 28 Jul 2020 16:26:24 GMT
 
 ### Updates
@@ -1772,25 +1494,21 @@ Tue, 28 Jul 2020 16:26:24 GMT
 - Use Tooltip and Popup for timeline and toolbars.
 
 ## 2.3.3
-
 Thu, 23 Jul 2020 12:57:15 GMT
 
 _Version update only_
 
 ## 2.3.2
-
 Tue, 14 Jul 2020 23:50:36 GMT
 
 _Version update only_
 
 ## 2.3.1
-
 Mon, 13 Jul 2020 18:50:14 GMT
 
 _Version update only_
 
 ## 2.3.0
-
 Fri, 10 Jul 2020 17:23:14 GMT
 
 ### Updates
@@ -1804,13 +1522,11 @@ Fri, 10 Jul 2020 17:23:14 GMT
 - Changing SelectableContent component to use ThemedSelect in place of a pure HTML select element
 
 ## 2.2.1
-
 Tue, 07 Jul 2020 14:44:52 GMT
 
 _Version update only_
 
 ## 2.2.0
-
 Fri, 19 Jun 2020 14:10:03 GMT
 
 ### Updates
@@ -1823,7 +1539,6 @@ Fri, 19 Jun 2020 14:10:03 GMT
 - Added ViewStateProp & support for obtaining ViewState from function in ViewportComponent and IModelViewportControl
 
 ## 2.1.0
-
 Thu, 28 May 2020 22:48:59 GMT
 
 ### Updates
@@ -1843,7 +1558,6 @@ Thu, 28 May 2020 22:48:59 GMT
 - Only show badges on toolbar buttons if toolbar background is not transparent.
 
 ## 2.0.0
-
 Wed, 06 May 2020 13:17:49 GMT
 
 ### Updates
@@ -1855,7 +1569,7 @@ Wed, 06 May 2020 13:17:49 GMT
 - Fixed Navigation cube jagged edges on iOS
 - Added new type of ImageSourceType "webfont-icon" which allows to load custom font-family icons by providing {className}:{iconName} format image value. It defaults to core-icon if value does not match this format.
 - Fix parsing of 0 (zero) value in CustomNumberEditor
-- Fix bug where toolbar buttons did not show expand arrow on custom button when not in 'DragInteraction' mode. Fix display of key-in browser 1.0 UI.
+- Fix bug where toolbar buttons did not show expand arrow on custom button when not in 'DragInteraction' mode.  Fix display of key-in browser 1.0 UI.
 - Fix ordering of button items in overflow in Navigation Widget.
 - Ensure ui-abstract is listed as peer dependency and not just a dev dependency.
 - Fix documentation tag
@@ -1906,19 +1620,16 @@ Wed, 06 May 2020 13:17:49 GMT
 - iModel write API development
 
 ## 1.14.1
-
 Wed, 22 Apr 2020 19:04:00 GMT
 
 _Version update only_
 
 ## 1.14.0
-
 Tue, 31 Mar 2020 15:44:19 GMT
 
 _Version update only_
 
 ## 1.13.0
-
 Wed, 04 Mar 2020 16:16:31 GMT
 
 ### Updates
@@ -1926,7 +1637,6 @@ Wed, 04 Mar 2020 16:16:31 GMT
 - Fix iOS Safari high CPU of enum button group.
 
 ## 1.12.0
-
 Wed, 12 Feb 2020 17:45:50 GMT
 
 ### Updates
@@ -1940,7 +1650,6 @@ Wed, 12 Feb 2020 17:45:50 GMT
 - Property grid border fix.
 
 ## 1.11.0
-
 Wed, 22 Jan 2020 19:24:12 GMT
 
 ### Updates
@@ -1950,7 +1659,6 @@ Wed, 22 Jan 2020 19:24:12 GMT
 - Upgrade to TypeScript 3.7.2.
 
 ## 1.10.0
-
 Tue, 07 Jan 2020 19:44:01 GMT
 
 ### Updates
@@ -1964,7 +1672,6 @@ Tue, 07 Jan 2020 19:44:01 GMT
 - Update timeline test to use fake timers to see if that resolved sporadic failures on CI builds.
 
 ## 1.9.0
-
 Tue, 10 Dec 2019 18:08:56 GMT
 
 ### Updates
@@ -1991,7 +1698,6 @@ Tue, 10 Dec 2019 18:08:56 GMT
 - Code cleanup based on code analysis report from lgtm.
 
 ## 1.8.0
-
 Fri, 22 Nov 2019 14:03:34 GMT
 
 ### Updates
@@ -2002,7 +1708,7 @@ Fri, 22 Nov 2019 14:03:34 GMT
 - Added Table cell context menu support
 - Added Tree Node.tsx export to ui-components package
 - Added tslint-react-hooks to UI packages
-- Change componentDidUpdate to call \_setDuration instead of setState directly. This will make sure the onChange handler is called.
+- Change componentDidUpdate to call _setDuration instead of setState directly. This will make sure the onChange handler is called.
 - Refactor ControlledTree custom hooks to use useEffectSkipFirst
 - Separated TreeModelSource and TreeNodeLoader. Added highlighting support to ControlledTree.
 - Added node icon rendering to ControlledTree
@@ -2010,7 +1716,6 @@ Fri, 22 Nov 2019 14:03:34 GMT
 - Add componentDidUpdate() to the TimelineComponent, updating currentDuration after the app changes the state of initialDuration.
 
 ## 1.7.0
-
 Fri, 01 Nov 2019 13:28:37 GMT
 
 ### Updates
@@ -2027,7 +1732,6 @@ Fri, 01 Nov 2019 13:28:37 GMT
 - Added initial implementation of ControlledTree
 
 ## 1.6.0
-
 Wed, 09 Oct 2019 20:28:42 GMT
 
 ### Updates
@@ -2038,7 +1742,6 @@ Wed, 09 Oct 2019 20:28:42 GMT
 - Focus EnumButtonGroupEditor without scrolling.
 
 ## 1.5.0
-
 Mon, 30 Sep 2019 22:28:48 GMT
 
 ### Updates
@@ -2054,10 +1757,9 @@ Mon, 30 Sep 2019 22:28:48 GMT
 - Upgrade to TypeScript 3.6.2
 - Fixed signature of BreadcrumbTreeUtils.aliasNodeListToTableDataProvider for consistent extract-api treatment
 - Tree: Clear page caches when reloading tree data
-- this.props.viewportRef(this.\_vp); callback moved to the end of async componentDidMount(); Additional check if (!this.\_mounted) after await
+- this.props.viewportRef(this._vp); callback moved to the end of async componentDidMount(); Additional check if (!this._mounted) after await
 
 ## 1.4.0
-
 Tue, 10 Sep 2019 12:09:49 GMT
 
 ### Updates
@@ -2073,7 +1775,6 @@ Tue, 10 Sep 2019 12:09:49 GMT
 - Fixed bug in style of the weight picker popup
 
 ## 1.3.0
-
 Tue, 13 Aug 2019 20:25:53 GMT
 
 ### Updates
@@ -2096,7 +1797,6 @@ Tue, 13 Aug 2019 20:25:53 GMT
 - Update to latest icon package version.
 
 ## 1.2.0
-
 Wed, 24 Jul 2019 11:47:26 GMT
 
 ### Updates
@@ -2107,7 +1807,6 @@ Wed, 24 Jul 2019 11:47:26 GMT
 - PropertyView: Update visual styles.
 
 ## 1.1.0
-
 Mon, 01 Jul 2019 19:04:29 GMT
 
 ### Updates
@@ -2133,7 +1832,6 @@ Mon, 01 Jul 2019 19:04:29 GMT
 - ui-component unit tests. NumericInput strict=true default.
 
 ## 1.0.0
-
 Mon, 03 Jun 2019 18:09:39 GMT
 
 ### Updates
@@ -2153,7 +1851,6 @@ Mon, 03 Jun 2019 18:09:39 GMT
 - Added ViewSelectorChangedEvent
 
 ## 0.191.0
-
 Mon, 13 May 2019 15:52:05 GMT
 
 ### Updates
@@ -2198,7 +1895,6 @@ Mon, 13 May 2019 15:52:05 GMT
 - Added test coverage for ViewportComponent
 
 ## 0.190.0
-
 Thu, 14 Mar 2019 14:26:49 GMT
 
 ### Updates
@@ -2209,7 +1905,6 @@ Thu, 14 Mar 2019 14:26:49 GMT
 - Add Transparency slider component.
 
 ## 0.189.0
-
 Wed, 06 Mar 2019 15:41:22 GMT
 
 ### Updates
@@ -2253,13 +1948,11 @@ Wed, 06 Mar 2019 15:41:22 GMT
 - WIP: ViewportComponent unit tests. Removed imodeljs-clients-backend dependency from ui-framework
 
 ## 0.188.0
-
 Wed, 16 Jan 2019 16:36:09 GMT
 
 _Version update only_
 
 ## 0.187.0
-
 Tue, 15 Jan 2019 15:18:59 GMT
 
 ### Updates
@@ -2268,7 +1961,6 @@ Tue, 15 Jan 2019 15:18:59 GMT
 - Add ability to assign context menu for properties in PropertyGrid
 
 ## 0.186.0
-
 Mon, 14 Jan 2019 23:09:10 GMT
 
 ### Updates
@@ -2276,13 +1968,11 @@ Mon, 14 Jan 2019 23:09:10 GMT
 - Property pane does not show struct or array info anymore
 
 ## 0.185.0
-
 Fri, 11 Jan 2019 18:29:00 GMT
 
 _Version update only_
 
 ## 0.184.0
-
 Thu, 10 Jan 2019 22:46:17 GMT
 
 ### Updates
@@ -2293,25 +1983,21 @@ Thu, 10 Jan 2019 22:46:17 GMT
 - Fix double and navigation property value renderers to not append ".0" to values in certain cases
 
 ## 0.183.0
-
 Mon, 07 Jan 2019 21:49:21 GMT
 
 _Version update only_
 
 ## 0.182.0
-
 Mon, 07 Jan 2019 13:31:34 GMT
 
 _Version update only_
 
 ## 0.181.0
-
 Fri, 04 Jan 2019 13:02:40 GMT
 
 _Version update only_
 
 ## 0.180.0
-
 Wed, 02 Jan 2019 15:18:23 GMT
 
 ### Updates
@@ -2322,7 +2008,6 @@ Wed, 02 Jan 2019 15:18:23 GMT
 - Added optional viewState prop to ViewportComponent
 
 ## 0.179.0
-
 Wed, 19 Dec 2018 18:26:14 GMT
 
 ### Updates
@@ -2344,13 +2029,11 @@ Wed, 19 Dec 2018 18:26:14 GMT
 - Show loading spinner in the Tree while root nodes are being loaded
 
 ## 0.178.0
-
 Thu, 13 Dec 2018 22:06:10 GMT
 
 _Version update only_
 
 ## 0.177.0
-
 Wed, 12 Dec 2018 17:21:32 GMT
 
 ### Updates
@@ -2363,19 +2046,16 @@ Wed, 12 Dec 2018 17:21:32 GMT
 - Improved speed & smoothness of CubeNavigationAid. Made class names unique to fix documentation. UI Tree doc fixes.
 
 ## 0.176.0
-
 Mon, 10 Dec 2018 21:19:45 GMT
 
 _Version update only_
 
 ## 0.175.0
-
 Mon, 10 Dec 2018 17:08:55 GMT
 
 _Version update only_
 
 ## 0.174.0
-
 Mon, 10 Dec 2018 13:24:09 GMT
 
 ### Updates
@@ -2387,7 +2067,6 @@ Mon, 10 Dec 2018 13:24:09 GMT
 - TreeNode can now render asynchronously.
 
 ## 0.173.0
-
 Thu, 06 Dec 2018 22:03:29 GMT
 
 ### Updates
@@ -2397,7 +2076,6 @@ Thu, 06 Dec 2018 22:03:29 GMT
 - Custom imodelJs noDirectImport lint rule implemented, noDuplicateImport lint rule turned on.
 
 ## 0.172.0
-
 Tue, 04 Dec 2018 17:24:39 GMT
 
 ### Updates
@@ -2405,7 +2083,6 @@ Tue, 04 Dec 2018 17:24:39 GMT
 - Changed index file name to match package name, eliminate subdirectory index files, decrease usage of default exports, change imports to use other packages' index file.
 
 ## 0.171.0
-
 Mon, 03 Dec 2018 18:52:58 GMT
 
 ### Updates
@@ -2420,7 +2097,6 @@ Mon, 03 Dec 2018 18:52:58 GMT
 - Implement pagination in Tree component
 
 ## 0.170.0
-
 Mon, 26 Nov 2018 19:38:42 GMT
 
 ### Updates
@@ -2432,7 +2108,6 @@ Mon, 26 Nov 2018 19:38:42 GMT
 - Enabled table to contain popups and dialog and slightly cleaned up it's CSS.
 
 ## 0.169.0
-
 Tue, 20 Nov 2018 16:17:15 GMT
 
 ### Updates
@@ -2440,13 +2115,11 @@ Tue, 20 Nov 2018 16:17:15 GMT
 - Virtualized nodes' rendering in the Tree component
 
 ## 0.168.0
-
 Sat, 17 Nov 2018 14:20:11 GMT
 
 _Version update only_
 
 ## 0.167.0
-
 Fri, 16 Nov 2018 21:45:44 GMT
 
 ### Updates
@@ -2459,19 +2132,16 @@ Fri, 16 Nov 2018 21:45:44 GMT
 - ui-framework unit tests & docs
 
 ## 0.166.0
-
 Mon, 12 Nov 2018 16:42:10 GMT
 
 _Version update only_
 
 ## 0.165.0
-
 Mon, 12 Nov 2018 15:47:00 GMT
 
 _Version update only_
 
 ## 0.164.0
-
 Thu, 08 Nov 2018 17:59:21 GMT
 
 ### Updates
@@ -2486,7 +2156,6 @@ Thu, 08 Nov 2018 17:59:21 GMT
 - Zone & Widget initial state, more ui-core unit tests, cleaned up ui-framework index.ts files.
 
 ## 0.163.0
-
 Wed, 31 Oct 2018 20:55:37 GMT
 
 ### Updates
@@ -2496,7 +2165,6 @@ Wed, 31 Oct 2018 20:55:37 GMT
 - Fixed ui-framework unit test
 
 ## 0.162.0
-
 Wed, 24 Oct 2018 19:20:07 GMT
 
 ### Updates
@@ -2517,31 +2185,26 @@ Wed, 24 Oct 2018 19:20:07 GMT
 - Custom property value renderer manager can now be provided to Table and Pane. Without it they use default property renderers.
 
 ## 0.161.0
-
 Fri, 19 Oct 2018 13:04:14 GMT
 
 _Version update only_
 
 ## 0.160.0
-
 Wed, 17 Oct 2018 18:18:38 GMT
 
 _Version update only_
 
 ## 0.159.0
-
 Tue, 16 Oct 2018 14:09:09 GMT
 
 _Version update only_
 
 ## 0.158.0
-
 Mon, 15 Oct 2018 19:36:09 GMT
 
 _Version update only_
 
 ## 0.157.0
-
 Sun, 14 Oct 2018 17:20:06 GMT
 
 ### Updates
@@ -2549,9 +2212,9 @@ Sun, 14 Oct 2018 17:20:06 GMT
 - Fixing scripts for linux
 
 ## 0.156.0
-
 Fri, 12 Oct 2018 23:00:10 GMT
 
 ### Updates
 
 - Initial release
+

--- a/ui/components-react/package.json
+++ b/ui/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/components-react",
-  "version": "5.5.0",
+  "version": "5.4.0",
   "description": "A react component library of iTwin.js UI data-oriented components",
   "type": "module",
   "types": "./lib/components-react.d.ts",

--- a/ui/core-react/CHANGELOG.md
+++ b/ui/core-react/CHANGELOG.md
@@ -1,19 +1,11 @@
 # Change Log - @itwin/core-react
 
-## 5.5.0
-
-### Minor Changes
-
-- c619667: Updated peer dependencies to support iTwin.js core v5 packages.
-
 ## 5.4.0
-
 Thu, 17 Apr 2025 09:55:41 GMT
 
 _Version update only_
 
 ## 5.3.1
-
 Thu, 20 Mar 2025 11:10:28 GMT
 
 ### Updates
@@ -21,13 +13,11 @@ Thu, 20 Mar 2025 11:10:28 GMT
 - Fixed web font icon sizes in IconComponent
 
 ## 5.3.0
-
 Fri, 14 Mar 2025 17:37:48 GMT
 
 _Version update only_
 
 ## 5.2.0
-
 Thu, 27 Feb 2025 08:07:36 GMT
 
 ### Updates
@@ -35,7 +25,6 @@ Thu, 27 Feb 2025 08:07:36 GMT
 - Update `dompurify` dependency version.
 
 ## 5.1.0
-
 Thu, 30 Jan 2025 09:15:23 GMT
 
 ### Updates
@@ -43,13 +32,11 @@ Thu, 30 Jan 2025 09:15:23 GMT
 - cSpell fixes
 
 ## 5.0.5
-
 Tue, 21 Jan 2025 11:38:58 GMT
 
 _Version update only_
 
 ## 5.0.4
-
 Fri, 17 Jan 2025 14:12:03 GMT
 
 ### Updates
@@ -57,13 +44,11 @@ Fri, 17 Jan 2025 14:12:03 GMT
 - Fixed `module 'lodash' does not provide an export named...` error when running in Node.js.
 
 ## 5.0.3
-
 Fri, 17 Jan 2025 11:42:02 GMT
 
 _Version update only_
 
 ## 5.0.2
-
 Thu, 16 Jan 2025 12:04:12 GMT
 
 ### Updates
@@ -71,13 +56,11 @@ Thu, 16 Jan 2025 12:04:12 GMT
 - Use import attributes for json imports.
 
 ## 5.0.1
-
 Wed, 15 Jan 2025 11:47:00 GMT
 
 _Version update only_
 
 ## 5.0.0
-
 Mon, 16 Dec 2024 11:43:27 GMT
 
 ### Updates
@@ -94,25 +77,21 @@ Mon, 16 Dec 2024 11:43:27 GMT
 - Replace buic variables with iTwinUI CSS variables.
 
 ## 4.17.6
-
 Wed, 20 Nov 2024 14:27:46 GMT
 
 _Version update only_
 
 ## 4.17.5
-
 Thu, 14 Nov 2024 08:22:04 GMT
 
 _Version update only_
 
 ## 4.17.4
-
 Fri, 08 Nov 2024 14:41:23 GMT
 
 _Version update only_
 
 ## 4.17.3
-
 Wed, 06 Nov 2024 09:04:20 GMT
 
 ### Updates
@@ -120,55 +99,46 @@ Wed, 06 Nov 2024 09:04:20 GMT
 - Fix Popup to adjust final position based on container size instead of window size.
 
 ## 4.17.2
-
 Wed, 30 Oct 2024 14:46:15 GMT
 
 _Version update only_
 
 ## 4.17.1
-
 Wed, 09 Oct 2024 10:50:47 GMT
 
 _Version update only_
 
 ## 4.17.0
-
 Thu, 19 Sep 2024 12:50:53 GMT
 
 _Version update only_
 
 ## 4.16.5
-
 Tue, 10 Sep 2024 16:40:46 GMT
 
 _Version update only_
 
 ## 4.16.4
-
 Wed, 04 Sep 2024 08:10:19 GMT
 
 _Version update only_
 
 ## 4.16.3
-
 Tue, 03 Sep 2024 14:32:22 GMT
 
 _Version update only_
 
 ## 4.16.2
-
 Wed, 28 Aug 2024 06:32:12 GMT
 
 _Version update only_
 
 ## 4.16.1
-
 Fri, 16 Aug 2024 08:18:14 GMT
 
 _Version update only_
 
 ## 4.16.0
-
 Wed, 07 Aug 2024 12:38:32 GMT
 
 ### Updates
@@ -179,19 +149,16 @@ Wed, 07 Aug 2024 12:38:32 GMT
 - Removed styling for the `theme-transition` class.
 
 ## 4.15.5
-
 Wed, 24 Jul 2024 16:09:26 GMT
 
 _Version update only_
 
 ## 4.15.4
-
 Mon, 22 Jul 2024 21:27:52 GMT
 
 _Version update only_
 
 ## 4.15.3
-
 Mon, 15 Jul 2024 12:12:01 GMT
 
 ### Updates
@@ -199,13 +166,11 @@ Mon, 15 Jul 2024 12:12:01 GMT
 - Fix `PopupContextMenu` to work in `StatusBarPopover`.
 
 ## 4.15.2
-
 Wed, 10 Jul 2024 11:54:56 GMT
 
 _Version update only_
 
 ## 4.15.1
-
 Tue, 09 Jul 2024 09:23:12 GMT
 
 ### Updates
@@ -213,7 +178,6 @@ Tue, 09 Jul 2024 09:23:12 GMT
 - Remove `ConditionalIconItem.isConditionalIconItem()` workaround to fix an underscore prefix issue.
 
 ## 4.15.0
-
 Fri, 28 Jun 2024 09:09:37 GMT
 
 ### Updates
@@ -222,19 +186,16 @@ Fri, 28 Jun 2024 09:09:37 GMT
 - Deprecated components, functions, enums that are intended for internal use, are not used by AppUI or can be replaced with alternatives.
 
 ## 4.14.2
-
 Mon, 22 Jul 2024 21:23:09 GMT
 
 _Version update only_
 
 ## 4.14.1
-
 Tue, 11 Jun 2024 15:58:29 GMT
 
 _Version update only_
 
 ## 4.14.0
-
 Thu, 06 Jun 2024 08:24:21 GMT
 
 ### Updates
@@ -243,13 +204,11 @@ Thu, 06 Jun 2024 08:24:21 GMT
 - Deprecate RadialMenu and RadialButton components.
 
 ## 4.13.4
-
 Tue, 21 May 2024 08:21:34 GMT
 
 _Version update only_
 
 ## 4.13.3
-
 Fri, 17 May 2024 09:43:31 GMT
 
 ### Updates
@@ -257,19 +216,16 @@ Fri, 17 May 2024 09:43:31 GMT
 - upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x
 
 ## 4.13.2
-
 Wed, 08 May 2024 08:24:46 GMT
 
 _Version update only_
 
 ## 4.13.1
-
 Tue, 07 May 2024 15:01:46 GMT
 
 _Version update only_
 
 ## 4.13.0
-
 Tue, 07 May 2024 08:44:06 GMT
 
 ### Updates
@@ -282,7 +238,6 @@ Tue, 07 May 2024 08:44:06 GMT
 - Bump `useCrossOriginPopup` to `@public`.
 
 ## 4.12.0
-
 Fri, 05 Apr 2024 09:55:35 GMT
 
 ### Updates
@@ -291,7 +246,6 @@ Fri, 05 Apr 2024 09:55:35 GMT
 - Add `LocalizationProvider` as an alternative to static package initializer.
 
 ## 4.11.0
-
 Thu, 21 Mar 2024 16:38:04 GMT
 
 ### Updates
@@ -300,7 +254,6 @@ Thu, 21 Mar 2024 16:38:04 GMT
 - Removed memoization for translated strings in components.
 
 ## 4.10.0
-
 Mon, 26 Feb 2024 15:50:45 GMT
 
 ### Updates
@@ -309,7 +262,6 @@ Mon, 26 Feb 2024 15:50:45 GMT
 - Fix a potential maximum update depth error caused by useResizeObserver.
 
 ## 4.9.0
-
 Tue, 06 Feb 2024 08:56:40 GMT
 
 ### Updates
@@ -319,7 +271,6 @@ Tue, 06 Feb 2024 08:56:40 GMT
 - Removed appui-layout-react mentions from Readme.md
 
 ## 4.8.3
-
 Tue, 30 Jan 2024 09:04:27 GMT
 
 ### Updates
@@ -328,37 +279,31 @@ Tue, 30 Jan 2024 09:04:27 GMT
 - Position popup relative to popup container.
 
 ## 4.8.2
-
 Wed, 24 Jan 2024 12:37:04 GMT
 
 _Version update only_
 
 ## 4.8.1
-
 Thu, 11 Jan 2024 13:05:42 GMT
 
 _Version update only_
 
 ## 4.8.0
-
 Thu, 21 Dec 2023 14:08:42 GMT
 
 _Version update only_
 
 ## 4.7.2
-
 Wed, 20 Dec 2023 23:11:37 GMT
 
 _Version update only_
 
 ## 4.7.1
-
 Thu, 07 Dec 2023 19:40:17 GMT
 
 _Version update only_
 
 ## 4.7.0
-
 Fri, 01 Dec 2023 20:01:16 GMT
 
 ### Updates
@@ -368,7 +313,6 @@ Fri, 01 Dec 2023 20:01:16 GMT
 - Add high contrast themes support and simplify unused css variables
 
 ## 4.6.3
-
 Wed, 25 Oct 2023 09:39:22 GMT
 
 ### Updates
@@ -376,7 +320,6 @@ Wed, 25 Oct 2023 09:39:22 GMT
 - Fix broken dataUri containing commas in `IconWebComponent`.
 
 ## 4.6.2
-
 Tue, 17 Oct 2023 19:16:23 GMT
 
 ### Updates
@@ -384,13 +327,11 @@ Tue, 17 Oct 2023 19:16:23 GMT
 - Support `data:image/svg+xml` web component icons. (base64 already supported)
 
 ## 4.6.1
-
 Thu, 12 Oct 2023 16:59:20 GMT
 
 _Version update only_
 
 ## 4.6.0
-
 Wed, 04 Oct 2023 18:05:34 GMT
 
 ### Updates
@@ -399,13 +340,11 @@ Wed, 04 Oct 2023 18:05:34 GMT
 - React to core/appui-abstract deprecations
 
 ## 4.5.1
-
 Fri, 08 Sep 2023 16:10:53 GMT
 
 _Version update only_
 
 ## 4.5.0
-
 Wed, 06 Sep 2023 17:29:22 GMT
 
 ### Updates
@@ -413,7 +352,6 @@ Wed, 06 Sep 2023 17:29:22 GMT
 - Added ControlledTree to component providers example. Fixed spacing issue with ControlledTree
 
 ## 4.4.0
-
 Tue, 15 Aug 2023 18:02:09 GMT
 
 ### Updates
@@ -422,7 +360,6 @@ Tue, 15 Aug 2023 18:02:09 GMT
 - `ConditionalIconItem.isConditionalIconItem` is now a _type predicate_.
 
 ## 4.3.0
-
 Mon, 17 Jul 2023 10:16:20 GMT
 
 ### Updates
@@ -431,7 +368,6 @@ Mon, 17 Jul 2023 10:16:20 GMT
 - Standardize core-react `Dialog` visuals and behavior by making iTwinUI `Dialog` its base component.
 
 ## 4.2.0
-
 Tue, 27 Jun 2023 14:50:22 GMT
 
 ### Updates
@@ -444,7 +380,6 @@ Tue, 27 Jun 2023 14:50:22 GMT
 - Update `@itwin/itwinui-react` version to 2.11.6.
 
 ## 4.1.0
-
 Mon, 29 May 2023 14:05:04 GMT
 
 ### Updates
@@ -452,13 +387,11 @@ Mon, 29 May 2023 14:05:04 GMT
 - Add gaps between TreeNodeItem content items.
 
 ## 4.0.1
-
 Fri, 19 May 2023 12:24:31 GMT
 
 _Version update only_
 
 ## 4.0.0
-
 Mon, 01 May 2023 13:32:16 GMT
 
 ### Updates
@@ -479,19 +412,16 @@ Mon, 01 May 2023 13:32:16 GMT
 - Remove webfont icons from components. Add ConditionIconComponent to allow IconSpec to be used conditionally instead of just a string.
 
 ## 3.7.2
-
 Wed, 12 Apr 2023 13:12:42 GMT
 
 _Version update only_
 
 ## 3.7.1
-
 Mon, 03 Apr 2023 15:15:37 GMT
 
 _Version update only_
 
 ## 3.7.0
-
 Wed, 29 Mar 2023 15:02:27 GMT
 
 ### Updates
@@ -499,25 +429,21 @@ Wed, 29 Mar 2023 15:02:27 GMT
 - Update @deprecated comments.
 
 ## 3.6.3
-
 Mon, 27 Mar 2023 16:26:47 GMT
 
 _Version update only_
 
 ## 3.6.2
-
 Fri, 17 Mar 2023 17:52:32 GMT
 
 _Version update only_
 
 ## 3.6.1
-
 Fri, 24 Feb 2023 22:00:48 GMT
 
 _Version update only_
 
 ## 3.6.0
-
 Wed, 08 Feb 2023 14:58:40 GMT
 
 ### Updates
@@ -526,43 +452,36 @@ Wed, 08 Feb 2023 14:58:40 GMT
 - Update UnderlineButton test.
 
 ## 3.5.6
-
 Fri, 24 Feb 2023 16:02:47 GMT
 
 _Version update only_
 
 ## 3.5.5
-
 Thu, 26 Jan 2023 22:53:27 GMT
 
 _Version update only_
 
 ## 3.5.4
-
 Wed, 18 Jan 2023 15:27:15 GMT
 
 _Version update only_
 
 ## 3.5.3
-
 Fri, 13 Jan 2023 17:23:07 GMT
 
 _Version update only_
 
 ## 3.5.2
-
 Wed, 11 Jan 2023 16:46:30 GMT
 
 _Version update only_
 
 ## 3.5.1
-
 Thu, 15 Dec 2022 16:38:29 GMT
 
 _Version update only_
 
 ## 3.5.0
-
 Wed, 07 Dec 2022 19:12:37 GMT
 
 ### Updates
@@ -572,49 +491,41 @@ Wed, 07 Dec 2022 19:12:37 GMT
 - Use --buic-toolbar-opacity to set the opacity of toolbar items.
 
 ## 3.4.7
-
 Wed, 30 Nov 2022 14:28:19 GMT
 
 _Version update only_
 
 ## 3.4.6
-
 Tue, 22 Nov 2022 14:24:19 GMT
 
 _Version update only_
 
 ## 3.4.5
-
 Thu, 17 Nov 2022 21:32:50 GMT
 
 _Version update only_
 
 ## 3.4.4
-
 Thu, 10 Nov 2022 19:32:17 GMT
 
 _Version update only_
 
 ## 3.4.3
-
 Fri, 28 Oct 2022 13:34:58 GMT
 
 _Version update only_
 
 ## 3.4.2
-
 Mon, 24 Oct 2022 13:23:45 GMT
 
 _Version update only_
 
 ## 3.4.1
-
 Mon, 17 Oct 2022 20:06:51 GMT
 
 _Version update only_
 
 ## 3.4.0
-
 Thu, 13 Oct 2022 20:24:47 GMT
 
 ### Updates
@@ -623,37 +534,31 @@ Thu, 13 Oct 2022 20:24:47 GMT
 - Updated Node types declaration to support latest v16
 
 ## 3.3.5
-
 Tue, 27 Sep 2022 11:50:59 GMT
 
 _Version update only_
 
 ## 3.3.4
-
 Thu, 08 Sep 2022 19:00:05 GMT
 
 _Version update only_
 
 ## 3.3.3
-
 Tue, 06 Sep 2022 20:54:19 GMT
 
 _Version update only_
 
 ## 3.3.2
-
 Thu, 01 Sep 2022 14:37:22 GMT
 
 _Version update only_
 
 ## 3.3.1
-
 Fri, 26 Aug 2022 15:40:02 GMT
 
 _Version update only_
 
 ## 3.3.0
-
 Thu, 18 Aug 2022 19:08:02 GMT
 
 ### Updates
@@ -664,31 +569,26 @@ Thu, 18 Aug 2022 19:08:02 GMT
 - Update iTwinUI-react to 1.38.1
 
 ## 3.2.9
-
 Fri, 26 Aug 2022 14:21:40 GMT
 
 _Version update only_
 
 ## 3.2.8
-
 Tue, 09 Aug 2022 15:52:41 GMT
 
 _Version update only_
 
 ## 3.2.7
-
 Mon, 01 Aug 2022 13:36:56 GMT
 
 _Version update only_
 
 ## 3.2.6
-
 Fri, 15 Jul 2022 19:04:43 GMT
 
 _Version update only_
 
 ## 3.2.5
-
 Wed, 13 Jul 2022 15:45:52 GMT
 
 ### Updates
@@ -696,25 +596,21 @@ Wed, 13 Jul 2022 15:45:52 GMT
 - Added a 'repositionOnResize' property on the 'Popup' component, to avoid closing the popup every time the browser window is resized.
 
 ## 3.2.4
-
 Tue, 21 Jun 2022 18:06:33 GMT
 
 _Version update only_
 
 ## 3.2.3
-
 Fri, 17 Jun 2022 15:18:39 GMT
 
 _Version update only_
 
 ## 3.2.2
-
 Fri, 10 Jun 2022 16:11:36 GMT
 
 _Version update only_
 
 ## 3.2.1
-
 Tue, 07 Jun 2022 15:02:56 GMT
 
 ### Updates
@@ -722,7 +618,6 @@ Tue, 07 Jun 2022 15:02:56 GMT
 - Backport change to update panel background to use same as buic-background-dialog so disabled itwin ui components display properly.
 
 ## 3.2.0
-
 Fri, 20 May 2022 13:10:54 GMT
 
 ### Updates
@@ -734,25 +629,21 @@ Fri, 20 May 2022 13:10:54 GMT
 - Allow React icons to be used on Widget tabs, backstage, and status bar items
 
 ## 3.1.3
-
 Fri, 15 Apr 2022 13:49:25 GMT
 
 _Version update only_
 
 ## 3.1.2
-
 Wed, 06 Apr 2022 22:27:56 GMT
 
 _Version update only_
 
 ## 3.1.1
-
 Thu, 31 Mar 2022 15:55:48 GMT
 
 _Version update only_
 
 ## 3.1.0
-
 Tue, 29 Mar 2022 20:53:47 GMT
 
 ### Updates
@@ -763,19 +654,16 @@ Tue, 29 Mar 2022 20:53:47 GMT
 - Update to latest itwinui-react - requires new compile option allowSyntheticDefaultImports=true.
 
 ## 3.0.3
-
 Fri, 25 Mar 2022 15:10:02 GMT
 
 _Version update only_
 
 ## 3.0.2
-
 Thu, 10 Mar 2022 21:18:13 GMT
 
 _Version update only_
 
 ## 3.0.1
-
 Thu, 24 Feb 2022 15:26:55 GMT
 
 ### Updates
@@ -783,7 +671,6 @@ Thu, 24 Feb 2022 15:26:55 GMT
 - `TreeNode`: Fix checkbox propagating click events to the parent element, resulting in unexpected TreeNodeProps.onClick invocations.
 
 ## 3.0.0
-
 Mon, 24 Jan 2022 14:00:52 GMT
 
 ### Updates
@@ -830,123 +717,103 @@ Mon, 24 Jan 2022 14:00:52 GMT
 - Lock down and update version numbers so docs will build.
 
 ## 2.19.28
-
 Wed, 12 Jan 2022 14:52:38 GMT
 
 _Version update only_
 
 ## 2.19.27
-
 Wed, 05 Jan 2022 20:07:20 GMT
 
 _Version update only_
 
 ## 2.19.26
-
 Wed, 08 Dec 2021 20:54:53 GMT
 
 _Version update only_
 
 ## 2.19.25
-
 Fri, 03 Dec 2021 20:05:49 GMT
 
 _Version update only_
 
 ## 2.19.24
-
 Mon, 29 Nov 2021 18:44:31 GMT
 
 _Version update only_
 
 ## 2.19.23
-
 Mon, 22 Nov 2021 20:41:40 GMT
 
 _Version update only_
 
 ## 2.19.22
-
 Wed, 17 Nov 2021 01:23:26 GMT
 
 _Version update only_
 
 ## 2.19.21
-
 Wed, 10 Nov 2021 10:58:24 GMT
 
 _Version update only_
 
 ## 2.19.20
-
 Fri, 29 Oct 2021 16:14:22 GMT
 
 _Version update only_
 
 ## 2.19.19
-
 Mon, 25 Oct 2021 16:16:25 GMT
 
 ### Updates
 
-- Drop unnecessary dep on @bentley/react-scripts; add a \*.d.ts file for svg?sprite loader syntax
+- Drop unnecessary dep on @bentley/react-scripts; add a *.d.ts file for svg?sprite loader syntax
 
 ## 2.19.18
-
 Thu, 21 Oct 2021 20:59:44 GMT
 
 _Version update only_
 
 ## 2.19.17
-
 Thu, 14 Oct 2021 21:19:43 GMT
 
 _Version update only_
 
 ## 2.19.16
-
 Mon, 11 Oct 2021 17:37:46 GMT
 
 _Version update only_
 
 ## 2.19.15
-
 Fri, 08 Oct 2021 16:44:23 GMT
 
 _Version update only_
 
 ## 2.19.14
-
 Fri, 01 Oct 2021 13:07:03 GMT
 
 _Version update only_
 
 ## 2.19.13
-
 Tue, 21 Sep 2021 21:06:40 GMT
 
 _Version update only_
 
 ## 2.19.12
-
 Wed, 15 Sep 2021 18:06:47 GMT
 
 _Version update only_
 
 ## 2.19.11
-
 Thu, 09 Sep 2021 21:04:58 GMT
 
 _Version update only_
 
 ## 2.19.10
-
 Wed, 08 Sep 2021 14:36:01 GMT
 
 _Version update only_
 
 ## 2.19.9
-
 Wed, 25 Aug 2021 15:36:01 GMT
 
 ### Updates
@@ -954,49 +821,41 @@ Wed, 25 Aug 2021 15:36:01 GMT
 - Test resizeObserver.current before calling unobserve.
 
 ## 2.19.8
-
 Mon, 23 Aug 2021 13:23:13 GMT
 
 _Version update only_
 
 ## 2.19.7
-
 Fri, 20 Aug 2021 17:47:22 GMT
 
 _Version update only_
 
 ## 2.19.6
-
 Tue, 17 Aug 2021 20:34:29 GMT
 
 _Version update only_
 
 ## 2.19.5
-
 Fri, 13 Aug 2021 21:48:09 GMT
 
 _Version update only_
 
 ## 2.19.4
-
 Thu, 12 Aug 2021 13:09:26 GMT
 
 _Version update only_
 
 ## 2.19.3
-
 Wed, 04 Aug 2021 20:29:34 GMT
 
 _Version update only_
 
 ## 2.19.2
-
 Tue, 03 Aug 2021 18:26:23 GMT
 
 _Version update only_
 
 ## 2.19.1
-
 Thu, 29 Jul 2021 20:01:11 GMT
 
 ### Updates
@@ -1004,7 +863,6 @@ Thu, 29 Jul 2021 20:01:11 GMT
 - Fix infinite loop in ContextMenu component for menus that are taller than parent window.
 
 ## 2.19.0
-
 Mon, 26 Jul 2021 12:21:25 GMT
 
 ### Updates
@@ -1014,31 +872,26 @@ Mon, 26 Jul 2021 12:21:25 GMT
 - Update ResizableContainerObserver to monitor parent size if no children are specified.
 
 ## 2.18.4
-
 Tue, 10 Aug 2021 19:35:13 GMT
 
 _Version update only_
 
 ## 2.18.3
-
 Wed, 28 Jul 2021 17:16:30 GMT
 
 _Version update only_
 
 ## 2.18.2
-
 Mon, 26 Jul 2021 16:18:31 GMT
 
 _Version update only_
 
 ## 2.18.1
-
 Fri, 16 Jul 2021 17:45:09 GMT
 
 _Version update only_
 
 ## 2.18.0
-
 Fri, 09 Jul 2021 18:11:24 GMT
 
 ### Updates
@@ -1046,25 +899,21 @@ Fri, 09 Jul 2021 18:11:24 GMT
 - Fix bug in ElementResizeObserver caused by using React.Ref and not an HTMLElement as a usedEffect dependency.
 
 ## 2.17.3
-
 Mon, 26 Jul 2021 16:08:36 GMT
 
 _Version update only_
 
 ## 2.17.2
-
 Thu, 08 Jul 2021 15:23:00 GMT
 
 _Version update only_
 
 ## 2.17.1
-
 Fri, 02 Jul 2021 15:38:31 GMT
 
 _Version update only_
 
 ## 2.17.0
-
 Mon, 28 Jun 2021 16:20:11 GMT
 
 ### Updates
@@ -1074,67 +923,56 @@ Mon, 28 Jun 2021 16:20:11 GMT
 - Publish in-use APIs
 
 ## 2.16.10
-
 Thu, 22 Jul 2021 20:23:45 GMT
 
 _Version update only_
 
 ## 2.16.9
-
 Tue, 06 Jul 2021 22:08:34 GMT
 
 _Version update only_
 
 ## 2.16.8
-
 Fri, 02 Jul 2021 17:40:46 GMT
 
 _Version update only_
 
 ## 2.16.7
-
 Mon, 28 Jun 2021 18:13:04 GMT
 
 _Version update only_
 
 ## 2.16.6
-
 Mon, 28 Jun 2021 13:12:55 GMT
 
 _Version update only_
 
 ## 2.16.5
-
 Fri, 25 Jun 2021 16:03:01 GMT
 
 _Version update only_
 
 ## 2.16.4
-
 Wed, 23 Jun 2021 17:09:07 GMT
 
 _Version update only_
 
 ## 2.16.3
-
 Wed, 16 Jun 2021 20:29:32 GMT
 
 _Version update only_
 
 ## 2.16.2
-
 Thu, 03 Jun 2021 18:08:11 GMT
 
 _Version update only_
 
 ## 2.16.1
-
 Thu, 27 May 2021 20:04:22 GMT
 
 _Version update only_
 
 ## 2.16.0
-
 Mon, 24 May 2021 15:58:39 GMT
 
 ### Updates
@@ -1146,25 +984,21 @@ Mon, 24 May 2021 15:58:39 GMT
 - Fix GlobalContextMenu layout issue in presentation-test-app by setting display:none on anchoring div.
 
 ## 2.15.6
-
 Wed, 26 May 2021 15:55:19 GMT
 
 _Version update only_
 
 ## 2.15.5
-
 Thu, 20 May 2021 15:06:26 GMT
 
 _Version update only_
 
 ## 2.15.4
-
 Tue, 18 May 2021 21:59:07 GMT
 
 _Version update only_
 
 ## 2.15.3
-
 Mon, 17 May 2021 13:31:38 GMT
 
 ### Updates
@@ -1172,19 +1006,16 @@ Mon, 17 May 2021 13:31:38 GMT
 - Wrap resizeObserver in a windows animation frame to prevent loop limit exceeded error.
 
 ## 2.15.2
-
 Wed, 12 May 2021 18:08:13 GMT
 
 _Version update only_
 
 ## 2.15.1
-
 Wed, 05 May 2021 13:18:31 GMT
 
 _Version update only_
 
 ## 2.15.0
-
 Fri, 30 Apr 2021 12:36:58 GMT
 
 ### Updates
@@ -1192,13 +1023,11 @@ Fri, 30 Apr 2021 12:36:58 GMT
 - Add more descriptive UiSettingsStorage, LocalSettingsStorage, and SessionSettingsStorage and deprecate badly name beta classes.
 
 ## 2.14.4
-
 Thu, 22 Apr 2021 21:07:34 GMT
 
 _Version update only_
 
 ## 2.14.3
-
 Thu, 15 Apr 2021 15:13:16 GMT
 
 ### Updates
@@ -1206,19 +1035,16 @@ Thu, 15 Apr 2021 15:13:16 GMT
 - Fix z-index of statusbar overflow panel to show footer popups.
 
 ## 2.14.2
-
 Thu, 08 Apr 2021 14:30:09 GMT
 
 _Version update only_
 
 ## 2.14.1
-
 Mon, 05 Apr 2021 16:28:00 GMT
 
 _Version update only_
 
 ## 2.14.0
-
 Fri, 02 Apr 2021 13:18:42 GMT
 
 ### Updates
@@ -1231,7 +1057,6 @@ Fri, 02 Apr 2021 13:18:42 GMT
 - Support for Focus into Tool Settings
 
 ## 2.13.0
-
 Tue, 09 Mar 2021 20:28:13 GMT
 
 ### Updates
@@ -1245,47 +1070,40 @@ Tue, 09 Mar 2021 20:28:13 GMT
 - begin rename project from iModel.js to iTwin.js
 
 ## 2.12.3
-
 Mon, 08 Mar 2021 15:32:00 GMT
 
 _Version update only_
 
 ## 2.12.2
-
 Wed, 03 Mar 2021 18:48:53 GMT
 
 _Version update only_
 
 ## 2.12.1
-
 Tue, 23 Feb 2021 20:54:45 GMT
 
 _Version update only_
 
 ## 2.12.0
-
 Thu, 18 Feb 2021 22:10:13 GMT
 
 ### Updates
 
-- Allow target \_blank in Message boxes if secure relationships exist on the element
+- Allow target _blank in Message boxes if secure relationships exist on the element
 - AccuDraw bi-directional value updates
 - Wrap the props.valueChanged call in the SearchBox to prevent a state change when the value has not really changed. This generally only happens when a valueChangedDelay is specified.
 
 ## 2.11.2
-
 Thu, 18 Feb 2021 02:50:59 GMT
 
 _Version update only_
 
 ## 2.11.1
-
 Thu, 04 Feb 2021 17:22:41 GMT
 
 _Version update only_
 
 ## 2.11.0
-
 Thu, 28 Jan 2021 13:39:27 GMT
 
 ### Updates
@@ -1306,25 +1124,21 @@ Thu, 28 Jan 2021 13:39:27 GMT
 - Added disabled support to Select component options
 
 ## 2.10.3
-
 Fri, 08 Jan 2021 18:34:03 GMT
 
 _Version update only_
 
 ## 2.10.2
-
 Fri, 08 Jan 2021 14:52:02 GMT
 
 _Version update only_
 
 ## 2.10.1
-
 Tue, 22 Dec 2020 00:53:38 GMT
 
 _Version update only_
 
 ## 2.10.0
-
 Fri, 18 Dec 2020 18:24:01 GMT
 
 ### Updates
@@ -1339,37 +1153,31 @@ Fri, 18 Dec 2020 18:24:01 GMT
 - Unified UI typography systems
 
 ## 2.9.9
-
 Sun, 13 Dec 2020 19:00:03 GMT
 
 _Version update only_
 
 ## 2.9.8
-
 Fri, 11 Dec 2020 02:57:36 GMT
 
 _Version update only_
 
 ## 2.9.7
-
 Wed, 09 Dec 2020 20:58:23 GMT
 
 _Version update only_
 
 ## 2.9.6
-
 Mon, 07 Dec 2020 18:40:48 GMT
 
 _Version update only_
 
 ## 2.9.5
-
 Sat, 05 Dec 2020 01:55:56 GMT
 
 _Version update only_
 
 ## 2.9.4
-
 Wed, 02 Dec 2020 20:55:40 GMT
 
 ### Updates
@@ -1377,19 +1185,16 @@ Wed, 02 Dec 2020 20:55:40 GMT
 - Clear FocusTrap timeout on unmount.
 
 ## 2.9.3
-
 Mon, 23 Nov 2020 20:57:56 GMT
 
 _Version update only_
 
 ## 2.9.2
-
 Mon, 23 Nov 2020 15:33:50 GMT
 
 _Version update only_
 
 ## 2.9.1
-
 Thu, 19 Nov 2020 17:03:42 GMT
 
 ### Updates
@@ -1397,7 +1202,6 @@ Thu, 19 Nov 2020 17:03:42 GMT
 - Added AutoSuggest props - renderInputComponent, renderSuggestionsContainer, onSuggestionsClearRequested
 
 ## 2.9.0
-
 Wed, 18 Nov 2020 16:01:50 GMT
 
 ### Updates
@@ -1410,13 +1214,11 @@ Wed, 18 Nov 2020 16:01:50 GMT
 - Added ProgressSpinner component
 
 ## 2.8.1
-
 Tue, 03 Nov 2020 00:33:56 GMT
 
 _Version update only_
 
 ## 2.8.0
-
 Fri, 23 Oct 2020 17:04:02 GMT
 
 ### Updates
@@ -1428,37 +1230,31 @@ Fri, 23 Oct 2020 17:04:02 GMT
 - Added jsdoc ESLint rule for UI packages
 
 ## 2.7.6
-
 Wed, 11 Nov 2020 16:28:23 GMT
 
 _Version update only_
 
 ## 2.7.5
-
 Fri, 23 Oct 2020 16:23:51 GMT
 
 _Version update only_
 
 ## 2.7.4
-
 Mon, 19 Oct 2020 17:57:02 GMT
 
 _Version update only_
 
 ## 2.7.3
-
 Wed, 14 Oct 2020 17:00:59 GMT
 
 _Version update only_
 
 ## 2.7.2
-
 Tue, 13 Oct 2020 18:20:39 GMT
 
 _Version update only_
 
 ## 2.7.1
-
 Thu, 08 Oct 2020 13:04:35 GMT
 
 ### Updates
@@ -1466,7 +1262,6 @@ Thu, 08 Oct 2020 13:04:35 GMT
 - Revert changes made to limit focus trap to contents only. Use class now to ignore unwanted focus target.
 
 ## 2.7.0
-
 Fri, 02 Oct 2020 18:03:32 GMT
 
 ### Updates
@@ -1482,37 +1277,31 @@ Fri, 02 Oct 2020 18:03:32 GMT
 - Minor styling fixes to ThemedSelect.
 
 ## 2.6.5
-
 Sat, 26 Sep 2020 16:06:34 GMT
 
 _Version update only_
 
 ## 2.6.4
-
 Tue, 22 Sep 2020 17:40:07 GMT
 
 _Version update only_
 
 ## 2.6.3
-
 Mon, 21 Sep 2020 14:47:10 GMT
 
 _Version update only_
 
 ## 2.6.2
-
 Mon, 21 Sep 2020 13:07:44 GMT
 
 _Version update only_
 
 ## 2.6.1
-
 Fri, 18 Sep 2020 13:15:09 GMT
 
 _Version update only_
 
 ## 2.6.0
-
 Thu, 17 Sep 2020 13:16:12 GMT
 
 ### Updates
@@ -1530,37 +1319,31 @@ Thu, 17 Sep 2020 13:16:12 GMT
 - Add ThemedEnumEditor for DialogItems and ToolSettings, using the ThemedSelect component.
 
 ## 2.5.5
-
 Wed, 02 Sep 2020 17:42:23 GMT
 
 _Version update only_
 
 ## 2.5.4
-
 Fri, 28 Aug 2020 15:34:15 GMT
 
 _Version update only_
 
 ## 2.5.3
-
 Wed, 26 Aug 2020 11:46:00 GMT
 
 _Version update only_
 
 ## 2.5.2
-
 Tue, 25 Aug 2020 22:09:08 GMT
 
 _Version update only_
 
 ## 2.5.1
-
 Mon, 24 Aug 2020 18:13:04 GMT
 
 _Version update only_
 
 ## 2.5.0
-
 Thu, 20 Aug 2020 20:57:10 GMT
 
 ### Updates
@@ -1579,19 +1362,16 @@ Thu, 20 Aug 2020 20:57:10 GMT
 - Update to @bentley/react-scripts@3.4.2
 
 ## 2.4.2
-
 Fri, 14 Aug 2020 16:34:09 GMT
 
 _Version update only_
 
 ## 2.4.1
-
 Fri, 07 Aug 2020 19:57:43 GMT
 
 _Version update only_
 
 ## 2.4.0
-
 Tue, 28 Jul 2020 16:26:24 GMT
 
 ### Updates
@@ -1609,13 +1389,11 @@ Tue, 28 Jul 2020 16:26:24 GMT
 - Replace slider specific Tooltip with generic Tooltip.
 
 ## 2.3.3
-
 Thu, 23 Jul 2020 12:57:15 GMT
 
 _Version update only_
 
 ## 2.3.2
-
 Tue, 14 Jul 2020 23:50:36 GMT
 
 ### Updates
@@ -1623,13 +1401,11 @@ Tue, 14 Jul 2020 23:50:36 GMT
 - Fixed Checkbox sizing/rendering & Dialog focus problems
 
 ## 2.3.1
-
 Mon, 13 Jul 2020 18:50:14 GMT
 
 _Version update only_
 
 ## 2.3.0
-
 Fri, 10 Jul 2020 17:23:14 GMT
 
 ### Updates
@@ -1643,13 +1419,11 @@ Fri, 10 Jul 2020 17:23:14 GMT
 - Support for indeterminate state in Checkbox component
 
 ## 2.2.1
-
 Tue, 07 Jul 2020 14:44:52 GMT
 
 _Version update only_
 
 ## 2.2.0
-
 Fri, 19 Jun 2020 14:10:03 GMT
 
 ### Updates
@@ -1665,7 +1439,6 @@ Fri, 19 Jun 2020 14:10:03 GMT
 - Specify the props that can passed to ThemedSelect instead of just allowing all the react-select props.
 
 ## 2.1.0
-
 Thu, 28 May 2020 22:48:59 GMT
 
 ### Updates
@@ -1680,7 +1453,6 @@ Thu, 28 May 2020 22:48:59 GMT
 - Add ThemedSelect, a react-select component that uses iModel.js UI theming.
 
 ## 2.0.0
-
 Wed, 06 May 2020 13:17:49 GMT
 
 ### Updates
@@ -1700,7 +1472,7 @@ Wed, 06 May 2020 13:17:49 GMT
 - Made React functional component specifications consistent across UI packages
 - Slider component tooltipBelow prop & tooltip styling
 - Added API in MessageManager to display either a Toast or Sticky message using React components.
-- Updates to remove need for svg-sprite-loader, use default CRA svgr loader instead.
+-  Updates to remove need for svg-sprite-loader, use default CRA svgr loader instead.
 - Revert back to using svg-sprite-loader and sprite resourceQuery.
 - Upgrade to Rush 5.23.2
 - Fixed Safari browser issues
@@ -1731,7 +1503,6 @@ Wed, 06 May 2020 13:17:49 GMT
 - set z-index on toolSettings overflow panel
 
 ## 1.14.1
-
 Wed, 22 Apr 2020 19:04:00 GMT
 
 ### Updates
@@ -1739,13 +1510,11 @@ Wed, 22 Apr 2020 19:04:00 GMT
 - Documentation
 
 ## 1.14.0
-
 Tue, 31 Mar 2020 15:44:19 GMT
 
 _Version update only_
 
 ## 1.13.0
-
 Wed, 04 Mar 2020 16:16:31 GMT
 
 ### Updates
@@ -1753,7 +1522,6 @@ Wed, 04 Mar 2020 16:16:31 GMT
 - Placeholder text not supported by Select component
 
 ## 1.12.0
-
 Wed, 12 Feb 2020 17:45:50 GMT
 
 ### Updates
@@ -1762,7 +1530,6 @@ Wed, 12 Feb 2020 17:45:50 GMT
 - Added useDisposable hook
 
 ## 1.11.0
-
 Wed, 22 Jan 2020 19:24:12 GMT
 
 ### Updates
@@ -1771,7 +1538,6 @@ Wed, 22 Jan 2020 19:24:12 GMT
 - Upgrade to TypeScript 3.7.2.
 
 ## 1.10.0
-
 Tue, 07 Jan 2020 19:44:01 GMT
 
 ### Updates
@@ -1779,7 +1545,6 @@ Tue, 07 Jan 2020 19:44:01 GMT
 - Fixed lgtm issues in UI folders
 
 ## 1.9.0
-
 Tue, 10 Dec 2019 18:08:56 GMT
 
 ### Updates
@@ -1793,7 +1558,6 @@ Tue, 10 Dec 2019 18:08:56 GMT
 - Added ConditionalField and FooterModeField components. StatusBar responsive changes.
 
 ## 1.8.0
-
 Fri, 22 Nov 2019 14:03:34 GMT
 
 ### Updates
@@ -1809,7 +1573,6 @@ Fri, 22 Nov 2019 14:03:34 GMT
 - Update Statusbar index scss file.
 
 ## 1.7.0
-
 Fri, 01 Nov 2019 13:28:37 GMT
 
 ### Updates
@@ -1825,7 +1588,6 @@ Fri, 01 Nov 2019 13:28:37 GMT
 - Added useLifecycleLogging hook to help debugging react functional components
 
 ## 1.6.0
-
 Wed, 09 Oct 2019 20:28:42 GMT
 
 ### Updates
@@ -1833,7 +1595,6 @@ Wed, 09 Oct 2019 20:28:42 GMT
 - Added AutoSuggest component and improved KeyinBrowser component
 
 ## 1.5.0
-
 Mon, 30 Sep 2019 22:28:48 GMT
 
 ### Updates
@@ -1846,7 +1607,6 @@ Mon, 30 Sep 2019 22:28:48 GMT
 - Upgrade to TypeScript 3.6.2
 
 ## 1.4.0
-
 Tue, 10 Sep 2019 12:09:49 GMT
 
 ### Updates
@@ -1862,7 +1622,6 @@ Tue, 10 Sep 2019 12:09:49 GMT
 - Added VerticalTabs component to ui-core
 
 ## 1.3.0
-
 Tue, 13 Aug 2019 20:25:53 GMT
 
 ### Updates
@@ -1878,7 +1637,6 @@ Tue, 13 Aug 2019 20:25:53 GMT
 - Update to latest icon package version.
 
 ## 1.2.0
-
 Wed, 24 Jul 2019 11:47:26 GMT
 
 ### Updates
@@ -1896,7 +1654,6 @@ Wed, 24 Jul 2019 11:47:26 GMT
 - Update light and dark theme colors.
 
 ## 1.1.0
-
 Mon, 01 Jul 2019 19:04:29 GMT
 
 ### Updates
@@ -1911,7 +1668,6 @@ Mon, 01 Jul 2019 19:04:29 GMT
 - ui-component unit tests. NumericInput strict=true default.
 
 ## 1.0.0
-
 Mon, 03 Jun 2019 18:09:39 GMT
 
 ### Updates
@@ -1928,7 +1684,6 @@ Mon, 03 Jun 2019 18:09:39 GMT
 - Remove unused z-index layers and move backstage to the end (since zones no longer create a stacking context).
 
 ## 0.191.0
-
 Mon, 13 May 2019 15:52:05 GMT
 
 ### Updates
@@ -1951,7 +1706,7 @@ Mon, 13 May 2019 15:52:05 GMT
 - Added ViewportDialog in ui-test-app, ui-core/ContributeGuidelines.md. TSLint rules in ui-core for no-default-export & completed-docs. @beta release tags.
 - Update icons-generic-webfont version to latest available.
 - Added TableProp to hide header and supporting style changes
-- Fixed \_scrollbar.scss include
+- Fixed _scrollbar.scss include
 - Modify GlobalContextMenu to better follow UX guidelines
 - Added release tags to ui-framework, ui-components and ui-core.
 - UI documentation - added to Learning section
@@ -1963,7 +1718,6 @@ Mon, 13 May 2019 15:52:05 GMT
 - Upgrade TypeDoc dependency to 0.14.2
 
 ## 0.190.0
-
 Thu, 14 Mar 2019 14:26:49 GMT
 
 ### Updates
@@ -1974,7 +1728,6 @@ Thu, 14 Mar 2019 14:26:49 GMT
 - Restructure `Node` component to allow more flexible layout
 
 ## 0.189.0
-
 Wed, 06 Mar 2019 15:41:22 GMT
 
 ### Updates
@@ -2013,31 +1766,26 @@ Wed, 06 Mar 2019 15:41:22 GMT
 - Upgrade to TypeScript 3.2.2
 
 ## 0.188.0
-
 Wed, 16 Jan 2019 16:36:09 GMT
 
 _Version update only_
 
 ## 0.187.0
-
 Tue, 15 Jan 2019 15:18:59 GMT
 
 _Version update only_
 
 ## 0.186.0
-
 Mon, 14 Jan 2019 23:09:10 GMT
 
 _Version update only_
 
 ## 0.185.0
-
 Fri, 11 Jan 2019 18:29:00 GMT
 
 _Version update only_
 
 ## 0.184.0
-
 Thu, 10 Jan 2019 22:46:17 GMT
 
 ### Updates
@@ -2045,25 +1793,21 @@ Thu, 10 Jan 2019 22:46:17 GMT
 - Ensure unique relative file paths.
 
 ## 0.183.0
-
 Mon, 07 Jan 2019 21:49:21 GMT
 
 _Version update only_
 
 ## 0.182.0
-
 Mon, 07 Jan 2019 13:31:34 GMT
 
 _Version update only_
 
 ## 0.181.0
-
 Fri, 04 Jan 2019 13:02:40 GMT
 
 _Version update only_
 
 ## 0.180.0
-
 Wed, 02 Jan 2019 15:18:23 GMT
 
 ### Updates
@@ -2073,7 +1817,6 @@ Wed, 02 Jan 2019 15:18:23 GMT
 - TreeNode checkbox fixes
 
 ## 0.179.0
-
 Wed, 19 Dec 2018 18:26:14 GMT
 
 ### Updates
@@ -2081,13 +1824,11 @@ Wed, 19 Dec 2018 18:26:14 GMT
 - Use arrow cursor on tree nodes
 
 ## 0.178.0
-
 Thu, 13 Dec 2018 22:06:10 GMT
 
 _Version update only_
 
 ## 0.177.0
-
 Wed, 12 Dec 2018 17:21:32 GMT
 
 ### Updates
@@ -2096,25 +1837,21 @@ Wed, 12 Dec 2018 17:21:32 GMT
 - Fix tree Node checkbox-related props
 
 ## 0.176.0
-
 Mon, 10 Dec 2018 21:19:45 GMT
 
 _Version update only_
 
 ## 0.175.0
-
 Mon, 10 Dec 2018 17:08:55 GMT
 
 _Version update only_
 
 ## 0.174.0
-
 Mon, 10 Dec 2018 13:24:09 GMT
 
 _Version update only_
 
 ## 0.173.0
-
 Thu, 06 Dec 2018 22:03:29 GMT
 
 ### Updates
@@ -2123,7 +1860,6 @@ Thu, 06 Dec 2018 22:03:29 GMT
 - Custom imodelJs noDirectImport lint rule implemented, noDuplicateImport lint rule turned on.
 
 ## 0.172.0
-
 Tue, 04 Dec 2018 17:24:39 GMT
 
 ### Updates
@@ -2131,7 +1867,6 @@ Tue, 04 Dec 2018 17:24:39 GMT
 - Changed index file name to match package name, eliminate subdirectory index files, decrease usage of default exports, change imports to use other packages' index file.
 
 ## 0.171.0
-
 Mon, 03 Dec 2018 18:52:58 GMT
 
 ### Updates
@@ -2146,7 +1881,6 @@ Mon, 03 Dec 2018 18:52:58 GMT
 - Add Placeholder that can be displayed instead of tree node while it's being loaded
 
 ## 0.170.0
-
 Mon, 26 Nov 2018 19:38:42 GMT
 
 ### Updates
@@ -2158,7 +1892,6 @@ Mon, 26 Nov 2018 19:38:42 GMT
 - Added Omit type definition to Utils.
 
 ## 0.169.0
-
 Tue, 20 Nov 2018 16:17:15 GMT
 
 ### Updates
@@ -2166,13 +1899,11 @@ Tue, 20 Nov 2018 16:17:15 GMT
 - Base Tree component improvements to allow virtualization
 
 ## 0.168.0
-
 Sat, 17 Nov 2018 14:20:11 GMT
 
 _Version update only_
 
 ## 0.167.0
-
 Fri, 16 Nov 2018 21:45:44 GMT
 
 ### Updates
@@ -2182,19 +1913,16 @@ Fri, 16 Nov 2018 21:45:44 GMT
 - ui-framework unit tests & docs
 
 ## 0.166.0
-
 Mon, 12 Nov 2018 16:42:10 GMT
 
 _Version update only_
 
 ## 0.165.0
-
 Mon, 12 Nov 2018 15:47:00 GMT
 
 _Version update only_
 
 ## 0.164.0
-
 Thu, 08 Nov 2018 17:59:21 GMT
 
 ### Updates
@@ -2206,7 +1934,6 @@ Thu, 08 Nov 2018 17:59:21 GMT
 - Zone & Widget initial state, more ui-core unit tests, cleaned up ui-framework index.ts files.
 
 ## 0.163.0
-
 Wed, 31 Oct 2018 20:55:37 GMT
 
 ### Updates
@@ -2214,7 +1941,6 @@ Wed, 31 Oct 2018 20:55:37 GMT
 - Added JSX specification for Frontstage, Zone & Widget
 
 ## 0.162.0
-
 Wed, 24 Oct 2018 19:20:07 GMT
 
 ### Updates
@@ -2225,31 +1951,26 @@ Wed, 24 Oct 2018 19:20:07 GMT
 - Added an ElementSeparator component which allows resizing ratio between left/right column or upper/lower row.
 
 ## 0.161.0
-
 Fri, 19 Oct 2018 13:04:14 GMT
 
 _Version update only_
 
 ## 0.160.0
-
 Wed, 17 Oct 2018 18:18:38 GMT
 
 _Version update only_
 
 ## 0.159.0
-
 Tue, 16 Oct 2018 14:09:09 GMT
 
 _Version update only_
 
 ## 0.158.0
-
 Mon, 15 Oct 2018 19:36:09 GMT
 
 _Version update only_
 
 ## 0.157.0
-
 Sun, 14 Oct 2018 17:20:06 GMT
 
 ### Updates
@@ -2257,9 +1978,9 @@ Sun, 14 Oct 2018 17:20:06 GMT
 - Fixing scripts for linux
 
 ## 0.156.0
-
 Fri, 12 Oct 2018 23:00:10 GMT
 
 ### Updates
 
 - Initial release
+

--- a/ui/core-react/package.json
+++ b/ui/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/core-react",
-  "version": "5.5.0",
+  "version": "5.4.0",
   "description": "A react component library of iTwin.js UI general purpose components",
   "type": "module",
   "types": "./lib/core-react.d.ts",

--- a/ui/imodel-components-react/CHANGELOG.md
+++ b/ui/imodel-components-react/CHANGELOG.md
@@ -1,21 +1,6 @@
 # Change Log - @itwin/imodel-components-react
 
-## 5.5.0
-
-### Minor Changes
-
-- c619667: Updated peer dependencies to support iTwin.js core v5 packages.
-
-### Patch Changes
-
-- Updated dependencies [c619667]
-- Updated dependencies [c619667]
-- Updated dependencies [a69108d]
-  - @itwin/components-react@5.5.0
-  - @itwin/core-react@5.5.0
-
 ## 5.4.0
-
 Thu, 17 Apr 2025 09:55:41 GMT
 
 ### Updates
@@ -23,25 +8,21 @@ Thu, 17 Apr 2025 09:55:41 GMT
 - Added Quantity and Weight property editor specifications for the new editors system.
 
 ## 5.3.1
-
 Thu, 20 Mar 2025 11:10:28 GMT
 
 _Version update only_
 
 ## 5.3.0
-
 Fri, 14 Mar 2025 17:37:48 GMT
 
 _Version update only_
 
 ## 5.2.0
-
 Thu, 27 Feb 2025 08:07:36 GMT
 
 _Version update only_
 
 ## 5.1.0
-
 Thu, 30 Jan 2025 09:15:23 GMT
 
 ### Updates
@@ -49,25 +30,21 @@ Thu, 30 Jan 2025 09:15:23 GMT
 - cSpell fixes
 
 ## 5.0.5
-
 Tue, 21 Jan 2025 11:38:58 GMT
 
 _Version update only_
 
 ## 5.0.4
-
 Fri, 17 Jan 2025 14:12:03 GMT
 
 _Version update only_
 
 ## 5.0.3
-
 Fri, 17 Jan 2025 11:42:02 GMT
 
 _Version update only_
 
 ## 5.0.2
-
 Thu, 16 Jan 2025 12:04:12 GMT
 
 ### Updates
@@ -75,13 +52,11 @@ Thu, 16 Jan 2025 12:04:12 GMT
 - Use import attributes for json imports.
 
 ## 5.0.1
-
 Wed, 15 Jan 2025 11:47:00 GMT
 
 _Version update only_
 
 ## 5.0.0
-
 Mon, 16 Dec 2024 11:43:27 GMT
 
 ### Updates
@@ -98,43 +73,36 @@ Mon, 16 Dec 2024 11:43:27 GMT
 - Replace buic variables with iTwinUI CSS variables.
 
 ## 4.17.6
-
 Wed, 20 Nov 2024 14:27:46 GMT
 
 _Version update only_
 
 ## 4.17.5
-
 Thu, 14 Nov 2024 08:22:04 GMT
 
 _Version update only_
 
 ## 4.17.4
-
 Fri, 08 Nov 2024 14:41:23 GMT
 
 _Version update only_
 
 ## 4.17.3
-
 Wed, 06 Nov 2024 09:04:20 GMT
 
 _Version update only_
 
 ## 4.17.2
-
 Wed, 30 Oct 2024 14:46:15 GMT
 
 _Version update only_
 
 ## 4.17.1
-
 Wed, 09 Oct 2024 10:50:47 GMT
 
 _Version update only_
 
 ## 4.17.0
-
 Thu, 19 Sep 2024 12:50:53 GMT
 
 ### Updates
@@ -142,37 +110,31 @@ Thu, 19 Sep 2024 12:50:53 GMT
 - Deprecated component props in favor of type helper
 
 ## 4.16.5
-
 Tue, 10 Sep 2024 16:40:46 GMT
 
 _Version update only_
 
 ## 4.16.4
-
 Wed, 04 Sep 2024 08:10:19 GMT
 
 _Version update only_
 
 ## 4.16.3
-
 Tue, 03 Sep 2024 14:32:22 GMT
 
 _Version update only_
 
 ## 4.16.2
-
 Wed, 28 Aug 2024 06:32:12 GMT
 
 _Version update only_
 
 ## 4.16.1
-
 Fri, 16 Aug 2024 08:18:14 GMT
 
 _Version update only_
 
 ## 4.16.0
-
 Wed, 07 Aug 2024 12:38:32 GMT
 
 ### Updates
@@ -181,67 +143,56 @@ Wed, 07 Aug 2024 12:38:32 GMT
 - Added `trackContainerProps` property to `TimelineComponent`.
 
 ## 4.15.5
-
 Wed, 24 Jul 2024 16:09:26 GMT
 
 _Version update only_
 
 ## 4.15.4
-
 Mon, 22 Jul 2024 21:27:52 GMT
 
 _Version update only_
 
 ## 4.15.3
-
 Mon, 15 Jul 2024 12:12:01 GMT
 
 _Version update only_
 
 ## 4.15.2
-
 Wed, 10 Jul 2024 11:54:56 GMT
 
 _Version update only_
 
 ## 4.15.1
-
 Tue, 09 Jul 2024 09:23:12 GMT
 
 _Version update only_
 
 ## 4.15.0
-
 Fri, 28 Jun 2024 09:09:37 GMT
 
 _Version update only_
 
 ## 4.14.2
-
 Mon, 22 Jul 2024 21:23:09 GMT
 
 _Version update only_
 
 ## 4.14.1
-
 Tue, 11 Jun 2024 15:58:29 GMT
 
 _Version update only_
 
 ## 4.14.0
-
 Thu, 06 Jun 2024 08:24:21 GMT
 
 _Version update only_
 
 ## 4.13.4
-
 Tue, 21 May 2024 08:21:34 GMT
 
 _Version update only_
 
 ## 4.13.3
-
 Fri, 17 May 2024 09:43:31 GMT
 
 ### Updates
@@ -250,19 +201,16 @@ Fri, 17 May 2024 09:43:31 GMT
 - upgrade to TypeScript@5.3.3 and @itwin/build-tools@4.6.x
 
 ## 4.13.2
-
 Wed, 08 May 2024 08:24:46 GMT
 
 _Version update only_
 
 ## 4.13.1
-
 Tue, 07 May 2024 15:01:46 GMT
 
 _Version update only_
 
 ## 4.13.0
-
 Tue, 07 May 2024 08:44:06 GMT
 
 ### Updates
@@ -270,13 +218,11 @@ Tue, 07 May 2024 08:44:06 GMT
 - Deprecated all UI event classes.
 
 ## 4.12.0
-
 Fri, 05 Apr 2024 09:55:35 GMT
 
 _Version update only_
 
 ## 4.11.0
-
 Thu, 21 Mar 2024 16:38:04 GMT
 
 ### Updates
@@ -288,7 +234,6 @@ Thu, 21 Mar 2024 16:38:04 GMT
 - Removed memoization for translated strings in components.
 
 ## 4.10.0
-
 Mon, 26 Feb 2024 15:50:45 GMT
 
 ### Updates
@@ -297,7 +242,6 @@ Mon, 26 Feb 2024 15:50:45 GMT
 - Use iTwinUI 3.x.
 
 ## 4.9.0
-
 Tue, 06 Feb 2024 08:56:40 GMT
 
 ### Updates
@@ -305,31 +249,26 @@ Tue, 06 Feb 2024 08:56:40 GMT
 - ignore appui-abstract eslint deprecation m
 
 ## 4.8.3
-
 Tue, 30 Jan 2024 09:04:27 GMT
 
 _Version update only_
 
 ## 4.8.2
-
 Wed, 24 Jan 2024 12:37:04 GMT
 
 _Version update only_
 
 ## 4.8.1
-
 Thu, 11 Jan 2024 13:05:42 GMT
 
 _Version update only_
 
 ## 4.8.0
-
 Thu, 21 Dec 2023 14:08:43 GMT
 
 _Version update only_
 
 ## 4.7.2
-
 Wed, 20 Dec 2023 23:11:37 GMT
 
 ### Updates
@@ -337,7 +276,6 @@ Wed, 20 Dec 2023 23:11:37 GMT
 - Revert Viewport creation delay from 0x0.
 
 ## 4.7.1
-
 Thu, 07 Dec 2023 19:40:17 GMT
 
 ### Updates
@@ -345,7 +283,6 @@ Thu, 07 Dec 2023 19:40:17 GMT
 - `ViewportComponent` will now wait to have positive space before creating iTwin.js viewport.
 
 ## 4.7.0
-
 Fri, 01 Dec 2023 20:01:16 GMT
 
 ### Updates
@@ -355,49 +292,41 @@ Fri, 01 Dec 2023 20:01:16 GMT
 - Remove additional `changeView` call on `ViewportComponent` mount.
 
 ## 4.6.3
-
 Wed, 25 Oct 2023 09:39:22 GMT
 
 _Version update only_
 
 ## 4.6.2
-
 Tue, 17 Oct 2023 19:16:23 GMT
 
 _Version update only_
 
 ## 4.6.1
-
 Thu, 12 Oct 2023 16:59:20 GMT
 
 _Version update only_
 
 ## 4.6.0
-
 Wed, 04 Oct 2023 18:05:34 GMT
 
 _Version update only_
 
 ## 4.5.1
-
 Fri, 08 Sep 2023 16:10:53 GMT
 
 _Version update only_
 
 ## 4.5.0
-
 Wed, 06 Sep 2023 17:29:22 GMT
 
 _Version update only_
 
 ## 4.4.0
-
 Tue, 15 Aug 2023 18:02:09 GMT
 
 _Version update only_
 
 ## 4.3.0
-
 Mon, 17 Jul 2023 10:16:20 GMT
 
 ### Updates
@@ -405,7 +334,6 @@ Mon, 17 Jul 2023 10:16:20 GMT
 - Update sinon to 15.2.0 and @types/sinon to 10.0.15
 
 ## 4.2.0
-
 Tue, 27 Jun 2023 14:50:22 GMT
 
 ### Updates
@@ -414,7 +342,6 @@ Tue, 27 Jun 2023 14:50:22 GMT
 - Update `@itwin/itwinui-react` version to 2.11.6.
 
 ## 4.1.0
-
 Mon, 29 May 2023 14:05:04 GMT
 
 ### Updates
@@ -423,13 +350,11 @@ Mon, 29 May 2023 14:05:04 GMT
 - Change arrow-click rotation logic to allow rotation to rotated faces.
 
 ## 4.0.1
-
 Fri, 19 May 2023 12:24:31 GMT
 
 _Version update only_
 
 ## 4.0.0
-
 Mon, 01 May 2023 13:32:16 GMT
 
 ### Updates
@@ -448,19 +373,16 @@ Mon, 01 May 2023 13:32:16 GMT
 - Remove webfont icons from components.
 
 ## 3.7.2
-
 Wed, 12 Apr 2023 13:12:42 GMT
 
 _Version update only_
 
 ## 3.7.1
-
 Mon, 03 Apr 2023 15:15:37 GMT
 
 _Version update only_
 
 ## 3.7.0
-
 Wed, 29 Mar 2023 15:02:27 GMT
 
 ### Updates
@@ -471,25 +393,21 @@ Wed, 29 Mar 2023 15:02:27 GMT
 - Update @deprecated comments
 
 ## 3.6.3
-
 Mon, 27 Mar 2023 16:26:47 GMT
 
 _Version update only_
 
 ## 3.6.2
-
 Fri, 17 Mar 2023 17:52:32 GMT
 
 _Version update only_
 
 ## 3.6.1
-
 Fri, 24 Feb 2023 22:00:48 GMT
 
 _Version update only_
 
 ## 3.6.0
-
 Wed, 08 Feb 2023 14:58:40 GMT
 
 ### Updates
@@ -497,43 +415,36 @@ Wed, 08 Feb 2023 14:58:40 GMT
 - Use EmptyLocalization for localization in tests to increase test performance
 
 ## 3.5.6
-
 Fri, 24 Feb 2023 16:02:47 GMT
 
 _Version update only_
 
 ## 3.5.5
-
 Thu, 26 Jan 2023 22:53:27 GMT
 
 _Version update only_
 
 ## 3.5.4
-
 Wed, 18 Jan 2023 15:27:15 GMT
 
 _Version update only_
 
 ## 3.5.3
-
 Fri, 13 Jan 2023 17:23:07 GMT
 
 _Version update only_
 
 ## 3.5.2
-
 Wed, 11 Jan 2023 16:46:30 GMT
 
 _Version update only_
 
 ## 3.5.1
-
 Thu, 15 Dec 2022 16:38:29 GMT
 
 _Version update only_
 
 ## 3.5.0
-
 Wed, 07 Dec 2022 19:12:37 GMT
 
 ### Updates
@@ -541,49 +452,41 @@ Wed, 07 Dec 2022 19:12:37 GMT
 - Unpin classnames package
 
 ## 3.4.7
-
 Wed, 30 Nov 2022 14:28:19 GMT
 
 _Version update only_
 
 ## 3.4.6
-
 Tue, 22 Nov 2022 14:24:19 GMT
 
 _Version update only_
 
 ## 3.4.5
-
 Thu, 17 Nov 2022 21:32:50 GMT
 
 _Version update only_
 
 ## 3.4.4
-
 Thu, 10 Nov 2022 19:32:17 GMT
 
 _Version update only_
 
 ## 3.4.3
-
 Fri, 28 Oct 2022 13:34:58 GMT
 
 _Version update only_
 
 ## 3.4.2
-
 Mon, 24 Oct 2022 13:23:45 GMT
 
 _Version update only_
 
 ## 3.4.1
-
 Mon, 17 Oct 2022 20:06:51 GMT
 
 _Version update only_
 
 ## 3.4.0
-
 Thu, 13 Oct 2022 20:24:47 GMT
 
 ### Updates
@@ -592,37 +495,31 @@ Thu, 13 Oct 2022 20:24:47 GMT
 - Fix/Remove skipped tests
 
 ## 3.3.5
-
 Tue, 27 Sep 2022 11:50:59 GMT
 
 _Version update only_
 
 ## 3.3.4
-
 Thu, 08 Sep 2022 19:00:05 GMT
 
 _Version update only_
 
 ## 3.3.3
-
 Tue, 06 Sep 2022 20:54:19 GMT
 
 _Version update only_
 
 ## 3.3.2
-
 Thu, 01 Sep 2022 14:37:22 GMT
 
 _Version update only_
 
 ## 3.3.1
-
 Fri, 26 Aug 2022 15:40:02 GMT
 
 _Version update only_
 
 ## 3.3.0
-
 Thu, 18 Aug 2022 19:08:02 GMT
 
 ### Updates
@@ -634,55 +531,46 @@ Thu, 18 Aug 2022 19:08:02 GMT
 - Update iTwinUI-react to 1.38.1
 
 ## 3.2.9
-
 Fri, 26 Aug 2022 14:21:40 GMT
 
 _Version update only_
 
 ## 3.2.8
-
 Tue, 09 Aug 2022 15:52:41 GMT
 
 _Version update only_
 
 ## 3.2.7
-
 Mon, 01 Aug 2022 13:36:56 GMT
 
 _Version update only_
 
 ## 3.2.6
-
 Fri, 15 Jul 2022 19:04:43 GMT
 
 _Version update only_
 
 ## 3.2.5
-
 Wed, 13 Jul 2022 15:45:53 GMT
 
 _Version update only_
 
 ## 3.2.4
-
 Tue, 21 Jun 2022 18:06:33 GMT
 
 _Version update only_
 
 ## 3.2.3
-
 Fri, 17 Jun 2022 15:18:39 GMT
 
 _Version update only_
 
 ## 3.2.2
-
 Fri, 10 Jun 2022 16:11:37 GMT
 
 _Version update only_
 
 ## 3.2.1
-
 Tue, 07 Jun 2022 15:02:56 GMT
 
 ### Updates
@@ -690,7 +578,6 @@ Tue, 07 Jun 2022 15:02:56 GMT
 - Remove fix height from ColorPicker dialog.
 
 ## 3.2.0
-
 Fri, 20 May 2022 13:10:54 GMT
 
 ### Updates
@@ -698,25 +585,21 @@ Fri, 20 May 2022 13:10:54 GMT
 - Fix for losing viewport content after clicking PW link
 
 ## 3.1.3
-
 Fri, 15 Apr 2022 13:49:25 GMT
 
 _Version update only_
 
 ## 3.1.2
-
 Wed, 06 Apr 2022 22:27:56 GMT
 
 _Version update only_
 
 ## 3.1.1
-
 Thu, 31 Mar 2022 15:55:48 GMT
 
 _Version update only_
 
 ## 3.1.0
-
 Tue, 29 Mar 2022 20:53:47 GMT
 
 ### Updates
@@ -730,19 +613,16 @@ Tue, 29 Mar 2022 20:53:47 GMT
 - Update to latest itwinui-react.
 
 ## 3.0.3
-
 Fri, 25 Mar 2022 15:10:02 GMT
 
 _Version update only_
 
 ## 3.0.2
-
 Thu, 10 Mar 2022 21:18:13 GMT
 
 _Version update only_
 
 ## 3.0.1
-
 Thu, 24 Feb 2022 15:26:55 GMT
 
 ### Updates
@@ -750,7 +630,6 @@ Thu, 24 Feb 2022 15:26:55 GMT
 - Avoid processing stale viewStates that reference closed imodels.
 
 ## 3.0.0
-
 Mon, 24 Jan 2022 14:00:52 GMT
 
 ### Updates
@@ -765,7 +644,7 @@ Mon, 24 Jan 2022 14:00:52 GMT
 - tool.run and tool.parseAndRun are now async methods
 - Deprecate obsolete code.
 - Create empty frontstage and UiItemsProviders to populate it and update how ContentGroups are defined.
-- update immer to fix security warning
+-  update immer to fix security warning
 - Deprecate and promote apis
 - Deprecate obsolete APIs. Publish beta APIs from last release.
 - Upgraded itwinui-react to 1.16.2. Fixed editor sizes.
@@ -784,3 +663,4 @@ Mon, 24 Jan 2022 14:00:52 GMT
 - Update to latest types/react package
 - Update ViewportComponent to function component that properly processes async method to get viewState.
 - Lock down and update version numbers so docs will build.
+

--- a/ui/imodel-components-react/package.json
+++ b/ui/imodel-components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/imodel-components-react",
-  "version": "5.5.0",
+  "version": "5.4.0",
   "description": "A react component library of iTwin.js UI iModel components",
   "type": "module",
   "types": "./lib/imodel-components-react.d.ts",


### PR DESCRIPTION
## Changes

This should fix a release failure due to missing `registry-url` param in `actions/setup-node@v4`:
`an error occurred while publishing @itwin/imodel-components-react: ENEEDAUTH This command requires you to be logged in to https://registry.npmjs.org/ `

## Testing

N/A
