### PR TITLE
Add sharding to unit tests on CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -102,9 +102,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [macos-latest]
-    runs-on: ${{ matrix.os }}
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -120,12 +120,7 @@ jobs:
 
       - run: pnpm install
       - run: pnpm build
-      - run: pnpm cover
-
-      - name: Run codemod tests
-        run: npm run test
-        working-directory: tools/codemod
-        if: matrix.os == 'macos-latest'
+      - run: pnpm test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
   e2e:
     name: Run e2e tests

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -22,8 +22,6 @@
     "start:backend": "node --max-http-header-size=16000 lib/backend/main.js",
     "pseudolocalize": "npm run copy:locales && betools pseudolocalize --englishDir ./lib/locales/en --out ./lib/locales/en-PSEUDO",
     "docs:extract": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=../../../generated-docs/extract",
-    "test": "",
-    "cover": "",
     "docs": "npm run docs:extract",
     "copy:locales": "copyfiles -f ./node_modules/@itwin/*/lib/public/locales/en/*.json ./public/locales/en/*.json ./lib/locales/en",
     "copy:webfont": "copyfiles -f ./node_modules/@bentley/icons-generic-webfont/dist/**/* ./lib/webfont"

--- a/apps/test-providers/package.json
+++ b/apps/test-providers/package.json
@@ -15,10 +15,8 @@
     "copy:css": "cpx \"./src/**/*.{*css,json,svg}\" ./lib",
     "copy:locale": "cpx \"./public/**/*\" ./lib/public",
     "clean": "rimraf -g lib",
-    "cover": "",
     "docs": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=../../generated-docs/extract",
-    "lint": "eslint \"./src/**/*.{ts,tsx}\"",
-    "test": ""
+    "lint": "eslint \"./src/**/*.{ts,tsx}\""
   },
   "keywords": [
     "iModel",

--- a/docs/storybook/package.json
+++ b/docs/storybook/package.json
@@ -8,11 +8,7 @@
     "start": "npm run copy:webfont && storybook dev -p 3000",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0",
     "copy:webfont": "cpx ./node_modules/@bentley/icons-generic-webfont/dist/**/* ./lib/webfont",
-    "build": "",
-    "clean": "",
-    "cover": "",
-    "docs": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=../../generated-docs/extract",
-    "test": ""
+    "docs": "betools extract --fileExt=ts,tsx --extractFrom=./src --recursive --out=../../generated-docs/extract"
   },
   "dependencies": {
     "@bentley/icons-generic": "catalog:",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -10,12 +10,6 @@
   },
   "private": true,
   "scripts": {
-    "build": "",
-    "clean": "",
-    "cover": "",
-    "docs": "",
-    "lint": "",
-    "test": "",
     "start": "tsx scripts/run-with-docker.ts",
     "test:e2e": "npm start -- pnpm exec playwright -- test"
   },

--- a/tools/codemod/package.json
+++ b/tools/codemod/package.json
@@ -11,10 +11,6 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "",
-    "cover": "",
-    "docs": "",
-    "lint": "",
     "test": "vitest"
   },
   "keywords": [


### PR DESCRIPTION
## Changes

This PR adds [sharding](https://vitest.dev/guide/improving-performance.html#sharding) to unit tests when running on CI to improve the speed.
This should save around 4 minutes of wait time from current ~11 minutes.

Additionally removed unused empty script definitions (previously required by `rush.js`).

## Testing

N/A
