### PR TITLE
Avoid `@internal` linter error on `StatusBarPopover.ExpandIndicator`

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4594,7 +4594,7 @@ export function StatusBarPopover({ content, middleware, ...other }: React_2.Comp
 
 // @public
 export namespace StatusBarPopover {
-    const ExpandIndicator: typeof ButtonExpandIndicator;
+    export function ExpandIndicator(): React_2.JSX.Element;
 }
 
 // @public @deprecated

--- a/ui/appui-react/src/appui-react/statusbar/popup/StatusBarPopover.tsx
+++ b/ui/appui-react/src/appui-react/statusbar/popup/StatusBarPopover.tsx
@@ -52,5 +52,7 @@ export namespace StatusBarPopover {
   /** Indicator to be used in popover trigger buttons to show expandable content.
    * @public
    */
-  export const ExpandIndicator = ButtonExpandIndicator;
+  export function ExpandIndicator() {
+    return <ButtonExpandIndicator />;
+  }
 }


### PR DESCRIPTION

## Changes

This PR fixes false-positive `@internal` linter error on `StatusBarPopover.ExpandIndicator`.

## Testing

N/A
