### PR TITLE
Update colors of `<WidgetPanelGrip />`

### DIFF
--- a/.changeset/pretty-bugs-study.md
+++ b/.changeset/pretty-bugs-study.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Update colors of widget panel grip displayed when stage panel is collapsed to match the correct semantical iTwinUI CSS variables.

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
@@ -85,7 +85,7 @@ $line-grip-width: calc(#{$nz-grip-width} - 2px);
     .nz-collapsed & {
       display: flex;
       background-color: var(--iui-color-background);
-      border: 1px solid var(--iui-color-border);
+      border: 1px solid var(--iui-color-border-foreground);
       border-radius: 999px;
       box-sizing: border-box;
       opacity: 1;
@@ -119,7 +119,7 @@ $line-grip-width: calc(#{$nz-grip-width} - 2px);
 
       .nz-line-grip-detail {
         height: 70%;
-        border-left: 1px solid var(--iui-color-border);
+        border-left: 1px solid var(--iui-color-border-foreground);
       }
     }
 
@@ -130,7 +130,7 @@ $line-grip-width: calc(#{$nz-grip-width} - 2px);
 
       .nz-line-grip-detail {
         width: 70%;
-        border-top: 1px solid var(--iui-color-border);
+        border-top: 1px solid var(--iui-color-border-foreground);
       }
     }
   }

--- a/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
+++ b/ui/appui-react/src/appui-react/layout/widget-panels/Grip.scss
@@ -64,7 +64,7 @@ $line-grip-width: calc(#{$nz-grip-width} - 2px);
 
     &:hover,
     &.nz-resizing {
-      background-color: var(--iui-color-icon-accent);
+      background-color: var(--iui-color-background-accent);
     }
   }
 
@@ -84,8 +84,8 @@ $line-grip-width: calc(#{$nz-grip-width} - 2px);
 
     .nz-collapsed & {
       display: flex;
-      background-color: var(--iui-color-background-disabled);
-      border: 1px solid var(--iui-color-border-subtle);
+      background-color: var(--iui-color-background);
+      border: 1px solid var(--iui-color-border);
       border-radius: 999px;
       box-sizing: border-box;
       opacity: 1;
@@ -118,8 +118,8 @@ $line-grip-width: calc(#{$nz-grip-width} - 2px);
       width: $line-grip-width;
 
       .nz-line-grip-detail {
-        width: 1px;
         height: 70%;
+        border-left: 1px solid var(--iui-color-border);
       }
     }
 
@@ -130,12 +130,8 @@ $line-grip-width: calc(#{$nz-grip-width} - 2px);
 
       .nz-line-grip-detail {
         width: 70%;
-        height: 1px;
+        border-top: 1px solid var(--iui-color-border);
       }
-    }
-
-    .nz-line-grip-detail {
-      background-color: var(--iui-color-border-subtle);
     }
   }
 }


### PR DESCRIPTION
## Changes

This PR updates colors used in `WidgetPanelGrip` component to correctly match the iTwinUI CSS variables semantically.

| Descr | Before | After |
| --- | --- | --- |
| iTwinUI | <img width="92" height="211" alt="Screenshot 2025-08-29 at 15 59 23" src="https://github.com/user-attachments/assets/c2dabcf1-e39f-431c-80c0-f5fe329ebf79" /> | <img width="79" height="202" alt="Screenshot 2025-09-03 at 10 36 31" src="https://github.com/user-attachments/assets/54af2de8-a7bc-46ce-a198-ba4ce4cdb11a" /> |
| iTwinUI + `themeBridge` | <img width="105" height="235" alt="Screenshot 2025-08-29 at 15 59 01" src="https://github.com/user-attachments/assets/5c7b4a6f-ac5c-4015-b851-40402a6f7311" /> | <img width="58" height="220" alt="Screenshot 2025-09-03 at 10 35 03" src="https://github.com/user-attachments/assets/88f7fafb-b618-400c-a20e-140137ab42d4" /> |

Additionally this fixes a visual issue where widget panel grip is barely visible due to transparency when `themeBridge` is enabled: https://github.com/iTwin/appui/issues/1380#issuecomment-3207543379

## Testing

Before:
- https://itwin.github.io/appui/storybook/?path=/story/widget-widget--default
- `themeBridge` https://itwin.github.io/appui/storybook/?path=/story/widget-widget--default&globals=themeBridge:true

After:
- https://itwin.github.io/appui/1399/?path=/story/widget-widget--default
- `themeBridge` https://itwin.github.io/appui/1399/?path=/story/widget-widget--default&globals=themeBridge:true
