### PR TITLE
Update link rendering in `UrlPropertyValueRenderer`

### DIFF
--- a/.changeset/deep-pears-start.md
+++ b/.changeset/deep-pears-start.md
@@ -1,0 +1,5 @@
+---
+"@itwin/components-react": minor
+---
+
+Updated rendering logic to use [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a) elements in the `UrlPropertyValueRenderer` class.

--- a/docs/storybook/src/components/PropertyGrid.stories.tsx
+++ b/docs/storybook/src/components/PropertyGrid.stories.tsx
@@ -517,7 +517,24 @@ export const Links: Story = {
       records: {
         Group_1: [
           PropertyRecord.fromString("https://www.bentley.com"),
+          PropertyRecord.fromString("www.bentley.com"),
           PropertyRecord.fromString("pw://test"),
+          PropertyRecord.fromString(
+            "https://itwinui.bentley.com,https://stratakit.bentley.com"
+          ),
+          PropertyRecord.fromString("mailto:test@test.com"),
+          PropertyRecord.fromString("test@test.com"),
+          createPropertyRecord(
+            {
+              valueFormat: PropertyValueFormat.Primitive,
+              value: "https://itwinui.bentley.com",
+            },
+            {
+              name: "urlProperty",
+              displayLabel: "URL Property",
+              typename: StandardTypeNames.URL,
+            }
+          ),
         ],
       },
     },

--- a/ui/components-react/src/components-react/common/Links.ts
+++ b/ui/components-react/src/components-react/common/Links.ts
@@ -79,27 +79,3 @@ export const matchLinks = (
       }>)
     : [];
 };
-
-/**
- * @internal
- */
-export const openLink = (url: string) => {
-  if (url.startsWith("mailto:")) {
-    location.href = url;
-    return;
-  }
-
-  const openAndFocus = (link: string) => {
-    const windowOpen = window.open(link, "_blank");
-    windowOpen?.focus();
-  };
-
-  if (url.startsWith("pw:")) {
-    // remove // or \\ from the link. Links with custom schema should use opaque path like `schema:path` instead of `schema://path`
-    const validUrl = url.replace(/pw:\/\/|pw:\\\\/g, "pw:");
-    openAndFocus(validUrl);
-    return;
-  }
-
-  openAndFocus(url);
-};

--- a/ui/components-react/src/components-react/properties/LinkHandler.tsx
+++ b/ui/components-react/src/components-react/properties/LinkHandler.tsx
@@ -9,25 +9,60 @@
 import * as React from "react";
 import { BentleyError, BentleyStatus } from "@itwin/core-bentley";
 import type { LinkElementsInfo } from "@itwin/appui-abstract";
-import { UnderlinedButton } from "@itwin/core-react";
+import { Anchor } from "@itwin/itwinui-react";
+import { matchLinks } from "../common/Links.js";
 
-/** Render a single anchor tag */
-function renderTag(
-  text: string,
-  links: LinkElementsInfo,
-  highlight?: (text: string) => React.ReactNode
-) {
+const allowedSchemas = ["http:", "https:", "mailto:", "pw:"];
+
+/**
+ * Ensures that provided text contains exactly one link and returns its href.
+ */
+function useTagHref(text: string) {
+  const matches = matchLinks(text);
+  if (matches.length !== 1) return undefined;
+
+  const match = matches[0];
+  if (match.index !== 0 || match.lastIndex !== text.length) return undefined;
+
+  if (!allowedSchemas.includes(match.schema)) return undefined;
+
+  const url = match.url;
+  if (match.schema === "pw:" && url.startsWith("pw:")) {
+    // remove // or \\ from the link. Links with custom schema should use opaque path like `schema:path` instead of `schema://path`
+    return url.replace(/pw:\/\/|pw:\\\\/g, "pw:");
+  }
+
+  return url;
+}
+
+interface TagProps {
+  text: string;
+  links: LinkElementsInfo;
+  highlight?: (text: string) => React.ReactNode;
+}
+
+function Tag(props: TagProps) {
+  const { text, links, highlight } = props;
+
+  const highlighted = highlight ? highlight(text) : text;
+
+  const href = useTagHref(text);
+  if (!href) {
+    return <>{highlighted}</>;
+  }
+
   return (
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    <UnderlinedButton
-      onClick={(e) => {
-        e.preventDefault();
+    <Anchor
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
         e.stopPropagation();
         links.onClick(text);
       }}
     >
-      {highlight ? highlight(text) : text}
-    </UnderlinedButton>
+      {highlighted}
+    </Anchor>
   );
 }
 
@@ -56,7 +91,9 @@ function renderText(
 ): React.ReactNode {
   const { matcher } = links;
 
-  if (!matcher) return renderTag(text, links, highlight);
+  if (!matcher) {
+    return <Tag text={text} links={links} highlight={highlight} />;
+  }
 
   const matches = matcher(text);
 
@@ -79,7 +116,7 @@ function renderText(
       );
 
     const anchorText = text.substring(match.start, match.end);
-    parts.push(renderTag(anchorText, links, highlight));
+    parts.push(<Tag text={anchorText} links={links} highlight={highlight} />);
 
     lastIndex = match.end;
   }

--- a/ui/components-react/src/components-react/properties/renderers/value/PrimitivePropertyValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/PrimitivePropertyValueRenderer.tsx
@@ -54,17 +54,13 @@ interface PrimitivePropertyValueRendererImplProps {
 export function PrimitivePropertyValueRendererImpl(
   props: PrimitivePropertyValueRendererImplProps
 ) {
-  const { stringValue, element } = useRenderedStringValue(
+  const { element } = useRenderedStringValue(
     props.record,
     props.stringValueCalculator,
     props.context,
     props.linksHandler
   );
-  return (
-    <span style={props.context?.style} title={stringValue}>
-      {element}
-    </span>
-  );
+  return <span style={props.context?.style}>{element}</span>;
 }
 
 /**
@@ -77,7 +73,7 @@ export function PrimitivePropertyValueRendererImpl(
  */
 export const DEFAULT_LINKS_HANDLER: LinkElementsInfo = {
   matcher: PropertyGridCommons.getLinks,
-  onClick: PropertyGridCommons.handleLinkClick,
+  onClick: () => {},
 };
 
 /** @internal */

--- a/ui/components-react/src/components-react/properties/renderers/value/UrlPropertyValueRenderer.tsx
+++ b/ui/components-react/src/components-react/properties/renderers/value/UrlPropertyValueRenderer.tsx
@@ -15,7 +15,6 @@ import type {
 } from "../../ValueRendererManager.js";
 import { PrimitivePropertyValueRendererImpl } from "./PrimitivePropertyValueRenderer.js";
 import { convertRecordToString } from "./Common.js";
-import { openLink } from "../../../common/Links.js";
 
 /**
  * URL property value renderer that renders the whole value as a URL without matching it
@@ -53,5 +52,5 @@ export class UrlPropertyValueRenderer implements IPropertyValueRenderer {
 }
 
 const URI_PROPERTY_LINK_HANDLER: LinkElementsInfo = {
-  onClick: openLink,
+  onClick: () => {},
 };

--- a/ui/components-react/src/components-react/propertygrid/component/PropertyGridCommons.ts
+++ b/ui/components-react/src/components-react/propertygrid/component/PropertyGridCommons.ts
@@ -9,7 +9,7 @@
 import type { PropertyRecord } from "@itwin/appui-abstract";
 import type { CommonProps } from "@itwin/core-react";
 import type { HighlightingComponentProps } from "../../common/HighlightingComponentProps.js";
-import { matchLinks, openLink } from "../../common/Links.js";
+import { matchLinks } from "../../common/Links.js";
 import type { PropertyUpdatedArgs } from "../../editors/EditorContainer.js";
 import type { ActionButtonRenderer } from "../../properties/renderers/ActionButtonRenderer.js";
 import type { PropertyValueRendererManager } from "../../properties/ValueRendererManager.js";
@@ -125,21 +125,6 @@ export class PropertyGridCommons {
     if (width < horizontalOrientationMinWidth) return Orientation.Vertical;
 
     return orientation;
-  }
-
-  /**
-   * Helper method to handle link clicks
-   * @internal
-   */
-  public static handleLinkClick(text: string) {
-    const linksArray = matchLinks(text);
-    if (linksArray.length <= 0) return;
-    const foundLink = linksArray[0];
-    if (!foundLink || !foundLink.url) {
-      return;
-    }
-
-    openLink(foundLink.url);
   }
 
   /**

--- a/ui/components-react/src/test/favorite/FavoritePropertyList.test.tsx
+++ b/ui/components-react/src/test/favorite/FavoritePropertyList.test.tsx
@@ -48,14 +48,10 @@ describe("FavoritePropertyList", () => {
       );
 
       expect(screen.getByTitle("CADID1")).toEqual(screen.getByText("CADID1"));
-      expect(screen.getByTitle("0000 0005 00E0 02D8")).toEqual(
-        screen.getByText("0000 0005 00E0 02D8")
-      );
+      screen.getByText("0000 0005 00E0 02D8");
       expect(screen.getByTitle("CADID2")).toEqual(screen.getByText("CADID2"));
 
-      expect(screen.getByTitle("0000 0005 00E0 02D9")).toEqual(
-        screen.getByText("0000 0005 00E0 02D9")
-      );
+      screen.getByText("0000 0005 00E0 02D9");
       expect(container).to.satisfy(
         childStructure(
           ".components-favorite-property-list .components-property-list--horizontal .components-property-record--horizontal"

--- a/ui/components-react/src/test/properties/LinkHandler.test.tsx
+++ b/ui/components-react/src/test/properties/LinkHandler.test.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import type { LinkElementsInfo } from "@itwin/appui-abstract";
-import { fireEvent, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import {
   LinksRenderer,
   renderLinks,
@@ -26,7 +26,14 @@ describe("LinkHandler", () => {
       const testString = "Example text";
       const highlightSpy = vi.fn();
 
-      void renderLinks(testString, links, highlightSpy);
+      render(
+        <LinksRenderer
+          value={testString}
+          links={links}
+          highlighter={highlightSpy}
+        />
+      );
+
       expect(highlightSpy).toHaveBeenCalledOnce();
     });
 
@@ -34,63 +41,35 @@ describe("LinkHandler", () => {
       links.matcher = () => [{ start: 0, end: 7 }];
       const testString = "Example text";
       let matchedPartHighlighted = false;
+
       const highlighter = (text: string) => {
-        if (text === testString.substring(0, 7)) matchedPartHighlighted = true;
+        if (text === "Example") matchedPartHighlighted = true;
         return text;
       };
 
-      void renderLinks(testString, links, highlighter);
+      render(
+        <LinksRenderer
+          value={testString}
+          links={links}
+          highlighter={highlighter}
+        />
+      );
 
       expect(matchedPartHighlighted).toEqual(true);
-    });
-
-    it("rendered anchor tag calls appropriate callback on click", () => {
-      const anchor = render(<>{renderLinks("Example text", links)}</>);
-
-      expect(onClickSpy).not.toHaveBeenCalled();
-      fireEvent.click(
-        anchor.container.getElementsByClassName("core-underlined-button")[0]
-      );
-      expect(onClickSpy).toHaveBeenCalledOnce();
     });
 
     it("rendered anchor tag container's onClick event will not trigger on anchor click", () => {
       const parentOnClickSpy = vi.fn();
 
-      const anchor = render(
+      const { getByRole } = render(
         <div onClick={parentOnClickSpy} role="presentation">
-          {renderLinks("Example text", links)}
+          <LinksRenderer value="www.testLink.com" links={links} />
         </div>
       );
 
+      const link = getByRole("link");
+      link.click();
       expect(parentOnClickSpy).not.toHaveBeenCalled();
-      fireEvent.click(
-        anchor.container.getElementsByClassName("core-underlined-button")[0]
-      );
-      expect(parentOnClickSpy).not.toHaveBeenCalled();
-    });
-
-    it("returns text split up into anchor tags when text matcher is provided", () => {
-      links.matcher = () => [
-        { start: 0, end: 2 },
-        { start: 4, end: 6 },
-        { start: 7, end: 12 },
-      ];
-
-      let anchor = render(<>{renderLinks("Example text", links)}</>);
-
-      expect(anchor.container.innerHTML).to.contain(">Ex</");
-      expect(anchor.container.innerHTML).to.contain(">am<");
-      expect(anchor.container.innerHTML).to.contain(">pl</");
-      expect(anchor.container.innerHTML).to.contain(">e<");
-      expect(anchor.container.innerHTML).to.contain("> text</");
-
-      links.matcher = () => [{ start: 0, end: 7 }];
-
-      anchor = render(<>{renderLinks("Example text", links)}</>);
-
-      expect(anchor.container.innerHTML).to.contain(">Example</");
-      expect(anchor.container.innerHTML).to.contain("> text");
     });
 
     it("throws when matcher returns overlapping bounds", () => {
@@ -132,6 +111,7 @@ describe("LinkHandler", () => {
       const highlightSpy = vi.fn();
 
       void withLinks(testString, undefined, highlightSpy);
+
       expect(highlightSpy).toHaveBeenCalledOnce();
     });
   });
@@ -141,6 +121,70 @@ describe("LinkHandler", () => {
       const value = "some value";
       const { getByText } = render(<LinksRenderer value={value} />);
       getByText(value);
+    });
+
+    it("opens new window if the link text was found without http schema", () => {
+      const { getByRole } = render(
+        <LinksRenderer value="www.testLink.com" links={links} />
+      );
+
+      const link = getByRole("link", {
+        name: "www.testLink.com (opens in new tab)",
+      });
+      expect(link.getAttribute("href")).toEqual("http://www.testLink.com");
+      expect(link.getAttribute("target")).toEqual("_blank");
+      expect(link.getAttribute("rel")).toEqual("noreferrer");
+    });
+
+    it("opens new window if the link text was found in record with http schema", () => {
+      const { getByRole } = render(
+        <LinksRenderer value="https://www.testLink.com" links={links} />
+      );
+
+      const link = getByRole("link", {
+        name: "https://www.testLink.com (opens in new tab)",
+      });
+      expect(link.getAttribute("href")).toEqual("https://www.testLink.com");
+      expect(link.getAttribute("target")).toEqual("_blank");
+      expect(link.getAttribute("rel")).toEqual("noreferrer");
+    });
+
+    it("does not open new window if there were no url links", () => {
+      const { queryByRole } = render(
+        <LinksRenderer value="not an url link" links={links} />
+      );
+
+      const link = queryByRole("link");
+      expect(link).toEqual(null);
+    });
+
+    it("sets location href value to value got in the text if it is an email link", () => {
+      const { getByRole } = render(
+        <LinksRenderer value="someOtherLink@mail.com" links={links} />
+      );
+
+      const link = getByRole("link");
+      expect(link.getAttribute("href")).toEqual(
+        "mailto:someOtherLink@mail.com"
+      );
+      expect(link.getAttribute("target")).toEqual("_blank");
+      expect(link.getAttribute("rel")).toEqual("noreferrer");
+    });
+
+    it("opens new window if it is an ProjectWise Explorer link", () => {
+      const { getByRole } = render(
+        <LinksRenderer
+          value="pw://server.bentley.com:datasource-01/Documents/ProjectName"
+          links={links}
+        />
+      );
+
+      const link = getByRole("link");
+      expect(link.getAttribute("href")).toEqual(
+        "pw:server.bentley.com:datasource-01/Documents/ProjectName"
+      );
+      expect(link.getAttribute("target")).toEqual("_blank");
+      expect(link.getAttribute("rel")).toEqual("noreferrer");
     });
   });
 });

--- a/ui/components-react/src/test/properties/ValueRendererManager.test.tsx
+++ b/ui/components-react/src/test/properties/ValueRendererManager.test.tsx
@@ -105,7 +105,7 @@ describe("PropertyValueRendererManager", () => {
       );
 
       render(<>{value}</>);
-      expect(screen.getByTitle("Test prop")).to.exist;
+      screen.getByText("Test prop");
     });
 
     it("renders an array type", () => {

--- a/ui/components-react/src/test/properties/renderers/NonPrimitivePropertyRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/NonPrimitivePropertyRenderer.test.tsx
@@ -70,8 +70,8 @@ describe("NonPrimitivePropertyRenderer", () => {
         ])}
       />
     );
-    expect(screen.getByTitle("Water pipe")).to.exist;
-    expect(screen.getByTitle("Sewage pipe")).to.exist;
+    screen.getByText("Water pipe");
+    screen.getByText("Sewage pipe");
   });
 
   it("changes component state from collapsed to expanded when label is clicked", async () => {
@@ -122,10 +122,10 @@ describe("NonPrimitivePropertyRenderer", () => {
       />
     );
 
-    expect(screen.getByTitle("Title")).to.exist;
-    expect(screen.getByTitle("Model")).to.exist;
-    expect(screen.queryByTitle("Size")).toEqual(null);
-    expect(screen.queryByTitle("Huge")).toEqual(null);
+    screen.getByText("Title");
+    screen.getByText("Model");
+    expect(screen.queryByText("Size")).toEqual(null);
+    expect(screen.queryByText("Huge")).toEqual(null);
   });
 
   it("renders property with an offset when indentation is more than 0", () => {

--- a/ui/components-react/src/test/properties/renderers/PropertyRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/PropertyRenderer.test.tsx
@@ -171,7 +171,7 @@ describe("PropertyRenderer", () => {
       />
     );
 
-    expect(screen.getByTitle(originalValue)).to.exist;
+    screen.getByText(originalValue);
 
     rerender(
       <PropertyRenderer
@@ -183,8 +183,8 @@ describe("PropertyRenderer", () => {
       />
     );
 
-    expect(screen.queryByTitle(originalValue)).toEqual(null);
-    expect(screen.getByTitle(recordValue)).to.exist;
+    screen.getByText(recordValue);
+    expect(screen.queryByText(originalValue)).toEqual(null);
   });
 
   it("renders value differently if provided with custom propertyValueRendererManager", async () => {
@@ -399,15 +399,7 @@ describe("PropertyRenderer", () => {
       />
     );
 
-    expect(screen.getByText("Model")).satisfy(
-      selectorMatches(
-        [
-          "div.components-property-record-value",
-          "span",
-          "span[title='Model']",
-        ].join(" > ")
-      )
-    );
+    screen.getByText("Model");
   });
 
   it("does not wrap valueElement in span if it's not a string", async () => {

--- a/ui/components-react/src/test/properties/renderers/value/DoublePropertyValueRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/value/DoublePropertyValueRenderer.test.tsx
@@ -71,15 +71,9 @@ describe("DoublePropertyValueRenderer", () => {
       };
 
       const element = renderer.render(property);
-      const renderedElement = render(<>{element}</>);
+      const { getByText } = render(<>{element}</>);
 
-      renderedElement.getByText("zero point forty five meters");
-
-      expect(
-        renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )
-      ).to.not.be.empty;
+      getByText("zero point forty five meters");
     });
 
     it("renders double property with highlighting", () => {

--- a/ui/components-react/src/test/properties/renderers/value/NavigationPropertyValueRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/value/NavigationPropertyValueRenderer.test.tsx
@@ -68,15 +68,9 @@ describe("NavigationPropertyValueRenderer", () => {
       };
 
       const element = renderer.render(stringProperty);
-      const renderedElement = render(<>{element}</>);
+      const { getByText } = render(<>{element}</>);
 
-      renderedElement.getByText("Test property");
-
-      expect(
-        renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )
-      ).to.not.be.empty;
+      getByText("Test property");
     });
 
     it("renders navigation property with highlighting", () => {

--- a/ui/components-react/src/test/properties/renderers/value/PrimitivePropertyValueRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/value/PrimitivePropertyValueRenderer.test.tsx
@@ -77,15 +77,9 @@ describe("PrimitivePropertyValueRenderer", () => {
       };
 
       const element = renderer.render(stringProperty);
-      const renderedElement = render(<>{element}</>);
+      const { getByText } = render(<>{element}</>);
 
-      renderedElement.getByText("Test property");
-
-      expect(
-        renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )
-      ).to.not.be.empty;
+      getByText("Test property");
     });
 
     it("renders primitive property applying default links behavior - matches all links using regex if PropertyRecord does not have LinkElementsInfo", () => {
@@ -96,13 +90,11 @@ describe("PrimitivePropertyValueRenderer", () => {
       );
 
       const element = renderer.render(stringProperty);
-      const renderedElement = render(<>{element}</>);
+      const { getByRole } = render(<>{element}</>);
 
-      expect(
-        renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )[0].textContent
-      ).toEqual("www.test.com");
+      getByRole("link", {
+        name: "www.test.com (opens in new tab)",
+      });
     });
 
     it("renders primitive property applying custom LinkElementsInfo specified in PropertyRecord's LinkElementsInfo", () => {
@@ -116,14 +108,12 @@ describe("PrimitivePropertyValueRenderer", () => {
         matcher: () => [{ start: 0, end: 4 }],
       };
 
-      const element = renderer.render(stringProperty);
-      const renderedElement = render(<>{element}</>);
+      const element = renderer.render(stringProperty, {
+        textHighlighter: (text) => <div>{text}</div>,
+      });
+      const { getByText } = render(<>{element}</>);
 
-      expect(
-        renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )[0].textContent
-      ).toEqual("Test");
+      getByText("Test");
     });
 
     it("renders async value with default value in context", async () => {

--- a/ui/components-react/src/test/properties/renderers/value/UrlPropertyValueRenderer.test.tsx
+++ b/ui/components-react/src/test/properties/renderers/value/UrlPropertyValueRenderer.test.tsx
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as React from "react";
 import { Id64 } from "@itwin/core-bentley";
-import { fireEvent, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import type { PropertyValueRendererContext } from "../../../../components-react/properties/ValueRendererManager.js";
 import TestUtils from "../../../TestUtils.js";
 import { UrlPropertyValueRenderer } from "../../../../components-react/properties/renderers/value/UrlPropertyValueRenderer.js";
@@ -13,26 +13,7 @@ import * as moq from "typemoq";
 
 describe("UrlPropertyValueRenderer", () => {
   describe("render", () => {
-    it("renders URI property wrapped in an anchored tag from value", () => {
-      const renderer = new UrlPropertyValueRenderer();
-      const property = TestUtils.createURIProperty(
-        "Category",
-        "Test Uri Value: pw:\\wsp-aus-pw.bentley.com:wsp-aus-pw-10DocumentsSouthern Program Alliance"
-      );
-
-      const element = renderer.render(property);
-      const elementRender = render(<>{element}</>);
-
-      expect(
-        elementRender.container.getElementsByClassName(
-          "core-underlined-button"
-        )[0].textContent
-      ).toEqual(
-        "Test Uri Value: pw:\\wsp-aus-pw.bentley.com:wsp-aus-pw-10DocumentsSouthern Program Alliance"
-      );
-    });
-
-    it("renders URI property wrapped in an anchored tag if custom LinkElementsInfo is specified in the PropertyRecord", () => {
+    it("should wrap text based on matcher", () => {
       const renderer = new UrlPropertyValueRenderer();
       const property: PropertyRecord = TestUtils.createURIProperty(
         "Category",
@@ -44,14 +25,17 @@ describe("UrlPropertyValueRenderer", () => {
         matcher: () => [{ start: 0, end: 4 }],
       };
 
-      const element = renderer.render(property);
-      const elementRender = render(<>{element}</>);
+      const element = renderer.render(property, {
+        textHighlighter: (text: string) => {
+          if (text === "Test") {
+            return <div>Wrapped-Test</div>;
+          }
+          return text;
+        },
+      });
+      const { getByText } = render(<>{element}</>);
 
-      expect(
-        elementRender.container.getElementsByClassName(
-          "core-underlined-button"
-        )[0].textContent
-      ).toEqual("Test");
+      getByText("Wrapped-Test");
     });
 
     it("renders URI property with highlighting and in anchored tag", () => {
@@ -61,22 +45,17 @@ describe("UrlPropertyValueRenderer", () => {
         "Test property"
       );
 
-      const highlightNode = (text: string) => (
+      const textHighlighter = (text: string) => (
         <span>{`${text} Highlighted`}</span>
       );
       const renderContext: PropertyValueRendererContext = {
-        textHighlighter: highlightNode,
+        textHighlighter,
       };
 
       const element = renderer.render(stringProperty, renderContext);
-      const renderedElement = render(<>{element}</>);
+      const { getByText } = render(<>{element}</>);
 
-      renderedElement.getByText("Test property Highlighted");
-      expect(
-        renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )
-      ).to.not.be.empty;
+      getByText("Test property Highlighted");
     });
 
     it("throws when trying to render array property", () => {
@@ -99,49 +78,51 @@ describe("UrlPropertyValueRenderer", () => {
         locationMockRef.reset();
       });
 
-      it("opens window using the whole URI value, when link which doesn't start with pw: or mailto: is clicked", () => {
+      it("renders as text when links are not found", () => {
         const renderer = new UrlPropertyValueRenderer();
         const stringProperty = TestUtils.createURIProperty(
           "Label",
           "Random Test property"
         );
-        const spy = vi.spyOn(window, "open");
-        spy.mockReturnValue(null);
 
         const element = renderer.render(stringProperty);
-        const renderedElement = render(<>{element}</>);
+        const { queryByRole } = render(<>{element}</>);
 
-        const linkElement = renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )[0];
-
-        expect(linkElement.textContent).toEqual("Random Test property");
-
-        fireEvent.click(linkElement);
-        expect(spy).toHaveBeenCalledWith("Random Test property", "_blank");
+        const link = queryByRole("link");
+        expect(link).toEqual(null);
       });
 
-      it("sets location.href to the whole URI value, when link starting with pw: is clicked", () => {
+      it("renders with pw: link", () => {
         const renderer = new UrlPropertyValueRenderer();
         const stringProperty = TestUtils.createURIProperty(
           "Label",
-          "pw:Test property"
+          "pw://Test property"
         );
 
         const element = renderer.render(stringProperty);
-        const renderedElement = render(<>{element}</>);
+        const { getByRole } = render(<>{element}</>);
 
-        const linkElement = renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )[0];
-        expect(linkElement.textContent).toEqual("pw:Test property");
-
-        const spy = vi.spyOn(window, "open");
-        fireEvent.click(linkElement);
-        expect(spy).toHaveBeenCalledWith("pw:Test property", "_blank");
+        getByRole("link", {
+          name: "pw://Test property (opens in new tab)",
+        });
       });
 
-      it("sets location.href to the whole URI value, when link starting with mailto: is clicked", () => {
+      it("renders with mailto: link", () => {
+        const renderer = new UrlPropertyValueRenderer();
+        const stringProperty = TestUtils.createURIProperty(
+          "Label",
+          "mailto:test@test.com"
+        );
+
+        const element = renderer.render(stringProperty);
+        const { getByRole } = render(<>{element}</>);
+
+        getByRole("link", {
+          name: "mailto:test@test.com (opens in new tab)",
+        });
+      });
+
+      it("renders as text with incorrect mailto:", () => {
         const renderer = new UrlPropertyValueRenderer();
         const stringProperty = TestUtils.createURIProperty(
           "Label",
@@ -149,42 +130,10 @@ describe("UrlPropertyValueRenderer", () => {
         );
 
         const element = renderer.render(stringProperty);
-        const renderedElement = render(<>{element}</>);
+        const { queryByRole } = render(<>{element}</>);
 
-        const linkElement = renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )[0];
-
-        expect(linkElement.textContent).toEqual("mailto:Test property");
-
-        fireEvent.click(linkElement);
-        expect(locationMockRef.object.href).toEqual("mailto:Test property");
-      });
-
-      it("calls window.open.focus if window.open returns not null", () => {
-        const renderer = new UrlPropertyValueRenderer();
-        const stringProperty = TestUtils.createURIProperty(
-          "Label",
-          "Random Test property"
-        );
-        const windowMock = moq.Mock.ofType<Window>();
-        windowMock.setup((x) => x.focus());
-
-        const spy = vi.spyOn(window, "open");
-        spy.mockReturnValue(windowMock.object);
-
-        const element = renderer.render(stringProperty);
-        const renderedElement = render(<>{element}</>);
-
-        const linkElement = renderedElement.container.getElementsByClassName(
-          "core-underlined-button"
-        )[0];
-
-        expect(linkElement.textContent).toEqual("Random Test property");
-
-        fireEvent.click(linkElement);
-        expect(spy).toHaveBeenCalledWith("Random Test property", "_blank");
-        windowMock.verify((x) => x.focus(), moq.Times.once());
+        const link = queryByRole("link");
+        expect(link).toEqual(null);
       });
     });
   });

--- a/ui/components-react/src/test/propertygrid/component/internal/FlatPropertyRenderer.test.tsx
+++ b/ui/components-react/src/test/propertygrid/component/internal/FlatPropertyRenderer.test.tsx
@@ -28,7 +28,7 @@ describe("FlatPropertyRenderer", () => {
       originalValue
     );
 
-    const { rerender } = render(
+    const { rerender, getByText, queryByText } = render(
       <FlatPropertyRenderer
         orientation={Orientation.Horizontal}
         propertyRecord={propertyRecord}
@@ -37,7 +37,7 @@ describe("FlatPropertyRenderer", () => {
       />
     );
 
-    expect(screen.getByTitle(originalValue)).to.exist;
+    getByText("OriginalValue");
 
     rerender(
       <FlatPropertyRenderer
@@ -51,8 +51,8 @@ describe("FlatPropertyRenderer", () => {
       />
     );
 
-    expect(screen.getByTitle(recordValue)).to.exist;
-    expect(screen.queryByTitle(originalValue)).toEqual(null);
+    getByText("ChangedValue");
+    expect(queryByText("OriginalValue")).toEqual(null);
   });
 
   it("uses provided propertyValueRendererManager", async () => {
@@ -527,7 +527,7 @@ describe("FlatPropertyRenderer", () => {
   });
 
   it("wrap valueElement in span if it a string", async () => {
-    render(
+    const { getByText } = render(
       <FlatPropertyRenderer
         orientation={Orientation.Horizontal}
         propertyRecord={propertyRecord}
@@ -535,16 +535,7 @@ describe("FlatPropertyRenderer", () => {
         onExpansionToggled={() => {}}
       />
     );
-
-    expect(screen.getByText("Model")).satisfy(
-      selectorMatches(
-        [
-          "div.components-property-record-value",
-          "span",
-          "span[title='Model']",
-        ].join(" > ")
-      )
-    );
+    getByText("Model");
   });
 
   it("does not wrap valueElement in span if it's not a string", async () => {

--- a/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
+++ b/ui/components-react/src/test/propertygrid/component/internal/PropertyGridCommons.test.ts
@@ -3,7 +3,6 @@
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
 import { Orientation } from "@itwin/core-react";
-import * as moq from "typemoq";
 import { PropertyGridCommons } from "../../../../components-react/propertygrid/component/PropertyGridCommons.js";
 
 describe("PropertyGrid Commons", () => {
@@ -26,75 +25,6 @@ describe("PropertyGrid Commons", () => {
     it("defaults to Orientation.Horizontal", () => {
       const currentOrientation = PropertyGridCommons.getCurrentOrientation(500);
       expect(currentOrientation).toEqual(Orientation.Horizontal);
-    });
-  });
-
-  describe("handleLinkClick", () => {
-    const originalLocation = location;
-    const locationMockRef: moq.IMock<Location> = moq.Mock.ofInstance(location);
-    beforeEach(() => {
-      location = locationMockRef.object;
-    });
-
-    afterEach(() => {
-      location = originalLocation;
-      locationMockRef.reset();
-    });
-
-    it("opens new window if the link text was found without http schema", async () => {
-      const spy = vi.spyOn(window, "open");
-      spy.mockReturnValue(null);
-
-      PropertyGridCommons.handleLinkClick("www.testLink.com");
-      expect(spy).toHaveBeenCalledWith("http://www.testLink.com", "_blank");
-    });
-
-    it("opens new window if the link text was found in record with http schema", async () => {
-      const spy = vi.spyOn(window, "open");
-      spy.mockReturnValue(null);
-
-      PropertyGridCommons.handleLinkClick("http://www.testLink.com");
-      expect(spy).toHaveBeenCalledWith("http://www.testLink.com", "_blank");
-    });
-
-    it("does not open new window if there were no url links", async () => {
-      const spy = vi.spyOn(window, "open");
-      spy.mockReturnValue(null);
-
-      PropertyGridCommons.handleLinkClick("not an url link");
-      PropertyGridCommons.handleLinkClick("testEmail@mail.com");
-      expect(spy).not.toHaveBeenCalled();
-    });
-
-    it("sets location href value to value got in the text if it is an email link", async () => {
-      PropertyGridCommons.handleLinkClick("someOtherLink@mail.com");
-      expect(locationMockRef.object.href).toEqual(
-        "mailto:someOtherLink@mail.com"
-      );
-    });
-
-    it("opens new window if it is an ProjectWise Explorer link", async () => {
-      const spy = vi.spyOn(window, "open");
-      PropertyGridCommons.handleLinkClick(
-        "pw://server.bentley.com:datasource-01/Documents/ProjectName"
-      );
-      expect(spy).toHaveBeenCalledWith(
-        "pw:server.bentley.com:datasource-01/Documents/ProjectName",
-        "_blank"
-      );
-    });
-
-    it("calls window.open.focus if window.open returns not null", () => {
-      const windowMock = moq.Mock.ofType<Window>();
-      windowMock.setup((x) => x.focus());
-
-      const spy = vi.spyOn(window, "open");
-      spy.mockReturnValue(windowMock.object);
-
-      PropertyGridCommons.handleLinkClick("www.testLink.com");
-
-      expect(spy).toHaveBeenCalledWith("http://www.testLink.com", "_blank");
-      windowMock.verify((x) => x.focus(), moq.Times.once());
     });
   });
 });


### PR DESCRIPTION
## Changes

This PR updates link rendering to use actual anchor elements instead of relying on custom `onClick` handlers.

Notable changes:
- Link href is verified, when property with `typename: StandardTypeNames.URL` is created
- Explicit list of allowed schemas is used when verifying the href

## Testing

Tested manually, updated unit tests and storybook.
