### PR TITLE
Lock `@itwin/core-react` version in `@itwin/appui-react`

### DIFF
--- a/ui/appui-react/package.json
+++ b/ui/appui-react/package.json
@@ -60,7 +60,7 @@
     "@itwin/core-frontend": "^4.0.0 || ^5.0.0",
     "@itwin/core-geometry": "^4.0.0 || ^5.0.0",
     "@itwin/core-quantity": "^4.0.0 || ^5.0.0",
-    "@itwin/core-react": "workspace:^5.5.0",
+    "@itwin/core-react": "workspace:*",
     "@itwin/imodel-components-react": "workspace:*",
     "@itwin/itwinui-react": "^3.15.0",
     "react": "^18.0.0",


### PR DESCRIPTION
## Changes

This was missed by https://github.com/iTwin/appui/pull/1295

## Testing

N/A
