### PR TITLE
Add `renderModalFrontstage` prop to allow styling the modal frontstage

### DIFF
--- a/.changeset/fine-pens-wait.md
+++ b/.changeset/fine-pens-wait.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Added `renderModalFrontstage` prop to `ConfigurableUiContent` component. This prop allows you to override the default modal frontstage with a custom implementation. Use the `ModalFrontstage` component to customize the default layout and behavior of the modal frontstage.

--- a/.changeset/happy-flies-hammer.md
+++ b/.changeset/happy-flies-hammer.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Deprecated `closeModal` prop of `ModalFrontstage` component. Use `navigateBack` prop instead to close the modal frontstage. This prop is now optional when using the `ModalFrontstage` component.

--- a/.changeset/huge-suns-shop.md
+++ b/.changeset/huge-suns-shop.md
@@ -1,0 +1,5 @@
+---
+"@itwin/appui-react": minor
+---
+
+Deprecated `ModalFrontstageProps` interface. Use `React.ComponentProps<typeof ModalFrontstage>` instead.

--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -987,6 +987,11 @@ export interface ConfigurableUiContentProps extends CommonProps {
     idleTimeout?: number;
     // @internal (undocumented)
     intervalTimeout?: number;
+    // @alpha
+    renderModalFrontstage?: (args: {
+        info: ModalFrontstageInfo;
+        isOpen: boolean;
+    }) => React_2.ReactNode;
     showActiveWidgetLabel?: boolean;
     toolAsToolSettingsLabel?: boolean;
     toolbarOpacity?: number;
@@ -3252,11 +3257,7 @@ export class ModalDialogRenderer extends React_2.PureComponent<CommonProps> {
 }
 
 // @public
-export class ModalFrontstage extends React_2.Component<ModalFrontstageProps> {
-    constructor(props: ModalFrontstageProps);
-    // (undocumented)
-    render(): React_2.JSX.Element;
-}
+export function ModalFrontstage(props: Props): React_2.JSX.Element;
 
 // @public
 export function ModalFrontstageButton(props: ModalFrontstageButtonProps): React_2.JSX.Element;
@@ -3293,14 +3294,14 @@ export interface ModalFrontstageInfo {
     title: string;
 }
 
-// @public
+// @public @deprecated
 export interface ModalFrontstageProps extends CommonProps {
     appBarRight?: React_2.ReactNode;
     backButton?: React_2.ReactNode;
     children?: React_2.ReactNode;
-    closeModal: () => any;
+    closeModal: () => void;
     isOpen?: boolean;
-    navigateBack?: () => any;
+    navigateBack?: () => void;
     title: string;
 }
 
@@ -4719,7 +4720,7 @@ export interface ToolAssistanceChangedEventArgs {
 }
 
 // @public
-export function ToolAssistanceField(props: Props): React_2.JSX.Element;
+export function ToolAssistanceField(props: Props_2): React_2.JSX.Element;
 
 // @public
 export interface ToolAssistanceFieldProps extends CommonProps {

--- a/common/api/summary/appui-react.exports.csv
+++ b/common/api/summary/appui-react.exports.csv
@@ -427,7 +427,7 @@ deprecated;class;MessagesUpdatedEvent
 public;class;ModalDialogChangedEvent
 deprecated;class;ModalDialogChangedEvent
 public;class;ModalDialogRenderer
-public;class;ModalFrontstage
+public;function;ModalFrontstage
 public;function;ModalFrontstageButton
 public;class;ModalFrontstageChangedEvent
 deprecated;class;ModalFrontstageChangedEvent
@@ -439,6 +439,7 @@ public;interface;ModalFrontstageClosedEventArgs
 deprecated;interface;ModalFrontstageClosedEventArgs
 public;interface;ModalFrontstageInfo
 public;interface;ModalFrontstageProps
+deprecated;interface;ModalFrontstageProps
 alpha;class;ModalFrontstageRequestedCloseEvent
 deprecated;class;ModalFrontstageRequestedCloseEvent
 alpha;interface;ModalFrontstageRequestedCloseEventArgs

--- a/docs/storybook/src/AppUiStory.tsx
+++ b/docs/storybook/src/AppUiStory.tsx
@@ -36,8 +36,15 @@ import { createFrontstage } from "./Utils";
 import { DemoIModel, useDemoIModel } from "../.storybook/addons/DemoIModel";
 import { openDemoIModel } from "./openDemoIModel";
 
-export interface AppUiStoryProps {
-  appBackstage?: React.ReactNode;
+type ConfigurableUiContentProps = React.ComponentProps<
+  typeof ConfigurableUiContent
+>;
+
+export interface AppUiStoryProps
+  extends Pick<
+    ConfigurableUiContentProps,
+    "appBackstage" | "renderModalFrontstage"
+  > {
   children?: React.ReactNode;
   demoIModel?: boolean | { default: DemoIModel };
   frontstages?: Frontstage[] | (() => Frontstage[]);
@@ -156,6 +163,7 @@ function Initialized(props: AppUiStoryProps) {
               }}
               appBackstage={props.appBackstage}
               widgetIcon={true}
+              renderModalFrontstage={props.renderModalFrontstage}
             />
           )}
         </ThemeManager>

--- a/docs/storybook/src/frontstage/Modal.stories.tsx
+++ b/docs/storybook/src/frontstage/Modal.stories.tsx
@@ -65,10 +65,12 @@ export const CustomLayout: Story = {
       <ModalFrontstage
         isOpen
         title="Custom layout"
-        closeModal={() => {
+        navigateBack={() => {
           UiFramework.frontstages.closeModalFrontstage();
         }}
-      />
+      >
+        Content of a modal frontstage.
+      </ModalFrontstage>
     ),
   },
 };

--- a/docs/storybook/src/frontstage/Modal.stories.tsx
+++ b/docs/storybook/src/frontstage/Modal.stories.tsx
@@ -6,7 +6,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { AppUiDecorator } from "../Decorators";
 import { Page } from "../AppUiStory";
 import { ModalFrontstageStory } from "./Modal";
-import { ModalFrontstageButton, UiFramework } from "@itwin/appui-react";
+import {
+  ModalFrontstage,
+  ModalFrontstageButton,
+  UiFramework,
+} from "@itwin/appui-react";
 
 const meta = {
   title: "Frontstage/ModalFrontstage",
@@ -52,5 +56,19 @@ export const AppBarRight: Story = {
 export const NotifyCloseRequest: Story = {
   args: {
     notifyCloseRequest: true,
+  },
+};
+
+export const CustomLayout: Story = {
+  args: {
+    layout: (
+      <ModalFrontstage
+        isOpen
+        title="Custom layout"
+        closeModal={() => {
+          UiFramework.frontstages.closeModalFrontstage();
+        }}
+      />
+    ),
   },
 };

--- a/docs/storybook/src/frontstage/Modal.stories.tsx
+++ b/docs/storybook/src/frontstage/Modal.stories.tsx
@@ -61,15 +61,18 @@ export const NotifyCloseRequest: Story = {
 
 export const CustomLayout: Story = {
   args: {
-    layout: (
+    renderModalFrontstage: ({ info, isOpen }) => (
       <ModalFrontstage
-        isOpen
-        title="Custom layout"
+        isOpen={isOpen}
+        title={info.title}
         navigateBack={() => {
           UiFramework.frontstages.closeModalFrontstage();
         }}
+        style={{
+          backgroundColor: "var(--background-3)",
+        }}
       >
-        Content of a modal frontstage.
+        {info.content} (custom layout)
       </ModalFrontstage>
     ),
   },

--- a/docs/storybook/src/frontstage/Modal.tsx
+++ b/docs/storybook/src/frontstage/Modal.tsx
@@ -17,7 +17,7 @@ import { action } from "storybook/actions";
 
 type ModalFrontstageStoryProps = Pick<
   ModalFrontstageInfo,
-  "backButton" | "notifyCloseRequest" | "appBarRight"
+  "backButton" | "notifyCloseRequest" | "appBarRight" | "layout"
 >;
 
 /** [openModalFrontstage](https://www.itwinjs.org/reference/appui-react/frontstage/frameworkfrontstages/#openmodalfrontstage) can be used to open a modal frontstage. */

--- a/docs/storybook/src/frontstage/Modal.tsx
+++ b/docs/storybook/src/frontstage/Modal.tsx
@@ -15,13 +15,17 @@ import { AppUiStory } from "../AppUiStory";
 import { createFrontstage } from "../Utils";
 import { action } from "storybook/actions";
 
+type AppUiStoryProps = React.ComponentProps<typeof AppUiStory>;
+
 type ModalFrontstageStoryProps = Pick<
   ModalFrontstageInfo,
-  "backButton" | "notifyCloseRequest" | "appBarRight" | "layout"
->;
+  "backButton" | "notifyCloseRequest" | "appBarRight"
+> &
+  Pick<AppUiStoryProps, "renderModalFrontstage">;
 
 /** [openModalFrontstage](https://www.itwinjs.org/reference/appui-react/frontstage/frameworkfrontstages/#openmodalfrontstage) can be used to open a modal frontstage. */
 export function ModalFrontstageStory(props: ModalFrontstageStoryProps) {
+  const { renderModalFrontstage, ...rest } = props;
   return (
     <AppUiStory
       layout="fullscreen"
@@ -39,7 +43,7 @@ export function ModalFrontstageStory(props: ModalFrontstageStoryProps) {
                   id: "my-modal-frontstage",
                   content: <>Modal frontstage content</>,
                   title: "My Modal Frontstage",
-                  ...props,
+                  ...rest,
                 });
               },
               layouts: {
@@ -52,6 +56,7 @@ export function ModalFrontstageStory(props: ModalFrontstageStoryProps) {
           ],
         },
       ]}
+      renderModalFrontstage={renderModalFrontstage}
     >
       <ModalFrontstageEvents />
     </AppUiStory>

--- a/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
+++ b/ui/appui-react/src/appui-react/configurableui/ConfigurableUiContent.tsx
@@ -46,6 +46,8 @@ import type { Widget } from "../widgets/Widget.js";
 import type { WidgetState } from "../widgets/WidgetState.js";
 import { useActiveIModelConnection } from "../hooks/useActiveIModelConnection.js";
 import { EditorsRegistryProvider } from "@itwin/components-react";
+import type { ModalFrontstageInfo } from "../framework/FrameworkFrontstages.js";
+import type { ModalFrontstage } from "../frontstage/ModalFrontstage.js";
 
 /** @internal */
 export const ConfigurableUiContext = React.createContext<
@@ -86,6 +88,17 @@ export interface ConfigurableUiContentProps extends CommonProps {
   toolbarOpacity?: number;
   /** Component to wrap all popout widgets and other child windows opened via {@link UiFramework.childWindows}. */
   childWindow?: React.ComponentType;
+  /**
+   * Overrides the default modal frontstage.
+   * Use the {@link ModalFrontstage} component to customize the default layout and behavior.
+   * @alpha
+   */
+  renderModalFrontstage?: (args: {
+    /** Information about the modal frontstage to be rendered. */
+    info: ModalFrontstageInfo;
+    /** Might be used for open/close animations in the future. */
+    isOpen: boolean;
+  }) => React.ReactNode;
 
   /** @internal */
   idleTimeout?: number;

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -27,6 +27,7 @@ import type { Frontstage } from "../frontstage/Frontstage.js";
 import { FrameworkContent } from "./FrameworkContent.js";
 import type { ModalFrontstageButton } from "../frontstage/ModalFrontstageButton.js";
 import { InternalFrontstageManager } from "../frontstage/InternalFrontstageManager.js";
+import type { ModalFrontstage } from "../frontstage/ModalFrontstage.js";
 
 /** Frontstage Activated Event Args interface.
  * @public
@@ -193,6 +194,14 @@ export interface ModalFrontstageInfo {
   notifyCloseRequest?: boolean;
   /** If specified overrides the default back button. See {@link ModalFrontstageButton}. */
   backButton?: React.ReactNode;
+  /**
+   * Overrides the default modal frontstage layout.
+   * Use the {@link ModalFrontstage} component to customize the default layout and behavior.
+   *
+   * @note When set, `content`, `appBarRight`, and `backButton` properties are ignored.
+   * @alpha
+   */
+  layout?: React.ReactNode;
 }
 
 /** Modal Frontstage array item interface.

--- a/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
+++ b/ui/appui-react/src/appui-react/framework/FrameworkFrontstages.ts
@@ -27,7 +27,6 @@ import type { Frontstage } from "../frontstage/Frontstage.js";
 import { FrameworkContent } from "./FrameworkContent.js";
 import type { ModalFrontstageButton } from "../frontstage/ModalFrontstageButton.js";
 import { InternalFrontstageManager } from "../frontstage/InternalFrontstageManager.js";
-import type { ModalFrontstage } from "../frontstage/ModalFrontstage.js";
 
 /** Frontstage Activated Event Args interface.
  * @public
@@ -194,14 +193,6 @@ export interface ModalFrontstageInfo {
   notifyCloseRequest?: boolean;
   /** If specified overrides the default back button. See {@link ModalFrontstageButton}. */
   backButton?: React.ReactNode;
-  /**
-   * Overrides the default modal frontstage layout.
-   * Use the {@link ModalFrontstage} component to customize the default layout and behavior.
-   *
-   * @note When set, `content`, `appBarRight`, and `backButton` properties are ignored.
-   * @alpha
-   */
-  layout?: React.ReactNode;
 }
 
 /** Modal Frontstage array item interface.

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.scss
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.scss
@@ -13,9 +13,12 @@
   pointer-events: none;
   visibility: hidden;
   overflow: hidden;
-  background: transparent;
+  background: color-mix(
+    in srgb,
+    var(--iui-color-background-backdrop),
+    transparent 5%
+  );
   transition: background 0.25s ease, visibility 0s ease 0.275s;
-
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -61,16 +64,4 @@
       transition: transform 0.125s ease;
     }
   }
-}
-
-.uifw-modal-frontstage-overlay {
-  position: absolute;
-  left: 0px;
-  width: 100%;
-  top: 0px;
-  height: 100%;
-  opacity: 0.95;
-  background: var(--iui-color-background-backdrop);
-
-  @include uicore-z-index(modal-frontstage-overlay);
 }

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
@@ -16,6 +16,7 @@ import type { ModalFrontstageInfo } from "../framework/FrameworkFrontstages.js";
 
 /** Properties for the [[ModalFrontstage]] React component
  * @public
+ * @deprecated in 5.31.0. Use `React.ComponentProps<typeof ModalFrontstage>` instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export interface ModalFrontstageProps extends CommonProps {
@@ -29,10 +30,19 @@ export interface ModalFrontstageProps extends CommonProps {
   closeModal: () => void;
   /** An optional React node displayed in the upper right of the modal Frontstage. */
   appBarRight?: React.ReactNode;
-  /** If specified overrides the default back button. */
+  /** If specified overrides the default {@link ModalFrontstageButton}. */
   backButton?: React.ReactNode;
-  /** Content */
+  /** Content of the modal frontstage. */
   children?: React.ReactNode;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+interface Props extends Omit<ModalFrontstageProps, "closeModal"> {
+  /**
+   * Callback for closing the modal Frontstage.
+   * @deprecated in 5.31.0. Use {@link navigateBack} instead.
+   */
+  closeModal?: () => void;
 }
 
 /**
@@ -40,10 +50,11 @@ export interface ModalFrontstageProps extends CommonProps {
  * Use {@link ModalFrontstageInfo.layout} to override the modal frontstage layout.
  * @public
  */
-export function ModalFrontstage(props: ModalFrontstageProps) {
+export function ModalFrontstage(props: Props) {
   const {
     isOpen,
     navigateBack,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     closeModal,
     backButton,
     title,
@@ -52,8 +63,8 @@ export function ModalFrontstage(props: ModalFrontstageProps) {
   } = props;
 
   const handleBack = () => {
-    if (navigateBack) navigateBack();
-    closeModal();
+    navigateBack?.();
+    closeModal?.();
   };
 
   return (

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
@@ -68,31 +68,28 @@ export function ModalFrontstage(props: Props) {
   };
 
   return (
-    <>
-      <div
-        {...rest}
-        className={classnames(
-          "uifw-modal-frontstage",
-          isOpen && "uifw-modal-open",
-          props.className
+    <div
+      {...rest}
+      className={classnames(
+        "uifw-modal-frontstage",
+        isOpen && "uifw-modal-open",
+        props.className
+      )}
+    >
+      <div className="uifw-modal-app-bar">
+        {backButton ? (
+          backButton
+        ) : (
+          <ModalFrontstageButton onClick={handleBack} />
         )}
-      >
-        <div className="uifw-modal-app-bar">
-          {backButton ? (
-            backButton
-          ) : (
-            <ModalFrontstageButton onClick={handleBack} />
-          )}
-          <Text variant="headline" className="uifw-headline">
-            {title}
-          </Text>
-          {appBarRight && (
-            <span className="uifw-modal-app-bar-right">{appBarRight}</span>
-          )}
-        </div>
-        <div className="uifw-modal-stage-content">{props.children}</div>
+        <Text variant="headline" className="uifw-headline">
+          {title}
+        </Text>
+        {appBarRight && (
+          <span className="uifw-modal-app-bar-right">{appBarRight}</span>
+        )}
       </div>
-      <div className="uifw-modal-frontstage-overlay" />
-    </>
+      <div className="uifw-modal-stage-content">{props.children}</div>
+    </div>
   );
 }

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
@@ -23,9 +23,9 @@ export interface ModalFrontstageProps extends CommonProps {
   /** Indicates whether the modal Frontstage is open */
   isOpen?: boolean;
   /** Callback for navigating back from the modal Frontstage. */
-  navigateBack?: () => any;
+  navigateBack?: () => void;
   /** Callback for closing the modal Frontstage. */
-  closeModal: () => any;
+  closeModal: () => void;
   /** An optional React node displayed in the upper right of the modal Frontstage. */
   appBarRight?: React.ReactNode;
   /** If specified overrides the default back button. */

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
@@ -12,7 +12,7 @@ import classnames from "classnames";
 import type { CommonProps } from "@itwin/core-react";
 import { Text } from "@itwin/itwinui-react";
 import { ModalFrontstageButton } from "./ModalFrontstageButton.js";
-import type { ModalFrontstageInfo } from "../framework/FrameworkFrontstages.js";
+import type { ConfigurableUiContent } from "../configurableui/ConfigurableUiContent.js";
 
 /** Properties for the [[ModalFrontstage]] React component
  * @public
@@ -47,7 +47,7 @@ interface Props extends Omit<ModalFrontstageProps, "closeModal"> {
 
 /**
  * The default layout used for modal frontstages.
- * Use {@link ModalFrontstageInfo.layout} to override the modal frontstage layout.
+ * Use `renderModalFrontstage` prop of {@link ConfigurableUiContent} to override the modal frontstage layout.
  * @public
  */
 export function ModalFrontstage(props: Props) {

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
@@ -37,45 +37,39 @@ export interface ModalFrontstageProps extends CommonProps {
 /** ModalFrontstage React component
  * @public
  */
-export class ModalFrontstage extends React.Component<ModalFrontstageProps> {
-  constructor(props: ModalFrontstageProps) {
-    super(props);
-  }
+export function ModalFrontstage(props: ModalFrontstageProps) {
+  const classNames = classnames(
+    "uifw-modal-frontstage",
+    props.isOpen && "uifw-modal-open",
+    props.className
+  );
 
-  private _onGoBack = () => {
-    if (this.props.navigateBack) this.props.navigateBack();
-    this.props.closeModal();
+  const onGoBack = () => {
+    if (props.navigateBack) props.navigateBack();
+    props.closeModal();
   };
 
-  public override render() {
-    const classNames = classnames(
-      "uifw-modal-frontstage",
-      this.props.isOpen && "uifw-modal-open",
-      this.props.className
-    );
-
-    return (
-      <>
-        <div className={classNames} style={this.props.style}>
-          <div className="uifw-modal-app-bar">
-            {this.props.backButton ? (
-              this.props.backButton
-            ) : (
-              <ModalFrontstageButton onClick={this._onGoBack} />
-            )}
-            <Text variant="headline" className="uifw-headline">
-              {this.props.title}
-            </Text>
-            {this.props.appBarRight && (
-              <span className="uifw-modal-app-bar-right">
-                {this.props.appBarRight}
-              </span>
-            )}
-          </div>
-          <div className="uifw-modal-stage-content">{this.props.children}</div>
+  return (
+    <>
+      <div className={classNames} style={props.style}>
+        <div className="uifw-modal-app-bar">
+          {props.backButton ? (
+            props.backButton
+          ) : (
+            <ModalFrontstageButton onClick={onGoBack} />
+          )}
+          <Text variant="headline" className="uifw-headline">
+            {props.title}
+          </Text>
+          {props.appBarRight && (
+            <span className="uifw-modal-app-bar-right">
+              {props.appBarRight}
+            </span>
+          )}
         </div>
-        <div className="uifw-modal-frontstage-overlay" />
-      </>
-    );
-  }
+        <div className="uifw-modal-stage-content">{props.children}</div>
+      </div>
+      <div className="uifw-modal-frontstage-overlay" />
+    </>
+  );
 }

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
@@ -12,6 +12,7 @@ import classnames from "classnames";
 import type { CommonProps } from "@itwin/core-react";
 import { Text } from "@itwin/itwinui-react";
 import { ModalFrontstageButton } from "./ModalFrontstageButton.js";
+import type { ModalFrontstageInfo } from "../framework/FrameworkFrontstages.js";
 
 /** Properties for the [[ModalFrontstage]] React component
  * @public
@@ -34,37 +35,48 @@ export interface ModalFrontstageProps extends CommonProps {
   children?: React.ReactNode;
 }
 
-/** ModalFrontstage React component
+/**
+ * The default layout used for modal frontstages.
+ * Use {@link ModalFrontstageInfo.layout} to override the modal frontstage layout.
  * @public
  */
 export function ModalFrontstage(props: ModalFrontstageProps) {
-  const classNames = classnames(
-    "uifw-modal-frontstage",
-    props.isOpen && "uifw-modal-open",
-    props.className
-  );
+  const {
+    isOpen,
+    navigateBack,
+    closeModal,
+    backButton,
+    title,
+    appBarRight,
+    ...rest
+  } = props;
 
-  const onGoBack = () => {
-    if (props.navigateBack) props.navigateBack();
-    props.closeModal();
+  const handleBack = () => {
+    if (navigateBack) navigateBack();
+    closeModal();
   };
 
   return (
     <>
-      <div className={classNames} style={props.style}>
+      <div
+        {...rest}
+        className={classnames(
+          "uifw-modal-frontstage",
+          isOpen && "uifw-modal-open",
+          props.className
+        )}
+      >
         <div className="uifw-modal-app-bar">
-          {props.backButton ? (
-            props.backButton
+          {backButton ? (
+            backButton
           ) : (
-            <ModalFrontstageButton onClick={onGoBack} />
+            <ModalFrontstageButton onClick={handleBack} />
           )}
           <Text variant="headline" className="uifw-headline">
-            {props.title}
+            {title}
           </Text>
-          {props.appBarRight && (
-            <span className="uifw-modal-app-bar-right">
-              {props.appBarRight}
-            </span>
+          {appBarRight && (
+            <span className="uifw-modal-app-bar-right">{appBarRight}</span>
           )}
         </div>
         <div className="uifw-modal-stage-content">{props.children}</div>

--- a/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/frontstage/ModalFrontstage.tsx
@@ -20,15 +20,15 @@ import type { ModalFrontstageInfo } from "../framework/FrameworkFrontstages.js";
  */
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export interface ModalFrontstageProps extends CommonProps {
-  /** Title displayed at the top of the modal Frontstage */
+  /** Title displayed at the top of the modal frontstage. */
   title: string;
-  /** Indicates whether the modal Frontstage is open */
+  /** Indicates whether the modal frontstage is open. */
   isOpen?: boolean;
-  /** Callback for navigating back from the modal Frontstage. */
+  /** Callback for navigating back from the modal frontstage. */
   navigateBack?: () => void;
-  /** Callback for closing the modal Frontstage. */
+  /** Callback for closing the modal frontstage. */
   closeModal: () => void;
-  /** An optional React node displayed in the upper right of the modal Frontstage. */
+  /** Optional content displayed in the upper right of the modal frontstage. */
   appBarRight?: React.ReactNode;
   /** If specified overrides the default {@link ModalFrontstageButton}. */
   backButton?: React.ReactNode;

--- a/ui/appui-react/src/appui-react/hooks/useActiveModalFrontstage.tsx
+++ b/ui/appui-react/src/appui-react/hooks/useActiveModalFrontstage.tsx
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+/** @packageDocumentation
+ * @module Hooks
+ */
+
+import { useSyncExternalStore } from "react";
+import { UiFramework } from "../UiFramework.js";
+
+const subscribe = (onStoreChange: () => void) => {
+  return UiFramework.frontstages.onModalFrontstageChangedEvent.addListener(
+    onStoreChange
+  );
+};
+
+const getSnapshot = () => {
+  return UiFramework.frontstages.activeModalFrontstage;
+};
+
+/** React hook that returns the active modal frontstage.
+ * @internal
+ */
+export function useActiveModalFrontstage() {
+  const frontstage = useSyncExternalStore(subscribe, getSnapshot);
+  return frontstage;
+}

--- a/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/Frontstage.tsx
@@ -44,10 +44,7 @@ import { WidgetContent } from "./Content.js";
 import { FloatingWidget } from "./FloatingWidget.js";
 import "./Frontstage.scss";
 import { WidgetPanelsFrontstageContent } from "./FrontstageContent.js";
-import {
-  ModalFrontstageComposer,
-  useActiveModalFrontstageInfo,
-} from "./ModalFrontstageComposer.js";
+import { ModalFrontstageComposer } from "./ModalFrontstageComposer.js";
 import { WidgetPanelsStatusBar } from "./StatusBar.js";
 import { WidgetPanelsTab } from "./Tab.js";
 import { WidgetPanelsToolbars } from "./Toolbars.js";
@@ -71,7 +68,6 @@ import { UiStateStorageStatus } from "../uistate/UiStateStorage.js";
 import { useLatestRef } from "../hooks/useLatestRef.js";
 
 function WidgetPanelsFrontstageComponent() {
-  const activeModalFrontstageInfo = useActiveModalFrontstageInfo();
   const uiIsVisible = useUiVisibility();
   const previewFeatures = usePreviewFeatures();
   useCursor();
@@ -82,7 +78,7 @@ function WidgetPanelsFrontstageComponent() {
         enabled={previewFeatures.horizontalPanelAlignment}
       >
         <ToolbarPopupAutoHideContext.Provider value={!uiIsVisible}>
-          <ModalFrontstageComposer stageInfo={activeModalFrontstageInfo} />
+          <ModalFrontstageComposer />
           <StandardLayout
             centerContent={
               <>

--- a/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
@@ -6,16 +6,13 @@
  * @module Frontstage
  */
 import * as React from "react";
-import type { ModalFrontstageInfo } from "../framework/FrameworkFrontstages.js";
 import { ModalFrontstage } from "../frontstage/ModalFrontstage.js";
 import { UiFramework } from "../UiFramework.js";
+import { useActiveModalFrontstage } from "../hooks/useActiveModalFrontstage.js";
 
 /** @internal */
-export function ModalFrontstageComposer({
-  stageInfo,
-}: {
-  stageInfo: ModalFrontstageInfo | undefined;
-}) {
+export function ModalFrontstageComposer() {
+  const stageInfo = useActiveModalFrontstage();
   const handleCloseModal = React.useCallback(
     () => UiFramework.frontstages.closeModalFrontstage(),
     []

--- a/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
@@ -51,7 +51,7 @@ export function ModalFrontstageComposer({
     <ModalFrontstage
       isOpen={true}
       title={title}
-      closeModal={handleCloseModal}
+      navigateBack={handleCloseModal}
       appBarRight={appBarRight}
       backButton={backButton}
     >

--- a/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
@@ -38,9 +38,14 @@ export function ModalFrontstageComposer({
     () => UiFramework.frontstages.closeModalFrontstage(),
     []
   );
+
   if (!stageInfo) return null;
 
   const { title, content, appBarRight, backButton } = stageInfo;
+
+  if (stageInfo.layout) {
+    return <>{stageInfo.layout}</>;
+  }
 
   return (
     <ModalFrontstage

--- a/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
@@ -9,32 +9,33 @@ import * as React from "react";
 import { ModalFrontstage } from "../frontstage/ModalFrontstage.js";
 import { UiFramework } from "../UiFramework.js";
 import { useActiveModalFrontstage } from "../hooks/useActiveModalFrontstage.js";
+import { ConfigurableUiContext } from "../configurableui/ConfigurableUiContent.js";
 
 /** @internal */
 export function ModalFrontstageComposer() {
-  const stageInfo = useActiveModalFrontstage();
+  const { renderModalFrontstage } = React.useContext(ConfigurableUiContext);
+  const info = useActiveModalFrontstage();
   const handleCloseModal = React.useCallback(
     () => UiFramework.frontstages.closeModalFrontstage(),
     []
   );
 
-  if (!stageInfo) return null;
-
-  const { title, content, appBarRight, backButton } = stageInfo;
-
-  if (stageInfo.layout) {
-    return <>{stageInfo.layout}</>;
-  }
-
+  if (!info) return null;
   return (
-    <ModalFrontstage
-      isOpen={true}
-      title={title}
-      navigateBack={handleCloseModal}
-      appBarRight={appBarRight}
-      backButton={backButton}
-    >
-      {content}
-    </ModalFrontstage>
+    <>
+      {renderModalFrontstage ? (
+        renderModalFrontstage({ info, isOpen: true })
+      ) : (
+        <ModalFrontstage
+          isOpen={true}
+          title={info.title}
+          navigateBack={handleCloseModal}
+          appBarRight={info.appBarRight}
+          backButton={info.backButton}
+        >
+          {info.content}
+        </ModalFrontstage>
+      )}
+    </>
   );
 }

--- a/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
+++ b/ui/appui-react/src/appui-react/widget-panels/ModalFrontstageComposer.tsx
@@ -11,24 +11,6 @@ import { ModalFrontstage } from "../frontstage/ModalFrontstage.js";
 import { UiFramework } from "../UiFramework.js";
 
 /** @internal */
-export function useActiveModalFrontstageInfo() {
-  const [activeModalFrontstageInfo, setActiveModalFrontstageInfo] =
-    React.useState(UiFramework.frontstages.activeModalFrontstage);
-  React.useEffect(() => {
-    return UiFramework.frontstages.onModalFrontstageChangedEvent.addListener(
-      (args) => {
-        setActiveModalFrontstageInfo(
-          args.modalFrontstageCount === 0
-            ? undefined
-            : UiFramework.frontstages.activeModalFrontstage
-        );
-      }
-    );
-  }, [setActiveModalFrontstageInfo]);
-  return activeModalFrontstageInfo;
-}
-
-/** @internal */
 export function ModalFrontstageComposer({
   stageInfo,
 }: {

--- a/ui/appui-react/src/test/hooks/useActiveModalFrontstage.test.tsx
+++ b/ui/appui-react/src/test/hooks/useActiveModalFrontstage.test.tsx
@@ -1,0 +1,58 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+import { act, renderHook } from "@testing-library/react";
+import * as React from "react";
+import { UiFramework } from "../../appui-react.js";
+import { useActiveModalFrontstage } from "../../appui-react/hooks/useActiveModalFrontstage.js";
+
+describe("useActiveModalFrontstage", () => {
+  it("should add tool activated event listener", () => {
+    const addListenerSpy = vi.spyOn(
+      UiFramework.frontstages.onModalFrontstageChangedEvent,
+      "addListener"
+    );
+    const removeListenerSpy = vi.spyOn(
+      UiFramework.frontstages.onModalFrontstageChangedEvent,
+      "removeListener"
+    );
+    const sut = renderHook(() => useActiveModalFrontstage());
+    sut.unmount();
+    expect(addListenerSpy).toHaveBeenCalledOnce();
+    expect(removeListenerSpy).toHaveBeenCalledOnce();
+  });
+
+  it("should update active modal info", () => {
+    const modalStageInfo = {
+      title: "TestModalStage",
+      content: <div>Hello World!</div>,
+    };
+
+    vi.spyOn(
+      UiFramework.frontstages,
+      "activeModalFrontstage",
+      "get"
+    ).mockImplementation(() => undefined);
+    renderHook(() => useActiveModalFrontstage());
+    act(() => {
+      vi.spyOn(
+        UiFramework.frontstages,
+        "activeModalFrontstage",
+        "get"
+      ).mockImplementation(() => undefined);
+      UiFramework.frontstages.onModalFrontstageChangedEvent.emit({
+        modalFrontstageCount: 0,
+      });
+
+      vi.spyOn(
+        UiFramework.frontstages,
+        "activeModalFrontstage",
+        "get"
+      ).mockImplementation(() => modalStageInfo);
+      UiFramework.frontstages.onModalFrontstageChangedEvent.emit({
+        modalFrontstageCount: 1,
+      });
+    });
+  });
+});

--- a/ui/appui-react/src/test/widget-panels/Frontstage.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/Frontstage.test.tsx
@@ -284,11 +284,11 @@ describe("Frontstage local storage wrapper", () => {
 
   describe("ModalFrontstageComposer", () => {
     it("should render modal stage content when mounted", () => {
-      const modalStageInfo = {
+      UiFramework.frontstages.openModalFrontstage({
         title: "TestModalStage",
         content: <div>Hello World!</div>,
-      };
-      render(<ModalFrontstageComposer stageInfo={modalStageInfo} />);
+      });
+      render(<ModalFrontstageComposer />);
       expect(
         screen.getByText("Hello World!", {
           selector:

--- a/ui/appui-react/src/test/widget-panels/Frontstage.test.tsx
+++ b/ui/appui-react/src/test/widget-panels/Frontstage.test.tsx
@@ -62,10 +62,7 @@ import {
   useUpdateNineZoneSize,
   WidgetPanelsFrontstage,
 } from "../../appui-react/widget-panels/Frontstage.js";
-import {
-  ModalFrontstageComposer,
-  useActiveModalFrontstageInfo,
-} from "../../appui-react/widget-panels/ModalFrontstageComposer.js";
+import { ModalFrontstageComposer } from "../../appui-react/widget-panels/ModalFrontstageComposer.js";
 
 function createFrontstageState(
   nineZone = createNineZoneState()
@@ -298,54 +295,6 @@ describe("Frontstage local storage wrapper", () => {
             ".uifw-modal-frontstage.uifw-modal-open .uifw-modal-stage-content > div",
         })
       ).to.exist;
-    });
-
-    it("should add tool activated event listener", () => {
-      const addListenerSpy = vi.spyOn(
-        UiFramework.frontstages.onModalFrontstageChangedEvent,
-        "addListener"
-      );
-      const removeListenerSpy = vi.spyOn(
-        UiFramework.frontstages.onModalFrontstageChangedEvent,
-        "removeListener"
-      );
-      const sut = renderHook(() => useActiveModalFrontstageInfo());
-      sut.unmount();
-      expect(addListenerSpy).toHaveBeenCalledOnce();
-      expect(removeListenerSpy).toHaveBeenCalledOnce();
-    });
-
-    it("should update active modal info", () => {
-      const modalStageInfo = {
-        title: "TestModalStage",
-        content: <div>Hello World!</div>,
-      };
-
-      vi.spyOn(
-        UiFramework.frontstages,
-        "activeModalFrontstage",
-        "get"
-      ).mockImplementation(() => undefined);
-      renderHook(() => useActiveModalFrontstageInfo());
-      act(() => {
-        vi.spyOn(
-          UiFramework.frontstages,
-          "activeModalFrontstage",
-          "get"
-        ).mockImplementation(() => undefined);
-        UiFramework.frontstages.onModalFrontstageChangedEvent.emit({
-          modalFrontstageCount: 0,
-        });
-
-        vi.spyOn(
-          UiFramework.frontstages,
-          "activeModalFrontstage",
-          "get"
-        ).mockImplementation(() => modalStageInfo);
-        UiFramework.frontstages.onModalFrontstageChangedEvent.emit({
-          modalFrontstageCount: 1,
-        });
-      });
     });
 
     describe("ActiveFrontstageDefProvider", () => {


### PR DESCRIPTION
## Changes

This PR fixes #1550 by adding the `renderModalFronstage` prop to `ConfigurableUiContent` component. Consumers can render the existing `ModalFrontstage` component (or a custom component) with additional configuration/styling to update the layout or behavior of every modal frontstage.

Initially I've considered [adding a `layout` property to `ModalFrontstageInfo` interface](https://github.com/iTwin/appui/commit/f93dae760bb417e2fade4126b90d45b58f50cfc6), however this approach would require the layout to be passed in each time when opening the modal frontstage.

Other changes:
- [Converted the `ModalFrontstage` from class to functional component](https://github.com/iTwin/appui/commit/37a6cc15ac84cd5c3980a83d3d42f78139129956)
- [Removed the overlay element](https://github.com/iTwin/appui/commit/e3b19b3278087e63df2d00aede97fcbb395fe5b6)
- `ModalFrontstage` component will now pass-down the props to it's root element
- Deprecated `ModalFrontstageProps` interface
- Deprecated `closeModal` prop of `ModalFrontstage` component (and made it optional)
- Added a new story for testing

## Testing

https://itwin.github.io/appui/storybook/?path=/story/frontstage-modalfrontstage--custom-layout
