### PR TITLE
Add controlled props to `ToolAssistanceField` component

### DIFF
--- a/.changeset/moody-turkeys-spend.md
+++ b/.changeset/moody-turkeys-spend.md
@@ -1,0 +1,22 @@
+---
+"@itwin/appui-react": minor
+---
+
+Add `visible`, `onVisibleChange`, `pinned` and `onPinnedChange` props to `ToolAssistanceField` component. These props can be used to manually control the visibility and pinned state of the field.
+
+```tsx
+function CustomField(props) {
+  // Field is open by default
+  const [visible, setVisible] = React.useState(true);
+  return (
+    <ToolAssistanceField
+      {...props}
+      visible={visible}
+      // Update the state so the field can be opened/closed
+      onVisibleChange={setVisible}
+      // Field is always pinned
+      pinned={true}
+    />
+  );
+}
+```

--- a/ui/appui-react/src/appui-react/hooks/useControlledState.ts
+++ b/ui/appui-react/src/appui-react/hooks/useControlledState.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
+
+/** @internal */
+export function useControlledState<T>(
+  initialValue: T,
+  controlledState: T | undefined,
+  setControlledState?: React.Dispatch<React.SetStateAction<T>>
+) {
+  const [uncontrolledState, setUncontrolledState] =
+    React.useState<T>(initialValue);
+
+  const state = React.useMemo(
+    () => (controlledState !== undefined ? controlledState : uncontrolledState),
+    [controlledState, uncontrolledState]
+  );
+
+  const setState = React.useCallback(
+    (value) => {
+      setUncontrolledState(value);
+      setControlledState?.(value);
+    },
+    [setControlledState, setUncontrolledState]
+  ) as React.Dispatch<React.SetStateAction<T>>;
+
+  return [state, setState] as const;
+}


### PR DESCRIPTION
## Changes

This PR closes #1307 by adding `visible`, `pinned` and related `onVisibleChange`, `onPinnedChange` props to the `ToolAssistanceField` component. This change enables consumers to manually control whether the field is visible and pinned.

## Testing

Added additional story.
https://itwin.github.io/appui/1325/?path=/story/components-status-fields-toolassistancefield--controlled