### PR TITLE
Remove overflow from `Toolbar` component

### DIFF
--- a/.changeset/empty-bears-cough.md
+++ b/.changeset/empty-bears-cough.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": patch
+---
+
+Removed height limit that caused vertical overflow in toolbars.

--- a/.changeset/empty-bears-cough.md
+++ b/.changeset/empty-bears-cough.md
@@ -2,4 +2,4 @@
 "@itwin/appui-react": patch
 ---
 
-Removed height limit that caused vertical overflow in toolbars.
+Removed height limit that caused vertical overflow in menu of `Toolbar` component.

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -500,6 +500,35 @@ export const ActiveItemIds: Story = {
   },
 };
 
+export const Overflow: Story = {
+  args: {
+    items: (() => {
+      const factory = createItemFactory();
+      const createItems = () =>
+        Array.from({ length: 8 }).map(() => factory.createActionItem());
+      return [
+        ...createItems(),
+        factory.createGroupItem({
+          items: [
+            ...createItems(),
+            factory.createGroupItem({
+              items: [
+                ...createItems(),
+                factory.createGroupItem({
+                  items: [...createItems(), ...createItems()],
+                }),
+                ...createItems(),
+              ],
+            }),
+            ...createItems(),
+          ],
+        }),
+        ...createItems(),
+      ];
+    })(),
+  },
+};
+
 function createAbstractReactIcon() {
   const internalData = new Map();
   const icon = IconHelper.getIconData(<SvgExport />, internalData);

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.scss
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.scss
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+.uifw-toolbar-newToolbars-groupItem_menu,
+// Can not customize iTwinUI submenu directly, so we use :has() to workaround it.
+[role="menu"]:has(.uifw-toolbar-newToolbars-groupItem_menuItem) {
+  --iui-menu-max-height: 100%;
+}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
@@ -90,19 +90,22 @@ export function GroupMenuItem({ item, onClose }: GroupMenuItemProps) {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     <Icon iconSpec={iconSpec} />
   );
+
   return (
     <MenuItem
       className="uifw-toolbar-newToolbars-groupItem_menuItem"
       startIcon={startIcon}
       disabled={isDisabled}
       subMenuItems={subMenuItems}
-      onClick={() => {
-        if (isToolbarActionItem(item)) {
-          item.execute();
-          onItemExecuted?.(item);
-          onClose?.();
-        }
-      }}
+      onClick={
+        isToolbarActionItem(item)
+          ? () => {
+              item.execute();
+              onItemExecuted?.(item);
+              onClose?.();
+            }
+          : undefined
+      }
       // eslint-disable-next-line @typescript-eslint/no-deprecated
       isSelected={isActiveCondition ?? item.isActive}
       data-item-id={item.id}

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/GroupItem.tsx
@@ -6,6 +6,8 @@
  * @module Toolbar
  */
 
+import "./GroupItem.scss";
+import classnames from "classnames";
 import * as React from "react";
 import { Icon } from "@itwin/core-react";
 import { DropdownMenu, MenuExtraContent, MenuItem } from "@itwin/itwinui-react";
@@ -39,7 +41,7 @@ export const GroupItem = React.forwardRef<HTMLButtonElement, GroupItemProps>(
       return <GroupMenuItem item={item} onClose={overflowContext.onClose} />;
     }
     return (
-      <DropdownMenu
+      <ToolbarMenu
         menuItems={(close) => {
           return toMenuItems(item, close);
         }}
@@ -51,7 +53,7 @@ export const GroupItem = React.forwardRef<HTMLButtonElement, GroupItemProps>(
         <Item item={item} ref={ref}>
           <ExpandIndicator />
         </Item>
-      </DropdownMenu>
+      </ToolbarMenu>
     );
   }
 );
@@ -90,6 +92,7 @@ export function GroupMenuItem({ item, onClose }: GroupMenuItemProps) {
   );
   return (
     <MenuItem
+      className="uifw-toolbar-newToolbars-groupItem_menuItem"
       startIcon={startIcon}
       disabled={isDisabled}
       subMenuItems={subMenuItems}
@@ -126,3 +129,24 @@ function toMenuItems(item: ToolbarItem, onClose?: () => void) {
   }
   return [];
 }
+
+type ToolbarMenuProps = React.ComponentProps<typeof DropdownMenu>;
+
+/** @internal */
+export const ToolbarMenu: React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<ToolbarMenuProps> & React.RefAttributes<HTMLDivElement>
+> = React.forwardRef<HTMLDivElement, ToolbarMenuProps>(function DropdownMenu1(
+  props,
+  ref
+) {
+  return (
+    <DropdownMenu
+      {...props}
+      className={classnames(
+        "uifw-toolbar-newToolbars-groupItem_menu",
+        props.className
+      )}
+      ref={ref}
+    />
+  );
+});

--- a/ui/appui-react/src/appui-react/toolbar/new-toolbars/OverflowButton.tsx
+++ b/ui/appui-react/src/appui-react/toolbar/new-toolbars/OverflowButton.tsx
@@ -7,10 +7,10 @@
  */
 
 import * as React from "react";
-import { DropdownMenu, IconButton } from "@itwin/itwinui-react";
+import { IconButton } from "@itwin/itwinui-react";
 import { SvgMore } from "@itwin/itwinui-icons-react";
 import { useLabelProps } from "./Item.js";
-import { usePopoverPlacement } from "./GroupItem.js";
+import { ToolbarMenu, usePopoverPlacement } from "./GroupItem.js";
 import { ToolbarContext } from "./Toolbar.js";
 import { useSafeContext } from "../../hooks/useSafeContext.js";
 
@@ -37,7 +37,7 @@ export const OverflowButton = React.forwardRef<
   const { setPopoverOpen } = useSafeContext(ToolbarContext);
 
   return (
-    <DropdownMenu
+    <ToolbarMenu
       menuItems={(close) => {
         return [
           <OverflowMenu key={0} onClose={close}>
@@ -58,7 +58,7 @@ export const OverflowButton = React.forwardRef<
       >
         <SvgMore />
       </IconButton>
-    </DropdownMenu>
+    </ToolbarMenu>
   );
 });
 


### PR DESCRIPTION
## Changes

This PR fixes #1366 by removing the height limit that caused vertical overflow in dropdown menus of `Toolbar` component.

| Before | After |
| --- | --- |
|  <img width="653" height="625" alt="Screenshot 2025-09-25 at 16 00 39" src="https://github.com/user-attachments/assets/64dbe7e2-d716-4349-a561-97876f90a877" /> | <img width="649" height="944" alt="Screenshot 2025-09-25 at 16 01 08" src="https://github.com/user-attachments/assets/693075b2-aa25-447d-b046-3d87fa248909" /> |

Additionally, fixed a dev-only warning: https://github.com/iTwin/iTwinUI/blob/f0faefbbe4e8bd7867a29ab89212317e903768a6/packages/itwinui-react/src/core/Menu/MenuItem.tsx#L127

## Testing

Added additional story: https://itwin.github.io/appui/1419/?path=/story/components-toolbarcomposer--overflow
