### PR TITLE
Render icon element of a `Tool` in `ToolAssistanceField`

### DIFF
--- a/common/api/appui-react.api.md
+++ b/common/api/appui-react.api.md
@@ -4976,6 +4976,8 @@ export class ToolIconChangedEvent extends UiEvent<ToolIconChangedEventArgs> {
 // @public @deprecated
 export interface ToolIconChangedEventArgs {
     // (undocumented)
+    iconElement?: React.ReactElement;
+    // (undocumented)
     iconSpec: string;
 }
 


### PR DESCRIPTION
## Changes

Follow-up to accidental push to `master` https://github.com/iTwin/appui/commit/2a5a42f006f02c5994cc0227101d5108cd541d73
Extracted from https://github.com/iTwin/appui/pull/1587

Changes:
- Added `iconElement` property to `UiFramework.frontstages.onToolIconChangedEvent`
- Updated `ToolAssistanceField` to render icon defined via `ToolUtilities.defineIcon`

## Testing

Tested manually in `test-app`.