### PR TITLE
[components-react] EditorInterop drops quantityType from PropertyRecord

### DIFF
--- a/.changeset/wild-corners-flow.md
+++ b/.changeset/wild-corners-flow.md
@@ -1,0 +1,5 @@
+---
+"@itwin/components-react": patch
+---
+
+Fixed `EditorInterop` not propagating `quantityType` from `PropertyRecord` to `ValueMetadata`.

--- a/ui/components-react/src/components-react/new-editors/interop/EditorInterop.ts
+++ b/ui/components-react/src/components-react/new-editors/interop/EditorInterop.ts
@@ -43,6 +43,7 @@ export namespace EditorInterop {
       extendedData: propertyRecord.extendedData,
       enum: propertyRecord.property.enum,
       typename: propertyRecord.property.typename,
+      quantityType: propertyRecord.property.quantityType,
     };
 
     const primitiveValue = propertyRecord.value as PrimitiveValue;

--- a/ui/components-react/src/test/new-editors/interop/EditorInterop.test.ts
+++ b/ui/components-react/src/test/new-editors/interop/EditorInterop.test.ts
@@ -345,6 +345,48 @@ describe("EditorInterop", () => {
     });
   });
 
+  it("converts PropertyRecord to ValueMetadata with additional properties", () => {
+    const record = new PropertyRecord(
+      {
+        valueFormat: PropertyValueFormat.Primitive,
+        value: 123,
+        displayValue: "123",
+      },
+      {
+        name: "TestProp",
+        typename: "int",
+        displayLabel: "Test Property",
+
+        editor: {
+          name: "TestEditor",
+        },
+        enum: {
+          choices: [
+            { value: 1, label: "One" },
+            { value: 2, label: "Two" },
+          ],
+        },
+        quantityType: "TestQuantity",
+      }
+    );
+    record.extendedData = { customData: "test" };
+
+    const { metadata } = EditorInterop.getMetadataAndValue(record);
+    expect(metadata).toMatchObject({
+      type: "number",
+      typename: "int",
+      preferredEditor: "TestEditor",
+      quantityType: "TestQuantity",
+      enum: {
+        choices: [
+          { value: 1, label: "One" },
+          { value: 2, label: "Two" },
+        ],
+      },
+      extendedData: { customData: "test" },
+    } satisfies OldEditorMetadata);
+  });
+
   describe("convertToPrimitiveValue converts Value to PrimitiveValue for type", () => {
     it("string", () => {
       const value = { value: "test" } satisfies TextValue;


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Fixed `EditorInterop` not propagating `quantityType` from `PropertyRecord` to `ValueMetada`

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Added unit test
