### PR TITLE
Fix tool settings location when layout is restored

### DIFF
--- a/.changeset/nasty-doors-fry.md
+++ b/.changeset/nasty-doors-fry.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": patch
+---
+
+Fix tool settings default location when frontstage layout is restored.

--- a/apps/test-app/src/frontend/appui/frontstages/TestToolSettingsFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/TestToolSettingsFrontstage.tsx
@@ -9,6 +9,7 @@ import {
   StandardLayout,
 } from "@itwin/appui-react";
 import { createTestFrontstage } from "./createTestFrontstage";
+import { getFrontstageParams } from "./TestWidgetFrontstage";
 
 type StandardLayoutProps = React.ComponentProps<typeof StandardLayout>;
 
@@ -16,11 +17,11 @@ type StandardLayoutProps = React.ComponentProps<typeof StandardLayout>;
 export const createTestToolSettingsFrontstage = () => {
   {
     const urlParams = new URLSearchParams(window.location.search);
+    const frontstageParams = getFrontstageParams(urlParams);
     const defaultLocation = getDefaultLocation(urlParams);
 
     const frontstage = createTestFrontstage({
       id: "test-tool-settings",
-      version: Math.random(),
       layout: (
         <StandardLayout
           toolSettings={{
@@ -31,6 +32,7 @@ export const createTestToolSettingsFrontstage = () => {
       toolSettings: {
         id: "toolSettings",
       },
+      ...frontstageParams,
     });
 
     return frontstage;
@@ -42,13 +44,17 @@ function getDefaultLocation(
 ): Required<StandardLayoutProps>["toolSettings"]["defaultLocation"] {
   const locationParam = params.get("location");
   const location = toStagePanelLocation(locationParam ?? "");
-  const section = params.get("section");
-  if (!location || !section) {
+  if (!location) {
     return undefined;
   }
+
+  const sectionParam = params.get("section");
+  const section = sectionParam
+    ? (Number(sectionParam) as StagePanelSection)
+    : undefined;
   return {
     location,
-    section: Number(section) as StagePanelSection,
+    section: section ?? StagePanelSection.Start,
   };
 }
 

--- a/apps/test-app/src/frontend/appui/frontstages/TestWidgetFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/TestWidgetFrontstage.tsx
@@ -45,10 +45,12 @@ export const createTestWidgetFrontstage = () => {
   }
 };
 
-function getFrontstageParams(params: URLSearchParams) {
+export function getFrontstageParams(params: URLSearchParams) {
   const versionParam = params.get("frontstageVersion");
   const version = versionParam ? Number(versionParam) : undefined;
-  return { version } satisfies Partial<Frontstage>;
+  return {
+    ...(version ? { version } : undefined),
+  } satisfies Partial<Frontstage>;
 }
 
 function getDefaultState(params: URLSearchParams): Widget["defaultState"] {

--- a/apps/test-app/src/frontend/appui/frontstages/createTestFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/createTestFrontstage.tsx
@@ -41,9 +41,9 @@ export const createTestFrontstage = (
     });
 
     return {
-      version: Math.random(),
       contentGroup,
       ...frontstageArgs,
+      version: frontstageArgs.version ?? Math.random(),
     } satisfies Frontstage;
   }
 };

--- a/e2e-tests/tests/Utils.ts
+++ b/e2e-tests/tests/Utils.ts
@@ -76,6 +76,12 @@ export function panelLocator(args: PanelLocatorArgs) {
   return args.page.locator(`.nz-widgetPanels-panel.nz-${args.side}`);
 }
 
+export function panelTargetLocator(args: { page: Page; side: PanelSide }) {
+  return args.page.locator(
+    `.nz-target-targetContainer.nz-${args.side} .nz-target-panelTarget`
+  );
+}
+
 export function titleBarHandleLocator(widget: Locator) {
   return widget.locator(".nz-handle");
 }

--- a/e2e-tests/tests/tool-settings.test.ts
+++ b/e2e-tests/tests/tool-settings.test.ts
@@ -4,8 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import { expect, test } from "@playwright/test";
 import {
+  dragTab,
   expectSavedFrontstageState,
+  expectTabInPanelSection,
   frontstageLocator,
+  panelLocator,
+  panelTargetLocator,
+  runKeyin,
   setWidgetState,
   tabLocator,
   toolbarItemLocator,
@@ -229,4 +234,19 @@ test.describe("tool settings", () => {
     await expect(widgetToolSettings).not.toBeVisible();
     await expect(finalStateField).toBeVisible();
   });
+});
+
+test("should respect default location when restoring the layout", async ({
+  page,
+}) => {
+  await page.goto("./blank?frontstageId=test-tool-settings&location=right");
+  const tab = tabLocator(page, "Tool Settings");
+  await expectTabInPanelSection(tab, "right", 0);
+
+  const panelTarget = panelTargetLocator({ page, side: "left" });
+  await dragTab(tab, panelTarget);
+  await expectTabInPanelSection(tab, "left", 0);
+
+  await runKeyin(page, "restore frontstage layout");
+  await expectTabInPanelSection(tab, "right", 0);
 });

--- a/ui/appui-react/src/appui-react/hooks/useLatestRef.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useLatestRef.tsx
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Hooks
+ */
+
+import * as React from "react";
+
+/** @internal */
+export function useLatestRef<T>(value: T) {
+  const valueRef = React.useRef<T>(value);
+
+  React.useInsertionEffect(() => {
+    valueRef.current = value;
+  });
+
+  return valueRef;
+}


### PR DESCRIPTION
## Changes

This PR fixes #1323 by correctly initializing the tool settings location when frontstage layout is restored.

## Testing

Added additional e2e test.
