### PR TITLE
Remove `isHidden` conditionals from lock field shortcuts of AccuDraw

### DIFF
--- a/.changeset/two-tigers-lie.md
+++ b/.changeset/two-tigers-lie.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Removed `isHidden` conditional values from AccuDraw shortcuts to ensure that all lock shortcuts are always available regardless of the current compass mode.

--- a/apps/test-app/src/frontend/appui/frontstages/EditorFrontstage.tsx
+++ b/apps/test-app/src/frontend/appui/frontstages/EditorFrontstage.tsx
@@ -39,7 +39,7 @@ export function createEditorFrontstage() {
     cornerButton: <BackstageAppButton />,
   });
 }
-createEditorFrontstage.stageId = "appui-test-app:editor-frontstage";
+createEditorFrontstage.stageId = "editor";
 
 export function createEditorFrontstageProvider(): UiItemsProvider {
   const id = "appui-test-app:editor-items";

--- a/ui/appui-react/src/appui-react/accudraw/AccuDrawKeyboardShortcuts.ts
+++ b/ui/appui-react/src/appui-react/accudraw/AccuDrawKeyboardShortcuts.ts
@@ -54,28 +54,16 @@ export class AccuDrawKeyboardShortcuts {
           ),
           KeyboardShortcutUtilities.createForTool("r", AccuDrawSetOriginTool),
           KeyboardShortcutUtilities.createForTool("t", AccuDrawChangeModeTool),
-          KeyboardShortcutUtilities.createForTool("x", AccuDrawSetLockXTool, {
-            isHidden: FrameworkAccuDraw.isPolarModeConditional,
-          }),
-          KeyboardShortcutUtilities.createForTool("y", AccuDrawSetLockYTool, {
-            isHidden: FrameworkAccuDraw.isPolarModeConditional,
-          }),
-          KeyboardShortcutUtilities.createForTool("z", AccuDrawSetLockZTool, {
-            isHidden: FrameworkAccuDraw.isPolarModeConditional,
-          }),
+          KeyboardShortcutUtilities.createForTool("x", AccuDrawSetLockXTool),
+          KeyboardShortcutUtilities.createForTool("y", AccuDrawSetLockYTool),
+          KeyboardShortcutUtilities.createForTool("z", AccuDrawSetLockZTool),
           KeyboardShortcutUtilities.createForTool(
             "a",
-            AccuDrawSetLockAngleTool,
-            {
-              isHidden: FrameworkAccuDraw.isRectangularModeConditional,
-            }
+            AccuDrawSetLockAngleTool
           ),
           KeyboardShortcutUtilities.createForTool(
             "d",
-            AccuDrawSetLockDistanceTool,
-            {
-              isHidden: FrameworkAccuDraw.isRectangularModeConditional,
-            }
+            AccuDrawSetLockDistanceTool
           ),
           KeyboardShortcutUtilities.createForTool("b", BumpToolSetting),
         ],


### PR DESCRIPTION
## Changes

Fixes first part for #1189 by removing the `isHidden` conditional values from lock shortcuts.

| Before | After |
| --- | --- |
|  <img width="277" height="405" alt="Screenshot 2025-10-08 at 15 58 26" src="https://github.com/user-attachments/assets/754a8b1a-bd58-4d6e-a3f3-0c0794aff058" /> | <img width="278" height="548" alt="Screenshot 2025-10-08 at 15 57 52" src="https://github.com/user-attachments/assets/90ad05ae-2d76-4a2a-8c0a-d9407b7ffbf6" /> |

Verified, that compass mode is changed when locking an unrelated field, i.e.: `Lock X` while in polar mode changes the compass to rectangular mode.

## Testing

Tested in `Editor` frontstage of `test-app` after opening a local iModel: `/local/Baytown.bim?frontstageId=editor`
