### PR TITLE
Add `data-item-id` attributes to `Toolbar` component

### DIFF
--- a/.changeset/famous-apples-sing.md
+++ b/.changeset/famous-apples-sing.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Add `data-item-id` attributes to toolbar items of `Toolbar` component.

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
@@ -103,6 +103,7 @@ export function GroupMenuItem({ item, onClose }: GroupMenuItemProps) {
         }
       }}
       isSelected={isActive}
+      data-item-id={item.id}
     >
       {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
       <Badge badge={item.badge} badgeKind={item.badgeKind} />

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Item.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Item.tsx
@@ -43,6 +43,7 @@ export const Item = React.forwardRef<HTMLButtonElement, ItemProps>(
         labelProps={labelProps}
         style={props.style}
         ref={ref}
+        data-item-id={item.id}
         {...other}
       >
         {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}


### PR DESCRIPTION
## Changes

This PR closes #1322 by setting `data-item-id` attribute on toolbar items. This change is done to stay consistent with previous implementation.

## Testing

Tested via the `ToolbarComposer` story.
