### PR TITLE
Update keyboard shortcut processing of `FrameworkToolAdmin`

### DIFF
--- a/.changeset/fancy-bottles-repeat.md
+++ b/.changeset/fancy-bottles-repeat.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Changed keyboard shortcut processing of `FrameworkToolAdmin` to ignore events triggered by editable elements like input, textarea and select. Previously it was ignoring all events, unless `document.body` was the active element.

--- a/ui/appui-react/src/appui-react/tools/FrameworkToolAdmin.ts
+++ b/ui/appui-react/src/appui-react/tools/FrameworkToolAdmin.ts
@@ -29,8 +29,8 @@ export class FrameworkToolAdmin extends ToolAdmin {
   ): Promise<boolean> {
     if (!wentDown) return false;
     if (UiFramework.isContextMenuOpen) return false;
-    if (!UiFramework.keyboardShortcuts.isFocusOnHome) return false;
     if (e.key === Key.Escape.valueOf()) return false;
+    if (isElement(e.target) && isEditable(e.target)) return false;
 
     UiFramework.keyboardShortcuts.processKey(
       e.key,
@@ -40,4 +40,14 @@ export class FrameworkToolAdmin extends ToolAdmin {
     );
     return true;
   }
+}
+
+function isElement(target: EventTarget | null): target is Element {
+  return target instanceof Element;
+}
+
+const editableTags = ["input", "textarea", "select"];
+function isEditable(element: Element) {
+  const tagName = element.tagName.toLowerCase();
+  return editableTags.includes(tagName);
 }


### PR DESCRIPTION
## Changes

Fixes part of https://github.com/iTwin/appui/issues/1189 

> FrameworkToolAdmin should not check that focus is on Home in processShortcutKey. This prevents shortcuts from being used with viewport div overlays that can take focus but don't handle all KeyboardEvents. If the event is propagated to ToolAdmin and processShortcutKey is called it shouldn't care where focus is.

by changing the keyboard shortcut processing of `FrameworkToolAdmin.processShortcutKey()` to ignore events triggered by editable elements like input, textarea and select. Previously it was ignoring all events, unless `document.body` was the active element.

## Testing

Tested manually in `Exercise Widget API` frontstage of `test-app` (`Floating Info` widget contains an input): `/blank?frontstageId=widget-api`