### PR TITLE
Refactor `useActiveIModelConnection` hook

### DIFF
--- a/.changeset/chubby-crabs-attack.md
+++ b/.changeset/chubby-crabs-attack.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Refactored the `useActiveIModelConnection` hook to use the `UiFramework.onIModelConnectionChanged` event instead of relying on the sync UI events. This removes the requirement for the redux store to be configured when using the hook.

--- a/ui/appui-react/src/appui-react/hooks/useActiveIModelConnection.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useActiveIModelConnection.tsx
@@ -10,18 +10,18 @@ import * as React from "react";
 import type { IModelConnection } from "@itwin/core-frontend";
 import { UiFramework } from "../UiFramework.js";
 
+const subscribe = (onStoreChange: () => void) => {
+  return UiFramework.onIModelConnectionChanged.addListener(onStoreChange);
+};
+
+const getSnapshot = () => {
+  return UiFramework.getIModelConnection();
+};
+
 /** React hook that maintains the active IModelConnection. For this hook to work properly the
  * IModelConnection must be set using {@link UiFramework.setIModelConnection} method.
  * @public
  */
 export function useActiveIModelConnection(): IModelConnection | undefined {
-  const [activeConnection, setActiveConnection] = React.useState(() =>
-    UiFramework.getIModelConnection()
-  );
-  React.useEffect(() => {
-    UiFramework.onIModelConnectionChanged.addListener((newConnection) => {
-      setActiveConnection(newConnection);
-    });
-  }, []);
-  return activeConnection;
+  return React.useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/ui/appui-react/src/appui-react/hooks/useActiveIModelConnection.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useActiveIModelConnection.tsx
@@ -6,34 +6,22 @@
  * @module Hooks
  */
 
-import { useEffect, useState } from "react";
+import * as React from "react";
 import type { IModelConnection } from "@itwin/core-frontend";
-import { SessionStateActionId } from "../redux/SessionState.js";
-import { SyncUiEventDispatcher } from "../syncui/SyncUiEventDispatcher.js";
 import { UiFramework } from "../UiFramework.js";
 
 /** React hook that maintains the active IModelConnection. For this hook to work properly the
- * IModelConnection must be set using UiFramework.setIModelConnection method. This also requires
- * that the host app includes the UiFramework reducer into its Redux store.
+ * IModelConnection must be set using {@link UiFramework.setIModelConnection} method.
  * @public
  */
 export function useActiveIModelConnection(): IModelConnection | undefined {
-  const [activeConnection, setActiveConnection] = useState(
+  const [activeConnection, setActiveConnection] = React.useState(() =>
     UiFramework.getIModelConnection()
   );
-  useEffect(() => {
-    return SyncUiEventDispatcher.onSyncUiEvent.addListener((args) => {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      const eventIds = [SessionStateActionId.SetIModelConnection];
-      if (
-        eventIds.some((value: string): boolean =>
-          args.eventIds.has(value.toLowerCase())
-        )
-      ) {
-        setActiveConnection(UiFramework.getIModelConnection());
-      }
+  React.useEffect(() => {
+    UiFramework.onIModelConnectionChanged.addListener((newConnection) => {
+      setActiveConnection(newConnection);
     });
-  }, [activeConnection]);
-
+  }, []);
   return activeConnection;
 }

--- a/ui/appui-react/src/test/TestUtils.ts
+++ b/ui/appui-react/src/test/TestUtils.ts
@@ -36,6 +36,10 @@ import {
 import { TestContentControl } from "./frontstage/FrontstageTestUtils.js";
 import { userEvent } from "@testing-library/user-event";
 import type { ContentLayoutProps } from "../appui-react/content/ContentLayoutProps.js";
+import type { BlankConnectionProps } from "@itwin/core-frontend";
+import { BlankConnection } from "@itwin/core-frontend";
+import { Cartographic } from "@itwin/core-common";
+import { Range3d } from "@itwin/core-geometry";
 export { userEvent };
 
 interface SampleAppState {
@@ -407,6 +411,22 @@ export function selectAllBeforeType() {
 /** https://floating-ui.com/docs/react#testing */
 export async function waitForPosition() {
   return act(async () => {});
+}
+
+/** Creates an iModel connection for testing purposes. */
+export function createBlankConnection(
+  overrides?: Partial<BlankConnectionProps>
+) {
+  return BlankConnection.create({
+    name: "Exton PA",
+    location: Cartographic.fromDegrees({
+      longitude: -75.686694,
+      latitude: 40.065757,
+      height: 0,
+    }),
+    extents: new Range3d(-1000, -1000, -100, 1000, 1000, 100),
+    ...overrides,
+  });
 }
 
 export default TestUtils;

--- a/ui/appui-react/src/test/hooks/useActiveIModelConnection.test.tsx
+++ b/ui/appui-react/src/test/hooks/useActiveIModelConnection.test.tsx
@@ -11,56 +11,78 @@ import {
 } from "../../appui-react.js";
 import { createBlankConnection } from "../TestUtils.js";
 
-describe("useActiveIModelConnection", () => {
-  it("should render", () => {
-    const { result } = renderHook(() => useActiveIModelConnection());
-    expect(result.current).toBeUndefined();
-    expect(UiFramework.getIModelConnection()).toEqual(undefined);
-    expect(
-      UiFramework.frameworkState?.sessionState.iModelConnection
-    ).toBeUndefined();
+it("useActiveIModelConnection", () => {
+  expect(UiFramework.frameworkState).toBeDefined();
 
-    const initEventStub = vi.spyOn(
-      SyncUiEventDispatcher,
-      "initializeConnectionEvents"
-    );
-    const clearEventStub = vi.spyOn(
-      SyncUiEventDispatcher,
-      "clearConnectionEvents"
-    );
+  const { result } = renderHook(() => useActiveIModelConnection());
+  expect(result.current).toBeUndefined();
+  expect(UiFramework.getIModelConnection()).toBeUndefined();
+  expect(
+    UiFramework.frameworkState?.sessionState.iModelConnection
+  ).toBeUndefined();
 
-    const newConnection = createBlankConnection({ name: "new" });
+  const initEventStub = vi.spyOn(
+    SyncUiEventDispatcher,
+    "initializeConnectionEvents"
+  );
+  const clearEventStub = vi.spyOn(
+    SyncUiEventDispatcher,
+    "clearConnectionEvents"
+  );
 
-    // should trigger dispatch action
-    act(() => {
-      UiFramework.setIModelConnection(newConnection, true);
-    });
-    expect(result.current?.name).toEqual("new");
-    expect(
-      UiFramework.frameworkState?.sessionState.iModelConnection?.name
-    ).toEqual("new");
-    expect(UiFramework.getIModelConnection()?.name).toEqual("new");
-    expect(initEventStub).toHaveBeenCalled();
-    expect(clearEventStub).not.toBeCalled();
-    initEventStub.mockReset();
+  const newConnection = createBlankConnection({ name: "new" });
 
-    // already set, so should not trigger dispatch action
-    act(() => {
-      UiFramework.setIModelConnection(newConnection, true);
-    });
-    expect(initEventStub).not.toBeCalled();
-    expect(clearEventStub).not.toBeCalled();
-
-    // should trigger clearing action
-    act(() => {
-      UiFramework.setIModelConnection(undefined, true);
-    });
-    expect(result.current).toBeUndefined();
-    expect(UiFramework.getIModelConnection()).toEqual(undefined);
-    expect(
-      UiFramework.frameworkState?.sessionState.iModelConnection
-    ).toBeUndefined();
-    expect(clearEventStub).toHaveBeenCalled();
-    expect(initEventStub).not.toBeCalled();
+  // should trigger dispatch action
+  act(() => {
+    UiFramework.setIModelConnection(newConnection, true);
   });
+  expect(result.current?.name).toEqual("new");
+  expect(
+    UiFramework.frameworkState?.sessionState.iModelConnection?.name
+  ).toEqual("new");
+  expect(UiFramework.getIModelConnection()?.name).toEqual("new");
+  expect(initEventStub).toHaveBeenCalled();
+  expect(clearEventStub).not.toBeCalled();
+  initEventStub.mockReset();
+
+  // already set, so should not trigger dispatch action
+  act(() => {
+    UiFramework.setIModelConnection(newConnection, true);
+  });
+  expect(initEventStub).not.toBeCalled();
+  expect(clearEventStub).not.toBeCalled();
+
+  // should trigger clearing action
+  act(() => {
+    UiFramework.setIModelConnection(undefined, true);
+  });
+  expect(result.current).toBeUndefined();
+  expect(UiFramework.getIModelConnection()).toBeUndefined();
+  expect(
+    UiFramework.frameworkState?.sessionState.iModelConnection
+  ).toBeUndefined();
+  expect(clearEventStub).toHaveBeenCalled();
+  expect(initEventStub).not.toBeCalled();
+});
+
+it("useActiveIModelConnection w/o redux", () => {
+  vi.spyOn(UiFramework, "frameworkState", "get").mockReturnValue(undefined);
+
+  const { result } = renderHook(() => useActiveIModelConnection());
+  expect(result.current).toBeUndefined();
+  expect(UiFramework.getIModelConnection()).toBeUndefined();
+
+  const newConnection = createBlankConnection({ name: "new" });
+
+  act(() => {
+    UiFramework.setIModelConnection(newConnection, true);
+  });
+  expect(result.current?.name).toEqual("new");
+  expect(UiFramework.getIModelConnection()?.name).toEqual("new");
+
+  act(() => {
+    UiFramework.setIModelConnection(undefined, true);
+  });
+  expect(result.current).toBeUndefined();
+  expect(UiFramework.getIModelConnection()).toBeUndefined();
 });

--- a/ui/appui-react/src/test/hooks/useActiveIModelConnection.test.tsx
+++ b/ui/appui-react/src/test/hooks/useActiveIModelConnection.test.tsx
@@ -2,88 +2,65 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
-import * as React from "react";
-import { Provider } from "react-redux";
-import * as moq from "typemoq";
 
-import type { IModelConnection } from "@itwin/core-frontend";
-import { SelectionSet } from "@itwin/core-frontend";
-import { render } from "@testing-library/react";
-import type { IModelRpcProps } from "@itwin/core-common";
+import { act, renderHook } from "@testing-library/react";
 import {
   SyncUiEventDispatcher,
   UiFramework,
   useActiveIModelConnection,
 } from "../../appui-react.js";
-import TestUtils from "../TestUtils.js";
+import { createBlankConnection } from "../TestUtils.js";
 
 describe("useActiveIModelConnection", () => {
-  describe("useActiveIModelConnection Hook", () => {
-    const imodelMock = moq.Mock.ofType<IModelConnection>();
-    const imodelToken: IModelRpcProps = { key: "" };
-    imodelMock.setup((x) => x.name).returns(() => "Fake");
-    imodelMock.setup((x) => x.getRpcProps()).returns(() => imodelToken);
-    const ss = new SelectionSet(imodelMock.object);
-    imodelMock.setup((x) => x.selectionSet).returns(() => ss);
+  it("should render", () => {
+    const { result } = renderHook(() => useActiveIModelConnection());
+    expect(result.current).toBeUndefined();
+    expect(UiFramework.getIModelConnection()).toEqual(undefined);
+    expect(
+      UiFramework.frameworkState?.sessionState.iModelConnection
+    ).toBeUndefined();
 
-    const HookTester = () => {
-      const activeIModelConnection = useActiveIModelConnection();
-      // I expected the following to work
-      // const connectionLabel = activeIModelConnection ? activeIModelConnection.name : "NoConnection";
+    const initEventStub = vi.spyOn(
+      SyncUiEventDispatcher,
+      "initializeConnectionEvents"
+    );
+    const clearEventStub = vi.spyOn(
+      SyncUiEventDispatcher,
+      "clearConnectionEvents"
+    );
 
-      // But it did not so I tried this way .... and it still did not update when I call UiFramework.setIModelConnection below
-      const [connectionLabel, setConnectionLabel] =
-        React.useState("NoConnection");
-      React.useEffect(() => {
-        const label = activeIModelConnection
-          ? activeIModelConnection.name
-          : "NoConnection";
-        setConnectionLabel(label);
-      }, [activeIModelConnection]);
-      return <div data-testid="mylabel">{connectionLabel}</div>;
-    };
+    const newConnection = createBlankConnection({ name: "new" });
 
-    it("should render", async () => {
-      // make sure redux store is set up via Provider
-      const result = render(
-        <Provider store={TestUtils.store}>
-          <div>
-            <HookTester />
-          </div>
-        </Provider>
-      );
-
-      const initialLabel = result.getByTestId("mylabel");
-      expect(initialLabel.innerHTML).toEqual("NoConnection");
-
-      const initEventStub = vi.spyOn(
-        SyncUiEventDispatcher,
-        "initializeConnectionEvents"
-      );
-      const clearEventStub = vi.spyOn(
-        SyncUiEventDispatcher,
-        "clearConnectionEvents"
-      );
-
-      // should trigger dispatch action
-      UiFramework.setIModelConnection(imodelMock.object, true);
-      expect(initEventStub).toHaveBeenCalled();
-      expect(clearEventStub).not.toBeCalled();
-      initEventStub.mockReset();
-
-      // already set, so should not trigger dispatch action
-      UiFramework.setIModelConnection(imodelMock.object, true);
-      expect(initEventStub).not.toBeCalled();
-      expect(clearEventStub).not.toBeCalled();
-
-      // should trigger clearing action
-      UiFramework.setIModelConnection(undefined, true);
-      expect(clearEventStub).toHaveBeenCalled();
-      expect(initEventStub).not.toBeCalled();
-
-      // --- the following does not work yet
-      // const updatedLabel = result.getByTestId("mylabel");
-      // expect(updatedLabel.innerHTML).toEqual("Fake");
+    // should trigger dispatch action
+    act(() => {
+      UiFramework.setIModelConnection(newConnection, true);
     });
+    expect(result.current?.name).toEqual("new");
+    expect(
+      UiFramework.frameworkState?.sessionState.iModelConnection?.name
+    ).toEqual("new");
+    expect(UiFramework.getIModelConnection()?.name).toEqual("new");
+    expect(initEventStub).toHaveBeenCalled();
+    expect(clearEventStub).not.toBeCalled();
+    initEventStub.mockReset();
+
+    // already set, so should not trigger dispatch action
+    act(() => {
+      UiFramework.setIModelConnection(newConnection, true);
+    });
+    expect(initEventStub).not.toBeCalled();
+    expect(clearEventStub).not.toBeCalled();
+
+    // should trigger clearing action
+    act(() => {
+      UiFramework.setIModelConnection(undefined, true);
+    });
+    expect(result.current).toBeUndefined();
+    expect(UiFramework.getIModelConnection()).toEqual(undefined);
+    expect(
+      UiFramework.frameworkState?.sessionState.iModelConnection
+    ).toBeUndefined();
+    expect(clearEventStub).toHaveBeenCalled();
+    expect(initEventStub).not.toBeCalled();
   });
 });


### PR DESCRIPTION
## Changes

This PR closes #1215 by refactoring `useActiveIModelConnection` hook. This removes the requirement for having a redux store configured, when using the hook.

## Testing

Refactored existing and added additional unit test.
