### PR TITLE
[components-react]: Editors should handle readonly properties

### DIFF
--- a/.changeset/solid-llamas-wave.md
+++ b/.changeset/solid-llamas-wave.md
@@ -1,0 +1,5 @@
+---
+"@itwin/components-react": patch
+---
+
+Fixed editors in property grid to correctly handle properties that are `isReadonly` or `isDisabled`.

--- a/docs/storybook/src/components/PropertyGrid.stories.tsx
+++ b/docs/storybook/src/components/PropertyGrid.stories.tsx
@@ -7,19 +7,36 @@ import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 import {
   ArrayValue,
   PrimitiveValue,
+  PropertyDescription,
   PropertyRecord,
+  PropertyValue,
   PropertyValueFormat,
+  StandardTypeNames,
   StructValue,
 } from "@itwin/appui-abstract";
-import {
-  PropertyDataChangeEvent,
-  PropertyValueRendererManager,
-  VirtualizedPropertyGridWithDataProvider,
-} from "@itwin/components-react";
+import { action } from "storybook/actions";
+import { PropertyValueRendererManager } from "@itwin/components-react";
 import { MultilineTextPropertyValueRenderer } from "@itwin/components-react-internal/src/components-react/properties/renderers/value/MultilineTextPropertyValueRenderer";
 
 import { AppUiDecorator } from "../Decorators";
 import { Orientation } from "@itwin/core-react";
+import { PropertyGridStory } from "./PropertyGrid";
+
+const structMembers = {
+  member1: PropertyRecord.fromString("Value 1", "Member 1"),
+  member2: PropertyRecord.fromString("Value 2", "Member 2"),
+  member3: PropertyRecord.fromString("Value 3", "Member 3"),
+};
+
+const arrayMembers = [
+  PropertyRecord.fromString("Value 1", "Item 1"),
+  PropertyRecord.fromString("Value 2", "Item 2"),
+  PropertyRecord.fromString("Value 3", "Item 3"),
+];
+
+const multilineString =
+  // cspell:disable-next-line
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\nExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n";
 
 const PaddingDecorator: Decorator = (Story) => {
   return (
@@ -33,39 +50,36 @@ const rendererManager = new PropertyValueRendererManager();
 
 const meta = {
   title: "Components/PropertyGrid",
-  component: VirtualizedPropertyGridWithDataProvider,
+  component: PropertyGridStory,
   tags: ["autodocs"],
   decorators: [PaddingDecorator, AppUiDecorator],
   args: {
     height: 600,
     width: 1300,
   },
-} satisfies Meta<typeof VirtualizedPropertyGridWithDataProvider>;
+} satisfies Meta<typeof PropertyGridStory>;
 
 export default meta;
-type Story = StoryObj<typeof VirtualizedPropertyGridWithDataProvider>;
+type Story = StoryObj<typeof PropertyGridStory>;
 
 export const Basic: Story = {
   args: {
-    dataProvider: {
-      getData: async () => ({
-        label: PropertyRecord.fromString("Record 1"),
-        categories: [
-          { name: "Group_1", label: "Group 1", expand: true },
-          { name: "Group_2", label: "Group 2", expand: false },
+    data: {
+      label: PropertyRecord.fromString("Record 1"),
+      categories: [
+        { name: "Group_1", label: "Group 1", expand: true },
+        { name: "Group_2", label: "Group 2", expand: false },
+      ],
+      records: {
+        Group_1: [
+          PropertyRecord.fromString("Record 1_1"),
+          PropertyRecord.fromString("Record 1_2"),
         ],
-        records: {
-          Group_1: [
-            PropertyRecord.fromString("Record 1_1"),
-            PropertyRecord.fromString("Record 1_2"),
-          ],
-          Group_2: [
-            PropertyRecord.fromString("Record 2_1"),
-            PropertyRecord.fromString("Record 2_2"),
-          ],
-        },
-      }),
-      onDataChanged: new PropertyDataChangeEvent(),
+        Group_2: [
+          PropertyRecord.fromString("Record 2_1"),
+          PropertyRecord.fromString("Record 2_2"),
+        ],
+      },
     },
     onPropertyContextMenu: undefined,
   },
@@ -75,91 +89,88 @@ export const StructRendering: Story = {
   args: {
     orientation: Orientation.Vertical,
     propertyValueRendererManager: rendererManager,
-    dataProvider: {
-      getData: async () => ({
-        label: PropertyRecord.fromString("Record 1"),
-        categories: [
-          {
-            name: "structPropertyRendering",
-            label: "Struct property rendering",
-            expand: true,
-          },
-        ],
-        records: {
-          structPropertyRendering: [
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: "string value",
-              },
-              {
-                name: "simpleProperty",
-                displayLabel: "Simple property",
-                typename: "string",
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: multilineString,
-              },
-              {
-                name: "multilineProperty",
-                displayLabel: "Multiline property",
-                typename: "string",
-                renderer: { name: "multiline" },
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: undefined,
-              },
-              {
-                name: "noValueStruct",
-                displayLabel: "Struct property with no value",
-                typename: "struct",
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Struct,
-                members: structMembers,
-              },
-              {
-                name: "noRendererStructProperty",
-                displayLabel: "Struct property (no renderer)",
-                typename: "struct",
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Struct,
-                members: structMembers,
-              },
-              {
-                name: "defaultRendererStructProperty",
-                displayLabel: "Struct property (default renderer)",
-                typename: "struct",
-                renderer: { name: "defaultRendererPropertyRenderer" },
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Struct,
-                members: structMembers,
-              },
-              {
-                name: "customRendererStructProperty",
-                displayLabel: "Struct property (custom renderer)",
-                typename: "struct",
-                renderer: { name: "customRendererStructPropertyRenderer" },
-              }
-            ),
-          ],
+    data: {
+      label: PropertyRecord.fromString("Record 1"),
+      categories: [
+        {
+          name: "structPropertyRendering",
+          label: "Struct property rendering",
+          expand: true,
         },
-      }),
-      onDataChanged: new PropertyDataChangeEvent(),
+      ],
+      records: {
+        structPropertyRendering: [
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: "string value",
+            },
+            {
+              name: "simpleProperty",
+              displayLabel: "Simple property",
+              typename: "string",
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: multilineString,
+            },
+            {
+              name: "multilineProperty",
+              displayLabel: "Multiline property",
+              typename: "string",
+              renderer: { name: "multiline" },
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: undefined,
+            },
+            {
+              name: "noValueStruct",
+              displayLabel: "Struct property with no value",
+              typename: "struct",
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Struct,
+              members: structMembers,
+            },
+            {
+              name: "noRendererStructProperty",
+              displayLabel: "Struct property (no renderer)",
+              typename: "struct",
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Struct,
+              members: structMembers,
+            },
+            {
+              name: "defaultRendererStructProperty",
+              displayLabel: "Struct property (default renderer)",
+              typename: "struct",
+              renderer: { name: "defaultRendererPropertyRenderer" },
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Struct,
+              members: structMembers,
+            },
+            {
+              name: "customRendererStructProperty",
+              displayLabel: "Struct property (custom renderer)",
+              typename: "struct",
+              renderer: { name: "customRendererStructPropertyRenderer" },
+            }
+          ),
+        ],
+      },
     },
   },
 };
@@ -168,95 +179,92 @@ export const ArrayRendering: Story = {
   args: {
     orientation: Orientation.Horizontal,
     propertyValueRendererManager: rendererManager,
-    dataProvider: {
-      getData: async () => ({
-        label: PropertyRecord.fromString("Record 1"),
-        categories: [
-          {
-            name: "arrayPropertyRendering",
-            label: "Array property rendering",
-            expand: true,
-          },
-        ],
-        records: {
-          arrayPropertyRendering: [
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: "string value",
-              },
-              {
-                name: "simpleProperty",
-                displayLabel: "Simple property",
-                typename: "string",
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: multilineString,
-              },
-              {
-                name: "multilineProperty",
-                displayLabel: "Multiline property",
-                typename: "string",
-                renderer: { name: "multiline" },
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Array,
-                items: [],
-                itemsTypeName: "array",
-              },
-              {
-                name: "emptyArray",
-                displayLabel: "Array property with no items",
-                typename: "array",
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Array,
-                items: arrayMembers,
-                itemsTypeName: "array",
-              },
-              {
-                name: "noRendererStructProperty",
-                displayLabel: "Array property (no renderer)",
-                typename: "array",
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Array,
-                items: arrayMembers,
-                itemsTypeName: "array",
-              },
-              {
-                name: "defaultRendererArrayProperty",
-                displayLabel: "Array property (default renderer)",
-                typename: "array",
-                renderer: { name: "defaultRendererPropertyRenderer" },
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Array,
-                items: arrayMembers,
-                itemsTypeName: "array",
-              },
-              {
-                name: "customRendererArrayPropertyRenderer",
-                displayLabel: "Array property (custom renderer)",
-                typename: "struct",
-                renderer: { name: "customRendererArrayPropertyRenderer" },
-              }
-            ),
-          ],
+    data: {
+      label: PropertyRecord.fromString("Record 1"),
+      categories: [
+        {
+          name: "arrayPropertyRendering",
+          label: "Array property rendering",
+          expand: true,
         },
-      }),
-      onDataChanged: new PropertyDataChangeEvent(),
+      ],
+      records: {
+        arrayPropertyRendering: [
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: "string value",
+            },
+            {
+              name: "simpleProperty",
+              displayLabel: "Simple property",
+              typename: "string",
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: multilineString,
+            },
+            {
+              name: "multilineProperty",
+              displayLabel: "Multiline property",
+              typename: "string",
+              renderer: { name: "multiline" },
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Array,
+              items: [],
+              itemsTypeName: "array",
+            },
+            {
+              name: "emptyArray",
+              displayLabel: "Array property with no items",
+              typename: "array",
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Array,
+              items: arrayMembers,
+              itemsTypeName: "array",
+            },
+            {
+              name: "noRendererStructProperty",
+              displayLabel: "Array property (no renderer)",
+              typename: "array",
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Array,
+              items: arrayMembers,
+              itemsTypeName: "array",
+            },
+            {
+              name: "defaultRendererArrayProperty",
+              displayLabel: "Array property (default renderer)",
+              typename: "array",
+              renderer: { name: "defaultRendererPropertyRenderer" },
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Array,
+              items: arrayMembers,
+              itemsTypeName: "array",
+            },
+            {
+              name: "customRendererArrayPropertyRenderer",
+              displayLabel: "Array property (custom renderer)",
+              typename: "struct",
+              renderer: { name: "customRendererArrayPropertyRenderer" },
+            }
+          ),
+        ],
+      },
     },
   },
 };
@@ -264,170 +272,189 @@ export const ArrayRendering: Story = {
 export const NestedCategories: Story = {
   args: {
     orientation: Orientation.Horizontal,
-    dataProvider: {
-      getData: async () => ({
-        label: PropertyRecord.fromString("Record 1"),
-        categories: [
-          {
-            name: "category1",
-            label: "Category 1",
-            expand: true,
-            childCategories: [
-              {
-                name: "category11",
-                label: "Category 1-1",
-                expand: true,
-                childCategories: [
-                  {
-                    name: "category111",
-                    label: "Category 1-1-1",
-                    expand: true,
-                  },
-                  {
-                    name: "category112",
-                    label: "Category 1-1-2",
-                    expand: true,
-                  },
-                ],
-              },
-              {
-                name: "category12",
-                label: "Category 1-2",
-                expand: true,
-              },
-            ],
-          },
-          {
-            name: "category2",
-            label: "Category 2",
-            expand: true,
-            childCategories: [
-              {
-                name: "category21",
-                label: "Category 2-1",
-                expand: true,
-                childCategories: [
-                  {
-                    name: "category211",
-                    label: "Category 2-1-1",
-                    expand: true,
-                  },
-                  {
-                    name: "category212",
-                    label: "Category 2-1-2",
-                    expand: true,
-                  },
-                ],
-              },
-              {
-                name: "category22",
-                label: "Category 2-2",
-                expand: true,
-              },
-            ],
-          },
-        ],
-        records: {
-          category1: createDefaultRecords(),
-          category11: createDefaultRecords(),
-          category111: createDefaultRecords(),
-          category112: createDefaultRecords(),
-          category12: createDefaultRecords(),
-          category2: createDefaultRecords(),
-          category21: createDefaultRecords(),
-          category211: createDefaultRecords(),
-          category212: createDefaultRecords(),
-          category22: createDefaultRecords(),
+    data: {
+      label: PropertyRecord.fromString("Record 1"),
+      categories: [
+        {
+          name: "category1",
+          label: "Category 1",
+          expand: true,
+          childCategories: [
+            {
+              name: "category11",
+              label: "Category 1-1",
+              expand: true,
+              childCategories: [
+                {
+                  name: "category111",
+                  label: "Category 1-1-1",
+                  expand: true,
+                },
+                {
+                  name: "category112",
+                  label: "Category 1-1-2",
+                  expand: true,
+                },
+              ],
+            },
+            {
+              name: "category12",
+              label: "Category 1-2",
+              expand: true,
+            },
+          ],
         },
-      }),
-      onDataChanged: new PropertyDataChangeEvent(),
+        {
+          name: "category2",
+          label: "Category 2",
+          expand: true,
+          childCategories: [
+            {
+              name: "category21",
+              label: "Category 2-1",
+              expand: true,
+              childCategories: [
+                {
+                  name: "category211",
+                  label: "Category 2-1-1",
+                  expand: true,
+                },
+                {
+                  name: "category212",
+                  label: "Category 2-1-2",
+                  expand: true,
+                },
+              ],
+            },
+            {
+              name: "category22",
+              label: "Category 2-2",
+              expand: true,
+            },
+          ],
+        },
+      ],
+      records: {
+        category1: createDefaultRecords(),
+        category11: createDefaultRecords(),
+        category111: createDefaultRecords(),
+        category112: createDefaultRecords(),
+        category12: createDefaultRecords(),
+        category2: createDefaultRecords(),
+        category21: createDefaultRecords(),
+        category211: createDefaultRecords(),
+        category212: createDefaultRecords(),
+        category22: createDefaultRecords(),
+      },
     },
   },
 };
 
 export const Links: Story = {
   args: {
-    dataProvider: {
-      getData: async () => ({
-        label: PropertyRecord.fromString("Record 1"),
-        categories: [{ name: "Group_1", label: "Group 1", expand: true }],
-        records: {
-          Group_1: [
-            PropertyRecord.fromString("https://www.bentley.com"),
-            PropertyRecord.fromString("pw://test"),
-          ],
-        },
-      }),
-      onDataChanged: new PropertyDataChangeEvent(),
+    data: {
+      label: PropertyRecord.fromString("Record 1"),
+      categories: [{ name: "Group_1", label: "Group 1", expand: true }],
+      records: {
+        Group_1: [
+          PropertyRecord.fromString("https://www.bentley.com"),
+          PropertyRecord.fromString("pw://test"),
+        ],
+      },
     },
     onPropertyContextMenu: undefined,
   },
 };
 
+export const Editable: Story = {
+  args: {
+    height: 1000,
+    isPropertyEditingEnabled: true,
+    onPropertyUpdated: async ({ propertyRecord, newValue }) => {
+      action("onPropertyUpdated")(
+        `Property "${propertyRecord.property.name}" updated to: ${
+          (newValue as PrimitiveValue).value
+        }`
+      );
+      return true;
+    },
+    data: {
+      label: PropertyRecord.fromString("Record 1"),
+      categories: [
+        { name: "Editable", label: "Editable", expand: true },
+        { name: "Readonly", label: "Readonly", expand: true },
+        { name: "Disabled", label: "Disabled", expand: true },
+      ],
+      records: {
+        Editable: createPropertyRecords("editable_"),
+        Readonly: createPropertyRecords("readonly_", { isReadonly: true }),
+        Disabled: createPropertyRecords("disabled_", { isDisabled: true }),
+      },
+    },
+  },
+};
+
 export const AlwaysVisibleEditor: Story = {
   args: {
-    dataProvider: {
-      getData: async () => ({
-        label: PropertyRecord.fromString("Record 1"),
-        categories: [
-          { name: "Group_1", label: "Group 1", expand: true },
-          { name: "Group_2", label: "Group 2", expand: true },
+    data: {
+      label: PropertyRecord.fromString("Record 1"),
+      categories: [
+        { name: "Group_1", label: "Group 1", expand: true },
+        { name: "Group_2", label: "Group 2", expand: true },
+      ],
+      records: {
+        Group_1: [
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: true,
+            },
+            {
+              name: "toggleProperty",
+              displayLabel: "Always visible toggle editor",
+              typename: "boolean",
+              editor: { name: "toggle" },
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: false,
+            },
+            {
+              name: "toggleProperty2",
+              displayLabel: "Always visible toggle editor",
+              typename: "boolean",
+              editor: { name: "toggle" },
+            }
+          ),
         ],
-        records: {
-          Group_1: [
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: true,
-              },
-              {
-                name: "toggleProperty",
-                displayLabel: "Always visible toggle editor",
-                typename: "boolean",
-                editor: { name: "toggle" },
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: false,
-              },
-              {
-                name: "toggleProperty2",
-                displayLabel: "Always visible toggle editor",
-                typename: "boolean",
-                editor: { name: "toggle" },
-              }
-            ),
-          ],
-          Group_2: [
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: true,
-              },
-              {
-                name: "toggleProperty3",
-                displayLabel: "Not always visible boolean editor",
-                typename: "boolean",
-              }
-            ),
-            new PropertyRecord(
-              {
-                valueFormat: PropertyValueFormat.Primitive,
-                value: "Text",
-              },
-              {
-                name: "stringProperty",
-                displayLabel: "Not always visible string editor",
-                typename: "string",
-              }
-            ),
-          ],
-          Group_3: [],
-        },
-      }),
-      onDataChanged: new PropertyDataChangeEvent(),
+        Group_2: [
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: true,
+            },
+            {
+              name: "toggleProperty3",
+              displayLabel: "Not always visible boolean editor",
+              typename: "boolean",
+            }
+          ),
+          new PropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: "Text",
+            },
+            {
+              name: "stringProperty",
+              displayLabel: "Not always visible string editor",
+              typename: "string",
+            }
+          ),
+        ],
+        Group_3: [],
+      },
     },
     onPropertyContextMenu: undefined,
     isPropertyEditingEnabled: true,
@@ -482,21 +509,104 @@ rendererManager.registerRenderer(
   new MultilineTextPropertyValueRenderer()
 );
 
-const structMembers = {
-  member1: PropertyRecord.fromString("Value 1", "Member 1"),
-  member2: PropertyRecord.fromString("Value 2", "Member 2"),
-  member3: PropertyRecord.fromString("Value 3", "Member 3"),
-};
+function createPropertyRecords(
+  prefix: string = "",
+  recordProps?: { isDisabled?: boolean; isReadonly?: boolean }
+) {
+  return [
+    createPropertyRecord(
+      {
+        valueFormat: PropertyValueFormat.Primitive,
+        value: "text value",
+      },
+      {
+        name: `${prefix}stringProperty`,
+        displayLabel: "String Property",
+        typename: StandardTypeNames.String,
+      },
+      recordProps
+    ),
+    createPropertyRecord(
+      {
+        valueFormat: PropertyValueFormat.Primitive,
+        value: 42,
+      },
+      {
+        name: `${prefix}intProperty`,
+        displayLabel: "Int Property",
+        typename: StandardTypeNames.Int,
+      },
+      recordProps
+    ),
+    createPropertyRecord(
+      {
+        valueFormat: PropertyValueFormat.Primitive,
+        value: true,
+        displayValue: "True",
+      },
+      {
+        name: `${prefix}boolProperty`,
+        displayLabel: "Boolean Property",
+        typename: StandardTypeNames.Boolean,
+      },
+      recordProps
+    ),
+    createPropertyRecord(
+      {
+        valueFormat: PropertyValueFormat.Primitive,
+        value: new Date(),
+      },
+      {
+        name: `${prefix}dateProperty`,
+        displayLabel: "Date Property",
+        typename: StandardTypeNames.ShortDate,
+      },
+      recordProps
+    ),
+    createPropertyRecord(
+      {
+        valueFormat: PropertyValueFormat.Primitive,
+        value: new Date(),
+      },
+      {
+        name: `${prefix}dateTimeProperty`,
+        displayLabel: "DateTime Property",
+        typename: StandardTypeNames.DateTime,
+      },
+      recordProps
+    ),
+    createPropertyRecord(
+      {
+        valueFormat: PropertyValueFormat.Primitive,
+        value: 1,
+      },
+      {
+        name: `${prefix}enumProperty`,
+        displayLabel: "Enum Property",
+        typename: StandardTypeNames.Enum,
+        enum: {
+          choices: [
+            { value: 1, label: "Choice 1" },
+            { value: 2, label: "Choice 2" },
+            { value: 3, label: "Choice 3" },
+          ],
+        },
+      },
+      recordProps
+    ),
+  ];
+}
 
-const arrayMembers = [
-  PropertyRecord.fromString("Value 1", "Item 1"),
-  PropertyRecord.fromString("Value 2", "Item 2"),
-  PropertyRecord.fromString("Value 3", "Item 3"),
-];
-
-const multilineString =
-  // cspell:disable-next-line
-  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\nExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n";
+function createPropertyRecord(
+  value: PropertyValue,
+  property: PropertyDescription,
+  recordProps?: { isDisabled?: boolean; isReadonly?: boolean }
+): PropertyRecord {
+  const record = new PropertyRecord(value, property);
+  record.isDisabled = recordProps?.isDisabled;
+  record.isReadonly = recordProps?.isReadonly;
+  return record;
+}
 
 function createDefaultRecords() {
   return [

--- a/docs/storybook/src/components/PropertyGrid.tsx
+++ b/docs/storybook/src/components/PropertyGrid.tsx
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import {
+  PropertyData,
+  PropertyDataChangeEvent,
+  VirtualizedPropertyGridWithDataProvider,
+} from "@itwin/components-react";
+import { useMemo } from "react";
+
+type VirtualizedPropertyGridWithDataProviderProps = React.ComponentProps<
+  typeof VirtualizedPropertyGridWithDataProvider
+>;
+interface PropertyGridStoryProps
+  extends Omit<VirtualizedPropertyGridWithDataProviderProps, "dataProvider"> {
+  data: PropertyData;
+}
+
+export function PropertyGridStory(props: PropertyGridStoryProps) {
+  const { data, ...rest } = props;
+
+  const provider = useMemo(
+    () => ({
+      getData: async () => data,
+      onDataChanged: new PropertyDataChangeEvent(),
+    }),
+    [data]
+  );
+
+  return (
+    <VirtualizedPropertyGridWithDataProvider
+      {...rest}
+      dataProvider={provider}
+    />
+  );
+}

--- a/ui/components-react/src/components-react/editors/BooleanEditor.tsx
+++ b/ui/components-react/src/components-react/editors/BooleanEditor.tsx
@@ -18,7 +18,6 @@ import { PropertyEditorBase } from "./PropertyEditorManager.js";
 /** @internal */
 interface BooleanEditorState {
   checkboxValue: boolean;
-  isDisabled?: boolean;
 }
 
 /** BooleanEditor React component that is a property editor with checkbox input
@@ -33,7 +32,6 @@ export class BooleanEditor
 
   public override readonly state: Readonly<BooleanEditorState> = {
     checkboxValue: false,
-    isDisabled: false,
   };
 
   public async getPropertyValue(): Promise<PropertyValue | undefined> {
@@ -105,7 +103,6 @@ export class BooleanEditor
   private setStateFromProps() {
     const { propertyRecord } = this.props;
     let checkboxValue = false;
-    let isDisabled = false;
 
     if (
       propertyRecord &&
@@ -115,10 +112,10 @@ export class BooleanEditor
       checkboxValue = primitiveValue as boolean;
     }
 
-    if (propertyRecord && propertyRecord.isDisabled)
-      isDisabled = propertyRecord.isDisabled;
-
-    if (this._isMounted) this.setState({ checkboxValue, isDisabled });
+    if (this._isMounted)
+      this.setState({
+        checkboxValue,
+      });
   }
 
   public override render() {
@@ -128,7 +125,6 @@ export class BooleanEditor
       this.props.className
     );
     const checked = this.state.checkboxValue;
-    const isDisabled = !!this.state.isDisabled;
 
     return (
       <Checkbox
@@ -139,7 +135,10 @@ export class BooleanEditor
         checked={checked}
         onChange={this._updateCheckboxValue}
         autoFocus={this.props.setFocus} // eslint-disable-line jsx-a11y/no-autofocus
-        disabled={isDisabled}
+        disabled={
+          this.props.propertyRecord?.isDisabled ||
+          this.props.propertyRecord?.isReadonly
+        }
         data-testid="components-checkbox-editor"
       ></Checkbox>
     );

--- a/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
+++ b/ui/components-react/src/components-react/editors/DateTimeEditor.tsx
@@ -36,7 +36,6 @@ interface DateTimeEditorState {
   value: Date;
   displayValue?: string;
   timeDisplay?: TimeDisplay;
-  isDisabled?: boolean;
   typeConverter?: TypeConverter;
   editInUtc: boolean;
 }
@@ -225,7 +224,6 @@ export class DateTimeEditor
       throw new Error("Unable to determine TypeConverter");
     }
 
-    const isDisabled = record && !!record.isDisabled;
     const displayValue = await typeConverter.convertPropertyToString(
       record!.property,
       initialValue
@@ -234,7 +232,6 @@ export class DateTimeEditor
     if (this._isMounted)
       this.setState({
         value: initialValue,
-        isDisabled,
         timeDisplay,
         typeConverter,
         displayValue,
@@ -300,6 +297,8 @@ export class DateTimeEditor
           onClose={this._handleClose}
           onEnter={this._handleEnter}
           setFocus={this.props.setFocus}
+          disabled={this.props.propertyRecord?.isDisabled}
+          readonly={this.props.propertyRecord?.isReadonly}
         >
           <PopupContent>
             <>

--- a/ui/components-react/src/components-react/editors/EnumButtonGroupEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumButtonGroupEditor.tsx
@@ -166,14 +166,18 @@ export class EnumButtonGroupEditor
     }
   };
 
-  private getButton(choice: EnumerationChoice, index: number) {
+  private getButton(
+    choice: EnumerationChoice,
+    index: number,
+    disabled?: boolean
+  ) {
     const choiceValue = this.state.choices
       ? this.state.choices[index].value
       : 0;
     const isActive = choiceValue === this.state.selectValue ? true : false;
-    let isDisabled = false;
+    let isDisabled = disabled;
     const isEnabledFunction = this.state.enumIcons[index].isEnabledFunction;
-    if (isEnabledFunction) {
+    if (isEnabledFunction && !isDisabled) {
       isDisabled = !isEnabledFunction();
     }
 
@@ -221,7 +225,12 @@ export class EnumButtonGroupEditor
         {this.state.choices &&
           this.state.enumIcons.length &&
           this.state.choices.map((choice: EnumerationChoice, index: number) =>
-            this.getButton(choice, index)
+            this.getButton(
+              choice,
+              index,
+              this.props.propertyRecord?.isDisabled ||
+                this.props.propertyRecord?.isReadonly
+            )
           )}
       </div>
     );

--- a/ui/components-react/src/components-react/editors/EnumEditor.tsx
+++ b/ui/components-react/src/components-react/editors/EnumEditor.tsx
@@ -191,6 +191,10 @@ export class EnumEditor
           }}
           aria-label={UiComponents.translate("editor.enum")}
           size="small"
+          disabled={
+            this.props.propertyRecord?.isDisabled ||
+            this.props.propertyRecord?.isReadonly
+          }
         />
       </div>
     );

--- a/ui/components-react/src/components-react/editors/IconEditor.tsx
+++ b/ui/components-react/src/components-react/editors/IconEditor.tsx
@@ -28,8 +28,6 @@ interface IconEditorState {
   icon: string;
   icons: string[];
   numColumns: number;
-  readonly?: boolean;
-  isDisabled?: boolean;
 }
 
 /** IconEditor React component that is a property editor with button and popup
@@ -49,7 +47,6 @@ export class IconEditor
     let icon = "";
     let numColumns = 4;
     const icons: string[] = [];
-    const readonly = false;
 
     // TODO: add support for following if we need to specify set of weights to display
     const record = props.propertyRecord;
@@ -71,7 +68,7 @@ export class IconEditor
       }
     }
 
-    this.state = { icon, icons, numColumns, readonly };
+    this.state = { icon, icons, numColumns };
   }
 
   public async getPropertyValue(): Promise<PropertyValue | undefined> {
@@ -101,7 +98,7 @@ export class IconEditor
   }
 
   private setFocus(): void {
-    if (this._control && !this.state.isDisabled) {
+    if (this._control && !this.props.propertyRecord?.isDisabled) {
       this._control.setFocus();
     }
   }
@@ -147,12 +144,8 @@ export class IconEditor
       initialValue = record.value.value as string;
     }
 
-    const readonly =
-      record && undefined !== record.isReadonly ? record.isReadonly : false;
-    const isDisabled = record ? record.isDisabled : undefined;
-
     if (this._isMounted)
-      this.setState({ icon: initialValue, readonly, isDisabled }, () => {
+      this.setState({ icon: initialValue }, () => {
         if (this.props.setFocus) {
           this.setFocus();
         }
@@ -172,8 +165,8 @@ export class IconEditor
           icon={icon}
           icons={icons}
           numColumns={numColumns}
-          disabled={this.state.isDisabled}
-          readonly={this.state.readonly}
+          disabled={this.props.propertyRecord?.isDisabled}
+          readonly={this.props.propertyRecord?.isReadonly}
           onIconChange={this._onIconChange}
           data-testid="components-icon-editor"
         />

--- a/ui/components-react/src/components-react/editors/ImageCheckBoxEditor.tsx
+++ b/ui/components-react/src/components-react/editors/ImageCheckBoxEditor.tsx
@@ -29,7 +29,6 @@ interface ImageCheckBoxEditorState {
   /** Image for the "unchecked" (default) state */
   imageOff: string;
   checkboxValue: boolean;
-  isDisabled?: boolean;
 }
 /** [[ImageCheckBoxEditor]]
  * Boolean editor that renders with an image instead of checkbox
@@ -46,7 +45,6 @@ export class ImageCheckBoxEditor
     imageOff: "",
     imageOn: "",
     checkboxValue: false,
-    isDisabled: false,
   };
 
   public async getPropertyValue(): Promise<PropertyValue | undefined> {
@@ -93,7 +91,6 @@ export class ImageCheckBoxEditor
     let checkboxValue = false;
     let imageOn = "";
     let imageOff = "";
-    let isDisabled = false;
 
     if (
       propertyRecord &&
@@ -102,9 +99,6 @@ export class ImageCheckBoxEditor
       const primitiveValue = propertyRecord.value.value;
       checkboxValue = primitiveValue as boolean;
     }
-
-    if (propertyRecord && propertyRecord.isDisabled)
-      isDisabled = propertyRecord.isDisabled;
 
     if (
       propertyRecord &&
@@ -121,7 +115,7 @@ export class ImageCheckBoxEditor
         imageOff = imageCheckBoxParams.imageOff;
       }
     }
-    this.setState({ imageOn, imageOff, checkboxValue, isDisabled });
+    this.setState({ imageOn, imageOff, checkboxValue });
   }
 
   private _handleClick = (checked: boolean) => {
@@ -150,7 +144,9 @@ export class ImageCheckBoxEditor
       this.props.className
     );
     const checked = this.state.checkboxValue;
-    const isDisabled = !!this.state.isDisabled;
+    const isDisabled =
+      this.props.propertyRecord?.isDisabled ||
+      this.props.propertyRecord?.isReadonly;
 
     return (
       // eslint-disable-next-line @typescript-eslint/no-deprecated

--- a/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
+++ b/ui/components-react/src/components-react/editors/NumericInputEditor.tsx
@@ -31,8 +31,6 @@ import { InputWithDecorations } from "@itwin/itwinui-react";
 /** @internal */
 interface NumericInputEditorState {
   value: number;
-  readonly: boolean;
-  isDisabled?: boolean;
   size?: number;
   maxLength?: number;
 
@@ -55,7 +53,6 @@ export class NumericInputEditor
 
   public override readonly state: Readonly<NumericInputEditorState> = {
     value: 0,
-    readonly: false,
   };
 
   public async getPropertyValue(): Promise<PropertyValue | undefined> {
@@ -130,16 +127,12 @@ export class NumericInputEditor
       initialValue = record.value.value as number;
     }
 
-    const readonly =
-      record && undefined !== record.isReadonly ? record.isReadonly : false;
     let size: number | undefined;
     let maxLength: number | undefined;
     let min: number | undefined;
     let max: number | undefined;
     let step: number | undefined;
     let precision: number | undefined;
-
-    const isDisabled = record ? record.isDisabled : undefined;
 
     if (
       record &&
@@ -171,10 +164,8 @@ export class NumericInputEditor
     if (this._isMounted)
       this.setState({
         value: initialValue,
-        readonly,
         size,
         maxLength,
-        isDisabled,
         min,
         max,
         step,
@@ -205,11 +196,15 @@ export class NumericInputEditor
         max={this.state.max}
         step={this.state.step}
         precision={this.state.precision}
-        readOnly={this.state.readonly}
+        readOnly={this.props.propertyRecord?.isReadonly}
+        disabled={this.props.propertyRecord?.isDisabled}
         maxLength={this.state.maxLength}
         onBlur={this.props.onBlur}
         onChange={this._updateValue}
-        autoFocus={this.props.setFocus && !this.state.isDisabled} // eslint-disable-line jsx-a11y/no-autofocus
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={
+          this.props.setFocus && !this.props.propertyRecord?.isDisabled
+        }
         isControlled={this.props.shouldCommitOnChange}
         decoration={decoration}
       />

--- a/ui/components-react/src/components-react/editors/PopupButton.scss
+++ b/ui/components-react/src/components-react/editors/PopupButton.scss
@@ -68,6 +68,26 @@
       }
     }
   }
+
+  &.readonly {
+    cursor: default;
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+    background-color: var(--iui-color-background-disabled);
+    border-color: var(--iui-color-border-foreground-disabled);
+    color: var(--iui-color-text-disabled);
+
+    > .components-popup-button-arrow {
+      background-color: var(--iui-color-background-disabled);
+      border-color: var(--iui-color-border-foreground-disabled);
+
+      > .components-popup-button-arrow-icon {
+        color: var(--iui-color-text-disabled);
+      }
+    }
+  }
 }
 
 .components-smallEditor-host {

--- a/ui/components-react/src/components-react/editors/PopupButton.tsx
+++ b/ui/components-react/src/components-react/editors/PopupButton.tsx
@@ -48,6 +48,10 @@ export interface PopupButtonProps extends CommonProps {
   setFocus?: boolean;
   /** Indicates whether to close the popup when Enter is pressed (defaults to true) */
   closeOnEnter?: boolean;
+  /** Disabled or not */
+  disabled?: boolean;
+  /** Readonly or not */
+  readonly?: boolean;
 
   /** Listens for click events on button area */
   onClick?: (event: React.MouseEvent) => void;
@@ -81,6 +85,8 @@ export class PopupButton extends React.PureComponent<
   }
 
   private _togglePopup = (event: React.MouseEvent) => {
+    if (this.props.readonly || this.props.disabled) return;
+
     this.setState(
       (prevState) => ({ showPopup: !prevState.showPopup }),
       () => this.props.onClick && this.props.onClick(event)
@@ -121,7 +127,9 @@ export class PopupButton extends React.PureComponent<
 
     const classNames = classnames(
       "components-popup-button",
-      this.state.showPopup && "components-popup-expanded"
+      this.state.showPopup && "components-popup-expanded",
+      this.props.readonly && "readonly",
+      this.props.disabled && "disabled"
     );
 
     const valueClassNames = classnames(
@@ -139,6 +147,7 @@ export class PopupButton extends React.PureComponent<
           tabIndex={0}
           ref={this._buttonRef}
           title={this.props.title}
+          aria-disabled={this.props.disabled}
           role="button"
         >
           <div className={valueClassNames}>

--- a/ui/components-react/src/components-react/editors/SliderEditor.tsx
+++ b/ui/components-react/src/components-react/editors/SliderEditor.tsx
@@ -34,7 +34,6 @@ type TooltipProps = React.ComponentPropsWithoutRef<typeof Tooltip>;
 /** @internal */
 interface SliderEditorState {
   value: number;
-  isDisabled?: boolean;
   min: number;
   max: number;
   size?: number;
@@ -152,8 +151,6 @@ export class SliderEditor
       | undefined;
     let thumbMode: "allow-crossing" | "inhibit-crossing" | undefined;
 
-    const isDisabled = record ? record.isDisabled : undefined;
-
     if (
       record &&
       record.property &&
@@ -223,7 +220,6 @@ export class SliderEditor
     if (this._isMounted)
       this.setState({
         value: initialValue,
-        isDisabled,
         size,
         min,
         max,
@@ -310,7 +306,7 @@ export class SliderEditor
         step={this.state.step}
         thumbMode={this.state.thumbMode}
         trackDisplayMode={this.state.trackDisplayMode}
-        disabled={this.state.isDisabled}
+        disabled={this.props.propertyRecord?.isDisabled}
         minLabel={this.state.minLabel}
         maxLabel={this.state.maxLabel}
         tooltipProps={this.tooltipProps}
@@ -327,6 +323,8 @@ export class SliderEditor
           onClose={this._handleClose}
           onEnter={this._handleEnter}
           setFocus={this.props.setFocus}
+          disabled={this.props.propertyRecord?.isDisabled}
+          readonly={this.props.propertyRecord?.isReadonly}
         >
           <PopupContent>
             {popupContent}

--- a/ui/components-react/src/components-react/editors/TextEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextEditor.tsx
@@ -35,8 +35,6 @@ type InputProps = React.ComponentPropsWithoutRef<typeof Input>;
 /** @internal */
 interface TextEditorState {
   inputValue: string;
-  readonly: boolean;
-  isDisabled?: boolean;
   size?: number;
   maxLength?: number;
   iconSpec?: string;
@@ -54,7 +52,6 @@ export class TextEditor
 
   public override readonly state: Readonly<TextEditorState> = {
     inputValue: "",
-    readonly: false,
   };
 
   public async getPropertyValue(): Promise<PropertyValue | undefined> {
@@ -131,13 +128,9 @@ export class TextEditor
       ).convertPropertyToString(record.property, value);
     }
 
-    const readonly =
-      record && undefined !== record.isReadonly ? record.isReadonly : false;
     let size: number | undefined;
     let maxLength: number | undefined;
     let iconSpec: string | undefined;
-
-    const isDisabled = record ? record.isDisabled : undefined;
 
     if (
       record &&
@@ -166,10 +159,8 @@ export class TextEditor
     if (this._isMounted)
       this.setState({
         inputValue: initialValue,
-        readonly,
         size,
         maxLength,
-        isDisabled,
         iconSpec,
       });
   }
@@ -189,13 +180,13 @@ export class TextEditor
       type: "text",
       className,
       style: this.props.style ? this.props.style : minWidthStyle,
-      readOnly: this.state.readonly,
-      disabled: this.state.isDisabled,
+      readOnly: this.props.propertyRecord?.isReadonly,
+      disabled: this.props.propertyRecord?.isDisabled,
       maxLength: this.state.maxLength,
       value: this.state.inputValue,
       onBlur: this.props.onBlur,
       onChange: this._updateInputValue,
-      autoFocus: this.props.setFocus && !this.state.isDisabled,
+      autoFocus: this.props.setFocus && !this.props.propertyRecord?.isDisabled,
       "aria-label": UiComponents.translate("editor.text"),
     };
 

--- a/ui/components-react/src/components-react/editors/TextareaEditor.tsx
+++ b/ui/components-react/src/components-react/editors/TextareaEditor.tsx
@@ -36,8 +36,6 @@ type TextareaProps = React.ComponentPropsWithoutRef<typeof Textarea>;
 /** @internal */
 interface TextareaEditorState {
   inputValue: string;
-  readonly: boolean;
-  isDisabled?: boolean;
   size?: number;
   maxLength?: number;
   rows: number;
@@ -58,7 +56,6 @@ export class TextareaEditor
 
   public override readonly state: Readonly<TextareaEditorState> = {
     inputValue: "",
-    readonly: false,
     rows: DEFAULT_ROWS,
   };
 
@@ -123,13 +120,9 @@ export class TextareaEditor
       ).convertPropertyToString(record.property, value);
     }
 
-    const readonly =
-      record && undefined !== record.isReadonly ? record.isReadonly : false;
     let size: number | undefined;
     let maxLength: number | undefined;
     let rows: number = DEFAULT_ROWS;
-
-    const isDisabled = record ? record.isDisabled : undefined;
 
     if (
       record &&
@@ -158,10 +151,8 @@ export class TextareaEditor
     if (this._isMounted)
       this.setState({
         inputValue: initialValue,
-        readonly,
         size,
         maxLength,
-        isDisabled,
         rows,
       });
   }
@@ -199,12 +190,12 @@ export class TextareaEditor
       className: "components-textarea-editor-textarea",
       style,
       rows: this.state.rows,
-      readOnly: this.state.readonly,
-      disabled: this.state.isDisabled,
+      readOnly: this.props.propertyRecord?.isReadonly,
+      disabled: this.props.propertyRecord?.isDisabled,
       maxLength: this.state.maxLength,
       value: this.state.inputValue,
       onChange: this._updateTextareaValue,
-      autoFocus: this.props.setFocus && !this.state.isDisabled,
+      autoFocus: this.props.setFocus && !this.props.propertyRecord?.isDisabled,
     };
 
     textareaProps["aria-label"] = UiComponents.translate("editor.textarea");

--- a/ui/components-react/src/components-react/editors/ToggleEditor.tsx
+++ b/ui/components-react/src/components-react/editors/ToggleEditor.tsx
@@ -18,7 +18,6 @@ import { ToggleSwitch } from "@itwin/itwinui-react";
 /** @internal */
 interface ToggleEditorState {
   toggleValue: boolean;
-  isDisabled?: boolean;
 }
 
 /** ToggleEditor React component that is a property editor with checkbox input
@@ -33,7 +32,6 @@ export class ToggleEditor
 
   public override readonly state: Readonly<ToggleEditorState> = {
     toggleValue: false,
-    isDisabled: false,
   };
 
   public async getPropertyValue(): Promise<PropertyValue | undefined> {
@@ -104,7 +102,6 @@ export class ToggleEditor
   private async setStateFromProps() {
     const { propertyRecord } = this.props;
     let toggleValue = false;
-    let isDisabled = false;
 
     if (
       propertyRecord &&
@@ -114,10 +111,10 @@ export class ToggleEditor
       toggleValue = primitiveValue as boolean;
     }
 
-    if (propertyRecord && propertyRecord.isDisabled)
-      isDisabled = propertyRecord.isDisabled;
-
-    if (this._isMounted) this.setState({ toggleValue, isDisabled });
+    if (this._isMounted)
+      this.setState({
+        toggleValue,
+      });
   }
 
   public override render() {
@@ -127,7 +124,6 @@ export class ToggleEditor
       this.props.className
     );
     const isChecked = this.state.toggleValue;
-    const isDisabled = !!this.state.isDisabled;
 
     return (
       <ToggleSwitch
@@ -136,7 +132,8 @@ export class ToggleEditor
         className={className}
         style={this.props.style}
         checked={isChecked}
-        disabled={isDisabled}
+        readOnly={this.props.propertyRecord?.isReadonly}
+        disabled={this.props.propertyRecord?.isDisabled}
         onChange={this._updateToggleValue}
         data-testid="components-toggle-editor"
         autoFocus={this.props.setFocus} // eslint-disable-line jsx-a11y/no-autofocus


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Closes https://github.com/iTwin/appui/issues/1370. Reviewed editors and made sure that they respect `isReadonly` or `isDisabled` flag from `PropertyRecord`.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Updated storybook with editable property grid story.