### PR TITLE
[New editors]: quantity editor update

### DIFF
--- a/.changeset/moody-owls-marry.md
+++ b/.changeset/moody-owls-marry.md
@@ -1,0 +1,5 @@
+---
+"@itwin/imodel-components-react": minor
+---
+
+Improved `QuantityEditor` empty and merged value handling. Empty values display the unit label as a placeholder, and focusing a merged value (`-- unit`) replaces it with the unit label for immediate editing.

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityEditor.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityEditor.tsx
@@ -69,7 +69,7 @@ export function QuantityEditor({
     maximumValue: undefined,
   };
   const handleChange = (newValue: NumericValue) => {
-    if (!newValue?.rawValue) {
+    if (newValue?.rawValue === undefined) {
       onChange(newValue);
       return;
     }

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
@@ -69,7 +69,10 @@ function useQuantityInput({
           ? prev
           : { ...prev, displayValue };
       }
-      return prev;
+      return {
+        ...prev,
+        displayValue: formatter.unitConversions?.[0]?.label ?? "",
+      };
     });
   }, [formatter]);
 

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
@@ -10,7 +10,8 @@ import type { FormatterSpec, ParserSpec } from "@itwin/core-quantity";
 
 /* v8 ignore start */
 
-interface QuantityInputProps extends Pick<
+interface QuantityInputProps
+  extends Pick<
     React.ComponentPropsWithoutRef<typeof Input>,
     "onBlur" | "onFocus" | "size"
   > {

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
@@ -81,16 +81,13 @@ function useQuantityInput({
     });
   }, [formatter]);
 
-  const onChangeRef = React.useRef(onChange);
-  onChangeRef.current = onChange;
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const inputText = e.target.value;
     const unit = formatter?.unitConversions?.[0]?.label;
     const rawValue = parseInput(inputText, parser, unit);
     const newValue: NumericValue = { rawValue, displayValue: inputText };
     setState(newValue);
-    onChangeRef.current(newValue);
+    onChange(newValue);
   };
 
   const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
@@ -4,64 +4,128 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as React from "react";
-import { FormattedNumericInput } from "@itwin/components-react";
+import { Input } from "@itwin/itwinui-react";
+import type { NumericValue } from "@itwin/components-react";
 import type { FormatterSpec, ParserSpec } from "@itwin/core-quantity";
 
 /* v8 ignore start */
 
-type FormattedNumericInputProps = React.ComponentPropsWithoutRef<
-  typeof FormattedNumericInput
->;
-
-interface QuantityInputProps
-  extends Omit<
-    FormattedNumericInputProps,
-    "parseValue" | "formatValue" | "disabled"
+interface QuantityInputProps extends Pick<
+    React.ComponentPropsWithoutRef<typeof Input>,
+    "onBlur" | "onFocus" | "size"
   > {
+  value: NumericValue;
+  onChange: (value: NumericValue) => void;
   formatter?: FormatterSpec;
   parser?: ParserSpec;
 }
 
 /**
- * A component that wraps `FormattedNumericInput` and takes a formatter and parser for quantity values.
+ * A quantity input that manages its own display state and uses formatter/parser for quantity values.
  * @internal
  */
-export function QuantityInput({
-  formatter,
-  parser,
-  ...props
-}: QuantityInputProps) {
-  const initialValue = React.useRef(props.value);
-  const formatValue = React.useCallback(
-    (currValue: number) => {
-      if (!formatter) {
-        return initialValue.current.displayValue;
-      }
-      return formatter.applyFormatting(currValue);
-    },
-    [formatter]
-  );
-
-  const parseString = React.useCallback(
-    (userInput: string) => {
-      if (!parser) {
-        return undefined;
-      }
-      const parseResult = parser.parseToQuantityValue(userInput);
-      return parseResult.ok ? parseResult.value : undefined;
-    },
-    [parser]
-  );
+export function QuantityInput(props: QuantityInputProps) {
+  const { formatter, parser, size, onBlur } = props;
+  const { inputProps } = useQuantityInput(props);
+  const placeholder = formatter?.unitConversions?.[0]?.label;
 
   return (
-    <FormattedNumericInput
-      {...props}
-      value={props.value}
-      formatValue={formatValue}
-      parseValue={parseString}
+    <Input
+      {...inputProps}
+      placeholder={placeholder}
       disabled={!formatter || !parser}
+      size={size}
+      onBlur={onBlur}
     />
   );
+}
+
+function useQuantityInput({
+  value,
+  onChange,
+  formatter,
+  parser,
+  onFocus,
+}: QuantityInputProps) {
+  const [state, setState] = React.useState<NumericValue>(() => {
+    if (value.rawValue !== undefined && formatter) {
+      return {
+        rawValue: value.rawValue,
+        displayValue: formatter.applyFormatting(value.rawValue),
+      };
+    }
+    return value;
+  });
+
+  React.useLayoutEffect(() => {
+    if (!formatter) {
+      return;
+    }
+    setState((prev) => {
+      if (prev.rawValue !== undefined) {
+        const displayValue = formatter.applyFormatting(prev.rawValue);
+        return prev.displayValue === displayValue
+          ? prev
+          : { ...prev, displayValue };
+      }
+      return prev;
+    });
+  }, [formatter]);
+
+  const onChangeRef = React.useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const inputText = e.target.value;
+    const unit = formatter?.unitConversions?.[0]?.label;
+    const rawValue = parseInput(inputText, parser, unit);
+    const newValue: NumericValue = { rawValue, displayValue: inputText };
+    setState(newValue);
+    onChangeRef.current(newValue);
+  };
+
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    onFocus?.(e);
+
+    const input = e.currentTarget;
+    const unit = formatter?.unitConversions?.[0]?.label ?? "";
+
+    if (state.rawValue === undefined) {
+      if (state.displayValue.startsWith("--")) {
+        setState({ rawValue: undefined, displayValue: unit });
+        requestAnimationFrame(() => {
+          input.setSelectionRange(0, 0);
+        });
+      }
+      return;
+    }
+
+    if (state.displayValue) {
+      requestAnimationFrame(() => {
+        input.select();
+      });
+    }
+  };
+
+  return {
+    inputProps: {
+      value: state.displayValue,
+      onChange: handleChange,
+      onFocus: handleFocus,
+    },
+  };
+}
+
+function parseInput(
+  userInput: string,
+  parser: ParserSpec | undefined,
+  placeholder: string | undefined
+): number | undefined {
+  if (!parser || userInput === placeholder) {
+    return undefined;
+  }
+  const parseResult = parser.parseToQuantityValue(userInput);
+  return parseResult.ok ? parseResult.value : undefined;
 }
 
 /* v8 ignore stop */

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/QuantityInput.tsx
@@ -69,6 +69,11 @@ function useQuantityInput({
           ? prev
           : { ...prev, displayValue };
       }
+
+      if (prev.displayValue !== "") {
+        return prev;
+      }
+
       return {
         ...prev,
         displayValue: formatter.unitConversions?.[0]?.label ?? "",

--- a/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/UseQuantityInfo.ts
+++ b/ui/imodel-components-react/src/imodel-components-react/inputs/new-editors/UseQuantityInfo.ts
@@ -159,7 +159,6 @@ async function getFormatterParserSpec({
   const defaultFormatterSpec =
     await IModelApp.quantityFormatter.createFormatterSpec({
       formatProps,
-
       persistenceUnitName,
     });
   const parserSpec = await IModelApp.quantityFormatter.createParserSpec({

--- a/ui/imodel-components-react/src/test/inputs/new-editors/QuantityEditor.test.tsx
+++ b/ui/imodel-components-react/src/test/inputs/new-editors/QuantityEditor.test.tsx
@@ -56,16 +56,6 @@ function renderQuantityEditor(
 }
 
 describe("QuantityEditor", () => {
-  const originalRAF = globalThis.requestAnimationFrame;
-  beforeEach(() => {
-    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
-      cb(0);
-      return 0;
-    });
-  });
-  afterEach(() => {
-    vi.stubGlobal("requestAnimationFrame", originalRAF);
-  });
 
   describe("persistence unit matches display unit", () => {
     const metadata: QuantityValueMetadata = {
@@ -89,6 +79,7 @@ describe("QuantityEditor", () => {
       const { getByRole } = renderQuantityEditor(metadata, undefined, onChange);
 
       const input = getByRole("textbox");
+      await user.clear(input);
       await user.type(input, "25");
 
       expect(onChange).toHaveBeenLastCalledWith(
@@ -112,6 +103,7 @@ describe("QuantityEditor", () => {
       );
 
       const input = getByRole("textbox");
+      await user.clear(input);
       await user.type(input, "-10");
 
       expect(onChange).toHaveBeenLastCalledWith(
@@ -135,6 +127,7 @@ describe("QuantityEditor", () => {
       );
 
       const input = getByRole("textbox");
+      await user.clear(input);
       await user.type(input, "200");
 
       expect(onChange).toHaveBeenLastCalledWith(
@@ -158,6 +151,7 @@ describe("QuantityEditor", () => {
       );
 
       const input = getByRole("textbox");
+      await user.clear(input);
       await user.type(input, "50");
 
       expect(onChange).toHaveBeenLastCalledWith(
@@ -171,6 +165,7 @@ describe("QuantityEditor", () => {
       const { getByRole } = renderQuantityEditor(metadata, undefined, onChange);
 
       const input = getByRole("textbox");
+      await user.clear(input);
       await user.type(input, "999");
 
       expect(onChange).toHaveBeenLastCalledWith(
@@ -241,6 +236,7 @@ describe("QuantityEditor", () => {
       const newValueInInches = 100;
 
       const input = getByRole("textbox");
+      await user.clear(input);
       await user.type(input, `${newValueInInches} in`);
 
       expect(onChange).toHaveBeenLastCalledWith(
@@ -269,6 +265,7 @@ describe("QuantityEditor", () => {
       const input = getByRole("textbox");
       // Type 50 inches = 1.27 meters, exceeds maximumValue of 1 meter
       const newValueInInches = 50;
+      await user.clear(input);
       await user.type(input, `${newValueInInches} in`);
 
       expect(onChange).toHaveBeenLastCalledWith(

--- a/ui/imodel-components-react/src/test/inputs/new-editors/QuantityEditor.test.tsx
+++ b/ui/imodel-components-react/src/test/inputs/new-editors/QuantityEditor.test.tsx
@@ -58,7 +58,10 @@ function renderQuantityEditor(
 describe("QuantityEditor", () => {
   const originalRAF = globalThis.requestAnimationFrame;
   beforeEach(() => {
-    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 0; });
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
   });
   afterEach(() => {
     vi.stubGlobal("requestAnimationFrame", originalRAF);

--- a/ui/imodel-components-react/src/test/inputs/new-editors/QuantityEditor.test.tsx
+++ b/ui/imodel-components-react/src/test/inputs/new-editors/QuantityEditor.test.tsx
@@ -56,7 +56,6 @@ function renderQuantityEditor(
 }
 
 describe("QuantityEditor", () => {
-
   describe("persistence unit matches display unit", () => {
     const metadata: QuantityValueMetadata = {
       type: "number",

--- a/ui/imodel-components-react/src/test/inputs/new-editors/QuantityEditor.test.tsx
+++ b/ui/imodel-components-react/src/test/inputs/new-editors/QuantityEditor.test.tsx
@@ -7,7 +7,7 @@ import { render } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { QuantityValueMetadata } from "../../imodel-components-react/inputs/new-editors/QuantityEditor.js";
+import type { QuantityValueMetadata } from "../../../imodel-components-react/inputs/new-editors/QuantityEditor.js";
 
 const METERS_PER_INCH = 0.0254;
 const convertMetersToInches = (meters: number) => meters / METERS_PER_INCH;
@@ -22,14 +22,16 @@ const mockConfig = {
 };
 
 vi.mock(
-  "../../imodel-components-react/inputs/new-editors/UseQuantityInfo.js",
+  "../../../imodel-components-react/inputs/new-editors/UseQuantityInfo.js",
   () => ({
     useQuantityInfo: () => ({
       defaultFormatter: {
         applyFormatting: (v: number) => mockConfig.formatter(v),
+        unitConversions: [{ label: "m", conversion: { factor: 1, offset: 0 } }],
       },
       highPrecisionFormatter: {
         applyFormatting: (v: number) => mockConfig.formatter(v),
+        unitConversions: [{ label: "m", conversion: { factor: 1, offset: 0 } }],
       },
       parser: {
         parseToQuantityValue: (input: string) => mockConfig.parser(input),
@@ -40,7 +42,7 @@ vi.mock(
 
 // Import after mock setup
 const { QuantityEditor } = await import(
-  "../../imodel-components-react/inputs/new-editors/QuantityEditor.js"
+  "../../../imodel-components-react/inputs/new-editors/QuantityEditor.js"
 );
 
 function renderQuantityEditor(
@@ -54,6 +56,14 @@ function renderQuantityEditor(
 }
 
 describe("QuantityEditor", () => {
+  const originalRAF = globalThis.requestAnimationFrame;
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => { cb(0); return 0; });
+  });
+  afterEach(() => {
+    vi.stubGlobal("requestAnimationFrame", originalRAF);
+  });
+
   describe("persistence unit matches display unit", () => {
     const metadata: QuantityValueMetadata = {
       type: "number",
@@ -164,6 +174,20 @@ describe("QuantityEditor", () => {
         expect.objectContaining({ rawValue: 999 })
       );
     });
+
+    it("switches merged display value to unit label on focus", async () => {
+      const onChange = vi.fn();
+      const { getByDisplayValue } = renderQuantityEditor(
+        metadata,
+        { rawValue: undefined, displayValue: "-- m" },
+        onChange
+      );
+
+      const input = getByDisplayValue("-- m");
+      await userEvent.click(input);
+
+      expect(input).toHaveProperty("value", "m");
+    });
   });
 
   describe("persistence unit is different from display unit", () => {
@@ -246,34 +270,6 @@ describe("QuantityEditor", () => {
 
       expect(onChange).toHaveBeenLastCalledWith(
         expect.objectContaining({ rawValue: 1 })
-      );
-    });
-
-    it("does not clamp value when within constraints in persistence units", async () => {
-      const user = userEvent.setup();
-      const onChange = vi.fn();
-      const constrainedMetadata: QuantityValueMetadata = {
-        type: "number",
-        quantityType: 1,
-        // Constraints in meters: max 5 meters
-        constraints: { minimumValue: 0, maximumValue: 5 },
-      };
-
-      const { getByRole } = renderQuantityEditor(
-        constrainedMetadata,
-        undefined,
-        onChange
-      );
-
-      const input = getByRole("textbox");
-      // 10 inches = 0.254 meters, is within maximumValue of 5 meters
-      const newValueInInches = 10;
-      await user.type(input, `${newValueInInches} in`);
-
-      expect(onChange).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          rawValue: convertInchesToMeters(newValueInInches),
-        })
       );
     });
   });

--- a/ui/imodel-components-react/src/test/inputs/new-editors/QuantityInput.test.tsx
+++ b/ui/imodel-components-react/src/test/inputs/new-editors/QuantityInput.test.tsx
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
+
+import { render } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { QuantityInput } from "../../../imodel-components-react/inputs/new-editors/QuantityInput.js";
+import type { FormatterSpec, ParserSpec } from "@itwin/core-quantity";
+import type { NumericValue } from "@itwin/components-react";
+
+function createMockFormatter(unitLabel: string): FormatterSpec {
+  return {
+    applyFormatting: (value: number) => `${value} ${unitLabel}`,
+    unitConversions: [
+      { label: unitLabel, conversion: { factor: 1, offset: 0 } },
+    ],
+  } as unknown as FormatterSpec;
+}
+
+function createMockParser(): ParserSpec {
+  return {
+    parseToQuantityValue: (input: string) => {
+      const num = parseFloat(input);
+      if (isNaN(num)) {
+        return { ok: false };
+      }
+      return { ok: true, value: num };
+    },
+  } as unknown as ParserSpec;
+}
+
+describe("QuantityInput (new-editors)", () => {
+  it("renders formatted value when rawValue is defined", () => {
+    const formatter = createMockFormatter("m");
+    const parser = createMockParser();
+    const value: NumericValue = { rawValue: 5, displayValue: "5 m" };
+
+    const { getByDisplayValue } = render(
+      <QuantityInput
+        formatter={formatter}
+        parser={parser}
+        value={value}
+        onChange={() => {}}
+      />
+    );
+
+    getByDisplayValue("5 m");
+  });
+
+  it("renders display value as-is when rawValue is undefined", () => {
+    const formatter = createMockFormatter("m");
+    const parser = createMockParser();
+    const value: NumericValue = {
+      rawValue: undefined,
+      displayValue: "-- m",
+    };
+
+    const { getByDisplayValue } = render(
+      <QuantityInput
+        formatter={formatter}
+        parser={parser}
+        value={value}
+        onChange={() => {}}
+      />
+    );
+
+    getByDisplayValue("-- m");
+  });
+
+  it("renders placeholder when formatter is provided", () => {
+    const formatter = createMockFormatter("m");
+    const parser = createMockParser();
+    const value: NumericValue = { rawValue: 5, displayValue: "5 m" };
+
+    const { getByRole } = render(
+      <QuantityInput
+        formatter={formatter}
+        parser={parser}
+        value={value}
+        onChange={() => {}}
+      />
+    );
+
+    expect(getByRole("textbox").getAttribute("placeholder")).toBe("m");
+  });
+
+  it("is disabled when formatter is not provided", () => {
+    const parser = createMockParser();
+    const value: NumericValue = { rawValue: 5, displayValue: "5 m" };
+
+    const { getByRole } = render(
+      <QuantityInput parser={parser} value={value} onChange={() => {}} />
+    );
+
+    expect(getByRole("textbox")).toHaveProperty("disabled", true);
+  });
+
+  it("is disabled when parser is not provided", () => {
+    const formatter = createMockFormatter("m");
+    const value: NumericValue = { rawValue: 5, displayValue: "5 m" };
+
+    const { getByRole } = render(
+      <QuantityInput formatter={formatter} value={value} onChange={() => {}} />
+    );
+
+    expect(getByRole("textbox")).toHaveProperty("disabled", true);
+  });
+
+  it("calls onChange when user types a valid value", async () => {
+    const user = userEvent.setup();
+    const formatter = createMockFormatter("m");
+    const parser = createMockParser();
+    const onChange = vi.fn();
+    const value: NumericValue = {
+      rawValue: 5,
+      displayValue: "5 m",
+    };
+
+    const { getByDisplayValue } = render(
+      <QuantityInput
+        formatter={formatter}
+        parser={parser}
+        value={value}
+        onChange={onChange}
+      />
+    );
+
+    const input = getByDisplayValue("5 m");
+    await user.clear(input);
+    await user.type(input, "10");
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ rawValue: 10 })
+    );
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->
closes https://github.com/iTwin/appui/issues/1561
## Changes
Quantity editor now:
 - Displays unit when property value is undefined
 - Selects all text on focus for properties with values, in case of properties with value of undefined cursor is placed at 0 position before unit
 - Merged values displayed as `-- unit` on focus becomes `unit` avoiding invalid input

Preview:

https://github.com/user-attachments/assets/2f0bf248-4299-44eb-8550-8aa23dc58342





<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->
Added unit tests.