### PR TITLE
[PropertyGrid]: Reset editor on cancel or abort

### DIFF
--- a/.changeset/property-grid-abort-commit-reset.md
+++ b/.changeset/property-grid-abort-commit-reset.md
@@ -1,0 +1,5 @@
+---
+"@itwin/components-react": patch
+---
+
+`VirtualizedPropertyGrid` now resets the active editor back to its initial value when a commit is aborted by the consumer (`onPropertyUpdated` returns `false`). Cancelling an edit now also resets editor.

--- a/apps/test-providers/src/ui/widgets/PropertyGridWidget.tsx
+++ b/apps/test-providers/src/ui/widgets/PropertyGridWidget.tsx
@@ -8,6 +8,7 @@ import {
   IPropertyDataProvider,
   PropertyData,
   PropertyDataChangeEvent,
+  PropertyUpdatedArgs,
   VirtualizedPropertyGridWithDataProvider,
 } from "@itwin/components-react";
 
@@ -68,10 +69,53 @@ class PropertyDataProvider implements IPropertyDataProvider {
   public async getData(): Promise<PropertyData> {
     return this._data;
   }
+
+  /** Updates the value of the record matching the given name and raises `onDataChanged`. */
+  public updateRecordValue(name: string, args: PropertyUpdatedArgs): boolean {
+    if (
+      args.newValue.valueFormat === PropertyValueFormat.Primitive &&
+      args.newValue.value === 100
+    ) {
+      return false; // Simulate a failed update for value 100 to test error handling.
+    }
+
+    for (const categoryName of Object.keys(this._data.records)) {
+      const records = this._data.records[categoryName];
+      const index = records.findIndex(
+        (record) => record.property.name === name
+      );
+      if (index === -1) continue;
+
+      const newRecords = [...records];
+      newRecords[index] = records[index].copyWithNewValue(args.newValue);
+
+      // Return a new data object with new references so React detects the change.
+      this._data = {
+        ...this._data,
+        records: {
+          ...this._data.records,
+          [categoryName]: newRecords,
+        },
+      };
+      this.onDataChanged.raiseEvent();
+      return true;
+    }
+    return false;
+  }
 }
 
 export function PropertyGridWidgetComponent() {
   const [dataProvider] = React.useState(() => new PropertyDataProvider());
+
+  const onPropertyUpdated = React.useCallback(
+    async (args: PropertyUpdatedArgs) => {
+      return dataProvider.updateRecordValue(
+        args.propertyRecord.property.name,
+        args
+      );
+    },
+    [dataProvider]
+  );
 
   return (
     <VirtualizedPropertyGridWithDataProvider
@@ -79,6 +123,9 @@ export function PropertyGridWidgetComponent() {
       width={300}
       height={300}
       editorSystem="new"
+      isPropertyEditingEnabled={true}
+      onPropertyUpdated={onPropertyUpdated}
+      alwaysShowEditor={() => true}
     />
   );
 }

--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -3411,6 +3411,8 @@ export interface VirtualizedPropertyGridContext {
     // (undocumented)
     editingPropertyKey?: string;
     // (undocumented)
+    editKey?: number;
+    // (undocumented)
     editorSystem: "legacy" | "new";
     // (undocumented)
     eventHandler: IPropertyGridEventHandler;

--- a/common/api/components-react.api.md
+++ b/common/api/components-react.api.md
@@ -3411,8 +3411,6 @@ export interface VirtualizedPropertyGridContext {
     // (undocumented)
     editingPropertyKey?: string;
     // (undocumented)
-    editKey?: number;
-    // (undocumented)
     editorSystem: "legacy" | "new";
     // (undocumented)
     eventHandler: IPropertyGridEventHandler;
@@ -3437,7 +3435,9 @@ export interface VirtualizedPropertyGridContext {
     // (undocumented)
     onEditCancel?: () => void;
     // (undocumented)
-    onEditCommit?: (args: PropertyUpdatedArgs, category: PropertyCategory) => void;
+    onEditCommit?: (args: PropertyUpdatedArgs, category: PropertyCategory) => void | Promise<{
+        status: "success" | "cancel";
+    }>;
     // (undocumented)
     onPropertyClicked?: (property: PropertyRecord, key?: string) => void;
     // (undocumented)

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
@@ -34,7 +34,9 @@ export type PropertyGridEventsRelatedProps = Pick<
       CommonPropertyGridProps,
       "isPropertyHoverEnabled" | "isPropertySelectionEnabled"
     >
-  >;
+  > & {
+    editKey?: number;
+  };
 
 /** Properties for [[PropertyGridEventsRelatedPropsSupplier]] React component
  * @internal
@@ -64,6 +66,10 @@ interface PropertyGridEventsRelatedPropsSupplierState {
   selectedPropertyKey?: string;
   /** Unique key of currently edited property */
   editingPropertyKey?: string;
+  /** Indicates if a property edit is currently being committed */
+  isCommitting: boolean;
+  /** Key used to force re-rendering of the editor */
+  editKey: number;
 }
 
 /** PropertyGridEventsRelatedPropsSupplier React component.
@@ -75,7 +81,7 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
 > {
   constructor(props: PropertyGridEventsRelatedPropsSupplierProps) {
     super(props);
-    this.state = {};
+    this.state = { isCommitting: false, editKey: 0 };
   }
 
   private _isClickSupported() {
@@ -116,13 +122,28 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
     category: PropertyCategory
   ) => {
     if (this.props.onPropertyUpdated) {
-      await this.props.onPropertyUpdated(args, category);
-      this.setState({ editingPropertyKey: undefined });
+      this.setState({ isCommitting: true });
+      const result = await this.props.onPropertyUpdated(args, category);
+      this.setState((prev) => ({
+        editingPropertyKey: undefined,
+        isCommitting: false,
+        // if update failed, change editKey to force editor to re-render with initial value
+        editKey: result === false ? prev.editKey + 1 : prev.editKey,
+      }));
     }
   };
 
   private _onEditCancel = () => {
-    this.setState({ editingPropertyKey: undefined });
+    this.setState((prev) =>
+      // do not reset editingPropertyKey if currently committing an edit, to prevent editor from being closed before commit finishes
+      prev.isCommitting
+        ? prev
+        : {
+            editingPropertyKey: undefined,
+            isCommitting: false,
+            editKey: prev.editKey,
+          }
+    );
   };
 
   private onEnabledPropertyRightClicked(
@@ -180,6 +201,7 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
       isPropertyEditingEnabled: this.props.isPropertyEditingEnabled,
       selectedPropertyKey: this.state.selectedPropertyKey,
       editingPropertyKey: this.state.editingPropertyKey,
+      editKey: this.state.editKey,
       onEditCommit: this._onEditCommit,
       onEditCancel: this._onEditCancel,
       onPropertyClicked: this._isClickSupported()

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridEventsRelatedPropsSupplier.tsx
@@ -20,7 +20,6 @@ export type PropertyGridEventsRelatedProps = Pick<
   | "onPropertyClicked"
   | "onPropertyRightClicked"
   | "onPropertyContextMenu"
-  | "onEditCommit"
   | "onEditCancel"
   | "selectedPropertyKey"
   | "editingPropertyKey"
@@ -35,7 +34,10 @@ export type PropertyGridEventsRelatedProps = Pick<
       "isPropertyHoverEnabled" | "isPropertySelectionEnabled"
     >
   > & {
-    editKey?: number;
+    onEditCommit: (
+      args: PropertyUpdatedArgs,
+      category: PropertyCategory
+    ) => void | Promise<{ status: "success" | "cancel" }>;
   };
 
 /** Properties for [[PropertyGridEventsRelatedPropsSupplier]] React component
@@ -68,8 +70,6 @@ interface PropertyGridEventsRelatedPropsSupplierState {
   editingPropertyKey?: string;
   /** Indicates if a property edit is currently being committed */
   isCommitting: boolean;
-  /** Key used to force re-rendering of the editor */
-  editKey: number;
 }
 
 /** PropertyGridEventsRelatedPropsSupplier React component.
@@ -81,7 +81,7 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
 > {
   constructor(props: PropertyGridEventsRelatedPropsSupplierProps) {
     super(props);
-    this.state = { isCommitting: false, editKey: 0 };
+    this.state = { isCommitting: false };
   }
 
   private _isClickSupported() {
@@ -120,17 +120,17 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
   private _onEditCommit = async (
     args: PropertyUpdatedArgs,
     category: PropertyCategory
-  ) => {
+  ): Promise<{ status: "success" | "cancel" }> => {
     if (this.props.onPropertyUpdated) {
       this.setState({ isCommitting: true });
       const result = await this.props.onPropertyUpdated(args, category);
-      this.setState((prev) => ({
+      this.setState({
         editingPropertyKey: undefined,
         isCommitting: false,
-        // if update failed, change editKey to force editor to re-render with initial value
-        editKey: result === false ? prev.editKey + 1 : prev.editKey,
-      }));
+      });
+      return { status: result === false ? "cancel" : "success" };
     }
+    return { status: "success" };
   };
 
   private _onEditCancel = () => {
@@ -141,7 +141,6 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
         : {
             editingPropertyKey: undefined,
             isCommitting: false,
-            editKey: prev.editKey,
           }
     );
   };
@@ -201,7 +200,6 @@ export class PropertyGridEventsRelatedPropsSupplier extends React.Component<
       isPropertyEditingEnabled: this.props.isPropertyEditingEnabled,
       selectedPropertyKey: this.state.selectedPropertyKey,
       editingPropertyKey: this.state.editingPropertyKey,
-      editKey: this.state.editKey,
       onEditCommit: this._onEditCommit,
       onEditCancel: this._onEditCancel,
       onPropertyClicked: this._isClickSupported()

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -169,12 +169,11 @@ export interface VirtualizedPropertyGridContext {
     e: React.MouseEvent
   ) => void;
 
-  editKey?: number;
   editingPropertyKey?: string;
   onEditCommit?: (
     args: PropertyUpdatedArgs,
     category: PropertyCategory
-  ) => void;
+  ) => void | Promise<{ status: "success" | "cancel" }>;
   onEditCancel?: () => void;
   editorSystem: "legacy" | "new";
 
@@ -442,7 +441,6 @@ class VirtualizedPropertyGridImpl extends React.Component<
                 onPropertyRightClicked: selectionContext.onPropertyRightClicked,
                 onPropertyContextMenu: selectionContext.onPropertyContextMenu,
 
-                editKey: selectionContext.editKey,
                 editingPropertyKey: selectionContext.editingPropertyKey,
                 onEditCommit: selectionContext.onEditCommit,
                 onEditCancel: selectionContext.onEditCancel,
@@ -667,7 +665,6 @@ const FlatGridItemNode = React.memo(
                 onRightClick={gridContext.onPropertyRightClicked}
                 onContextMenu={gridContext.onPropertyContextMenu}
                 category={parentCategoryItem.derivedCategory}
-                editKey={gridContext.editKey}
                 isEditing={selectionKey === gridContext.editingPropertyKey}
                 isPropertyEditingEnabled={gridContext.isPropertyEditingEnabled}
                 alwaysShowEditor={gridContext.alwaysShowEditor}

--- a/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
+++ b/ui/components-react/src/components-react/propertygrid/component/VirtualizedPropertyGrid.tsx
@@ -169,6 +169,7 @@ export interface VirtualizedPropertyGridContext {
     e: React.MouseEvent
   ) => void;
 
+  editKey?: number;
   editingPropertyKey?: string;
   onEditCommit?: (
     args: PropertyUpdatedArgs,
@@ -441,6 +442,7 @@ class VirtualizedPropertyGridImpl extends React.Component<
                 onPropertyRightClicked: selectionContext.onPropertyRightClicked,
                 onPropertyContextMenu: selectionContext.onPropertyContextMenu,
 
+                editKey: selectionContext.editKey,
                 editingPropertyKey: selectionContext.editingPropertyKey,
                 onEditCommit: selectionContext.onEditCommit,
                 onEditCancel: selectionContext.onEditCancel,
@@ -665,6 +667,7 @@ const FlatGridItemNode = React.memo(
                 onRightClick={gridContext.onPropertyRightClicked}
                 onContextMenu={gridContext.onPropertyContextMenu}
                 category={parentCategoryItem.derivedCategory}
+                editKey={gridContext.editKey}
                 isEditing={selectionKey === gridContext.editingPropertyKey}
                 isPropertyEditingEnabled={gridContext.isPropertyEditingEnabled}
                 alwaysShowEditor={gridContext.alwaysShowEditor}

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-properties/FlatPropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-properties/FlatPropertyRenderer.tsx
@@ -32,14 +32,13 @@ export interface FlatPropertyRendererProps extends SharedRendererProps {
   indentation?: number;
   /** Indicates property is being edited */
   isEditing?: boolean;
-  editKey?: number;
   /** Callback to determine which editors should be always visible */
   alwaysShowEditor?: (property: PropertyRecord) => boolean;
   /** Called when property edit is committed. */
   onEditCommit?: (
     args: PropertyUpdatedArgs,
     category: PropertyCategory
-  ) => void;
+  ) => void | Promise<{ status: "success" | "cancel" }>;
   /** Called when property edit is cancelled. */
   onEditCancel?: () => void;
   /** Used to switch between new and legacy editing system. */
@@ -129,7 +128,6 @@ export const FlatPropertyRenderer: React.FC<FlatPropertyRendererProps> = (
 
 interface DisplayValueProps {
   isEditing?: boolean;
-  editKey?: number;
   isPropertyEditingEnabled?: boolean;
   alwaysShowEditor?: (property: PropertyRecord) => boolean;
   propertyRecord: PropertyRecord;
@@ -151,7 +149,7 @@ interface DisplayValueProps {
   onEditCommit?: (
     args: PropertyUpdatedArgs,
     category: PropertyCategory
-  ) => void;
+  ) => void | Promise<{ status: "success" | "cancel" }>;
 
   highlight?: HighlightingComponentProps & {
     applyOnLabel: boolean;
@@ -172,15 +170,20 @@ const DisplayValue: React.FC<DisplayValueProps> = (props): React.ReactNode => {
 
   const { editorKey, onCancel } = useEditorKey({
     propertyRecord: props.propertyRecord,
-    editKey: props.editKey,
   });
 
   if (
     props.isEditing ||
     (alwaysShowsEditor && props.isPropertyEditingEnabled)
   ) {
-    const _onEditCommit = (args: PropertyUpdatedArgs) => {
-      if (props.category) props.onEditCommit?.(args, props.category);
+    const _onEditCommit = async (args: PropertyUpdatedArgs) => {
+      if (!props.category) {
+        return;
+      }
+      const result = await props.onEditCommit?.(args, props.category);
+      if (result?.status === "cancel") {
+        onCancel();
+      }
     };
 
     return (
@@ -216,13 +219,11 @@ const DisplayValue: React.FC<DisplayValueProps> = (props): React.ReactNode => {
 /**
  * Created key for editor component. Different key is produced to reset editor when:
  * - property value changes
- * - editKey changes (editor is forced to rerender)
  * - edit is cancelled (to reset editor internal state to initial value)
  */
 function useEditorKey({
   propertyRecord,
-  editKey,
-}: Pick<DisplayValueProps, "propertyRecord" | "editKey">) {
+}: Pick<DisplayValueProps, "propertyRecord">) {
   const [internalKey, setInternalKey] = React.useState(1);
 
   const onCancel = () => {
@@ -234,8 +235,8 @@ function useEditorKey({
       propertyRecord.value.valueFormat === PropertyValueFormat.Primitive
         ? JSON.stringify(propertyRecord.value.value)
         : "";
-    return `${serializedValue}-${(editKey ?? 0) + internalKey}`;
-  }, [editKey, internalKey, propertyRecord]);
+    return `${serializedValue}-${internalKey}`;
+  }, [internalKey, propertyRecord]);
 
   return { editorKey: key, onCancel };
 }

--- a/ui/components-react/src/components-react/propertygrid/internal/flat-properties/FlatPropertyRenderer.tsx
+++ b/ui/components-react/src/components-react/propertygrid/internal/flat-properties/FlatPropertyRenderer.tsx
@@ -32,6 +32,7 @@ export interface FlatPropertyRendererProps extends SharedRendererProps {
   indentation?: number;
   /** Indicates property is being edited */
   isEditing?: boolean;
+  editKey?: number;
   /** Callback to determine which editors should be always visible */
   alwaysShowEditor?: (property: PropertyRecord) => boolean;
   /** Called when property edit is committed. */
@@ -128,6 +129,7 @@ export const FlatPropertyRenderer: React.FC<FlatPropertyRendererProps> = (
 
 interface DisplayValueProps {
   isEditing?: boolean;
+  editKey?: number;
   isPropertyEditingEnabled?: boolean;
   alwaysShowEditor?: (property: PropertyRecord) => boolean;
   propertyRecord: PropertyRecord;
@@ -168,6 +170,11 @@ const DisplayValue: React.FC<DisplayValueProps> = (props): React.ReactNode => {
     ? props.alwaysShowEditor(props.propertyRecord)
     : false;
 
+  const { editorKey, onCancel } = useEditorKey({
+    propertyRecord: props.propertyRecord,
+    editKey: props.editKey,
+  });
+
   if (
     props.isEditing ||
     (alwaysShowsEditor && props.isPropertyEditingEnabled)
@@ -178,9 +185,13 @@ const DisplayValue: React.FC<DisplayValueProps> = (props): React.ReactNode => {
 
     return (
       <PropertyRecordEditor
+        key={editorKey}
         propertyRecord={props.propertyRecord}
         onCommit={_onEditCommit}
-        onCancel={props.onEditCancel ?? (() => {})}
+        onCancel={() => {
+          props.onEditCancel?.();
+          onCancel();
+        }}
         onClick={() => props.onClick?.(props.propertyRecord, props.uniqueKey)}
         setFocus={props.isEditing}
         // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -201,6 +212,33 @@ const DisplayValue: React.FC<DisplayValueProps> = (props): React.ReactNode => {
     props.highlight
   );
 };
+
+/**
+ * Created key for editor component. Different key is produced to reset editor when:
+ * - property value changes
+ * - editKey changes (editor is forced to rerender)
+ * - edit is cancelled (to reset editor internal state to initial value)
+ */
+function useEditorKey({
+  propertyRecord,
+  editKey,
+}: Pick<DisplayValueProps, "propertyRecord" | "editKey">) {
+  const [internalKey, setInternalKey] = React.useState(1);
+
+  const onCancel = () => {
+    setInternalKey((prev) => prev + 1);
+  };
+
+  const key = React.useMemo(() => {
+    const serializedValue =
+      propertyRecord.value.valueFormat === PropertyValueFormat.Primitive
+        ? JSON.stringify(propertyRecord.value.value)
+        : "";
+    return `${serializedValue}-${(editKey ?? 0) + internalKey}`;
+  }, [editKey, internalKey, propertyRecord]);
+
+  return { editorKey: key, onCancel };
+}
 
 function useResetHeightOnEdit(
   orientation: Orientation,

--- a/ui/components-react/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
+++ b/ui/components-react/src/test/propertygrid/component/VirtualizedPropertyGridWithDataProvider.test.tsx
@@ -1216,6 +1216,91 @@ describe("VirtualizedPropertyGridWithDataProvider", () => {
             .be.empty
       );
     });
+
+    it("resets always-shown editor when value update fails", async () => {
+      const { container } = render(
+        <VirtualizedPropertyGridWithDataProvider
+          {...defaultProps}
+          isPropertyEditingEnabled={true}
+          alwaysShowEditor={() => true}
+          onPropertyUpdated={async () => {
+            return false;
+          }}
+        />
+      );
+
+      await waitFor(() =>
+        expect(
+          container.querySelectorAll("input.components-cell-editor").length
+        ).to.be.greaterThan(0)
+      );
+
+      const editor = container.querySelector<HTMLInputElement>(
+        "input.components-cell-editor"
+      )!;
+      const initialValue = editor.value;
+
+      // Start editing the always-shown editor and ensure it is focused.
+      fireEvent.click(editor);
+      const editingEditor = container.querySelector<HTMLInputElement>(
+        "input.components-cell-editor"
+      )!;
+      editingEditor.focus();
+      expect(document.activeElement).toEqual(editingEditor);
+
+      fireEvent.change(editingEditor, { target: { value: "changed value" } });
+      fireEvent.keyDown(editingEditor, { key: "Enter" });
+
+      // Cancel remounts the editor: value resets to initial and focus is dropped.
+      await waitFor(() => {
+        const resetEditor = container.querySelector<HTMLInputElement>(
+          "input.components-cell-editor"
+        )!;
+        expect(resetEditor.value).toEqual(initialValue);
+        expect(document.activeElement).to.not.equal(resetEditor);
+      });
+    });
+
+    it("resets always-shown editor and removes focus on cancel", async () => {
+      const { container } = render(
+        <VirtualizedPropertyGridWithDataProvider
+          {...defaultProps}
+          isPropertyEditingEnabled={true}
+          alwaysShowEditor={() => true}
+        />
+      );
+
+      await waitFor(() =>
+        expect(
+          container.querySelectorAll("input.components-cell-editor").length
+        ).to.be.greaterThan(0)
+      );
+
+      const editor = container.querySelector<HTMLInputElement>(
+        "input.components-cell-editor"
+      )!;
+      const initialValue = editor.value;
+
+      // Start editing the always-shown editor and ensure it is focused.
+      fireEvent.click(editor);
+      const editingEditor = container.querySelector<HTMLInputElement>(
+        "input.components-cell-editor"
+      )!;
+      editingEditor.focus();
+      expect(document.activeElement).toEqual(editingEditor);
+
+      fireEvent.change(editingEditor, { target: { value: "changed value" } });
+      fireEvent.keyDown(editingEditor, { key: "Escape" });
+
+      // Cancel remounts the editor: value resets to initial and focus is dropped.
+      await waitFor(() => {
+        const resetEditor = container.querySelector<HTMLInputElement>(
+          "input.components-cell-editor"
+        )!;
+        expect(resetEditor.value).toEqual(initialValue);
+        expect(document.activeElement).to.not.equal(resetEditor);
+      });
+    });
   });
 
   describe("context menu", () => {


### PR DESCRIPTION
<!--
Thank you for your contribution to AppUI.
-->

## Changes

<!--
What kind of code changes does this PR include?
Mention anything that could be helpful for reviewers and include screenshots for visual changes.
-->

Closes https://github.com/iTwin/appui/issues/1543

Updated PropertyGrid component to reset editor to initial state when edit is cancelled (`ESC` is pressed) or update is aborted (`onPropertyUpdated` returns `false`).

~~Solution is not straight forward because `onEditCommit` prop used by property renderer to commit value does not return any result. Ideally we could handle aborted commit where editor is rendered. However, those are public APIs and changed signature of `onEditCommit` would be a breaking changes.~~

~~Opted to introduce new `editKey` props to `VirtualizedPropertyGridContext`. It is updated when commit was aborted and can be used in editor component key to reset it. ~~

~~Cancellation is handled next to editor in a similar way where key is updated when `onCancel` is invoked.~~

`FlatPropertyRenderer` now handles editor reset:
- If `onCancel` is invoked new key for editor component is generated. 
- If `onEditCommit` returns `{ status: "cancel" }` new key for editor component is generated.

This should ensure that if new value is not desired either by cancelling edit using `ESC` key or cancelling/aborting during commit editor will reset back to initial state. If commit succeeds it will keep current state to avoid flashing `entered value` -> `reset to initial value` -> `new committed value`.

## Testing

<!--
How did you test your changes? If not applicable, you can write "N/A".
-->

Added unit tests and manually tested in test-app.