### PR TITLE
Update `changesets` patch to avoid major version bumps

### DIFF
--- a/patches/@changesets__assemble-release-plan.patch
+++ b/patches/@changesets__assemble-release-plan.patch
@@ -1,13 +1,13 @@
 diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
-index e32a5e5d39c3bd920201b5694632d2b44c92d486..7c8a87f49923781b61fedbe80ca1d24bcac12151 100644
+index e07ba6e793021b6cfdec898afca517e293386ddb..858a33c238613eb0627eb5c3df0f3bb29916887e 100644
 --- a/dist/changesets-assemble-release-plan.cjs.js
 +++ b/dist/changesets-assemble-release-plan.cjs.js
-@@ -347,7 +347,7 @@ function shouldBumpMajor({
-   // we check if it is a peerDependency because if it is, our dependent bump type might need to be major.
-   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && ( // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
+@@ -321,7 +321,7 @@ function shouldBumpMajor({
+   return depType === "peerDependencies" && nextRelease.type !== "none" && nextRelease.type !== "patch" && (
+   // 1. If onlyUpdatePeerDependentsWhenOutOfRange set to true, bump major if the version is leaving the range.
    // 2. If onlyUpdatePeerDependentsWhenOutOfRange set to false, bump major regardless whether or not the version is leaving the range.
--  !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange)) && ( // bump major only if the dependent doesn't already has a major release.
-+  !onlyUpdatePeerDependentsWhenOutOfRange) && ( // bump major only if the dependent doesn't already has a major release.
+-  !onlyUpdatePeerDependentsWhenOutOfRange || !semverSatisfies__default["default"](incrementVersion(nextRelease, preInfo), versionRange)) && (
++  !onlyUpdatePeerDependentsWhenOutOfRange) && (
+   // bump major only if the dependent doesn't already has a major release.
    !releases.has(dependent) || releases.has(dependent) && releases.get(dependent).type !== "major");
  }
- 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ catalogs:
 
 patchedDependencies:
   '@changesets/assemble-release-plan':
-    hash: 51cfbc83be96c1c78af9d4343f7c516bddd8b66e3f3be92f916d6d0cfc85d04b
+    hash: 0f8a77f53f0818a1ecfd2dc9bb94eccdc5c87eb3108fb8448af2aa0c6ed4e1b0
     path: patches/@changesets__assemble-release-plan.patch
 
 importers:
@@ -8266,7 +8266,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.7.1
 
-  '@changesets/assemble-release-plan@6.0.9(patch_hash=51cfbc83be96c1c78af9d4343f7c516bddd8b66e3f3be92f916d6d0cfc85d04b)':
+  '@changesets/assemble-release-plan@6.0.9(patch_hash=0f8a77f53f0818a1ecfd2dc9bb94eccdc5c87eb3108fb8448af2aa0c6ed4e1b0)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.3
@@ -8282,7 +8282,7 @@ snapshots:
   '@changesets/cli@2.29.6(@types/node@20.17.8)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.12
-      '@changesets/assemble-release-plan': 6.0.9(patch_hash=51cfbc83be96c1c78af9d4343f7c516bddd8b66e3f3be92f916d6d0cfc85d04b)
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=0f8a77f53f0818a1ecfd2dc9bb94eccdc5c87eb3108fb8448af2aa0c6ed4e1b0)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.1
       '@changesets/errors': 0.2.0
@@ -8335,7 +8335,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.13':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9(patch_hash=51cfbc83be96c1c78af9d4343f7c516bddd8b66e3f3be92f916d6d0cfc85d04b)
+      '@changesets/assemble-release-plan': 6.0.9(patch_hash=0f8a77f53f0818a1ecfd2dc9bb94eccdc5c87eb3108fb8448af2aa0c6ed4e1b0)
       '@changesets/config': 3.1.1
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.5


### PR DESCRIPTION
## Changes

This PR fixes patch of `@changesets/assemble-release-plan` after recent version bump in #1391 

See [`pnpm patch`](https://pnpm.io/cli/patch)

## Testing

Ran `pnpm changeset status` to verify
