### PR TITLE
Add separators to `Toolbar` component

### DIFF
--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -11,6 +11,7 @@ import {
 import {
   CommandItemDef,
   ToolItemDef,
+  ToolbarActionItem,
   ToolbarComposer,
   ToolbarHelper,
   ToolbarItemUtilities,
@@ -380,6 +381,49 @@ export const GroupIcons: Story = {
   },
 };
 
+const separatorItems = createItemFactory();
+
+export const Separators: Story = {
+  args: {
+    items: [
+      // All items of first group are hidden
+      separatorItems.createActionItem({
+        groupPriority: 1,
+        isHidden: true,
+      }),
+      // Single item in a group
+      separatorItems.createActionItem({
+        groupPriority: 2,
+      }),
+      // All items in a group are hidden
+      separatorItems.createActionItem({
+        groupPriority: 3,
+        isHidden: true,
+      }),
+      // Last item of a group is hidden
+      separatorItems.createActionItem({
+        groupPriority: 4,
+      }),
+      separatorItems.createActionItem({
+        groupPriority: 4,
+        isHidden: true,
+      }),
+      // Multiple items in a group
+      separatorItems.createActionItem({
+        groupPriority: 5,
+      }),
+      separatorItems.createActionItem({
+        groupPriority: 5,
+      }),
+      // All items of last group are hidden
+      separatorItems.createActionItem({
+        groupPriority: 6,
+        isHidden: true,
+      }),
+    ],
+  },
+};
+
 function createAbstractReactIcon() {
   const internalData = new Map();
   const icon = IconHelper.getIconData(<SvgExport />, internalData);
@@ -398,6 +442,27 @@ function createAbstractConditionalIcon() {
   return {
     internalData,
     icon,
+  };
+}
+
+function createItemFactory() {
+  let i = 0;
+  function createActionItem(
+    overrides?: Omit<Partial<ToolbarActionItem>, "icon">
+  ) {
+    const id = `item${++i}`;
+    const label = `Item ${i}`;
+    return ToolbarItemUtilities.createActionItem({
+      id,
+      label,
+      icon: <SvgPlaceholder />,
+      execute: () => action(label)(),
+      ...overrides,
+    });
+  }
+
+  return {
+    createActionItem,
   };
 }
 

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -36,6 +36,7 @@ import placeholderIcon from "@bentley/icons-generic/icons/placeholder.svg";
 import { AppUiDecorator, InitializerDecorator } from "../Decorators";
 import { withResizer } from "../../.storybook/addons/Resizer";
 import { createBumpEvent } from "../createBumpEvent";
+import { enumArgType } from "../Utils";
 
 const meta = {
   title: "Components/ToolbarComposer",
@@ -45,6 +46,10 @@ const meta = {
   args: {
     orientation: ToolbarOrientation.Horizontal,
     usage: ToolbarUsage.ContentManipulation,
+  },
+  argTypes: {
+    orientation: enumArgType(ToolbarOrientation),
+    usage: enumArgType(ToolbarUsage),
   },
   parameters: {
     layout: "centered",

--- a/ui/appui-react/src/appui-react/hooks/useSafeContext.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useSafeContext.tsx
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Hooks
+ */
+
+import * as React from "react";
+
+/** @internal */
+export function useSafeContext<C>(context: React.Context<C>) {
+  const value = React.useContext(context);
+
+  if (value === undefined) {
+    throw new Error(`${context.displayName || "Context"} is undefined`);
+  }
+
+  return value;
+}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/ActionItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/ActionItem.tsx
@@ -12,6 +12,7 @@ import { ToolGroupOverflowContext } from "./OverflowButton.js";
 import { Item } from "./Item.js";
 import { GroupMenuItem } from "./GroupItem.js";
 import { ToolbarContext } from "./Toolbar.js";
+import { useSafeContext } from "../../hooks/useSafeContext.js";
 
 interface ActionItemProps {
   item: ToolbarActionItem;
@@ -20,7 +21,7 @@ interface ActionItemProps {
 /** @internal */
 export const ActionItem = React.forwardRef<HTMLButtonElement, ActionItemProps>(
   function ActionItem({ item }, ref) {
-    const { onItemExecuted } = React.useContext(ToolbarContext) ?? {};
+    const { onItemExecuted } = useSafeContext(ToolbarContext);
     const overflowContext = React.useContext(ToolGroupOverflowContext);
     if (overflowContext) {
       return <GroupMenuItem item={item} onClose={overflowContext.onClose} />;

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/ActionItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/ActionItem.tsx
@@ -13,8 +13,7 @@ import { Item } from "./Item.js";
 import { GroupMenuItem } from "./GroupItem.js";
 import { ToolbarContext } from "./Toolbar.js";
 
-/** @internal */
-export interface ActionItemProps {
+interface ActionItemProps {
   item: ToolbarActionItem;
 }
 

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/CustomItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/CustomItem.tsx
@@ -14,6 +14,7 @@ import { Item } from "./Item.js";
 import { GroupMenuItem, usePopoverPlacement } from "./GroupItem.js";
 import { ToolGroupOverflowContext } from "./OverflowButton.js";
 import { ToolbarContext } from "./Toolbar.js";
+import { useSafeContext } from "../../hooks/useSafeContext.js";
 
 interface CustomItemProps {
   item: ToolbarCustomItem;
@@ -23,7 +24,7 @@ interface CustomItemProps {
 export const CustomItem = React.forwardRef<HTMLButtonElement, CustomItemProps>(
   function CustomItem({ item }, ref) {
     const placement = usePopoverPlacement();
-    const context = React.useContext(ToolbarContext);
+    const { setPopoverOpen } = useSafeContext(ToolbarContext);
     const overflowContext = React.useContext(ToolGroupOverflowContext);
 
     if (overflowContext) {
@@ -38,7 +39,7 @@ export const CustomItem = React.forwardRef<HTMLButtonElement, CustomItemProps>(
         }}
         placement={placement}
         onVisibleChange={(newVisible) => {
-          context?.setPopoverOpen(newVisible);
+          setPopoverOpen(newVisible);
         }}
       >
         <Item ref={ref} item={item}>

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/CustomItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/CustomItem.tsx
@@ -15,8 +15,7 @@ import { GroupMenuItem, usePopoverPlacement } from "./GroupItem.js";
 import { ToolGroupOverflowContext } from "./OverflowButton.js";
 import { ToolbarContext } from "./Toolbar.js";
 
-/** @internal */
-export interface CustomItemProps {
+interface CustomItemProps {
   item: ToolbarCustomItem;
 }
 

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
@@ -23,8 +23,7 @@ import { Badge } from "./Badge.js";
 import { ToolGroupOverflowContext } from "./OverflowButton.js";
 import { ToolbarContext } from "./Toolbar.js";
 
-/** @internal */
-export interface GroupItemProps {
+interface GroupItemProps {
   item: ToolbarGroupItem;
 }
 

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
@@ -22,6 +22,7 @@ import { Item } from "./Item.js";
 import { Badge } from "./Badge.js";
 import { ToolGroupOverflowContext } from "./OverflowButton.js";
 import { ToolbarContext } from "./Toolbar.js";
+import { useSafeContext } from "../../hooks/useSafeContext.js";
 
 interface GroupItemProps {
   item: ToolbarGroupItem;
@@ -31,7 +32,7 @@ interface GroupItemProps {
 export const GroupItem = React.forwardRef<HTMLButtonElement, GroupItemProps>(
   function GroupItem({ item }, ref) {
     const placement = usePopoverPlacement();
-    const context = React.useContext(ToolbarContext);
+    const { setPopoverOpen } = useSafeContext(ToolbarContext);
     const overflowContext = React.useContext(ToolGroupOverflowContext);
 
     if (overflowContext) {
@@ -44,7 +45,7 @@ export const GroupItem = React.forwardRef<HTMLButtonElement, GroupItemProps>(
         }}
         placement={placement}
         onVisibleChange={(newVisible) => {
-          context?.setPopoverOpen(newVisible);
+          setPopoverOpen(newVisible);
         }}
       >
         <Item item={item} ref={ref}>
@@ -57,10 +58,8 @@ export const GroupItem = React.forwardRef<HTMLButtonElement, GroupItemProps>(
 
 /** @internal */
 export function usePopoverPlacement() {
-  const context = React.useContext(ToolbarContext);
-  if (!context) return undefined;
-
-  return `${context.expandsTo}-${context.panelAlignment}` as const;
+  const { expandsTo, panelAlignment } = useSafeContext(ToolbarContext);
+  return `${expandsTo}-${panelAlignment}` as const;
 }
 
 interface GroupMenuItemProps {
@@ -70,7 +69,7 @@ interface GroupMenuItemProps {
 
 /** @internal */
 export function GroupMenuItem({ item, onClose }: GroupMenuItemProps) {
-  const { onItemExecuted } = React.useContext(ToolbarContext) ?? {};
+  const { onItemExecuted } = useSafeContext(ToolbarContext);
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const iconSpec = useConditionalProp(item.icon);
   const label = useConditionalProp(item.label);

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Item.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Item.tsx
@@ -15,9 +15,7 @@ import { useConditionalProp } from "../../hooks/useConditionalProp.js";
 import { Badge } from "./Badge.js";
 import { ToolbarContext } from "./Toolbar.js";
 
-/** @internal */
-export interface ItemProps
-  extends Partial<React.ComponentProps<typeof IconButton>> {
+interface ItemProps extends Partial<React.ComponentProps<typeof IconButton>> {
   item: ToolbarItem;
 }
 

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Item.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Item.tsx
@@ -7,13 +7,13 @@
  */
 
 import * as React from "react";
-import { assert } from "@itwin/core-bentley";
 import { Icon } from "@itwin/core-react";
 import { IconButton } from "@itwin/itwinui-react";
 import type { ToolbarItem } from "../../toolbar/ToolbarItem.js";
 import { useConditionalProp } from "../../hooks/useConditionalProp.js";
 import { Badge } from "./Badge.js";
 import { ToolbarContext } from "./Toolbar.js";
+import { useSafeContext } from "../../hooks/useSafeContext.js";
 
 interface ItemProps extends Partial<React.ComponentProps<typeof IconButton>> {
   item: ToolbarItem;
@@ -56,22 +56,12 @@ export const Item = React.forwardRef<HTMLButtonElement, ItemProps>(
 );
 
 /** @internal */
-export function useExpandsTo() {
-  const context = React.useContext(ToolbarContext);
-  assert(!!context);
-
-  const { expandsTo } = context;
-  return expandsTo;
-}
-
-/** @internal */
 export function useLabelProps() {
-  const context = React.useContext(ToolbarContext);
+  const { popoverOpen, expandsTo } = useSafeContext(ToolbarContext);
   const [internalVisible, setInternalVisible] = React.useState(false);
-  const visible = context?.popoverOpen ? false : internalVisible;
-  const placement = useExpandsTo();
+  const visible = popoverOpen ? false : internalVisible;
   return {
-    placement,
+    placement: expandsTo,
     visible,
     onVisibleChange: setInternalVisible,
   } as const;

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/OverflowButton.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/OverflowButton.tsx
@@ -13,7 +13,6 @@ import { useLabelProps } from "./Item.js";
 import { usePopoverPlacement } from "./GroupItem.js";
 import { ToolbarContext } from "./Toolbar.js";
 
-/** @internal */
 interface ToolGroupOverflow {
   onClose?: () => void;
 }

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/OverflowButton.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/OverflowButton.tsx
@@ -12,6 +12,7 @@ import { SvgMore } from "@itwin/itwinui-icons-react";
 import { useLabelProps } from "./Item.js";
 import { usePopoverPlacement } from "./GroupItem.js";
 import { ToolbarContext } from "./Toolbar.js";
+import { useSafeContext } from "../../hooks/useSafeContext.js";
 
 interface ToolGroupOverflow {
   onClose?: () => void;
@@ -33,7 +34,7 @@ export const OverflowButton = React.forwardRef<
 >(function OverflowButton(props, ref) {
   const placement = usePopoverPlacement();
   const labelProps = useLabelProps();
-  const context = React.useContext(ToolbarContext);
+  const { setPopoverOpen } = useSafeContext(ToolbarContext);
 
   return (
     <DropdownMenu
@@ -46,7 +47,7 @@ export const OverflowButton = React.forwardRef<
       }}
       placement={placement}
       onVisibleChange={(newVisible) => {
-        context?.setPopoverOpen(newVisible);
+        setPopoverOpen(newVisible);
       }}
     >
       <IconButton

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.scss
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.scss
@@ -3,23 +3,38 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .uifw-toolbar-newToolbars-separator {
-  width: 0;
   display: none;
   pointer-events: none;
+
+  &.uifw-horizontal {
+    width: 0;
+
+    &:after {
+      border-right: var(--iui-surface-border);
+      border-color: var(--_uifw-toolbar-border-color);
+      height: 100%;
+      transform: translateX(-50%);
+    }
+  }
+
+  &.uifw-vertical {
+    height: 0;
+
+    &:after {
+      border-bottom: var(--iui-surface-border);
+      border-color: var(--_uifw-toolbar-border-color);
+      width: 100%;
+      transform: translateY(-50%);
+    }
+  }
 
   &:after {
     content: "";
     display: block;
-    border-right: var(--iui-surface-border);
-    border-color: var(--_uifw-toolbar-border-color);
-    height: 100%;
-    transform: translateX(-50%);
   }
 
-  // Handles the case where separator is the first element in a toolbar or when there are multiple separators.
   button + & {
     &:not(:last-child) {
-      //
       display: block;
     }
   }

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.scss
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.scss
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+.uifw-toolbar-newToolbars-separator {
+  width: 0;
+  display: none;
+  pointer-events: none;
+
+  &:after {
+    content: "";
+    display: block;
+    border-right: var(--iui-surface-border);
+    border-color: var(--_uifw-toolbar-border-color);
+    height: 100%;
+    transform: translateX(-50%);
+  }
+
+  // Handles the case where separator is the first element in a toolbar or when there are multiple separators.
+  button + & {
+    &:not(:last-child) {
+      //
+      display: block;
+    }
+  }
+}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.tsx
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Toolbar
+ */
+
+import "./Separator.scss";
+import * as React from "react";
+
+/** @internal */
+export function Separator() {
+  return <div className="uifw-toolbar-newToolbars-separator" />;
+}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.tsx
@@ -9,13 +9,12 @@
 import "./Separator.scss";
 import classnames from "classnames";
 import * as React from "react";
-import { assert } from "@itwin/core-bentley";
 import { ToolbarContext } from "./Toolbar.js";
+import { useSafeContext } from "../../hooks/useSafeContext.js";
 
 /** @internal */
 export function Separator() {
-  const context = React.useContext(ToolbarContext);
-  assert(!!context);
+  const context = useSafeContext(ToolbarContext);
   const { orientation } = context;
   return (
     <div

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Separator.tsx
@@ -7,9 +7,22 @@
  */
 
 import "./Separator.scss";
+import classnames from "classnames";
 import * as React from "react";
+import { assert } from "@itwin/core-bentley";
+import { ToolbarContext } from "./Toolbar.js";
 
 /** @internal */
 export function Separator() {
-  return <div className="uifw-toolbar-newToolbars-separator" />;
+  const context = React.useContext(ToolbarContext);
+  assert(!!context);
+  const { orientation } = context;
+  return (
+    <div
+      className={classnames(
+        "uifw-toolbar-newToolbars-separator",
+        `uifw-${orientation}`
+      )}
+    />
+  );
 }

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Surface.scss
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Surface.scss
@@ -3,10 +3,12 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 .uifw-toolbar-group-surface {
+  --_uifw-toolbar-border-color: var(--iui-color-border-foreground);
+
   display: flex;
   width: fit-content;
   height: fit-content;
-  border-color: var(--iui-color-border-foreground);
+  border-color: var(--_uifw-toolbar-border-color);
   transition: border-color var(--iui-duration-1) ease;
   // TODO: needed due to opacity on toolbar container (since pointer events are disabled for center content).
   pointer-events: all;
@@ -26,7 +28,7 @@
 
   &:hover,
   &:focus-within {
-    border-color: var(--iui-color-border-foreground-hover);
+    --_uifw-toolbar-border-color: var(--iui-color-border-foreground-hover);
   }
 
   &:empty {

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Surface.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Surface.tsx
@@ -20,9 +20,14 @@ import { UiFramework } from "../../UiFramework.js";
 import { ProcessDetector } from "@itwin/core-bentley";
 import { useConditionalValue } from "../../hooks/useConditionalValue.js";
 import { SyncUiEventId } from "../../syncui/SyncUiEventDispatcher.js";
+import type { ToolbarContext } from "./Toolbar.js";
+
+type ToolbarContextProps = NonNullable<
+  React.ContextType<typeof ToolbarContext>
+>;
 
 interface SurfaceProps extends React.ComponentProps<typeof IUI_Surface> {
-  orientation: "horizontal" | "vertical";
+  orientation: ToolbarContextProps["orientation"];
 }
 
 /** @internal */

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Surface.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Surface.tsx
@@ -21,9 +21,9 @@ import { ProcessDetector } from "@itwin/core-bentley";
 import { useConditionalValue } from "../../hooks/useConditionalValue.js";
 import { SyncUiEventId } from "../../syncui/SyncUiEventDispatcher.js";
 
-type SurfaceProps = React.ComponentProps<typeof IUI_Surface> & {
+interface SurfaceProps extends React.ComponentProps<typeof IUI_Surface> {
   orientation: "horizontal" | "vertical";
-};
+}
 
 /** @internal */
 export const Surface = React.forwardRef<HTMLDivElement, SurfaceProps>(

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/ToolGroup.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/ToolGroup.tsx
@@ -10,6 +10,7 @@ import "./ToolGroup.scss";
 import classnames from "classnames";
 import * as React from "react";
 import type { CommonProps } from "@itwin/core-react";
+import { assert } from "@itwin/core-bentley";
 import { OverflowButton } from "./OverflowButton.js";
 import { useOverflow } from "./useOverflow.js";
 import { getChildKey } from "../../layout/tool-settings/Docked.js";
@@ -26,9 +27,8 @@ type Child = ReturnType<typeof React.Children.toArray>[0];
 /** @internal */
 export function ToolGroup({ children, className, ...props }: ToolGroupProps) {
   const context = React.useContext(ToolbarContext);
-  const expandsTo = context?.expandsTo ?? "bottom";
-  const panelAlignment = context?.panelAlignment ?? "start";
-  const orientation = getOrientation(expandsTo);
+  assert(!!context);
+  const { panelAlignment, orientation } = context;
   const childrenArray = React.Children.toArray(children);
 
   const keyToChildMap = childrenArray.reduce<Map<string, Child>>(
@@ -92,19 +92,4 @@ export function ToolGroup({ children, className, ...props }: ToolGroupProps) {
       </Surface>
     </div>
   );
-}
-
-type ToolbarContextProps = React.ContextType<typeof ToolbarContext>;
-
-function getOrientation(
-  expandsTo: NonNullable<ToolbarContextProps>["expandsTo"]
-) {
-  switch (expandsTo) {
-    case "left":
-    case "right":
-      return "vertical";
-    case "top":
-    case "bottom":
-      return "horizontal";
-  }
 }

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/ToolGroup.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/ToolGroup.tsx
@@ -10,9 +10,6 @@ import "./ToolGroup.scss";
 import classnames from "classnames";
 import * as React from "react";
 import type { CommonProps } from "@itwin/core-react";
-import { ActionItem } from "./ActionItem.js";
-import { GroupItem } from "./GroupItem.js";
-import { CustomItem } from "./CustomItem.js";
 import { OverflowButton } from "./OverflowButton.js";
 import { useOverflow } from "./useOverflow.js";
 import { getChildKey } from "../../layout/tool-settings/Docked.js";
@@ -96,10 +93,6 @@ export function ToolGroup({ children, className, ...props }: ToolGroupProps) {
     </div>
   );
 }
-
-ToolGroup.ActionItem = ActionItem;
-ToolGroup.GroupItem = GroupItem;
-ToolGroup.CustomItem = CustomItem;
 
 type ToolbarContextProps = React.ContextType<typeof ToolbarContext>;
 

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/ToolGroup.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/ToolGroup.tsx
@@ -10,12 +10,12 @@ import "./ToolGroup.scss";
 import classnames from "classnames";
 import * as React from "react";
 import type { CommonProps } from "@itwin/core-react";
-import { assert } from "@itwin/core-bentley";
 import { OverflowButton } from "./OverflowButton.js";
 import { useOverflow } from "./useOverflow.js";
 import { getChildKey } from "../../layout/tool-settings/Docked.js";
 import { ToolbarContext } from "./Toolbar.js";
 import { Surface } from "./Surface.js";
+import { useSafeContext } from "../../hooks/useSafeContext.js";
 
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 interface ToolGroupProps extends CommonProps {
@@ -26,9 +26,7 @@ type Child = ReturnType<typeof React.Children.toArray>[0];
 
 /** @internal */
 export function ToolGroup({ children, className, ...props }: ToolGroupProps) {
-  const context = React.useContext(ToolbarContext);
-  assert(!!context);
-  const { panelAlignment, orientation } = context;
+  const { panelAlignment, orientation } = useSafeContext(ToolbarContext);
   const childrenArray = React.Children.toArray(children);
 
   const keyToChildMap = childrenArray.reduce<Map<string, Child>>(

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Toolbar.tsx
@@ -15,6 +15,9 @@ import {
 } from "../../toolbar/ToolbarItem.js";
 import { ToolGroup } from "./ToolGroup.js";
 import type { ToolbarProps as OldToolbarProps } from "../Toolbar.js";
+import { ActionItem } from "./ActionItem.js";
+import { GroupItem } from "./GroupItem.js";
+import { CustomItem } from "./CustomItem.js";
 
 /** These exist for backwards compatibility only. */
 type ToolbarInternalProps = Pick<OldToolbarProps, "onItemExecuted">;
@@ -52,13 +55,13 @@ export function Toolbar({
       <ToolGroup>
         {items.map((item) => {
           if (isToolbarActionItem(item)) {
-            return <ToolGroup.ActionItem key={item.id} item={item} />;
+            return <ActionItem key={item.id} item={item} />;
           }
           if (isToolbarGroupItem(item)) {
-            return <ToolGroup.GroupItem key={item.id} item={item} />;
+            return <GroupItem key={item.id} item={item} />;
           }
           if (isToolbarCustomItem(item)) {
-            return <ToolGroup.CustomItem key={item.id} item={item} />;
+            return <CustomItem key={item.id} item={item} />;
           }
           return null;
         })}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Toolbar.tsx
@@ -40,17 +40,26 @@ export function Toolbar({
   onItemExecuted,
 }: ToolbarProps) {
   const [popoverOpen, setPopoverOpen] = React.useState(false);
+  const orientation = getOrientation(expandsTo);
   return (
     <ToolbarContext.Provider
       value={React.useMemo(
         () => ({
           expandsTo,
+          orientation,
           panelAlignment,
           popoverOpen,
           setPopoverOpen,
           onItemExecuted,
         }),
-        [expandsTo, panelAlignment, popoverOpen, setPopoverOpen, onItemExecuted]
+        [
+          expandsTo,
+          orientation,
+          panelAlignment,
+          popoverOpen,
+          setPopoverOpen,
+          onItemExecuted,
+        ]
       )}
     >
       <ToolGroup>
@@ -90,6 +99,7 @@ interface ToolbarContextProps
     Pick<ToolbarProps, "onItemExecuted"> {
   popoverOpen: boolean;
   setPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  orientation: "horizontal" | "vertical";
 }
 
 /** @internal */
@@ -97,3 +107,14 @@ export const ToolbarContext = React.createContext<
   ToolbarContextProps | undefined
 >(undefined);
 ToolbarContext.displayName = "uifw:ToolbarContext";
+
+function getOrientation(expandsTo: ToolbarContextProps["expandsTo"]) {
+  switch (expandsTo) {
+    case "left":
+    case "right":
+      return "vertical";
+    case "top":
+    case "bottom":
+      return "horizontal";
+  }
+}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Toolbar.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Toolbar.tsx
@@ -18,6 +18,7 @@ import type { ToolbarProps as OldToolbarProps } from "../Toolbar.js";
 import { ActionItem } from "./ActionItem.js";
 import { GroupItem } from "./GroupItem.js";
 import { CustomItem } from "./CustomItem.js";
+import { Separator } from "./Separator.js";
 
 /** These exist for backwards compatibility only. */
 type ToolbarInternalProps = Pick<OldToolbarProps, "onItemExecuted">;
@@ -53,21 +54,35 @@ export function Toolbar({
       )}
     >
       <ToolGroup>
-        {items.map((item) => {
+        {items.map((item, index) => {
+          const renderSeparator = shouldRenderSeparator(index, items);
+          let itemElement: React.JSX.Element | undefined;
           if (isToolbarActionItem(item)) {
-            return <ActionItem key={item.id} item={item} />;
+            itemElement = <ActionItem item={item} />;
+          } else if (isToolbarGroupItem(item)) {
+            itemElement = <GroupItem item={item} />;
+          } else if (isToolbarCustomItem(item)) {
+            itemElement = <CustomItem item={item} />;
           }
-          if (isToolbarGroupItem(item)) {
-            return <GroupItem key={item.id} item={item} />;
-          }
-          if (isToolbarCustomItem(item)) {
-            return <CustomItem key={item.id} item={item} />;
-          }
-          return null;
+          return (
+            <React.Fragment key={item.id}>
+              {itemElement}
+              {renderSeparator && <Separator />}
+            </React.Fragment>
+          );
         })}
       </ToolGroup>
     </ToolbarContext.Provider>
   );
+}
+
+function shouldRenderSeparator(index: number, items: ToolbarItem[]) {
+  if (items.length <= index + 1) return false;
+
+  const item = items[index];
+  const nextItem = items[index + 1];
+
+  return item.groupPriority !== nextItem.groupPriority;
 }
 
 interface ToolbarContextProps


### PR DESCRIPTION
## Changes

This PR closes #1333 by adding separators between different item groups in the same toolbar.

TODO: need to nest the Separators inside the toolbar items (since overflow logic uses `cloneElement`).

## Testing

Added additional stories.
