### PR TITLE
Add `isActiveCondition` property to `CommonToolbarItem` interface

### DIFF
--- a/.changeset/mighty-needles-stop.md
+++ b/.changeset/mighty-needles-stop.md
@@ -1,0 +1,20 @@
+---
+"@itwin/appui-react": minor
+---
+
+Added `isActiveCondition` property to `CommonToolbarItem` interface, which allows to dynamically update the active state of a toolbar item using a conditional value.
+
+```tsx
+let isActive = false;
+const eventId = "my-action-active-changed";
+function toggleActive() {
+  isActive = !isActive;
+  SyncUiEventDispatcher.dispatchSyncUiEvent(eventId);
+}
+
+ToolbarItemUtilities.createActionItem({
+  id: "my-action",
+  execute: toggleActive,
+  isActiveCondition: new ConditionalBooleanValue(() => isActive, [eventId]),
+});
+```

--- a/.changeset/red-pugs-remain.md
+++ b/.changeset/red-pugs-remain.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Deprecated `isActive` property of `CommonToolbarItem` interface. Use `isActiveCondition` property instead.

--- a/apps/test-app/src/frontend/appui/frontstages/WidgetApiFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/WidgetApiFrontstage.tsx
@@ -5,7 +5,6 @@
 import * as React from "react";
 import { ConditionalStringValue } from "@itwin/appui-abstract";
 import {
-  BackstageAppButton,
   BackstageItemUtilities,
   ConditionalBooleanValue,
   Frontstage,
@@ -16,14 +15,11 @@ import {
   StageUsage,
   StandardContentLayouts,
   StandardLayout,
-  ToolbarComposer,
   ToolbarItemUtilities,
   ToolbarOrientation,
   ToolbarUsage,
-  ToolWidgetComposer,
   UiFramework,
   UiItemsProvider,
-  useActiveToolId,
   useConditionalValue,
   Widget,
   WidgetAction,

--- a/apps/test-app/src/frontend/appui/frontstages/WidgetApiFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/WidgetApiFrontstage.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 import { ConditionalStringValue } from "@itwin/appui-abstract";
 import {
+  BackstageAppButton,
   BackstageItemUtilities,
   ConditionalBooleanValue,
   Frontstage,
@@ -70,6 +71,12 @@ export function createWidgetApiFrontstage(): Frontstage {
         },
       ],
     },
+    cornerButton: (
+      <BackstageAppButton
+        key="appui-test-providers-WidgetApi-backstage"
+        icon="icon-bentley-systems"
+      />
+    ),
     defaultTool: MeasureDistanceTool.toolId,
     usage: StageUsage.General,
     topPanelProps: {

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -880,7 +880,9 @@ export interface CommonToolbarItem {
     readonly groupPriority?: number;
     readonly iconNode?: React.ReactNode;
     readonly id: string;
+    // @deprecated
     readonly isActive?: boolean;
+    readonly isActiveCondition?: boolean | ConditionalBooleanValue_2;
     readonly isDisabled?: boolean | ConditionalBooleanValue_2;
     readonly isHidden?: boolean | ConditionalBooleanValue_2;
     readonly itemPriority: number;

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -219,6 +219,10 @@ export const Conditional: Story = {
           bump();
           items.action1.execute();
         },
+        isActiveCondition: new ConditionalBooleanValue(
+          () => getVal() % 2 === 1,
+          [eventId]
+        ),
       },
       {
         ...items.action2,

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
@@ -195,13 +195,14 @@ export interface ExtensibleToolbarProps {
   orientation: ToolbarOrientation;
   /** Describes the ids of active toolbar items.
    * By default only the toolbar item with id that matches the active `Tool` id is active.
+   * @note Property {@link ToolbarItem.isActiveCondition} takes precedence when determining the active state of a toolbar item.
    */
   activeItemIds?: string[];
 }
 
 /**
  * Toolbar that is populated and maintained by UI item providers.
- * @note Overrides `isActive` property based on the active tool id, unless `activeItemIds` is specified.
+ * @note Overrides {@link ToolbarItem.isActive} property based on the active tool id, unless {@link ExtensibleToolbarProps.activeItemIds} is specified.
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -282,6 +283,7 @@ export function updateActiveItems(
       const [current, ancestors] = stack.pop()!;
 
       const isActive = activeItemIds.includes(current.id);
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       current.isActive = isActive;
 
       if ("items" in current) {
@@ -294,6 +296,7 @@ export function updateActiveItems(
 
       // Mark ancestors of active item as active.
       for (const ancestor of ancestors) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ancestor.isActive = true;
       }
     }

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarComposer.tsx
@@ -17,6 +17,7 @@ import { Logger, ProcessDetector } from "@itwin/core-bentley";
 import { UiFramework } from "../UiFramework.js";
 import { ToolbarDragInteractionContext } from "./DragInteraction.js";
 import type {
+  CommonToolbarItem,
   ToolbarActionItem,
   ToolbarGroupItem,
   ToolbarItem,
@@ -195,14 +196,14 @@ export interface ExtensibleToolbarProps {
   orientation: ToolbarOrientation;
   /** Describes the ids of active toolbar items.
    * By default only the toolbar item with id that matches the active `Tool` id is active.
-   * @note Property {@link ToolbarItem.isActiveCondition} takes precedence when determining the active state of a toolbar item.
+   * @note Property {@link CommonToolbarItem.isActiveCondition} takes precedence when determining the active state of a toolbar item.
    */
   activeItemIds?: string[];
 }
 
 /**
  * Toolbar that is populated and maintained by UI item providers.
- * @note Overrides {@link ToolbarItem.isActive} property based on the active tool id, unless {@link ExtensibleToolbarProps.activeItemIds} is specified.
+ * @note Overrides {@link CommonToolbarItem.isActive} property based on the active tool id, unless {@link ExtensibleToolbarProps.activeItemIds} is specified.
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-deprecated

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItem.ts
@@ -51,8 +51,12 @@ export interface CommonToolbarItem {
   readonly badgeKind?: BadgeKind;
   /** Optional description */
   readonly description?: string | ConditionalStringValue;
-  /** Defines if the item is active (shown with an active stripe/bar). */
+  /** Defines if the item is active (shown with an active stripe/bar).
+   * @deprecated in 5.13.0. Ignored by `ToolbarComposer` component. Use {@link CommonToolbarItem.isActiveCondition} instead.
+   */
   readonly isActive?: boolean;
+  /** Describes if the item is active. Use conditional value to dynamically update the active state. */
+  readonly isActiveCondition?: boolean | ConditionalBooleanValue;
   /** Describes if the item is visible or hidden. The default is for the item to be visible. */
   readonly isHidden?: boolean | ConditionalBooleanValue;
   /** Describes if the item is enabled or disabled. The default is for the item to be enabled. */

--- a/ui/appui-react/src/appui-react/toolbar/ToolbarItemsManager.ts
+++ b/ui/appui-react/src/appui-react/toolbar/ToolbarItemsManager.ts
@@ -266,6 +266,7 @@ export class ToolbarItemsManager {
         if (this.isActiveToolIdRefreshRequiredForChildren(item.items, toolId))
           return true;
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const isActive = !!item.isActive;
         if (
           (isActive && item.id !== toolId) ||
@@ -289,6 +290,7 @@ export class ToolbarItemsManager {
         )
           return true;
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const isActive = !!item.isActive;
         if (
           (isActive && item.id !== toolId) ||
@@ -320,6 +322,7 @@ export class ToolbarItemsManager {
         };
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       updatedItem.isActive = updatedItem.id === toolId;
       newChildren.push(updatedItem);
     }
@@ -345,6 +348,7 @@ export class ToolbarItemsManager {
         };
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       updatedItem.isActive = updatedItem.id === toolId;
       newItems.push(updatedItem);
     }

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
@@ -75,7 +75,7 @@ export function GroupMenuItem({ item, onClose }: GroupMenuItemProps) {
   const label = useConditionalProp(item.label);
   const isDisabled = useConditionalProp(item.isDisabled);
   const isHidden = useConditionalProp(item.isHidden);
-  const isActive = useConditionalProp(item.isActive);
+  const isActiveCondition = useConditionalProp(item.isActiveCondition);
 
   if (isHidden) {
     return null;
@@ -100,7 +100,8 @@ export function GroupMenuItem({ item, onClose }: GroupMenuItemProps) {
           onClose?.();
         }
       }}
-      isSelected={isActive}
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      isSelected={isActiveCondition ?? item.isActive}
       data-item-id={item.id}
     >
       {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/Item.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/Item.tsx
@@ -26,6 +26,7 @@ export const Item = React.forwardRef<HTMLButtonElement, ItemProps>(
     const { item, ...other } = props;
     const { renderSeparator } = useSafeContext(ToolbarItemContext);
     const label = useConditionalProp(item.label);
+    const isActiveCondition = useConditionalProp(item.isActiveCondition);
     const isDisabled = useConditionalProp(item.isDisabled);
     const isHidden = useConditionalProp(item.isHidden);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -38,7 +39,8 @@ export const Item = React.forwardRef<HTMLButtonElement, ItemProps>(
           <IconButton
             styleType="borderless"
             disabled={isDisabled}
-            isActive={item.isActive}
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            isActive={isActiveCondition ?? item.isActive}
             label={label}
             labelProps={labelProps}
             style={props.style}


### PR DESCRIPTION
## Changes

This PR fixes #1381 by adding an `isActiveCondition` property to `CommonToolbarItem` interface as a replacement to now deprecated `isActive` property.

This change adds similar capability to https://github.com/iTwin/appui/pull/1379, however the active state management is done from the toolbar item itself (usually in a `UiItemsProvider`), which is handy for package developers and avoids explicit/global active toolbar item management.
Applications, that want explicit control over what toolbar items are active should use the `Toolbar` component directly and override the `isActive/isActiveCondition` properties.

## Testing

- Updated storybook story to use the conditional value for active state: https://itwin.github.io/appui/1383/?path=/story/components-toolbarcomposer--conditional
- Updated `/blank?frontstageId=widget-api` route of a `test-app` to toggle the active state of the `Show/hide overlay` button using the `isActiveCondition` conditional value.
