### PR TITLE
Remove noisy CursorMenu logging

### DIFF
--- a/.changeset/funny-humans-peel.md
+++ b/.changeset/funny-humans-peel.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": patch
+---
+
+Remove noisy CursorMenu logging

--- a/ui/appui-react/src/appui-react/cursor/cursormenu/CursorMenu.tsx
+++ b/ui/appui-react/src/appui-react/cursor/cursormenu/CursorMenu.tsx
@@ -14,7 +14,6 @@ import type { CursorMenuItemProps } from "../../shared/MenuItem.js";
 import { MenuItemHelpers } from "../../shared/MenuItem.js";
 import { SyncUiEventDispatcher } from "../../syncui/SyncUiEventDispatcher.js";
 import { UiFramework } from "../../UiFramework.js";
-import { Logger } from "@itwin/core-bentley";
 
 /** Popup Menu to show at cursor typically used by tools to provide a right-click context menu.
  * @alpha
@@ -65,10 +64,6 @@ export function CursorPopupMenu(props: CommonProps) {
         const parentWindow = el?.ownerDocument.defaultView ?? undefined;
         const windowId = UiFramework.childWindows.findId(parentWindow);
         windowIdRef.current = windowId;
-        Logger.logInfo(
-          UiFramework.loggerCategory("UiFramework"),
-          `Cursor Menu for ${windowId ?? "main"} window`
-        );
       }}
     >
       {items && items.length > 0 && opened && (


### PR DESCRIPTION
## Changes

Removes noisy logging

This log line can be emitted hundreds of times when starting an iTwin.js app

![Screenshot 2026-01-12 at 10 07 45 AM](https://github.com/user-attachments/assets/e623e4d9-76ed-480e-9613-b95ca67cd8d6)



## Testing

`pnpm test`