### PR TITLE
Add option to disable search in WidgetContentLayout header

### DIFF
--- a/.changeset/gentle-sheep-matter.md
+++ b/.changeset/gentle-sheep-matter.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Add option to disable search in WidgetContentLayout

--- a/docs/storybook/src/widget/WidgetContentLayout/WidgetContentLayout.Header.stories.tsx
+++ b/docs/storybook/src/widget/WidgetContentLayout/WidgetContentLayout.Header.stories.tsx
@@ -107,6 +107,7 @@ export const IconsAndSearch: Story = {
       },
     ],
     onSearch: action("Search performed"),
+    disableSearch: false,
   },
   argTypes: {
     iconSize: unionArgType(["small", undefined, "large"]),

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/WidgetContentLayout.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/WidgetContentLayout.tsx
@@ -58,6 +58,10 @@ interface WidgetContentLayoutHeaderProps extends ComponentPropsWithRef<"div"> {
    */
   onSearch?: (value: string) => void;
   /**
+   * Whether to disable the search functionality.
+   */
+  disableSearch?: boolean;
+  /**
    * Array of icon menu items to display in the header.
    */
   icons?: IconMenu[];
@@ -81,6 +85,7 @@ const Header = React.forwardRef<HTMLDivElement, WidgetContentLayoutHeaderProps>(
       menu,
       title,
       onSearch,
+      disableSearch,
       icons,
       iconSize,
       ...rest
@@ -101,6 +106,7 @@ const Header = React.forwardRef<HTMLDivElement, WidgetContentLayoutHeaderProps>(
           menu={menu}
           title={title}
           onSearch={onSearch}
+          disableSearch={disableSearch}
           icons={icons}
           iconSize={iconSize}
         >

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderIconToolbar.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderIconToolbar.scss
@@ -1,16 +1,17 @@
 @layer appui.component {
   .nz-widget-widgetContentLayout-header-headerIconToolbar {
+    display: flex;
     --_appui-icon-size: var(--iui-component-height);
     --_appui-max-search-width: 200px;
     min-width: var(--_appui-icon-size);
     min-height: var(--_appui-icon-size);
 
     &[data-_appui-icon-size="small"] {
-      --icon-size: var(--iui-component-height-small);
+      --_appui-icon-size: var(--iui-component-height-small);
     }
 
     &[data-_appui-icon-size="large"] {
-      --icon-size: var(--iui-component-height-large);
+      --_appui-icon-size: var(--iui-component-height-large);
     }
 
     &[data-_appui-search-expanded="true"] {
@@ -39,6 +40,10 @@
       .nz-iconButton[data-iui-active="true"]:after {
         inset-block: unset;
       }
+    }
+
+    .nz-header-overflow-button {
+      border: 0px;
     }
   }
 }

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderIconToolbar.scss
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderIconToolbar.scss
@@ -42,6 +42,8 @@
       }
     }
 
+    // when icon-size is small, the button width is 2px wider than the icon size due to a transparent border,
+    // so we need to remove the border to make it the same width as the icon
     .nz-header-overflow-button {
       border: 0px;
     }

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderIconToolbar.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderIconToolbar.tsx
@@ -34,7 +34,10 @@ type SearchExpandedState = [
 ];
 
 interface HeaderIconToolbarProps
-  extends Pick<WidgetContentLayoutHeaderProps, "iconSize" | "onSearch" | "disableSearch"> {
+  extends Pick<
+    WidgetContentLayoutHeaderProps,
+    "iconSize" | "onSearch" | "disableSearch"
+  > {
   /** Array of icon menu items to display, including regular icons, search, and dividers. */
   menuIcons: (IconMenu | IconMenuSearch)[];
   /** State tuple controlling whether the search box is expanded or collapsed. */

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderIconToolbar.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderIconToolbar.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import "./HeaderIconToolbar.scss";
-import * as React from "react";
+import React from "react";
 import {
   ButtonGroup,
   Divider,
@@ -34,7 +34,7 @@ type SearchExpandedState = [
 ];
 
 interface HeaderIconToolbarProps
-  extends Pick<WidgetContentLayoutHeaderProps, "iconSize" | "onSearch"> {
+  extends Pick<WidgetContentLayoutHeaderProps, "iconSize" | "onSearch" | "disableSearch"> {
   /** Array of icon menu items to display, including regular icons, search, and dividers. */
   menuIcons: (IconMenu | IconMenuSearch)[];
   /** State tuple controlling whether the search box is expanded or collapsed. */
@@ -86,6 +86,7 @@ export function HeaderIconToolbar(props: HeaderIconToolbarProps) {
                           setSearchIsExpanded(true);
                         }}
                         startIcon={<SvgSearch />}
+                        disabled={props.disableSearch}
                       >
                         Search
                       </MenuItem>
@@ -128,6 +129,7 @@ export function HeaderIconToolbar(props: HeaderIconToolbarProps) {
               size={props.iconSize}
               styleType="borderless"
               aria-label="More"
+              className="nz-header-overflow-button"
             >
               <SvgMore />
             </IconButton>
@@ -147,6 +149,7 @@ export function HeaderIconToolbar(props: HeaderIconToolbarProps) {
               searchState={searchState}
               iconSize={props.iconSize}
               onSearch={props.onSearch}
+              disableSearch={props.disableSearch}
             />
           ) : (
             <IconButton

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderLayout.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderLayout.tsx
@@ -25,6 +25,7 @@ type HeaderLayoutProps = Pick<
   | "menu"
   | "title"
   | "onSearch"
+  | "disableSearch"
   | "icons"
   | "iconSize"
   | "children"
@@ -72,6 +73,7 @@ export function HeaderLayout(props: HeaderLayoutProps) {
         <HeaderTopBar
           primaryContent={topBarLeftItems}
           onSearch={props.onSearch}
+          disableSearch={props.disableSearch}
           icons={icons}
           iconSize={props.iconSize}
         />

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderSearch.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderSearch.tsx
@@ -4,22 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import "./HeaderSearch.scss";
-import * as React from "react";
+import React from "react";
 
 import { SearchBox } from "@itwin/itwinui-react";
 
 import { SvgClose, SvgSearch } from "@itwin/itwinui-icons-react";
-import type { WidgetContentLayout } from "../WidgetContentLayout.js";
 import type { HeaderIconToolbar } from "./HeaderIconToolbar.js";
 
-type WidgetContentLayoutHeaderProps = React.ComponentProps<
-  typeof WidgetContentLayout.Header
->;
 type HeaderIconToolbarProps = React.ComponentProps<typeof HeaderIconToolbar>;
 
 interface HeaderSearchProps
-  extends Pick<WidgetContentLayoutHeaderProps, "iconSize" | "onSearch">,
-    Pick<HeaderIconToolbarProps, "searchExpandedState"> {
+  extends Pick<HeaderIconToolbarProps, "iconSize" | "onSearch" | "disableSearch" | "searchExpandedState"> {
   /** State tuple for the search text value and its setter function. */
   searchState: [string, React.Dispatch<React.SetStateAction<string>>];
 }
@@ -61,6 +56,7 @@ export function HeaderSearch(props: HeaderSearchProps) {
           labelProps={{ placement: "bottom" }}
           size={props.iconSize}
           styleType="borderless"
+          disabled={props.disableSearch}
         >
           <SvgSearch />
         </SearchBox.ExpandButton>

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderSearch.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderSearch.tsx
@@ -14,7 +14,10 @@ import type { HeaderIconToolbar } from "./HeaderIconToolbar.js";
 type HeaderIconToolbarProps = React.ComponentProps<typeof HeaderIconToolbar>;
 
 interface HeaderSearchProps
-  extends Pick<HeaderIconToolbarProps, "iconSize" | "onSearch" | "disableSearch" | "searchExpandedState"> {
+  extends Pick<
+    HeaderIconToolbarProps,
+    "iconSize" | "onSearch" | "disableSearch" | "searchExpandedState"
+  > {
   /** State tuple for the search text value and its setter function. */
   searchState: [string, React.Dispatch<React.SetStateAction<string>>];
 }

--- a/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderTopBar.tsx
+++ b/ui/appui-react/src/appui-react/layout/widget/widget-content-layout/header/HeaderTopBar.tsx
@@ -18,7 +18,7 @@ type HeaderIconToolbarProps = React.ComponentProps<typeof HeaderIconToolbar>;
 interface HeaderTopBarProps
   extends Pick<
     WidgetContentLayoutHeaderProps,
-    "icons" | "onSearch" | "iconSize"
+    "icons" | "onSearch" | "iconSize" | "disableSearch"
   > {
   primaryContent: React.JSX.Element[];
 }
@@ -66,6 +66,7 @@ export function HeaderTopBar(props: HeaderTopBarProps) {
           onSearch={props.onSearch}
           searchExpandedState={searchExpandedState}
           iconSize={props.iconSize}
+          disableSearch={props.disableSearch}
         />
       )}
     </div>


### PR DESCRIPTION
## Changes

- Add option to disable the search in WidgetContentLayout header component.
- Fix the header icon toolbar's height for different icon sizes

## Testing

https://itwin.github.io/appui/storybook/?path=/story/widget-layout-header--icons-and-search&args=disableSearch:!true
