### PR TITLE
Add `id` property to `ModalFrontstageInfo`

### DIFF
--- a/.changeset/odd-peas-rescue.md
+++ b/.changeset/odd-peas-rescue.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Added optional `id` property to `ModalFrontstageInfo` interface to uniquely identify modal frontstages.

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -3309,14 +3309,12 @@ export interface ModalFrontstageClosedEventArgs {
 
 // @public
 export interface ModalFrontstageInfo {
-    // (undocumented)
     appBarRight?: React.ReactNode;
     backButton?: React.ReactNode;
-    // (undocumented)
     content: React.ReactNode;
+    id?: string;
     // @alpha
     notifyCloseRequest?: boolean;
-    // (undocumented)
     title: string;
 }
 

--- a/docs/storybook/src/frontstage/Modal.stories.tsx
+++ b/docs/storybook/src/frontstage/Modal.stories.tsx
@@ -43,6 +43,12 @@ export const BackButton: Story = {
   },
 };
 
+export const AppBarRight: Story = {
+  args: {
+    appBarRight: <>appBarRight</>,
+  },
+};
+
 export const NotifyCloseRequest: Story = {
   args: {
     notifyCloseRequest: true,

--- a/docs/storybook/src/frontstage/Modal.stories.tsx
+++ b/docs/storybook/src/frontstage/Modal.stories.tsx
@@ -19,6 +19,9 @@ const meta = {
     },
     layout: "fullscreen",
   },
+  args: {
+    notifyCloseRequest: false,
+  },
 } satisfies Meta<typeof ModalFrontstageStory>;
 
 export default meta;
@@ -37,5 +40,11 @@ export const BackButton: Story = {
         }}
       />
     ),
+  },
+};
+
+export const NotifyCloseRequest: Story = {
+  args: {
+    notifyCloseRequest: true,
   },
 };

--- a/docs/storybook/src/frontstage/Modal.tsx
+++ b/docs/storybook/src/frontstage/Modal.tsx
@@ -2,6 +2,7 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+import * as React from "react";
 import {
   ModalFrontstageInfo,
   ToolbarItemUtilities,
@@ -12,12 +13,15 @@ import {
 import { SvgPlaceholder } from "@itwin/itwinui-icons-react";
 import { AppUiStory } from "../AppUiStory";
 import { createFrontstage } from "../Utils";
+import { action } from "storybook/internal/actions";
 
-type ModalFrontstageStoryProps = Pick<ModalFrontstageInfo, "backButton">;
+type ModalFrontstageStoryProps = Pick<
+  ModalFrontstageInfo,
+  "backButton" | "notifyCloseRequest"
+>;
 
 /** [openModalFrontstage](https://www.itwinjs.org/reference/appui-react/frontstage/frameworkfrontstages/#openmodalfrontstage) can be used to open a modal frontstage. */
 export function ModalFrontstageStory(props: ModalFrontstageStoryProps) {
-  const { backButton } = props;
   return (
     <AppUiStory
       layout="fullscreen"
@@ -34,7 +38,7 @@ export function ModalFrontstageStory(props: ModalFrontstageStoryProps) {
                 UiFramework.frontstages.openModalFrontstage({
                   content: <>Modal frontstage content</>,
                   title: "My Modal Frontstage",
-                  backButton,
+                  ...props,
                 });
               },
               layouts: {
@@ -47,6 +51,30 @@ export function ModalFrontstageStory(props: ModalFrontstageStoryProps) {
           ],
         },
       ]}
-    />
+    >
+      <ModalFrontstageEvents />
+    </AppUiStory>
   );
+}
+
+function ModalFrontstageEvents() {
+  React.useEffect(() => {
+    return UiFramework.frontstages.onModalFrontstageChangedEvent.addListener(
+      action("onModalFrontstageChangedEvent")
+    );
+  }, []);
+  React.useEffect(() => {
+    return UiFramework.frontstages.onCloseModalFrontstageRequestedEvent.addListener(
+      async (args) => {
+        action("onCloseModalFrontstageRequestedEvent (close after 2s)")(args);
+        setTimeout(args.stageCloseFunc, 2000);
+      }
+    );
+  }, []);
+  React.useEffect(() => {
+    return UiFramework.frontstages.onModalFrontstageClosedEvent.addListener(
+      action("onModalFrontstageClosedEvent")
+    );
+  }, []);
+  return null;
 }

--- a/docs/storybook/src/frontstage/Modal.tsx
+++ b/docs/storybook/src/frontstage/Modal.tsx
@@ -36,6 +36,7 @@ export function ModalFrontstageStory(props: ModalFrontstageStoryProps) {
               label: "Open modal frontstage",
               execute: () => {
                 UiFramework.frontstages.openModalFrontstage({
+                  id: "my-modal-frontstage",
                   content: <>Modal frontstage content</>,
                   title: "My Modal Frontstage",
                   ...props,

--- a/docs/storybook/src/frontstage/Modal.tsx
+++ b/docs/storybook/src/frontstage/Modal.tsx
@@ -66,7 +66,7 @@ function ModalFrontstageEvents() {
   }, []);
   React.useEffect(() => {
     return UiFramework.frontstages.onCloseModalFrontstageRequestedEvent.addListener(
-      async (args) => {
+      (args) => {
         action("onCloseModalFrontstageRequestedEvent (close after 2s)")(args);
         setTimeout(args.stageCloseFunc, 2000);
       }

--- a/docs/storybook/src/frontstage/Modal.tsx
+++ b/docs/storybook/src/frontstage/Modal.tsx
@@ -17,7 +17,7 @@ import { action } from "storybook/internal/actions";
 
 type ModalFrontstageStoryProps = Pick<
   ModalFrontstageInfo,
-  "backButton" | "notifyCloseRequest"
+  "backButton" | "notifyCloseRequest" | "appBarRight"
 >;
 
 /** [openModalFrontstage](https://www.itwinjs.org/reference/appui-react/frontstage/frameworkfrontstages/#openmodalfrontstage) can be used to open a modal frontstage. */

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -180,8 +180,11 @@ export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> {}
 export interface ModalFrontstageInfo {
   /** Id used for frontstage identification. */
   id?: string;
+  /** Title displayed at the top of the modal frontstage. */
   title: string;
+  /** Content of the modal frontstage. */
   content: React.ReactNode;
+  /** Content displayed in the upper right of the modal frontstage. */
   appBarRight?: React.ReactNode;
   /** Set notifyCloseRequest to true on stages that register to listen for `onCloseModalFrontstageRequestedEvent` so
    * that the stage can save unsaved data before closing. Used by the ModalSettingsStage.

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -178,6 +178,8 @@ export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> {}
  * @public
  */
 export interface ModalFrontstageInfo {
+  /** Id used for frontstage identification. */
+  id?: string;
   title: string;
   content: React.ReactNode;
   appBarRight?: React.ReactNode;


### PR DESCRIPTION
## Changes

This PR closes #1395 by adding an `id` property to `ModalFrontstageInfo` interface. `id` property is optional for backwards compatibility.

This change allows consumers to uniquely identify modal frontstages, when `id` is specified when opening a modal frontstage via `UiFramework.frontstages.openModalFrontstage()`.

## Testing

Updated stories of `ModalFrontstage` https://itwin.github.io/appui/1431/?path=/story/frontstage-modalfrontstage--basic
