### PR TITLE
Fix potential infinite recursion in `dispose`

### DIFF
--- a/.changeset/curly-pumas-cover.md
+++ b/.changeset/curly-pumas-cover.md
@@ -1,0 +1,5 @@
+---
+"@itwin/components-react": patch
+---
+
+Fix potential infinite recursion in dispose methods of `TreeEventHandler` and `FilteringPropertyDataProvider` classes.

--- a/ui/components-react/src/components-react/propertygrid/dataproviders/FilteringDataProvider.ts
+++ b/ui/components-react/src/components-react/propertygrid/dataproviders/FilteringDataProvider.ts
@@ -83,15 +83,19 @@ export class FilteringPropertyDataProvider
       });
   }
 
-  /** Destructor. Must be called to clean up.  */
-  public [Symbol.dispose]() {
+  #dispose() {
     this._disposeDataChangedListener();
     this._disposeFilterChangedListener();
   }
 
+  /** Destructor. Must be called to clean up.  */
+  public [Symbol.dispose]() {
+    this.#dispose();
+  }
+
   /** @deprecated in 5.5.0. Use `[Symbol.dispose]` instead. */
   public dispose(): void {
-    this[Symbol.dispose]();
+    this.#dispose();
   }
 
   public async getData(): Promise<FilteredPropertyData> {

--- a/ui/components-react/src/components-react/tree/controlled/TreeEventHandler.ts
+++ b/ui/components-react/src/components-react/tree/controlled/TreeEventHandler.ts
@@ -67,16 +67,20 @@ export class TreeEventHandler implements TreeEvents, Disposable {
     this._editingParams = params.editingParams;
   }
 
+  #dispose() {
+    this._disposed.next();
+  }
+
   /** Destructor. Must be called to clean up.  */
   public [Symbol.dispose]() {
-    this._disposed.next();
+    this.#dispose();
   }
 
   /** Disposes tree event handler.
    * @deprecated in 5.5.0. Use `[Symbol.dispose]` instead.
    */
   public dispose() {
-    this[Symbol.dispose]();
+    this.#dispose();
   }
 
   public get modelSource() {


### PR DESCRIPTION
## Changes

This fixes a potential infinite recursion caused by superclasses that need to call `super.dispose` in their `[Symbol.dispose]` method (i.e. when needing to support older versions - before `Symbol.dispose` was introduced).

## Testing

N/A
