### PR TITLE
Fix navigation aid of `NavigationAidHost`

### DIFF
--- a/.changeset/sweet-spies-camp.md
+++ b/.changeset/sweet-spies-camp.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": patch
+---
+
+Fixed `NavigationAidHost` component to correctly update the navigation aid when view class name is changed while content control is active.

--- a/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
@@ -123,21 +123,15 @@ export function NavigationAidHost(props: NavigationAidHostProps) {
     );
   }, []);
 
-  const [activeViewClass, setActiveViewClass] = React.useState(() => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const content = UiFramework.content.getActiveContentControl();
-    const viewport = content?.viewport;
-    if (!viewport) return "";
-    return viewport.view.classFullName;
-  });
-
   React.useEffect(() => {
     return ViewportComponentEvents.onViewClassFullNameChangedEvent.addListener(
-      (args) => {
-        setActiveViewClass(args.newName);
+      () => {
+        if (!activeContentControl) return;
+        // Use active control, since multiple viewports can be displayed.
+        setNavigationAidId(activeContentControl.navigationAidControl);
       }
     );
-  }, []);
+  }, [activeContentControl]);
 
   const navigationAidControl = React.useMemo(
     () =>

--- a/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
@@ -136,7 +136,7 @@ export function NavigationAidHost(props: NavigationAidHostProps) {
         setActiveViewClass(args.newName);
       }
     );
-  }, [activeViewClass]);
+  }, []);
 
   const navigationAidControl = React.useMemo(
     () =>

--- a/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
@@ -126,8 +126,9 @@ export function NavigationAidHost(props: NavigationAidHostProps) {
   const [activeViewClass, setActiveViewClass] = React.useState(() => {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const content = UiFramework.content.getActiveContentControl();
-    if (content && content.viewport) return content.viewport.view.classFullName;
-    return "";
+    const viewport = content?.viewport;
+    if (!viewport) return "";
+    return viewport.view.classFullName;
   });
 
   React.useEffect(() => {

--- a/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
+++ b/ui/appui-react/src/appui-react/widgets/NavigationWidgetComposer.tsx
@@ -104,7 +104,6 @@ export function NavigationAidHost(props: NavigationAidHostProps) {
   React.useEffect(() => {
     return UiFramework.content.onActiveContentChangedEvent.addListener(
       (args) => {
-        args.id;
         const frontstageDef = UiFramework.frontstages.activeFrontstageDef;
         if (!frontstageDef) return;
 


### PR DESCRIPTION
## Changes

This PR fixes #1332 by correctly updating the navigation aid when view class name is changed while content control is active in the `NavigationAidHost` component.

Previously the event handler of `onViewClassFullNameChangedEvent` was doing nothing, since the `activeViewClass` variable  was not used.

## Testing

Tested in `test-app`, i.e.  `/local/Baytown.bim?frontstageId=custom-content`
And temporary adding a view selector to that frontstage: `getCustomViewSelectorPopupItem()` to `CustomContentStageUiProvider`.
