### PR TITLE
Enable accent on status bar elements

### DIFF
--- a/ui/appui-react/src/appui-react/statusbar/StatusBar.scss
+++ b/ui/appui-react/src/appui-react/statusbar/StatusBar.scss
@@ -71,6 +71,11 @@
         padding-left: 0;
       }
     }
+
+    & > [aria-haspopup] {
+      border-radius: 0;
+      border-width: 2px 0 0 0;
+    }
   }
 
   .uifw-statusBar-left .uifw-statusBar-item-container {
@@ -86,4 +91,19 @@
   flex-direction: row;
   align-content: center;
   align-items: center;
+
+  & > [data-iui-has-popover="open"] {
+    --_iui-field-color-icon: var(--iui-color-icon-accent);
+    --_iui-field-color-icon-hover: var(--iui-color-icon-accent);
+    --_iui-field-color-background: var(--iui-color-background-accent-muted);
+    --_iui-field-color-background-hover: var(
+      --iui-color-background-accent-muted
+    );
+    --_iui-field-color-background-disabled: var(
+      --iui-color-background-disabled
+    );
+    --_iui-field-color-border-hover: var(--iui-color-border-accent);
+    --_iui-field-color-text: var(--iui-color-text-accent);
+    --_iui-field-color-text-hover: var(--iui-color-text-accent);
+  }
 }


### PR DESCRIPTION

## Changes
We apply colour accents to the status bar item container, and slightly adjust the button style. The idea is for status bar elements that have popovers to get the accent colour when the popover shows up.

## Testing
Tested using the test-app, both web and electron, and with and without the theme bridge.

Here is how it looks like with the theme bridge:
https://github.com/user-attachments/assets/5748cb1a-0e14-425b-812d-60b7448bce3d

and without:
https://github.com/user-attachments/assets/c74bb163-c457-4bad-b3c8-5ff518e73185


