### PR TITLE
Set default message centre popover background

### DIFF
--- a/.changeset/social-paths-push.md
+++ b/.changeset/social-paths-push.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Remove default background color from status bar dialog popovers

--- a/ui/appui-react/src/appui-react/layout/footer/dialog/Dialog.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/dialog/Dialog.scss
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 .nz-footer-dialog-dialog {
   border-radius: var(--iui-border-radius-1);
-  background-color: var(--iui-color-background);
   overflow: hidden;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);

--- a/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss
+++ b/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss
@@ -5,7 +5,6 @@
 @use "~@itwin/core-react/lib/core-react/typography" as *;
 
 .nz-footer-snapMode-panel {
-  background-color: var(--iui-color-background);
   border-radius: var(--iui-border-radius-1);
   overflow: hidden;
 

--- a/ui/appui-react/src/appui-react/statusfields/message-center/MessageCenterField.scss
+++ b/ui/appui-react/src/appui-react/statusfields/message-center/MessageCenterField.scss
@@ -20,5 +20,6 @@
 }
 
 .uifw-statusFields-messageCenter-messageCenterField_popover {
+  background-color: var(--iui-color-background);
   width: 305px;
 }

--- a/ui/appui-react/src/appui-react/statusfields/message-center/MessageCenterField.scss
+++ b/ui/appui-react/src/appui-react/statusfields/message-center/MessageCenterField.scss
@@ -20,6 +20,5 @@
 }
 
 .uifw-statusFields-messageCenter-messageCenterField_popover {
-  background-color: var(--iui-color-background);
   width: 305px;
 }


### PR DESCRIPTION
## Changes
When the message centre is used in combination with the tool assistant and snap mode elements in the status bar, and the stratakit bridge is used, we can see a discrepancy between the backgrounds of the message centre and other popover panels. The issue is that stratakit [sets a background colour](https://github.com/iTwin/iTwinUI/blob/9d6a12a7f8eabc11898edb1e1471af38d571fe9c/packages/itwinui-css/src/bridge.scss#L322) on `.iui-popover-surface`. The [toolbox assistant](https://github.com/iTwin/appui/blob/2b75e0523a022ce72f1f53abec2805e9606fa64e/ui/appui-react/src/appui-react/statusfields/toolassistance/ToolAssistanceField.scss#L33) and [snap mode](https://github.com/iTwin/appui/blob/2b75e0523a022ce72f1f53abec2805e9606fa64e/ui/appui-react/src/appui-react/layout/footer/snap-mode/Panel.scss#L8) elements set their background in a way that takes precedence over stratakit, thus overriding the stratakit background colour.

The fix here removes the default background colour from footer dialogs, including the snap mode dialog. This ensures that all status bar elements will now share the same background colour when the stratakit bridge is applied.

## Testing
Tested on the imodel-extents-editor app, by manually applying the background colour to the component and comparing with/without. See the screenshots:

What happens at the moment (with the change commented out):
<img width="2604" height="894" alt="Screenshot 2025-09-04 at 7 40 06 PM" src="https://github.com/user-attachments/assets/4b034d63-4130-40a5-ab48-9a1b8b34b243" />

With the fix:
<img width="2614" height="898" alt="Screenshot 2025-09-04 at 7 40 14 PM" src="https://github.com/user-attachments/assets/5839e3d0-54d7-40a0-a0e4-ebc761e735d8" />
