### PR TITLE
Lock button in new editors

### DIFF
--- a/.changeset/fluffy-gifts-judge.md
+++ b/.changeset/fluffy-gifts-judge.md
@@ -1,0 +1,27 @@
+---
+"@itwin/components-react": minor
+---
+
+Updated the `editors` prop of `EditorsRegistryProvider` component. You can now either supply a list of editors or provide a function that customizes the current list of editors, allowing full control over the final set of editors.
+
+```tsx
+// New editors are higher priority than existing ones.
+<EditorsRegistryProvider editors={(editors) => [...newEditors, ...editors]} />
+
+// New editors are lower priority than existing ones.
+<EditorsRegistryProvider editors={(editors) => [...editors, ...newEditors]} />
+
+// Filter the editors.
+<EditorsRegistryProvider
+  editors={(editors) =>
+    editors.filter((e) =>
+      e.applies(
+        {
+          type: "bool",
+        },
+        undefined
+      )
+    )
+  }
+/>
+```

--- a/.changeset/major-steaks-admire.md
+++ b/.changeset/major-steaks-admire.md
@@ -2,7 +2,7 @@
 "@itwin/appui-react": minor
 ---
 
-Updated tool settings to display the lock button as an input decoration when the `toolSettingsLockButton` preview feature is enabled.
+Updated tool settings to display the lock button as an input decoration when the `toolSettingsLockButton` preview feature is enabled. This is supported when using the new editor system via the `toolSettingsNewEditors` preview feature.
 
 A separate control will still be displayed as a sibling if the lock cannot be displayed by the editor. Common cases include:
 

--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -608,7 +608,7 @@ export interface EditorSpec {
 // @beta
 export function EditorsRegistryProvider({ children, editors, }: {
     children: React_3.ReactNode;
-    editors: EditorSpec[];
+    editors: EditorSpec[] | ((editors: EditorSpec[]) => EditorSpec[]);
 }): React_3.JSX.Element;
 
 // @public

--- a/docs/storybook/src/preview/ToolSettingsLockButton.stories.tsx
+++ b/docs/storybook/src/preview/ToolSettingsLockButton.stories.tsx
@@ -28,6 +28,7 @@ const meta = {
   },
   args: {
     toolSettingsLockButton: true,
+    toolSettingsNewEditors: false,
   },
 } satisfies Meta<typeof PreviewStory>;
 

--- a/docs/storybook/src/preview/ToolSettingsLockButton.tsx
+++ b/docs/storybook/src/preview/ToolSettingsLockButton.tsx
@@ -26,7 +26,7 @@ import {
 
 type PreviewStoryProps = Pick<
   Required<PreviewFeatures>,
-  "toolSettingsLockButton"
+  "toolSettingsLockButton" | "toolSettingsNewEditors"
 > & {
   lockLabel?: string;
   disabled?: boolean;
@@ -40,6 +40,7 @@ export function PreviewStory(props: PreviewStoryProps) {
     <PreviewFeaturesProvider
       features={{
         toolSettingsLockButton: props.toolSettingsLockButton,
+        toolSettingsNewEditors: props.toolSettingsNewEditors,
       }}
     >
       <AppUiStory

--- a/ui/appui-react/src/appui-react/editors/LockProvider.tsx
+++ b/ui/appui-react/src/appui-react/editors/LockProvider.tsx
@@ -131,7 +131,8 @@ interface UseLockPropertyArgs {
   itemPropertyName: string;
 }
 
-function useLockProperty(args: UseLockPropertyArgs | undefined) {
+/** @internal */
+export function useLockProperty(args: UseLockPropertyArgs | undefined) {
   const { provider, itemPropertyName } = args ?? {};
   const subscribe = React.useCallback(
     (onStoreChange: () => void) => {

--- a/ui/appui-react/src/appui-react/new-editors/CustomNumberEditor.tsx
+++ b/ui/appui-react/src/appui-react/new-editors/CustomNumberEditor.tsx
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import {
+  CustomNumberEditor as BaseCustomNumberEditor,
+  CustomNumberEditorSpec as BaseCustomNumberEditorSpec,
+} from "@itwin/components-react/internal";
+import { LockButtonInputDecoration } from "../editors/LockProvider.js";
+
+/* v8 ignore start */
+
+/** @internal */
+export const CustomNumberEditorSpec = {
+  ...BaseCustomNumberEditorSpec,
+  Editor: CustomNumberEditor as (typeof BaseCustomNumberEditorSpec)["Editor"],
+};
+
+type BaseCustomNumberEditorProps = React.ComponentProps<
+  typeof BaseCustomNumberEditor
+>;
+
+function CustomNumberEditor(
+  props: Omit<BaseCustomNumberEditorProps, "decoration">
+) {
+  return (
+    <BaseCustomNumberEditor
+      {...props}
+      decoration={<LockButtonInputDecoration />}
+    />
+  );
+}
+
+/* v8 ignore stop */

--- a/ui/appui-react/src/appui-react/new-editors/LockEditor.tsx
+++ b/ui/appui-react/src/appui-react/new-editors/LockEditor.tsx
@@ -32,7 +32,7 @@ export const LockEditorSpec = createEditorSpec({
 /** Used in tool settings as the default lock editor when `toolSettingsLockButton` preview feature is enabled.
  * @internal
  */
-export function LockEditor({
+function LockEditor({
   value,
   onChange,
   commit,

--- a/ui/appui-react/src/appui-react/new-editors/LockEditor.tsx
+++ b/ui/appui-react/src/appui-react/new-editors/LockEditor.tsx
@@ -37,6 +37,7 @@ export function LockEditor({
   onChange,
   commit,
   disabled,
+  size,
 }: EditorProps<ValueMetadata, BooleanValue>) {
   const context = React.useContext(PropertyEditorContext);
   const property = useLockProperty(
@@ -54,7 +55,7 @@ export function LockEditor({
   return (
     <IconButton
       label={label}
-      size="small"
+      size={size}
       styleType="borderless"
       isActive={currentValue}
       disabled={disabled}

--- a/ui/appui-react/src/appui-react/new-editors/LockEditor.tsx
+++ b/ui/appui-react/src/appui-react/new-editors/LockEditor.tsx
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import type {
+  BooleanValue,
+  EditorProps,
+  ValueMetadata,
+} from "@itwin/components-react";
+import { createEditorSpec, ValueUtilities } from "@itwin/components-react";
+import { IconButton } from "@itwin/itwinui-react";
+import { SvgLock, SvgLockUnlocked } from "@itwin/itwinui-icons-react";
+import { LockPropertyEditorName } from "../editors/LockEditor.js";
+import {
+  PropertyEditorContext,
+  useLockProperty,
+} from "../editors/LockProvider.js";
+
+/* v8 ignore start */
+
+/** @internal */
+export const LockEditorSpec = createEditorSpec({
+  isMetadataSupported: (metadata): metadata is ValueMetadata =>
+    metadata.type === "bool" &&
+    metadata.preferredEditor === LockPropertyEditorName,
+  isValueSupported: ValueUtilities.isBoolean,
+  Editor: LockEditor,
+});
+
+/** Used in tool settings as the default lock editor when `toolSettingsLockButton` preview feature is enabled.
+ * @internal
+ */
+export function LockEditor({
+  value,
+  onChange,
+  commit,
+  disabled,
+}: EditorProps<ValueMetadata, BooleanValue>) {
+  const context = React.useContext(PropertyEditorContext);
+  const property = useLockProperty(
+    context
+      ? {
+          provider: context.uiDataProvider,
+          itemPropertyName: context.itemPropertyName,
+        }
+      : undefined
+  );
+  const displayLabel = property?.property.displayLabel;
+  const label = displayLabel ? displayLabel : "Toggle lock";
+
+  const currentValue = value?.value ?? false;
+  return (
+    <IconButton
+      label={label}
+      size="small"
+      styleType="borderless"
+      isActive={currentValue}
+      disabled={disabled}
+      onClick={() => {
+        const newValue = { value: !currentValue };
+        onChange(newValue);
+        commit?.();
+      }}
+    >
+      {currentValue ? <SvgLock /> : <SvgLockUnlocked />}
+    </IconButton>
+  );
+}
+
+/* v8 ignore stop */

--- a/ui/appui-react/src/appui-react/new-editors/NumericEditor.tsx
+++ b/ui/appui-react/src/appui-react/new-editors/NumericEditor.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { InputWithDecorations } from "@itwin/itwinui-react";
 import type {
   EditorProps,
-  TextValue,
+  NumericValue,
   ValueMetadata,
 } from "@itwin/components-react";
 import { createEditorSpec, ValueUtilities } from "@itwin/components-react";
@@ -16,32 +16,43 @@ import { LockButtonInputDecoration } from "../editors/LockProvider.js";
 /* v8 ignore start */
 
 /** @internal */
-export const TextEditorSpec = createEditorSpec({
+export const NumericEditorSpec = createEditorSpec({
   isMetadataSupported: (metadata): metadata is ValueMetadata =>
-    metadata.type === "string",
-  isValueSupported: ValueUtilities.isText,
-  Editor: TextEditor,
+    metadata.type === "number",
+  isValueSupported: ValueUtilities.isNumeric,
+  Editor: NumericEditor,
 });
 
-function TextEditor({
+function NumericEditor({
   value,
   onChange,
   size,
   disabled,
-}: EditorProps<ValueMetadata, TextValue>) {
-  const currentValue = value ? value : { value: "" };
-
+}: EditorProps<ValueMetadata, NumericValue>) {
+  const currentValue = getNumericValue(value);
   return (
     <InputWithDecorations size={size}>
       <InputWithDecorations.Input
-        value={currentValue.value}
-        onChange={(e) => onChange({ value: e.target.value })}
+        value={currentValue.displayValue}
+        onChange={(e) => {
+          const parsedValue = parseFloat(e.target.value);
+          onChange({
+            rawValue: Number.isNaN(parsedValue)
+              ? undefined
+              : parseFloat(e.target.value),
+            displayValue: e.target.value,
+          });
+        }}
         size={size}
         disabled={disabled}
       />
       <LockButtonInputDecoration />
     </InputWithDecorations>
   );
+}
+
+function getNumericValue(value: NumericValue | undefined): NumericValue {
+  return value ? value : { rawValue: undefined, displayValue: "" };
 }
 
 /* v8 ignore stop */

--- a/ui/appui-react/src/appui-react/new-editors/TextEditor.tsx
+++ b/ui/appui-react/src/appui-react/new-editors/TextEditor.tsx
@@ -1,0 +1,48 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as React from "react";
+import { InputWithDecorations } from "@itwin/itwinui-react";
+import type {
+  EditorProps,
+  TextValue,
+  ValueMetadata,
+} from "@itwin/components-react";
+import { createEditorSpec, ValueUtilities } from "@itwin/components-react";
+import { LockButtonInputDecoration } from "../editors/LockProvider.js";
+
+/* v8 ignore start */
+
+/** @internal */
+export const TextEditorSpec = createEditorSpec({
+  isMetadataSupported: (metadata): metadata is ValueMetadata =>
+    metadata.type === "string",
+  isValueSupported: ValueUtilities.isText,
+  Editor: TextEditor,
+});
+
+/** @internal */
+export function TextEditor({
+  value,
+  onChange,
+  size,
+  disabled,
+}: EditorProps<ValueMetadata, TextValue>) {
+  const currentValue = value ? value : { value: "" };
+
+  return (
+    <InputWithDecorations size={size}>
+      <InputWithDecorations.Input
+        value={currentValue.value}
+        onChange={(e) => onChange({ value: e.target.value })}
+        size={size}
+        disabled={disabled}
+      />
+      <LockButtonInputDecoration />
+    </InputWithDecorations>
+  );
+}
+
+/* v8 ignore stop */

--- a/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
@@ -8,8 +8,11 @@ import {
   type PropertyRecord,
   StandardTypeNames,
 } from "@itwin/appui-abstract";
+import type { EditorSpec } from "@itwin/components-react";
+import { EditorsRegistryProvider } from "@itwin/components-react";
 import { usePreviewFeatures } from "../PreviewFeatures.js";
 import { LockPropertyEditorName } from "../../editors/LockEditor.js";
+import { LockEditorSpec } from "../../new-editors/LockEditor.js";
 
 /** @internal */
 export function useLockButtonPropertyRecord(
@@ -43,4 +46,19 @@ function isDefaultLockEditor(property: PropertyDescription) {
     return false;
   if (property.editor?.name) return false;
   return true;
+}
+
+/** @internal */
+export function ToolSettingsEditorsProvider({
+  children,
+}: React.PropsWithChildren) {
+  return (
+    <EditorsRegistryProvider
+      editors={React.useCallback((editors: EditorSpec[]) => {
+        return [...editors, LockEditorSpec];
+      }, [])}
+    >
+      {children}
+    </EditorsRegistryProvider>
+  );
 }

--- a/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
@@ -15,6 +15,7 @@ import { LockPropertyEditorName } from "../../editors/LockEditor.js";
 import { LockEditorSpec } from "../../new-editors/LockEditor.js";
 import { TextEditorSpec } from "../../new-editors/TextEditor.js";
 import { NumericEditorSpec } from "../../new-editors/NumericEditor.js";
+import { CustomNumberEditorSpec } from "../../new-editors/CustomNumberEditor.js";
 
 /** @internal */
 export function useLockButtonPropertyRecord(
@@ -57,7 +58,13 @@ export function ToolSettingsEditorsProvider({
   return (
     <EditorsRegistryProvider
       editors={React.useCallback((editors: EditorSpec[]) => {
-        return [...editors, LockEditorSpec, TextEditorSpec, NumericEditorSpec];
+        return [
+          ...editors,
+          LockEditorSpec,
+          TextEditorSpec,
+          NumericEditorSpec,
+          CustomNumberEditorSpec,
+        ];
       }, [])}
     >
       {children}

--- a/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
@@ -60,10 +60,10 @@ export function ToolSettingsEditorsProvider({
       editors={React.useCallback((editors: EditorSpec[]) => {
         return [
           ...editors,
+          CustomNumberEditorSpec,
           LockEditorSpec,
           TextEditorSpec,
           NumericEditorSpec,
-          CustomNumberEditorSpec,
         ];
       }, [])}
     >

--- a/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
@@ -13,6 +13,7 @@ import { EditorsRegistryProvider } from "@itwin/components-react";
 import { usePreviewFeatures } from "../PreviewFeatures.js";
 import { LockPropertyEditorName } from "../../editors/LockEditor.js";
 import { LockEditorSpec } from "../../new-editors/LockEditor.js";
+import { TextEditorSpec } from "../../new-editors/TextEditor.js";
 
 /** @internal */
 export function useLockButtonPropertyRecord(
@@ -55,7 +56,7 @@ export function ToolSettingsEditorsProvider({
   return (
     <EditorsRegistryProvider
       editors={React.useCallback((editors: EditorSpec[]) => {
-        return [...editors, LockEditorSpec];
+        return [...editors, LockEditorSpec, TextEditorSpec];
       }, [])}
     >
       {children}

--- a/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
+++ b/ui/appui-react/src/appui-react/preview/tool-settings-lock-button/useToolSettingsLockButton.tsx
@@ -14,6 +14,7 @@ import { usePreviewFeatures } from "../PreviewFeatures.js";
 import { LockPropertyEditorName } from "../../editors/LockEditor.js";
 import { LockEditorSpec } from "../../new-editors/LockEditor.js";
 import { TextEditorSpec } from "../../new-editors/TextEditor.js";
+import { NumericEditorSpec } from "../../new-editors/NumericEditor.js";
 
 /** @internal */
 export function useLockButtonPropertyRecord(
@@ -56,7 +57,7 @@ export function ToolSettingsEditorsProvider({
   return (
     <EditorsRegistryProvider
       editors={React.useCallback((editors: EditorSpec[]) => {
-        return [...editors, LockEditorSpec, TextEditorSpec];
+        return [...editors, LockEditorSpec, TextEditorSpec, NumericEditorSpec];
       }, [])}
     >
       {children}

--- a/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
@@ -195,11 +195,13 @@ export function ToolSettingsWidgetContent() {
       key={forceRefreshKey}
     >
       <ScrollableWidgetContent>
-        <LockProvider>
-          {node ?? frontstageDef?.activeToolEmptyNode ?? (
-            <EmptyToolSettingsLabel toolId={activeToolId} />
-          )}
-        </LockProvider>
+        <ToolSettingsEditorsProvider>
+          <LockProvider>
+            {node ?? frontstageDef?.activeToolEmptyNode ?? (
+              <EmptyToolSettingsLabel toolId={activeToolId} />
+            )}
+          </LockProvider>
+        </ToolSettingsEditorsProvider>
       </ScrollableWidgetContent>
     </div>
   );

--- a/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ToolSettings.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "../hooks/useTranslation.js";
 import { DockedBar } from "./DockedBar.js";
 import { useActiveFrontstageDef } from "../frontstage/FrontstageDef.js";
 import { LockProvider } from "../editors/LockProvider.js";
+import { ToolSettingsEditorsProvider } from "../preview/tool-settings-lock-button/useToolSettingsLockButton.js";
 
 /** Defines a ToolSettings property entry.
  * @public
@@ -88,22 +89,24 @@ export function ToolSettingsDockedContent() {
   // for the overflow to work properly each setting in the DockedToolSettings should be wrapped by a DockedToolSetting component
   return (
     <DockedBar placement="top">
-      <DockedToolSettings
-        itemId={
-          InternalFrontstageManager.activeToolSettingsProvider?.uniqueId ??
-          "none"
-        }
-        key={forceRefreshKey}
-      >
-        {entries.map((entry, index) => (
-          <DockedToolSetting key={index}>
-            <LockProvider>
-              {entry.labelNode}
-              {entry.editorNode}
-            </LockProvider>
-          </DockedToolSetting>
-        ))}
-      </DockedToolSettings>
+      <ToolSettingsEditorsProvider>
+        <DockedToolSettings
+          itemId={
+            InternalFrontstageManager.activeToolSettingsProvider?.uniqueId ??
+            "none"
+          }
+          key={forceRefreshKey}
+        >
+          {entries.map((entry, index) => (
+            <DockedToolSetting key={index}>
+              <LockProvider>
+                {entry.labelNode}
+                {entry.editorNode}
+              </LockProvider>
+            </DockedToolSetting>
+          ))}
+        </DockedToolSettings>
+      </ToolSettingsEditorsProvider>
     </DockedBar>
   );
 }

--- a/ui/components-react/src/components-react/new-editors/editors-registry/EditorsRegistryProvider.tsx
+++ b/ui/components-react/src/components-react/new-editors/editors-registry/EditorsRegistryProvider.tsx
@@ -12,8 +12,10 @@ import type { EditorSpec } from "../Types.js";
 import { EditorsRegistryContext } from "./EditorsRegistryContext.js";
 
 /**
- * Provider that adds supplied editors into `EditorsRegistry`. Multiple providers can be nested together.
- * Editors added through the lowest level provider will have the highest priority.
+ * Provider that adds supplied editors into `EditorsRegistry`.
+ * Multiple providers can be nested, with editors from the innermost provider taking the highest priority.
+ * You can either supply a list of editors or provide a function that customizes the current list of editors,
+ * allowing full control over the final set of editors.
  * @beta
  */
 export function EditorsRegistryProvider({
@@ -21,11 +23,14 @@ export function EditorsRegistryProvider({
   editors,
 }: {
   children: React.ReactNode;
-  editors: EditorSpec[];
+  editors: EditorSpec[] | ((editors: EditorSpec[]) => EditorSpec[]);
 }) {
   const parentContext = useContext(EditorsRegistryContext);
 
   const value = useMemo(() => {
+    if (typeof editors === "function") {
+      return { editors: editors(parentContext.editors) };
+    }
     return {
       editors: [...editors, ...parentContext.editors],
     };

--- a/ui/components-react/src/components-react/new-editors/interop/old-editors/CustomNumber.tsx
+++ b/ui/components-react/src/components-react/new-editors/interop/old-editors/CustomNumber.tsx
@@ -38,13 +38,20 @@ export const CustomNumberEditorSpec = createEditorSpec({
   Editor: CustomNumberEditor,
 });
 
-function CustomNumberEditor({
+interface CustomNumberEditorProps
+  extends EditorProps<OldEditorMetadata, NumericValue> {
+  decoration?: React.ReactNode;
+}
+
+/** @internal */
+export function CustomNumberEditor({
   metadata,
   value,
   onChange,
   size,
   disabled,
-}: EditorProps<OldEditorMetadata, NumericValue>) {
+  decoration,
+}: CustomNumberEditorProps) {
   const formatParams = useCustomFormattedNumberParams(metadata);
   const sizeParams = useInputEditorSizeParams(metadata);
   const iconParams = useIconEditorParams(metadata);
@@ -96,6 +103,7 @@ function CustomNumberEditor({
         onChange={handleChange}
         value={inputValue}
       />
+      {decoration}
     </InputWithDecorations>
   );
 }

--- a/ui/components-react/src/internal.ts
+++ b/ui/components-react/src/internal.ts
@@ -8,6 +8,16 @@ export { registerDefaultPropertyEditor } from "./components-react/editors/Proper
 export { useTranslation } from "./components-react/l10n/useTranslation.js";
 
 export {
+  CustomNumberEditor,
+  CustomNumberEditorSpec,
+} from "./components-react/new-editors/interop/old-editors/CustomNumber.js";
+
+export {
+  OldEditorMetadata,
+  isOldEditorMetadata,
+} from "./components-react/new-editors/interop/Metadata.js";
+
+export {
   addIconNodeParam,
   IconNodeEditorParams,
 } from "./components-react/properties/IconNodeEditorParam.js";


### PR DESCRIPTION
## Changes

This PR continues on https://github.com/iTwin/appui/pull/1311 to add lock button decoration capability when new editor system is enabled.

## Testing

N/A
