### PR TITLE
Fix future releases

### DIFF
--- a/.github/workflows/changeset-release.yaml
+++ b/.github/workflows/changeset-release.yaml
@@ -15,6 +15,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Changes

This should fix future releases due to permissions failure which caused GH release creation and commit tagging failures when releasing 5.5.0.

## Testing

N/A
