### PR TITLE
Fix `<ToolbarComposer />` to highlight group items via conditional values

### DIFF
--- a/.changeset/strong-moments-wonder.md
+++ b/.changeset/strong-moments-wonder.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": patch
+---
+
+Fixed `ToolbarComposer` component to highlight group items that contain toolbar items active via conditional value.

--- a/.changeset/warm-frogs-listen.md
+++ b/.changeset/warm-frogs-listen.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": patch
+---
+
+Fixed `Toolbar` component to correctly refresh conditional values when mounting nested items.

--- a/docs/storybook/src/components/ToolbarComposer.stories.tsx
+++ b/docs/storybook/src/components/ToolbarComposer.stories.tsx
@@ -212,42 +212,65 @@ const { getVal, bump, eventId } = createBumpEvent();
 
 export const Conditional: Story = {
   args: {
-    items: [
-      {
-        ...items.action1,
-        execute: () => {
-          bump();
-          items.action1.execute();
+    items: (() => {
+      const factory = createItemFactory();
+      return [
+        factory.createActionItem({
+          isActiveCondition: new ConditionalBooleanValue(
+            () => getVal() % 2 === 1,
+            [eventId]
+          ),
+          execute: () => {
+            bump();
+          },
+        }),
+        {
+          ...factory.createActionItem({
+            label: new ConditionalStringValue(
+              () => `Item 2 (${getVal()})`,
+              [eventId]
+            ),
+            isDisabled: new ConditionalBooleanValue(
+              () => getVal() % 2 === 1,
+              [eventId]
+            ),
+            description: new ConditionalStringValue(
+              () =>
+                `Conditional item. Click 'Item 1' to toggle. (${getVal()}).`,
+              [eventId]
+            ),
+          }),
+          iconNode: undefined,
+          icon: new ConditionalIconItem(
+            () => (getVal() % 2 === 0 ? <Svg3D /> : <Svg2D />),
+            [eventId]
+          ),
         },
-        isActiveCondition: new ConditionalBooleanValue(
-          () => getVal() % 2 === 1,
-          [eventId]
-        ),
-      },
-      {
-        ...items.action2,
-        icon: new ConditionalIconItem(
-          () => (getVal() % 2 === 0 ? <Svg3D /> : <Svg2D />),
-          [eventId]
-        ),
-        label: new ConditionalStringValue(
-          () => `Item 2 (${getVal()})`,
-          [eventId]
-        ),
-        isDisabled: new ConditionalBooleanValue(
-          () => getVal() % 2 === 1,
-          [eventId]
-        ),
-        description: new ConditionalStringValue(
-          () => `Conditional item. Click 'Item 1' to toggle. (${getVal()}).`,
-          [eventId]
-        ),
-      },
-      {
-        ...items.action3,
-        icon: <ConditionalReactIcon />,
-      },
-    ],
+        factory.createActionItem({
+          iconNode: <ConditionalReactIcon />,
+        }),
+        factory.createGroupItem({
+          items: [
+            factory.createActionItem({
+              label: new ConditionalStringValue(
+                () => `Item 4 (${getVal()})`,
+                [eventId]
+              ),
+            }),
+            factory.createGroupItem({
+              items: [
+                factory.createActionItem({
+                  isActiveCondition: new ConditionalBooleanValue(
+                    () => getVal() % 2 === 0,
+                    [eventId]
+                  ),
+                }),
+              ],
+            }),
+          ],
+        }),
+      ];
+    })(),
   },
 };
 

--- a/ui/appui-react/src/appui-react/hooks/useConditionalProp.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useConditionalProp.tsx
@@ -6,7 +6,7 @@
  * @module Utilities
  */
 
-import { useCallback, useSyncExternalStore } from "react";
+import { useCallback, useRef, useSyncExternalStore } from "react";
 import { SyncUiEventDispatcher } from "../syncui/SyncUiEventDispatcher.js";
 
 /** Defines a common interface for existing conditional value classes: `ConditionalBooleanValue`, `ConditionalStringValue`, `ConditionalIconItem`. */
@@ -34,6 +34,7 @@ function isConditionalValue<T>(
 
 /** @internal */
 export function useConditionalProp<T>(conditionalProp: ConditionalProp<T>) {
+  const refreshedRef = useRef(false);
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       if (isConditionalValue(conditionalProp)) {
@@ -57,7 +58,14 @@ export function useConditionalProp<T>(conditionalProp: ConditionalProp<T>) {
     [conditionalProp]
   );
   const getSnapshot = useCallback(() => {
-    if (isConditionalValue(conditionalProp)) return conditionalProp.value;
+    if (isConditionalValue(conditionalProp)) {
+      if (!refreshedRef.current) {
+        conditionalProp.refresh();
+        refreshedRef.current = true;
+      }
+
+      return conditionalProp.value;
+    }
     return conditionalProp;
   }, [conditionalProp]);
   return useSyncExternalStore(subscribe, getSnapshot);


### PR DESCRIPTION
## Changes

This PR fixes #1402 by correctly highlighting parent group items https://github.com/iTwin/appui/pull/1348 when conditional value is used https://github.com/iTwin/appui/pull/1383

Additionally, fixes [`useConditionalProp` to refresh the conditional on initial mount](https://github.com/iTwin/appui/commit/e697d6c4b42850347a8018ce18df14113c8be8bb) which resulted in usage of outdated value in nested men items when related sync events are dispatched while the menu is closed.

## Testing


