### PR TITLE
Fix badge color in `Toolbar` component

### DIFF
--- a/.changeset/old-carrots-sit.md
+++ b/.changeset/old-carrots-sit.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": patch
+---
+
+Fix svg fill color of `technical-preview` and `deprecated` badges in `Toolbar` component.

--- a/apps/test-providers/src/ui/providers/CustomContentStageUiProvider.tsx
+++ b/apps/test-providers/src/ui/providers/CustomContentStageUiProvider.tsx
@@ -70,6 +70,7 @@ export class CustomContentStageUiProvider implements UiItemsProvider {
       },
       {
         layouts,
+        badgeKind: "technical-preview",
       }
     );
 

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Badge.scss
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Badge.scss
@@ -6,8 +6,4 @@
   position: absolute;
   left: -1px;
   top: -1px;
-
-  svg {
-    fill: currentColor;
-  }
 }


### PR DESCRIPTION
## Changes

This PR fixes #1357 by setting correct svg fill color of `technical-preview` and `deprecated` badges in `Toolbar` component.

## Testing

Tested in: storybook and test-app.
- Storybook: https://itwin.github.io/appui/storybook/?path=/story/components-toolbarcomposer--badge
- test-app: `/blank?frontstageId=custom-content`

