### PR TITLE
Configure tool settings as a regular widget

### DIFF
--- a/.changeset/slimy-bobcats-feel.md
+++ b/.changeset/slimy-bobcats-feel.md
@@ -1,0 +1,25 @@
+---
+"@itwin/appui-react": minor
+---
+
+Update tool settings layout initialization. When `toolSettings.defaultLocation` is set on `StandardLayout` component the tool settings will be initialized as a regular widget. For example to initialize the layout with floating tool settings:
+
+```tsx
+const frontstage: Frontstage = {
+  id: "MyFrontstage",
+  toolSettings: {
+    id: "toolSettings",
+    defaultState: WidgetState.Floating,
+  },
+  layout: (
+    <StandardLayout
+      toolSettings={{
+        defaultLocation: {
+          location: StagePanelLocation.Right,
+          section: StagePanelSection.Start,
+        },
+      }}
+    />
+  ),
+};
+```

--- a/apps/test-app/src/frontend/appui/frontstages/TestToolSettingsFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/TestToolSettingsFrontstage.tsx
@@ -9,7 +9,7 @@ import {
   StandardLayout,
 } from "@itwin/appui-react";
 import { createTestFrontstage } from "./createTestFrontstage";
-import { getFrontstageParams } from "./TestWidgetFrontstage";
+import { getFrontstageParams, getWidgetParams } from "./TestWidgetFrontstage";
 
 type StandardLayoutProps = React.ComponentProps<typeof StandardLayout>;
 
@@ -19,6 +19,7 @@ export const createTestToolSettingsFrontstage = () => {
     const urlParams = new URLSearchParams(window.location.search);
     const frontstageParams = getFrontstageParams(urlParams);
     const defaultLocation = getDefaultLocation(urlParams);
+    const widgetParams = getWidgetParams(urlParams);
 
     const frontstage = createTestFrontstage({
       id: "test-tool-settings",
@@ -31,6 +32,7 @@ export const createTestToolSettingsFrontstage = () => {
       ),
       toolSettings: {
         id: "toolSettings",
+        ...widgetParams,
       },
       ...frontstageParams,
     });

--- a/apps/test-app/src/frontend/appui/frontstages/TestWidgetFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/TestWidgetFrontstage.tsx
@@ -7,6 +7,7 @@ import {
   Frontstage,
   StagePanelState,
   Widget,
+  WidgetConfig,
   WidgetState,
 } from "@itwin/appui-react";
 import { createTestFrontstage } from "./createTestFrontstage";
@@ -16,9 +17,7 @@ export const createTestWidgetFrontstage = () => {
   {
     const urlParams = new URLSearchParams(window.location.search);
     const frontstageParams = getFrontstageParams(urlParams);
-
-    const defaultState = getDefaultState(urlParams);
-    const useSavedState = urlParams.has("useSavedState");
+    const widgetParams = getWidgetParams(urlParams);
 
     const frontstage = createTestFrontstage({
       id: "test-widget",
@@ -35,8 +34,7 @@ export const createTestWidgetFrontstage = () => {
               id: "widget-1",
               label: "Widget 1",
               content: <>Widget 1 content</>,
-              defaultState,
-              useSavedState,
+              ...widgetParams,
             },
           ],
         },
@@ -56,5 +54,15 @@ export function getFrontstageParams(params: URLSearchParams) {
 function getDefaultState(params: URLSearchParams): Widget["defaultState"] {
   const param = params.get("defaultState");
   if (param === "hidden") return WidgetState.Hidden;
+  if (param === "floating") return WidgetState.Floating;
   return undefined;
+}
+
+export function getWidgetParams(params: URLSearchParams) {
+  const defaultState = getDefaultState(params);
+  const useSavedState = params.has("useSavedState");
+  return {
+    ...(defaultState !== undefined ? { defaultState } : undefined),
+    useSavedState,
+  } satisfies Partial<WidgetConfig>;
 }

--- a/docs/storybook/src/Utils.tsx
+++ b/docs/storybook/src/Utils.tsx
@@ -16,12 +16,21 @@ import {
 } from "@itwin/appui-react";
 
 export function createFrontstage(
-  overrides?: Partial<StandardFrontstageProps> & {
-    content?: React.ReactNode;
-    contentProps?: Partial<ContentProps>;
-    contentManipulation?: Frontstage["contentManipulation"];
-  }
+  overrides?: Partial<StandardFrontstageProps> &
+    Pick<Frontstage, "layout" | "toolSettings"> & {
+      content?: React.ReactNode;
+      contentProps?: Partial<ContentProps>;
+      contentManipulation?: Frontstage["contentManipulation"];
+    }
 ): Frontstage {
+  const {
+    content,
+    contentProps,
+    contentManipulation,
+    layout,
+    toolSettings,
+    ...rest
+  } = overrides ?? {};
   const config = FrontstageUtilities.createStandardFrontstage({
     id: "main-frontstage",
     usage: StageUsage.Private,
@@ -33,7 +42,7 @@ export function createFrontstage(
         {
           id: "Content",
           classId: "",
-          content: overrides?.content ?? (
+          content: content ?? (
             <h1
               style={{
                 display: "flex",
@@ -45,21 +54,21 @@ export function createFrontstage(
               Content
             </h1>
           ),
-          ...overrides?.contentProps,
+          ...contentProps,
         },
       ],
     },
     hideStatusBar: true,
     hideToolSettings: true,
     hideNavigationAid: true,
-    ...overrides,
+    ...rest,
   });
 
-  const contentManipulation =
-    overrides?.contentManipulation ?? config.contentManipulation;
   return {
     ...config,
-    contentManipulation,
+    layout,
+    contentManipulation: contentManipulation ?? config.contentManipulation,
+    toolSettings: toolSettings ?? config.toolSettings,
   };
 }
 

--- a/docs/storybook/src/frontstage/ToolSettings.stories.tsx
+++ b/docs/storybook/src/frontstage/ToolSettings.stories.tsx
@@ -3,15 +3,11 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import {
-  IModelViewportControl,
-  StandardContentLayouts,
-  UiFramework,
-} from "@itwin/appui-react";
+import { UiFramework } from "@itwin/appui-react";
 import { IModelApp } from "@itwin/core-frontend";
 import { AppUiDecorator } from "../Decorators";
 import { Page } from "../AppUiStory";
-import { createFrontstage, removeProperty } from "../Utils";
+import { removeProperty } from "../Utils";
 import { ToolSettingsStory } from "./ToolSettings";
 import { CustomTool } from "../tools/CustomTool";
 import { LockPropertyTool } from "../tools/LockPropertyTool";
@@ -33,24 +29,15 @@ const meta = {
     layout: "fullscreen",
   },
   args: {
-    frontstages: [
-      createFrontstage({
-        contentGroupProps: {
-          id: "ViewportContentGroup",
-          layout: StandardContentLayouts.singleView,
-          contents: [
-            {
-              id: "ViewportContent",
-              classId: IModelViewportControl,
-            },
-          ],
-        },
-        hideToolSettings: false,
-      }),
-    ],
+    onInitialize: async () => {
+      IModelApp.tools.register(CustomTool, UiFramework.localizationNamespace);
+    },
+    onFrontstageActivated: async () => {
+      await IModelApp.tools.run(CustomTool.toolId);
+    },
   },
   argTypes: {
-    frontstages: removeProperty(),
+    mode: removeProperty(),
     onFrontstageActivated: removeProperty(),
     onInitialize: removeProperty(),
   },
@@ -59,16 +46,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    onInitialize: async () => {
-      IModelApp.tools.register(CustomTool, UiFramework.localizationNamespace);
-    },
-    onFrontstageActivated: async () => {
-      await IModelApp.tools.run(CustomTool.toolId);
-    },
-  },
-};
+export const Default: Story = {};
 
 export const LockProperty: Story = {
   args: {
@@ -99,5 +77,17 @@ export const CustomEditor: Story = {
     onFrontstageActivated: async () => {
       await IModelApp.tools.run(CustomEditorTool.toolId);
     },
+  },
+};
+
+export const Widget: Story = {
+  args: {
+    mode: "widget",
+  },
+};
+
+export const Floating: Story = {
+  args: {
+    mode: "floating",
   },
 };

--- a/docs/storybook/src/frontstage/ToolSettings.tsx
+++ b/docs/storybook/src/frontstage/ToolSettings.tsx
@@ -2,20 +2,66 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import { createFrontstage } from "../Utils";
 import { AppUiStory, AppUiStoryProps } from "../AppUiStory";
+import {
+  IModelViewportControl,
+  StagePanelLocation,
+  StagePanelSection,
+  StandardContentLayouts,
+  StandardLayout,
+  WidgetState,
+} from "@itwin/appui-react";
 
-/** [FrontstageProvider](https://www.itwinjs.org/reference/appui-react/frontstage/frontstageprovider/) can be used to configure a frontstage. */
-export function ToolSettingsStory(
-  props: Pick<
+interface Props
+  extends Pick<
     AppUiStoryProps,
     "onInitialize" | "frontstages" | "onFrontstageActivated"
-  >
-) {
+  > {
+  mode?: "widget" | "floating";
+}
+
+/** [FrontstageProvider](https://www.itwinjs.org/reference/appui-react/frontstage/frontstageprovider/) can be used to configure a frontstage. */
+export function ToolSettingsStory(props: Props) {
+  const { mode, ...rest } = props;
   return (
     <AppUiStory
       layout="fullscreen"
       demoIModel={{ default: "blank" }}
-      {...props}
+      frontstages={[
+        createFrontstage({
+          contentGroupProps: {
+            id: "ViewportContentGroup",
+            layout: StandardContentLayouts.singleView,
+            contents: [
+              {
+                id: "ViewportContent",
+                classId: IModelViewportControl,
+              },
+            ],
+          },
+          hideToolSettings: false,
+          toolSettings: {
+            id: "toolSettings",
+            defaultState:
+              mode === "floating" ? WidgetState.Floating : undefined,
+          },
+          layout: (
+            <StandardLayout
+              toolSettings={{
+                defaultLocation:
+                  mode === undefined
+                    ? undefined
+                    : {
+                        location: StagePanelLocation.Right,
+                        section: StagePanelSection.Start,
+                      },
+              }}
+            />
+          ),
+        }),
+      ]}
+      {...rest}
     />
   );
 }

--- a/e2e-tests/tests/tool-settings.test.ts
+++ b/e2e-tests/tests/tool-settings.test.ts
@@ -254,7 +254,7 @@ test("should respect default location when restoring the layout", async ({
 
 test("should respect floating default state", async ({ page }) => {
   await page.goto(
-    "./blank?frontstageId=test-tool-settings&defaultState=floating"
+    "./blank?frontstageId=test-tool-settings&location=right&defaultState=floating"
   );
   const tab = tabLocator(page, "Tool Settings");
   const floatingWidget = floatingWidgetLocator({ page, tab });

--- a/e2e-tests/tests/tool-settings.test.ts
+++ b/e2e-tests/tests/tool-settings.test.ts
@@ -7,6 +7,7 @@ import {
   dragTab,
   expectSavedFrontstageState,
   expectTabInPanelSection,
+  floatingWidgetLocator,
   frontstageLocator,
   panelLocator,
   panelTargetLocator,
@@ -249,4 +250,13 @@ test("should respect default location when restoring the layout", async ({
 
   await runKeyin(page, "restore frontstage layout");
   await expectTabInPanelSection(tab, "right", 0);
+});
+
+test("should respect floating default state", async ({ page }) => {
+  await page.goto(
+    "./blank?frontstageId=test-tool-settings&defaultState=floating"
+  );
+  const tab = tabLocator(page, "Tool Settings");
+  const floatingWidget = floatingWidgetLocator({ page, tab });
+  await expect(floatingWidget).toBeVisible();
 });

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -37,6 +37,8 @@ import { useActiveFrontstageDef } from "../frontstage/FrontstageDef.js";
 import type { WidgetActions } from "../layout/widget/WidgetActions.js";
 import type { StagePanelSection } from "../stagepanels/StagePanelSection.js";
 import type { StagePanelLocation } from "../stagepanels/StagePanelLocation.js";
+import type { Widget } from "../widgets/Widget.js";
+import type { WidgetState } from "../widgets/WidgetState.js";
 
 /** @internal */
 export const ConfigurableUiContext = React.createContext<
@@ -126,6 +128,8 @@ interface StandardLayoutProps {
    */
   toolSettings?: {
     /** The default location of the tool settings. Only used when initializing the layout and ignored when restoring a saved layout.
+     * When this is specified, the tool settings will be initialized as a widget, instead of the default docked state.
+     * @note Use {@link Widget} for further configuration. I.e. set {@link Widget.defaultState} to {@link WidgetState.Floating} to initialize the tool settings as a floating widget.
      * @alpha
      */
     defaultLocation?: ToolSettingsLocation;

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneAction.ts
@@ -303,6 +303,19 @@ export interface WidgetTabUpdateAction {
 }
 
 /** @internal */
+export interface ToolSettingsAddDockedAction {
+  readonly type: "TOOL_SETTINGS_ADD_DOCKED";
+  readonly id: TabState["id"];
+  readonly overrides?: Partial<TabState>;
+}
+
+/** @internal */
+export interface ToolSettingsAddWidgetAction {
+  readonly type: "TOOL_SETTINGS_ADD_WIDGET";
+  readonly id: TabState["id"];
+}
+
+/** @internal */
 export interface ToolSettingsDragStartAction {
   readonly type: "TOOL_SETTINGS_DRAG_START";
   readonly newFloatingWidgetId: FloatingWidgetState["id"];
@@ -328,14 +341,6 @@ export interface WidgetDefAddAction {
     readonly index: number;
     readonly side: PanelSide;
   };
-}
-
-/** @internal */
-export interface WidgetDefAddToolSettingsAction {
-  readonly type: "WIDGET_DEF_ADD_TOOL_SETTINGS";
-  readonly id: TabState["id"];
-  readonly overrides?: Partial<TabState>;
-  readonly panelSection?: WidgetDefAddAction["panelSection"];
 }
 
 /** @internal */
@@ -380,7 +385,8 @@ export type NineZoneAction =
   | WidgetTabShowAction
   | WidgetTabUnloadAction
   | WidgetTabUpdateAction
+  | ToolSettingsAddDockedAction
+  | ToolSettingsAddWidgetAction
   | ToolSettingsDragStartAction
   | ToolSettingsDockAction
-  | WidgetDefAddAction
-  | WidgetDefAddToolSettingsAction;
+  | WidgetDefAddAction;

--- a/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
+++ b/ui/appui-react/src/appui-react/layout/state/NineZoneStateReducer.ts
@@ -834,6 +834,13 @@ export function NineZoneStateReducer(
         }
       });
     }
+    case "TOOL_SETTINGS_ADD_DOCKED": {
+      state = addTab(state, action.id, action.overrides);
+      return addDockedToolSettings(state, action.id);
+    }
+    case "TOOL_SETTINGS_ADD_WIDGET": {
+      return addWidgetToolSettings(state, action.id);
+    }
     case "TOOL_SETTINGS_DRAG_START": {
       if (!state.toolSettings) return state;
       if (state.toolSettings.type === "widget") return state;
@@ -905,14 +912,6 @@ export function NineZoneStateReducer(
       }
 
       return addTabToPanelSection(state, action.id, action.panelSection);
-    }
-    case "WIDGET_DEF_ADD_TOOL_SETTINGS": {
-      state = addTab(state, action.id, action.overrides);
-      if (action.panelSection) {
-        state = addTabToPanelSection(state, action.id, action.panelSection);
-        return addWidgetToolSettings(state, action.id);
-      }
-      return addDockedToolSettings(state, action.id);
     }
   }
   return state;

--- a/ui/appui-react/src/appui-react/widgets/Widget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/Widget.tsx
@@ -55,8 +55,9 @@ export interface Widget {
    * - Defaults to `Floating` if the widget is not allowed to dock to any panels.
    * - Otherwise, defaults to `Closed`.
    *
-   * @note If set to `Hidden`, the widget will be hidden after the layout is restored, independently of the saved layout state. Set `useSavedState` to `true` to disable this behavior.
-   * @note If set to `Unloaded`, the widget will be unloaded after the layout is restored, independently of the saved layout state. Set `useSavedState` to `true` to disable this behavior.
+   * @note If set to {@link WidgetState.Floating}, the widget will be displayed as a floating widget in the initial layout. Use {@link canFloat} to configure the floating widget behavior.
+   * @note If set to {@link WidgetState.Hidden}, the widget will be hidden after the layout is restored, independently of the saved layout state. Set {@link useSavedState} to `true` to disable this behavior.
+   * @note If set to {@link WidgetState.Unloaded}, the widget will be unloaded after the layout is restored, independently of the saved layout state. Set {@link useSavedState} to `true` to disable this behavior.
    */
   readonly defaultState?: WidgetState;
   /** When enabled, the widget will always use the saved layout state. `defaultState` will only be used for the initial layout setup.

--- a/ui/appui-react/src/appui-react/widgets/Widget.tsx
+++ b/ui/appui-react/src/appui-react/widgets/Widget.tsx
@@ -55,9 +55,9 @@ export interface Widget {
    * - Defaults to `Floating` if the widget is not allowed to dock to any panels.
    * - Otherwise, defaults to `Closed`.
    *
-   * @note If set to {@link WidgetState.Floating}, the widget will be displayed as a floating widget in the initial layout. Use {@link canFloat} to configure the floating widget behavior.
-   * @note If set to {@link WidgetState.Hidden}, the widget will be hidden after the layout is restored, independently of the saved layout state. Set {@link useSavedState} to `true` to disable this behavior.
-   * @note If set to {@link WidgetState.Unloaded}, the widget will be unloaded after the layout is restored, independently of the saved layout state. Set {@link useSavedState} to `true` to disable this behavior.
+   * @note If set to {@link WidgetState.Floating}, the widget will be displayed as a floating widget in the initial layout. Use {@link Widget.canFloat} to configure the floating widget behavior.
+   * @note If set to {@link WidgetState.Hidden}, the widget will be hidden after the layout is restored, independently of the saved layout state. Set {@link Widget.useSavedState} to `true` to disable this behavior.
+   * @note If set to {@link WidgetState.Unloaded}, the widget will be unloaded after the layout is restored, independently of the saved layout state. Set {@link Widget.useSavedState} to `true` to disable this behavior.
    */
   readonly defaultState?: WidgetState;
   /** When enabled, the widget will always use the saved layout state. `defaultState` will only be used for the initial layout setup.

--- a/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
+++ b/ui/appui-react/src/test/layout/state/NineZoneStateReducer.test.ts
@@ -2674,7 +2674,7 @@ describe("NineZoneStateReducer", () => {
         };
       });
       const newState = NineZoneStateReducer(state, {
-        type: "WIDGET_DEF_ADD_TOOL_SETTINGS",
+        type: "TOOL_SETTINGS_ADD_DOCKED",
         id: "t1",
       });
       expect(newState.tabs.t1).to.exist;


### PR DESCRIPTION
## Changes

This PR closes #1320 by enhancing the tool settings layout initialization. When `toolSettings.defaultLocation` is set on `StandardLayout` component the tool settings will be initialized as a regular widget.

## Testing

Added additional e2e test.
To test in `test-app`: `/blank?frontstageId=test-tool-settings&location=right&defaultState=floating`

Added additional stories:
https://itwin.github.io/appui/1353/?path=/story/frontstage-toolsettings--widget
https://itwin.github.io/appui/1353/?path=/story/frontstage-toolsettings--floating