### PR TITLE
Retry release

### DIFF
--- a/.github/workflows/changeset-release.yaml
+++ b/.github/workflows/changeset-release.yaml
@@ -14,6 +14,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Changes

This should fix a release failure due to missing `id-token` permissions:
`an error occurred while publishing @itwin/imodel-components-react: EUSAGE Provenance generation in GitHub Actions requires "write" access to the "id-token" permission`

## Testing

N/A
